### PR TITLE
Utilise the Gradle Java Platform in the gradle module

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -22,6 +22,10 @@ on:
         required: false
         default: 'true'
         type: string
+      platform-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the platform'
+        required: true
+        type: string
 
 env:
   BRANCH: ${{ github.ref_name }}
@@ -67,6 +71,24 @@ jobs:
           gradle-version: 8.9
           cache-disabled: true
 
+      - name: Download platform from this workflow
+        id: download-platform
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+
+      # If the above failed because the platform hasn't changed in this PR...
+      - name: Download platform from last successful workflow
+        if: ${{ steps.download-platform.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.platform-artifact-id }}
+
       - name: Build Gradle source code
         working-directory: modules/gradle
         env:
@@ -78,7 +100,7 @@ jobs:
           set -o pipefail
           gradle check publish --info \
           --no-daemon --console plain \
-          -PsourceMaven=https://repo.maven.apache.org/maven2/ \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
           -PtargetMaven=${{ github.workspace }}/modules/gradle/repo \
           -PjacocoEnabled=${{ inputs.jacoco_enabled }} \

--- a/.github/workflows/pr-gradle.yaml
+++ b/.github/workflows/pr-gradle.yaml
@@ -12,6 +12,10 @@ on:
         description: 'True if this module has been changed and should be rebuilt'
         required: true
         type: string
+      platform-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the platform'
+        required: true
+        type: string
 
 jobs:
 
@@ -46,12 +50,30 @@ jobs:
           gradle-version: 8.9
           cache-disabled: true
 
+      - name: Download platform from this workflow
+        id: download-platform
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+
+      # If the above failed because the platform hasn't changed in this PR...
+      - name: Download platform from last successful workflow
+        if: ${{ steps.download-platform.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.platform-artifact-id }}
+
       - name: Build Gradle source code
         working-directory: modules/gradle
         run: |
           gradle check publish --info \
           --no-daemon --console plain \
-          -PsourceMaven=https://repo.maven.apache.org/maven2/ \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
           -PtargetMaven=${{ github.workspace }}/modules/gradle/repo
 

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -97,6 +97,7 @@ jobs:
     secrets: inherit
     with:
       changed: ${{ needs.get-changed-modules.outputs.gradle_changed }}
+      platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
 
   pr-build-maven:
     name: Build the 'maven' module

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -100,6 +100,7 @@ jobs:
     secrets: inherit
     with:
       changed: ${{ needs.get-changed-modules.outputs.gradle_changed }}
+      platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
 
   build-maven:
     name: Build the 'maven' module

