### PR TITLE
Remove/update Dockerfiles in galasa repo

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -325,7 +325,7 @@ jobs:
           labels: ${{ steps.metadata-obr.outputs.labels }}
           build-args: |
             dockerRepository=${{ env.REGISTRY }}
-            tag=${{ env.BRANCH }}
+            baseVersion=latest
       
       - name: Recycle OBR application in ArgoCD
         run: |

--- a/.github/workflows/pr-obr.yaml
+++ b/.github/workflows/pr-obr.yaml
@@ -341,7 +341,7 @@ jobs:
           tags: obr-maven-artefacts:test
           build-args: |
             dockerRepository=${{ env.REGISTRY }}
-            tag=main
+            baseVersion=latest
 
   build-obr-javadocs:
     name: Build OBR javadocs using galasabld image and maven

--- a/modules/extensions/dockerfiles/dockerfile
+++ b/modules/extensions/dockerfiles/dockerfile
@@ -1,6 +1,0 @@
-ARG dockerRepository
-ARG tag
-FROM ${dockerRepository}/galasa-dev/framework-maven-artefacts:${tag}
-
-COPY repo/ /usr/local/apache2/htdocs/
-COPY extensions.githash /usr/local/apache2/htdocs/extensions.githash

--- a/modules/framework/dockerfiles/dockerfile.framework
+++ b/modules/framework/dockerfiles/dockerfile.framework
@@ -1,7 +1,0 @@
-ARG dockerRepository
-ARG tag
-FROM ${dockerRepository}/galasa-dev/maven-maven-artefacts:${tag}
-
-COPY repo/ /usr/local/apache2/htdocs/
-COPY framework.githash /usr/local/apache2/htdocs/framework.githash
-COPY galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml /usr/local/apache2/htdocs/openapi.yaml

--- a/modules/gradle/dockerfiles/dockerfile.gradle
+++ b/modules/gradle/dockerfiles/dockerfile.gradle
@@ -1,6 +1,0 @@
-ARG dockerRepository
-ARG tag
-FROM ${dockerRepository}/galasa-dev/wrapping-maven-artefacts:${tag}
-
-COPY repo/ /usr/local/apache2/htdocs/
-COPY gradle.githash /usr/local/apache2/htdocs/gradle.githash

--- a/modules/managers/dockerfiles/dockerfile
+++ b/modules/managers/dockerfiles/dockerfile
@@ -1,6 +1,0 @@
-ARG dockerRepository
-ARG tag
-FROM ${dockerRepository}/galasa-dev/extensions-maven-artefacts:${tag}
-
-COPY repo/ /usr/local/apache2/htdocs/
-COPY managers.githash /usr/local/apache2/htdocs/managers.githash

--- a/modules/maven/dockerfiles/dockerfile
+++ b/modules/maven/dockerfiles/dockerfile
@@ -1,6 +1,0 @@
-ARG dockerRepository
-ARG tag
-FROM ${dockerRepository}/galasa-dev/gradle-maven-artefacts:${tag}
-
-COPY repo/ /usr/local/apache2/htdocs/
-COPY maven.githash /usr/local/apache2/htdocs/maven.githash

--- a/modules/obr/dockerfiles/dockerfile.obr
+++ b/modules/obr/dockerfiles/dockerfile.obr
@@ -1,7 +1,15 @@
 ARG dockerRepository
-ARG tag
+ARG baseVersion
 
-FROM ${dockerRepository}/galasa-dev/managers-maven-artefacts:${tag}
+FROM ${dockerRepository}/galasa-dev/base-image:${baseVersion}
 
 COPY repo/ /usr/local/apache2/htdocs/
+
 COPY obr.githash /usr/local/apache2/htdocs/obr.githash
+COPY buildutils.githash /usr/local/apache2/htdocs/buildutils.githash
+COPY wrapping.githash /usr/local/apache2/htdocs/wrapping.githash
+COPY gradle.githash /usr/local/apache2/htdocs/gradle.githash
+COPY maven.githash /usr/local/apache2/htdocs/maven.githash
+COPY framework.githash /usr/local/apache2/htdocs/framework.githash
+COPY extensions.githash /usr/local/apache2/htdocs/extensions.githash
+COPY managers.githash /usr/local/apache2/htdocs/managers.githash

--- a/modules/wrapping/dockerfiles/dockerfile.wrapping
+++ b/modules/wrapping/dockerfiles/dockerfile.wrapping
@@ -1,6 +1,0 @@
-ARG dockerRepository
-ARG baseVersion
-FROM ${dockerRepository}/galasa-dev/base-image:${baseVersion}
-
-COPY repo/ /usr/local/apache2/htdocs/
-COPY wrapping.githash /usr/local/apache2/htdocs/wrapping.githash


### PR DESCRIPTION
- Remove Dockerfiles that are no longer needed for intermediate maven repos
- Update OBR image's FROM image to the base image now intermediate images no longer built
- Update OBR Dockerfile to show all module githashes