### PR TITLE
Revert prometheus versions back to 0.6.0

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -477,14 +477,14 @@ jobs:
       # download artifacts from the last successful workflow.
 
       # Commented out for now as there are no historical runs with Platform artifacts.
-      # - name: Download platform from last successful workflow
-      #   if: ${{ steps.download-platform.outcome == 'failure' }}
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: platform
-      #     path: modules/artifacts
-      #     github-token: ${{ github.token }}
-      #     run-id: ${{ inputs.platform-artifact-id }}
+      - name: Download platform from last successful workflow
+        if: ${{ steps.download-platform.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.platform-artifact-id }}
 
       - name: Download wrapping artifacts from last successful workflow
         if: ${{ steps.download-wrapping.outcome == 'failure' }}
@@ -748,14 +748,14 @@ jobs:
       # download artifacts from the last successful workflow.
 
       # Commented out for now as there are no historical runs with Platform artifacts.
-      # - name: Download platform from last successful workflow
-      #   if: ${{ steps.download-platform.outcome == 'failure' }}
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: platform
-      #     path: modules/artifacts
-      #     github-token: ${{ github.token }}
-      #     run-id: ${{ inputs.platform-artifact-id }}
+      - name: Download platform from last successful workflow
+        if: ${{ steps.download-platform.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.platform-artifact-id }}
 
       - name: Download wrapping artifacts from last successful workflow
         if: ${{ steps.download-wrapping.outcome == 'failure' }}

--- a/.github/workflows/pr-framework.yaml
+++ b/.github/workflows/pr-framework.yaml
@@ -12,12 +12,12 @@ on:
         description: 'True if this module has been changed and should be rebuilt'
         required: true
         type: string
-      openapi2beans-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for openapi2beans'
-        required: true
-        type: string
       platform-artifact-id:
         description: 'The Workflow Run ID of the last workflow containing artifacts for the platform'
+        required: true
+        type: string
+      openapi2beans-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for openapi2beans'
         required: true
         type: string
       wrapping-artifact-id:
@@ -72,14 +72,6 @@ jobs:
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.
 
-      - name: Download openapi2beans artifacts from this workflow
-        id: download-openapi2beans
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: openapi2beans
-          path: modules/artifacts/openapi2beans
-
       - name: Download platform from this workflow
         id: download-platform
         continue-on-error: true
@@ -87,6 +79,14 @@ jobs:
         with:
           name: platform
           path: modules/artifacts
+
+      - name: Download openapi2beans artifacts from this workflow
+        id: download-openapi2beans
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: openapi2beans
+          path: modules/artifacts/openapi2beans
 
       - name: Download wrapping artifacts from this workflow
         id: download-wrapping
@@ -115,15 +115,6 @@ jobs:
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
 
-      - name: Download openapi2beans artifacts from last successful workflow
-        if: ${{ steps.download-openapi2beans.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: openapi2beans
-          path: modules/artifacts/openapi2beans
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.openapi2beans-artifact-id }}
-
       - name: Download platform from last successful workflow
         if: ${{ steps.download-platform.outcome == 'failure' }}
         uses: actions/download-artifact@v4
@@ -132,6 +123,15 @@ jobs:
           path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.platform-artifact-id }}
+
+      - name: Download openapi2beans artifacts from last successful workflow
+        if: ${{ steps.download-openapi2beans.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: openapi2beans
+          path: modules/artifacts/openapi2beans
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.openapi2beans-artifact-id }}
 
       - name: Download wrapping artifacts from last successful workflow
         if: ${{ steps.download-wrapping.outcome == 'failure' }}

--- a/.github/workflows/pr-obr.yaml
+++ b/.github/workflows/pr-obr.yaml
@@ -493,14 +493,14 @@ jobs:
           run-id: ${{ inputs.galasabld-artifact-id }}
 
       # Commented out for now as there are no historical runs with Platform artifacts.
-      # - name: Download platform from last successful workflow
-      #   if: ${{ steps.download-platform.outcome == 'failure' }}
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: platform
-      #     path: modules/artifacts
-      #     github-token: ${{ github.token }}
-      #     run-id: ${{ inputs.platform-artifact-id }}
+      - name: Download platform from last successful workflow
+        if: ${{ steps.download-platform.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.platform-artifact-id }}
 
       - name: Download wrapping artifacts from last successful workflow
         if: ${{ steps.download-wrapping.outcome == 'failure' }}

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      buildutils_changed: ${{ steps.get-changed-modules.outputs.BUILDUTILS_CHANGED }}
       platform_changed: ${{ steps.get-changed-modules.outputs.PLATFORM_CHANGED }}