--- a/modules/framework/galasa-parent/galasa-boot/build.gradle
+++ b/modules/framework/galasa-parent/galasa-boot/build.gradle
@@ -17,30 +17,6 @@ configurations {
 
 version = '0.38.0'
 
-dependencies {
-
-    implementation project (':dev.galasa.framework.maven.repository')
-    embedImplementation project (':dev.galasa.framework.maven.repository.spi')
-
-    implementation platform ('dev.galasa:dev.galasa.platform:0.38.0')
-    implementation 'org.apache.felix:org.apache.felix.scr'
-
-    embedImplementation 'org.apache.felix:org.apache.felix.framework:7.0.5'
-    embedImplementation 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2'
-
-    embedImplementation 'commons-cli:commons-cli:1.4'
-    embedImplementation 'commons-io:commons-io:2.16.1'
-
-    bundleDependency 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2'
-    bundleDependency 'org.apache.felix:org.apache.felix.scr:2.1.14'
-    bundleDependency 'org.apache.logging.log4j:log4j-api:2.24.1'
-    bundleDependency 'org.apache.logging.log4j:log4j-core:2.24.1'
-    bundleDependency project (':dev.galasa.framework.log4j2.bridge')
-    bundleDependency project (':dev.galasa.framework.maven.repository')
-    bundleDependency project (':dev.galasa.framework.maven.repository.spi')
-    
-}
-
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     manifest {
@@ -69,24 +45,22 @@ jar {
 dependencies {
 
     implementation project (':dev.galasa.framework.maven.repository')
+    implementation platform ('dev.galasa:dev.galasa.platform:0.38.0')
+    implementation 'org.apache.felix:org.apache.felix.scr'
+
     embedImplementation project (':dev.galasa.framework.maven.repository.spi')
-
     embedImplementation 'org.apache.felix:org.apache.felix.framework:7.0.5'
-    embedImplementation 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2'
-    implementation 'org.apache.felix:org.apache.felix.scr:2.1.14'
-
+    embedImplementation 'org.apache.felix:org.apache.felix.bundlerepository:2.0.10'
     embedImplementation 'commons-cli:commons-cli:1.4'
     embedImplementation 'commons-io:commons-io:2.16.1'
 
-    bundleDependency 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2'
+    bundleDependency 'org.apache.felix:org.apache.felix.bundlerepository:2.0.10'
     bundleDependency 'org.apache.felix:org.apache.felix.scr:2.1.14'
     bundleDependency 'org.apache.logging.log4j:log4j-api:2.24.1'
     bundleDependency 'org.apache.logging.log4j:log4j-core:2.24.1'
     bundleDependency project (':dev.galasa.framework.log4j2.bridge')
     bundleDependency project (':dev.galasa.framework.maven.repository')
     bundleDependency project (':dev.galasa.framework.maven.repository.spi')
-    
-
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/gradle/build.gradle
+++ b/modules/gradle/build.gradle
@@ -9,7 +9,7 @@ group   = "dev.galasa"
 
 // Note: The following line is changed by the set-version.sh script.
 // It is also read by other build scrips as required.
-version = "0.36.0"
+version = "0.38.0"
 
 signing {
     def signingKeyId = findProperty("signingKeyId")

--- a/modules/gradle/build.gradle
+++ b/modules/gradle/build.gradle
@@ -31,7 +31,7 @@ allprojects {
     repositories {
         mavenLocal()
         maven {
-            url "https://development.galasa.dev/main/maven-repo/obr/"
+            url = "$sourceMaven"
         }
         gradlePluginPortal()
         mavenCentral()

--- a/modules/gradle/dev.galasa.gradle.impl/build.gradle
+++ b/modules/gradle/dev.galasa.gradle.impl/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group   = "dev.galasa"
-version = "0.36.0"
+version = "0.38.0"
 
 repositories {
     mavenLocal()
@@ -18,10 +18,11 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.apache.felix:org.apache.felix.bundlerepository:2.0.10'
-    implementation 'org.reflections:reflections:0.9.11'
-    implementation 'com.google.code.gson:gson:2.10.1'
-    testImplementation 'junit:junit:4.13'
+    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
+    implementation 'org.apache.felix:org.apache.felix.bundlerepository'
+    implementation 'org.reflections:reflections'
+    implementation 'com.google.code.gson:gson'
+    testImplementation 'junit:junit'
     implementation project(':dev.galasa.plugin.common')
     implementation project(':dev.galasa.plugin.common.impl')
     testImplementation  project(':dev.galasa.plugin.common.test')

--- a/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
@@ -23,8 +23,8 @@ dependencies {
     implementation 'com.google.code.gson:gson'
     implementation 'commons-codec:commons-codec'
 	implementation 'commons-io:commons-io'
-	implementation 'org.apache.httpcomponents:httpcore'
-	implementation 'org.apache.httpcomponents:httpclient'
+    implementation 'org.apache.httpcomponents:httpcore:4.4.11'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'junit:junit'
     // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
     // to higher versions caused unit test failures. Fixes for this to be completed in a future story.

--- a/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
@@ -23,8 +23,8 @@ dependencies {
     implementation 'com.google.code.gson:gson'
     implementation 'commons-codec:commons-codec'
 	implementation 'commons-io:commons-io'
-    implementation 'org.apache.httpcomponents:httpcore:4.4.11'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+    implementation 'org.apache.httpcomponents:httpcore'
+    implementation 'org.apache.httpcomponents:httpclient'
     testImplementation 'junit:junit'
     // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
     // to higher versions caused unit test failures. Fixes for this to be completed in a future story.

--- a/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group   = "dev.galasa"
-version = "0.36.0"
+version = "0.38.0"
 
 repositories {
     maven {
@@ -19,13 +19,16 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.13'
-    implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'commons-codec:commons-codec:1.13'
-	implementation 'commons-io:commons-io:2.15.1'
+    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
+    implementation 'com.google.code.gson:gson'
+    implementation 'commons-codec:commons-codec'
+	implementation 'commons-io:commons-io'
+	implementation 'org.apache.httpcomponents:httpcore'
+	implementation 'org.apache.httpcomponents:httpclient'
+    testImplementation 'junit:junit'
+    // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
+    // to higher versions caused unit test failures. Fixes for this to be completed in a future story.
 	testImplementation 'org.assertj:assertj-core:3.25.3'
-	implementation 'org.apache.httpcomponents:httpcore:4.4.11'
-	implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation project(':dev.galasa.plugin.common')
     testImplementation project(':dev.galasa.plugin.common.test')
 }

--- a/modules/gradle/dev.galasa.plugin.common.test/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.test/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
     // to higher versions caused unit test failures. Fixes for this to be completed in a future story.
 	implementation 'org.assertj:assertj-core:3.25.3'
-	implementation 'org.apache.httpcomponents:httpcore'
-	implementation 'org.apache.httpcomponents:httpclient'
+    implementation 'org.apache.httpcomponents:httpcore:4.4.11'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation project(':dev.galasa.plugin.common')
 }
 

--- a/modules/gradle/dev.galasa.plugin.common.test/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.test/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group   = "dev.galasa"
-version = "0.36.0"
+version = "0.38.0"
 
 repositories {
     maven {
@@ -19,13 +19,16 @@ repositories {
 }
 
 dependencies {
-    implementation 'junit:junit:4.13'
-    implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'commons-codec:commons-codec:1.13'
-	implementation 'commons-io:commons-io:2.15.1'
+    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
+    implementation 'junit:junit'
+    implementation 'com.google.code.gson:gson'
+    implementation 'commons-codec:commons-codec'
+	implementation 'commons-io:commons-io'
+    // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
+    // to higher versions caused unit test failures. Fixes for this to be completed in a future story.
 	implementation 'org.assertj:assertj-core:3.25.3'
-	implementation 'org.apache.httpcomponents:httpcore:4.4.11'
-	implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+	implementation 'org.apache.httpcomponents:httpcore'
+	implementation 'org.apache.httpcomponents:httpclient'
     implementation project(':dev.galasa.plugin.common')
 }
 

--- a/modules/gradle/dev.galasa.plugin.common.test/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.test/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
     // to higher versions caused unit test failures. Fixes for this to be completed in a future story.
 	implementation 'org.assertj:assertj-core:3.25.3'
-    implementation 'org.apache.httpcomponents:httpcore:4.4.11'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+    implementation 'org.apache.httpcomponents:httpcore'
+    implementation 'org.apache.httpcomponents:httpclient'
     implementation project(':dev.galasa.plugin.common')
 }
 

--- a/modules/gradle/dev.galasa.plugin.common/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common/build.gradle
@@ -21,8 +21,8 @@ repositories {
 dependencies {
     implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
     implementation 'com.google.code.gson:gson'
-    implementation 'org.apache.httpcomponents:httpcore'
-    implementation 'org.apache.httpcomponents:httpclient'
+    implementation 'org.apache.httpcomponents:httpcore:4.4.11'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'junit:junit'
 }
 

--- a/modules/gradle/dev.galasa.plugin.common/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group   = "dev.galasa"
-version = "0.36.0"
+version = "0.38.0"
 
 repositories {
     maven {
@@ -19,10 +19,11 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'org.apache.httpcomponents:httpcore:4.4.11'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    testImplementation 'junit:junit:4.13'
+    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
+    implementation 'com.google.code.gson:gson'
+    implementation 'org.apache.httpcomponents:httpcore'
+    implementation 'org.apache.httpcomponents:httpclient'
+    testImplementation 'junit:junit'
 }
 
 tasks.withType(Javadoc) {

--- a/modules/gradle/dev.galasa.plugin.common/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common/build.gradle
@@ -21,8 +21,8 @@ repositories {
 dependencies {
     implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
     implementation 'com.google.code.gson:gson'
-    implementation 'org.apache.httpcomponents:httpcore:4.4.11'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+    implementation 'org.apache.httpcomponents:httpcore'
+    implementation 'org.apache.httpcomponents:httpclient'
     testImplementation 'junit:junit'
 }
 

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -55,9 +55,12 @@ dependencies {
         api 'org.apache.commons:commons-compress:1.26.0'
         api 'org.apache.commons:commons-lang3:3.14.0'
 
-        api 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.felix:org.apache.felix.bundlerepository:2.0.10' // If updating, also update in galasa-boot build.gradle.
         api 'org.apache.felix:org.apache.felix.framework:7.0.5' // If updating, also update in galasa-boot build.gradle.
         api 'org.apache.felix:org.apache.felix.scr:2.1.14' // If updating, also update in galasa-boot build.gradle.
+
+        api 'org.apache.httpcomponents:httpclient:4.5.14'
+        api 'org.apache.httpcomponents:httpcore:4.4.11'
 
         api 'org.apache.logging.log4j:log4j-api:2.24.1' // If updating, also update in galasa-boot build.gradle.
         api 'org.apache.logging.log4j:log4j-core:2.24.1' // If updating, also update in galasa-boot build.gradle.
@@ -85,6 +88,8 @@ dependencies {
         api 'org.osgi:org.osgi.core:6.0.0'
         api 'org.osgi:org.osgi.service.cm:1.6.0'
         api 'org.osgi:org.osgi.service.component.annotations:1.3.0'
+
+        api 'org.reflections:reflections:0.9.11'
 
         api 'org.yaml:snakeyaml:2.0'
 

--- a/tools/get-changed-modules-pull-request.sh
+++ b/tools/get-changed-modules-pull-request.sh
@@ -140,6 +140,7 @@ function get_changed_modules_and_set_in_environment() {
         if [[ "$module" == "platform" ]]; then
             echo "PLATFORM_CHANGED=true" >> $GITHUB_OUTPUT
             # Also rebuild modules that depend on the Platform...
+            echo "GRADLE_CHANGED=true" >> $GITHUB_OUTPUT
             echo "FRAMEWORK_CHANGED=true" >> $GITHUB_OUTPUT
             continue
         fi

--- a/tools/get-changed-modules-push.sh
+++ b/tools/get-changed-modules-push.sh
@@ -154,6 +154,7 @@ function get_changed_modules_and_set_in_environment() {
         if [[ "$module" == "platform" ]]; then
             echo "PLATFORM_CHANGED=true" >> $GITHUB_OUTPUT
             # Also rebuild modules that depend on the Platform...
+            echo "GRADLE_CHANGED=true" >> $GITHUB_OUTPUT
             echo "FRAMEWORK_CHANGED=true" >> $GITHUB_OUTPUT
             continue
         fi


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2052 - implementing the Gradle Java Platform for the gradle module of Galasa.
- Remove Gradle's dependencies' versions and pull from the Platform (other than assertj-core which has many conflicting versions throughout Galasa and will be handled at another point)
- Added download of Platform to Gradle workflows so it can be used in the workflows
- Update 'org.apache.felix:org.apache.felix.bundlerepository' dependency to 2.10.0 in platform and galasa-boot
- Fix mistake in galasa-boot from previous PR (duplicate `dependencies` block)