### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -176,7 +176,7 @@ jobs:
           -PjacocoEnabled=${{ inputs.jacoco_enabled }} \
           -PisMainOrRelease=${{ inputs.sign_artifacts }} 2>&1 | tee build.log
 
-      - name: Upload Gradle Build Log
+      - name: Upload Gradle build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -188,7 +188,6 @@ jobs:
         with:
           name: extensions
           path: modules/extensions/repo
-          retention-days: 7
 
   report-failure:
     name: Report failure in workflow

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -166,7 +166,7 @@ jobs:
           -PjacocoEnabled=${{ inputs.jacoco_enabled }} \
           -PisMainOrRelease=${{ inputs.sign_artifacts }} 2>&1 | tee build.log
 
-      - name: Upload Gradle Build Log
+      - name: Upload Gradle build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -178,7 +178,6 @@ jobs:
         with:
           name: framework
           path: modules/framework/repo
-          retention-days: 7
 
   build-rest-api-documentation:
     name: Build REST API documentation using openapi2beans and gradle

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -84,7 +84,7 @@ jobs:
           -PjacocoEnabled=${{ inputs.jacoco_enabled }} \
           -PisMainOrRelease=${{ inputs.sign_artifacts }} 2>&1 | tee build.log
 
-      - name: Upload Gradle Build Log
+      - name: Upload Gradle build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -96,7 +96,6 @@ jobs:
         with:
           name: gradle
           path: modules/gradle/repo
-          retention-days: 7
 
   report-failure:
     name: Report failure in workflow

--- a/.github/workflows/managers.yaml
+++ b/.github/workflows/managers.yaml
@@ -177,7 +177,7 @@ jobs:
           -PjacocoEnabled=${{ inputs.jacoco_enabled }} \
           -PisMainOrRelease=${{ inputs.sign_artifacts }} 2>&1 | tee build.log
         
-      - name: Upload Gradle Build Log
+      - name: Upload Gradle build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -185,7 +185,7 @@ jobs:
           path: modules/managers/build.log
           retention-days: 7
           
-      - name: Upload Jacoco Report
+      - name: Upload Jacoco report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -199,7 +199,6 @@ jobs:
         with:
           name: managers
           path: modules/managers/repo
-          retention-days: 7
 
   report-failure:
     name: Report failure in workflow

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -141,14 +141,14 @@ jobs:
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
       
-      - name: Upload Maven Build Log
+      - name: Upload Maven build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: maven-maven-build-log
           path: modules/maven/build.log
             
-      - name: Upload Junit Test report
+      - name: Upload Junit report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -160,7 +160,6 @@ jobs:
         with:
           name: maven
           path: modules/maven/repo
-          retention-days: 7
 
   report-failure:
     name: Report failure in workflow

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -241,7 +241,7 @@ jobs:
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-bom-build.log
         
-      - name: Upload Galasa BOM Build Log
+      - name: Upload Galasa BOM build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -268,7 +268,7 @@ jobs:
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-obr-build.log
     
-      - name: Upload Galasa OBR Build Log
+      - name: Upload Galasa OBR build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -299,7 +299,6 @@ jobs:
         with:
           name: obr
           path: modules/obr/repo
-          retention-days: 7
 
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
@@ -514,7 +513,7 @@ jobs:
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
       
-      - name: Upload javadoc site Build Log
+      - name: Upload Javadoc site build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -766,7 +765,7 @@ jobs:
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
         
-      - name: Upload galasa obr generic Build Log
+      - name: Upload Galasa OBR Generic build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pr-extensions.yaml
+++ b/.github/workflows/pr-extensions.yaml
@@ -150,4 +150,3 @@ jobs:
         with:
           name: extensions
           path: modules/extensions/repo
-          retention-days: 7

--- a/.github/workflows/pr-framework.yaml
+++ b/.github/workflows/pr-framework.yaml
@@ -168,7 +168,7 @@ jobs:
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
           -PtargetMaven=${{ github.workspace }}/modules/framework/repo
       
-      - name: Upload Jacoco Reports as artifact
+      - name: Upload Jacoco report
         if: failure()
         uses: actions/upload-artifact@v3
         with:
@@ -182,7 +182,6 @@ jobs:
         with:
           name: framework
           path: modules/framework/repo
-          retention-days: 7
 
   build-rest-api-documentation:
     name: Build REST API documentation using openapi2beans and gradle

