### PR TITLE
Bump bouncycastle dependencies to 1.79

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/bnd.bnd
+++ b/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/bnd.bnd
@@ -25,8 +25,8 @@ Embed-Dependency: *;scope=compile
     jna-5.12.1.jar; lib:=true,\
     jackson-annotations-2.10.3.jar; lib:=true,\
     jackson-core-2.10.3.jar; lib:=true,\
-    bcpkix-jdk18on-1.75.jar; lib:=true,\
-    bcprov-jdk18on-1.75.jar; lib:=true,\
+    bcpkix-jdk18on-1.79.jar; lib:=true,\
+    bcprov-jdk18on-1.79.jar; lib:=true,\
     httpcore5-5.0.2.jar; lib:=true,\
     commons-codec-1.16.1.jar; lib:=true
 -fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=warning

--- a/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
@@ -27,12 +27,12 @@ dependencies {
     implementation 'com.github.docker-java:docker-java-transport-httpclient5:3.2.14'
     implementation ('org.bouncycastle:bcpkix-jdk18on') {
         version {
-            strictly '1.75'
+            strictly '1.79'
         }
     }
     implementation ('org.bouncycastle:bcprov-jdk18on') {
         version {
-            strictly '1.75'
+            strictly '1.79'
         }
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/bnd.bnd
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/bnd.bnd
@@ -22,9 +22,9 @@ Import-Package: dev.galasa.framework,\
 Embed-Transitive: true
 Embed-Dependency: *;scope=compile
 -includeresource: client-java-16.0.2.jar; lib:=true,\
-    bcpkix-jdk18on-1.75.jar; lib:=true,\
-    bcprov-jdk18on-1.75.jar; lib:=true,\
-    bcutil-jdk18on-1.75.jar; lib:=true,\
+    bcpkix-jdk18on-1.79.jar; lib:=true,\
+    bcprov-jdk18on-1.79.jar; lib:=true,\
+    bcutil-jdk18on-1.79.jar; lib:=true,\
     client-java-api-16.0.2.jar; lib:=true,\
     client-java-proto-16.0.2.jar; lib:=true,\
     commons-codec-1.16.1.jar; lib:=true,\

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.2'
     implementation 'org.apache.servicemix.bundles:org.apache.servicemix.bundles.okio:2.8.0_1'
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle:1.4.0'
-    implementation 'org.bouncycastle:bcpkix-jdk18on:1.75'
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.75'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.79'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.79'
     implementation 'io.kubernetes:client-java:16.0.2'
     implementation ('org.yaml:snakeyaml'){
         version {

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager/bnd.bnd
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager/bnd.bnd
@@ -22,9 +22,9 @@ Import-Package: dev.galasa,\
     org.xml.sax.helpers
 Embed-Transitive: true
 Embed-Dependency: *;scope=compile
--includeresource: bcpkix-jdk18on-1.75.jar; lib:=true,\
-    bcprov-jdk18on-1.75.jar; lib:=true,\
-    bcutil-jdk18on-1.75.jar; lib:=true,\
+-includeresource: bcpkix-jdk18on-1.79.jar; lib:=true,\
+    bcprov-jdk18on-1.79.jar; lib:=true,\
+    bcutil-jdk18on-1.79.jar; lib:=true,\
     client-java-17.0.0.jar; lib:=true,\
     client-java-api-17.0.0.jar; lib:=true,\
     client-java-proto-17.0.0.jar; lib:=true,\

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     implementation ('org.bouncycastle:bcpkix-jdk18on') {
         version {
-            strictly '1.75'
+            strictly '1.79'
         }
     }
     implementation ('com.google.code.findbugs:jsr305') {

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -277,17 +277,17 @@ external:
 
   - group: org.bouncycastle
     artifact: bcpkix-jdk18on
-    version: 1.75
+    version: 1.79
     obr: true
 
   - group: org.bouncycastle
     artifact: bcprov-jdk18on
-    version: 1.75
+    version: 1.79
     obr: true
 
   - group: org.bouncycastle
     artifact: bcutil-jdk18on
-    version: 1.75
+    version: 1.79
     obr: true
 
   - group: org.slf4j


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2028

[bcpkix](https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk18on/1.75) and [bcprov](https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on/1.75) 1.75 have several high-severity vulnerabilities, so bumping to 1.79 to remove these.