+      buildutils_changed: ${{ steps.get-changed-modules.outputs.BUILDUTILS_CHANGED }}
       wrapping_changed: ${{ steps.get-changed-modules.outputs.WRAPPING_CHANGED }}
       gradle_changed: ${{ steps.get-changed-modules.outputs.GRADLE_CHANGED }}
       maven_changed: ${{ steps.get-changed-modules.outputs.MAVEN_CHANGED }}
@@ -44,9 +44,9 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs: 
+      platform_artifacts_id: ${{ steps.find-artifacts.outputs.platform_artifacts_id }}
       galasabld_artifacts_id: ${{ steps.find-artifacts.outputs.galasabld_artifacts_id }}
       openapi2beans_artifacts_id: ${{ steps.find-artifacts.outputs.openapi2beans_artifacts_id }}
-      platform_artifacts_id: ${{ steps.find-artifacts.outputs.platform_artifacts_id }}
       wrapping_artifacts_id: ${{ steps.find-artifacts.outputs.wrapping_artifacts_id }}
       gradle_artifacts_id: ${{ steps.find-artifacts.outputs.gradle_artifacts_id }}
       maven_artifacts_id: ${{ steps.find-artifacts.outputs.maven_artifacts_id }}
@@ -66,14 +66,6 @@ jobs:
         run: |
           ./tools/get-last-successful-workflow-run-for-artifacts.sh --repo ${{ github.repository }}
 
-  pr-build-buildutils:
-    name: Build the 'buildutils' module
-    needs: [get-changed-modules, find-artifacts]
-    uses: ./.github/workflows/pr-buildutils.yaml
-    secrets: inherit
-    with:
-      changed: ${{ needs.get-changed-modules.outputs.buildutils_changed }}
-
   pr-build-platform:
     name: Build the 'platform' module
     needs: [get-changed-modules, find-artifacts]
@@ -81,6 +73,14 @@ jobs:
     secrets: inherit
     with:
       changed: ${{ needs.get-changed-modules.outputs.platform_changed }}
+
+  pr-build-buildutils:
+    name: Build the 'buildutils' module
+    needs: [get-changed-modules, find-artifacts]
+    uses: ./.github/workflows/pr-buildutils.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.buildutils_changed }}
 
   pr-build-wrapping:
     name: Build the 'wrapping' module
@@ -114,8 +114,8 @@ jobs:
     secrets: inherit
     with:
       changed: ${{ needs.get-changed-modules.outputs.framework_changed }}
-      openapi2beans-artifact-id: ${{ needs.find-artifacts.outputs.openapi2beans_artifacts_id }}
       platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
+      openapi2beans-artifact-id: ${{ needs.find-artifacts.outputs.openapi2beans_artifacts_id }}
       wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
       gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
       maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
@@ -153,8 +153,8 @@ jobs:
     secrets: inherit
     with:
       changed: ${{ needs.get-changed-modules.outputs.obr_changed }}
-      galasabld-artifact-id: ${{ needs.find-artifacts.outputs.galasabld_artifacts_id }}
       platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
+      galasabld-artifact-id: ${{ needs.find-artifacts.outputs.galasabld_artifacts_id }}
       wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
       gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
       maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      buildutils_changed: ${{ steps.get-changed-modules.outputs.BUILDUTILS_CHANGED }}
       platform_changed: ${{ steps.get-changed-modules.outputs.PLATFORM_CHANGED }}
+      buildutils_changed: ${{ steps.get-changed-modules.outputs.BUILDUTILS_CHANGED }}
       wrapping_changed: ${{ steps.get-changed-modules.outputs.WRAPPING_CHANGED }}
       gradle_changed: ${{ steps.get-changed-modules.outputs.GRADLE_CHANGED }}
       maven_changed: ${{ steps.get-changed-modules.outputs.MAVEN_CHANGED }}
@@ -69,14 +69,6 @@ jobs:
         run: |
           ./tools/get-last-successful-workflow-run-for-artifacts.sh --repo ${{ github.repository }}
 
-  build-buildutils:
-    name: Build the 'buildutils' module
-    needs: [get-changed-modules]
-    uses: ./.github/workflows/buildutils.yaml
-    secrets: inherit
-    with:
-      changed: ${{ needs.get-changed-modules.outputs.buildutils_changed }}
-
   build-platform:
     name: Build the 'platform' module
     needs: [get-changed-modules]
@@ -84,6 +76,14 @@ jobs:
     secrets: inherit
     with:
       changed: ${{ needs.get-changed-modules.outputs.platform_changed }}