--- a/.github/workflows/pr-gradle.yaml
+++ b/.github/workflows/pr-gradle.yaml
@@ -60,4 +60,3 @@ jobs:
         with:
           name: gradle
           path: modules/gradle/repo
-          retention-days: 7

--- a/.github/workflows/pr-managers.yaml
+++ b/.github/workflows/pr-managers.yaml
@@ -147,7 +147,7 @@ jobs:
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
           -PtargetMaven=${{ github.workspace }}/modules/managers/repo 2>&1 | tee build.log
 
-      - name: Upload Gradle Build Log
+      - name: Upload Gradle build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -155,7 +155,7 @@ jobs:
           path: modules/managers/build.log
           retention-days: 7
             
-      - name: Upload Jacoco Report
+      - name: Upload Jacoco report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -169,4 +169,3 @@ jobs:
         with:
           name: managers
           path: modules/managers/repo
-          retention-days: 7

--- a/.github/workflows/pr-maven.yaml
+++ b/.github/workflows/pr-maven.yaml
@@ -123,4 +123,3 @@ jobs:
         with:
           name: maven
           path: modules/maven/repo
-          retention-days: 7

--- a/.github/workflows/pr-obr.yaml
+++ b/.github/workflows/pr-obr.yaml
@@ -264,7 +264,7 @@ jobs:
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-bom-build.log
         
-      - name: Upload Galasa BOM Build Log
+      - name: Upload Galasa BOM build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -299,7 +299,7 @@ jobs:
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-obr-build.log
 
-      - name: Upload Galasa OBR Build Log
+      - name: Upload Galasa OBR build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -330,7 +330,6 @@ jobs:
         with:
           name: obr
           path: modules/obr/repo
-          retention-days: 7
       
       - name: Build OBR image for testing
         uses: docker/build-push-action@v5
@@ -546,7 +545,7 @@ jobs:
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
 
-      - name: Upload javadoc site Build Log
+      - name: Upload Javadoc site build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pr-wrapping.yaml
+++ b/.github/workflows/pr-wrapping.yaml
@@ -93,4 +93,3 @@ jobs:
         with:
           name: wrapping
           path: modules/wrapping/repo
-          retention-days: 7

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -150,12 +150,12 @@ jobs:
 
   # This is required as all previous jobs are optional based on if a module has changed.
   # This job is set in the branch protection rules as required to merge a Pull Request.
-  end-pull-request-orchestrator:
-    name: End of Pull Request build
+  end-pull-request-build:
+    name: Pull Request build was successful
     needs: [pr-build-obr]
     runs-on: ubuntu-latest
 
     steps:
       - name: End of Pull Request build
         run: |
-          echo "End of Pull Request build - successful."
+          echo "Pull Request build was successful"

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -154,4 +154,8 @@ jobs:
     name: End of Pull Request build
     needs: [pr-build-obr]
     runs-on: ubuntu-latest
-    
+
+    steps:
+      - name: End of Pull Request build
+        run: |
+          echo "End of Pull Request build - successful."

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -147,3 +147,11 @@ jobs:
       framework-artifact-id: ${{ needs.find-artifacts.outputs.framework_artifacts_id }}
       extensions-artifact-id: ${{ needs.find-artifacts.outputs.extensions_artifacts_id }}
       managers-artifact-id: ${{ needs.find-artifacts.outputs.managers_artifacts_id }}
+
+  # This is required as all previous jobs are optional based on if a module has changed.
+  # This job is set in the branch protection rules as required to merge a Pull Request.
+  end-pull-request-orchestrator:
+    name: End of Pull Request build
+    needs: [pr-build-obr]
+    runs-on: ubuntu-latest
+    

--- a/.github/workflows/wrapping.yaml
+++ b/.github/workflows/wrapping.yaml
@@ -113,7 +113,7 @@ jobs:
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
 
-      - name: Upload Maven Build Log
+      - name: Upload Maven build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -125,7 +125,6 @@ jobs:
         with:
           name: wrapping
           path: modules/wrapping/repo
-          retention-days: 7
 
   report-failure:
     name: Report failure in workflow


### PR DESCRIPTION
- Remove retention policy for build artifacts as they might be needed more than 7 days after
- Create final job at the end of PR builds which will be marked as the required status check for a PR to be merged