### PR TITLE
Bump log4j dependencies to 2.24.1

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.log4j2.bridge/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.log4j2.bridge/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 description = 'Galasa log4j2 Bridge'
 
-version = "0.25.0"
+version = "0.38.0"
 
 dependencies {
-    implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
-    implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
-    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.24.1'
+    implementation 'org.apache.logging.log4j:log4j-core:2.24.1'
+    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.24.1'
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/framework/galasa-parent/dev.galasa.framework/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework/build.gradle
@@ -14,9 +14,9 @@ dependencies {
     api project (':dev.galasa')
     implementation project (':dev.galasa.framework.maven.repository.spi')
 
-    implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
-    implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
-    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.24.1'
+    implementation 'org.apache.logging.log4j:log4j-core:2.24.1'
+    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.24.1'
     implementation 'org.apache.commons:commons-lang3:3.14.0'
     implementation 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2'
 

--- a/modules/framework/galasa-parent/galasa-boot/build.gradle
+++ b/modules/framework/galasa-parent/galasa-boot/build.gradle
@@ -15,7 +15,7 @@ configurations {
 
 }
 
-version = '0.37.0'
+version = '0.38.0'
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
@@ -56,8 +56,8 @@ dependencies {
 
     bundleDependency 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2'
     bundleDependency 'org.apache.felix:org.apache.felix.scr:2.1.14'
-    bundleDependency 'org.apache.logging.log4j:log4j-api:2.17.1'
-    bundleDependency 'org.apache.logging.log4j:log4j-core:2.17.1'
+    bundleDependency 'org.apache.logging.log4j:log4j-api:2.24.1'
+    bundleDependency 'org.apache.logging.log4j:log4j-core:2.24.1'
     bundleDependency project (':dev.galasa.framework.log4j2.bridge')
     bundleDependency project (':dev.galasa.framework.maven.repository')
     bundleDependency project (':dev.galasa.framework.maven.repository.spi')

--- a/modules/framework/release.yaml
+++ b/modules/framework/release.yaml
@@ -69,7 +69,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework.log4j2.bridge
-    version: 0.25.0
+    version: 0.38.0
     obr:          false
     mvp:          false
     bom:          false
@@ -114,7 +114,7 @@ framework:
     codecoverage: true
 
   - artifact: galasa-boot
-    version: 0.37.0
+    version: 0.38.0
     obr:          false
     mvp:          true
     bom:          false

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -299,21 +299,21 @@ external:
 
   - group: org.apache.logging.log4j
     artifact: log4j-api
-    version: 2.17.1
+    version: 2.24.1
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.logging.log4j
     artifact: log4j-core
-    version: 2.17.1
+    version: 2.24.1
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.logging.log4j
     artifact: log4j-slf4j-impl
-    version: 2.17.1
+    version: 2.24.1
     obr: true
     mvp: true
     isolated: true


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2028