+        
+  build-buildutils:
+    name: Build the 'buildutils' module
+    needs: [get-changed-modules]
+    uses: ./.github/workflows/buildutils.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.buildutils_changed }}
 
   build-wrapping:
     name: Build the 'wrapping' module

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
@@ -17,9 +17,11 @@ dependencies {
     implementation 'commons-codec:commons-codec'
     implementation 'org.apache.commons:commons-compress'
 
-    implementation 'io.prometheus:simpleclient'
-    implementation 'io.prometheus:simpleclient_httpserver'
-    implementation 'io.prometheus:simpleclient_hotspot'
+    // Overriding version 0.6.0 suggested by the Platform - as upgrading the other projects
+    // to use 0.15.0 caused API start up problems. Fixes for this to be completed in a future story.
+    implementation 'io.prometheus:simpleclient:0.15.0'
+    implementation 'io.prometheus:simpleclient_httpserver:0.15.0'
+    implementation 'io.prometheus:simpleclient_hotspot:0.15.0'
 
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'org.apache.servicemix.bundles:org.apache.servicemix.bundles.okio'

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -33,9 +33,11 @@ dependencies {
 
         // Most bundles before implementing the Platform used 0.6.0 other than dev.galasa.framework.k8s.controller.
         // Upgrading all to 0.15.0 by using the Platform.
-        api 'io.prometheus:simpleclient:0.15.0'
-        api 'io.prometheus:simpleclient_httpserver:0.15.0'
-        api 'io.prometheus:simpleclient_hotspot:0.15.0'
+        // 0.15.0 found in dev.galasa.framework.k8s.controller but breaks API when used in other bundles.
+        // So using 0.6.0 as the default and 0.15.0 as override in dev.galasa.framework.k8s.controller.
+        api 'io.prometheus:simpleclient:0.6.0'
+        api 'io.prometheus:simpleclient_httpserver:0.6.0'
+        api 'io.prometheus:simpleclient_hotspot:0.6.0'
 
         api 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.41'
 
@@ -68,7 +70,6 @@ dependencies {
         api 'org.apache.tomcat:annotations-api:6.0.53'
 
         api 'org.assertj:assertj-core:3.16.1'
-        // api 'org.assertj:assertj-core:3.23.1'
         // 3.23.1 found in dev.galasa.framework.api.cps but breaks Extensions unit tests when used in other bundles.
         // So using 3.16.1 as the default and 3.23.1 as override in dev.galasa.framework.api.cps.
 

--- a/tools/get-changed-modules-pull-request.sh
+++ b/tools/get-changed-modules-pull-request.sh
@@ -137,12 +137,14 @@ function get_changed_modules_and_set_in_environment() {
     h1 "Finding changed modules and setting environment variables that can be used in the GitHub Actions workflows..."
 
     for module in "${unique_modules_found_in_pr[@]}"; do
-        if [[ "$module" == "buildutils" ]]; then
-            echo "BUILDUTILS_CHANGED=true" >> $GITHUB_OUTPUT
-            continue
-        fi
         if [[ "$module" == "platform" ]]; then
             echo "PLATFORM_CHANGED=true" >> $GITHUB_OUTPUT
+            # Also rebuild modules that depend on the Platform...
+            echo "FRAMEWORK_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "buildutils" ]]; then
+            echo "BUILDUTILS_CHANGED=true" >> $GITHUB_OUTPUT
             continue
         fi
         if [[ "$module" == "wrapping" ]]; then

--- a/tools/get-changed-modules-push.sh
+++ b/tools/get-changed-modules-push.sh
@@ -151,12 +151,14 @@ function get_changed_modules_and_set_in_environment() {
     h1 "Finding changed modules and setting environment variables that can be used in the GitHub Actions workflows..."
 
     for module in "${unique_modules_found_in_push[@]}"; do
-        if [[ "$module" == "buildutils" ]]; then
-            echo "BUILDUTILS_CHANGED=true" >> $GITHUB_OUTPUT
-            continue
-        fi
         if [[ "$module" == "platform" ]]; then
             echo "PLATFORM_CHANGED=true" >> $GITHUB_OUTPUT
+            # Also rebuild modules that depend on the Platform...
+            echo "FRAMEWORK_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "buildutils" ]]; then
+            echo "BUILDUTILS_CHANGED=true" >> $GITHUB_OUTPUT
             continue
         fi
         if [[ "$module" == "wrapping" ]]; then


### PR DESCRIPTION
## Why?

Merging Platform changes in #11 caused exceptions in Resource Monitor and Metrics startup.

- Reverting Platform version of prometheus to 0.6.0
- Still use the Platform to provide the versions to all bundles that originally used 0.6.0
- Override the suggested Platform version in dev.galasa.framework.k8s.controller which originally used 0.15.0
- Changes to build process - if Platform is changed, modules that use it should also be rebuilt even if not changed.