### PR TITLE
Bump commons-logging to 1.3.4

### DIFF
--- a/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
+++ b/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'dev.galasa:dev.galasa.framework:0.38.0'
     implementation 'dev.galasa:dev.galasa:0.34.0'
 
-    implementation 'commons-logging:commons-logging:1.2'
+    implementation 'commons-logging:commons-logging:1.3.4'
     implementation 'org.osgi:org.osgi.core:6.0.0'
     implementation 'org.osgi:org.osgi.service.component.annotations:1.3.0'
     implementation 'javax.validation:validation-api:2.0.1.Final'

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
@@ -7,7 +7,7 @@ plugins {
 dependencies {
     api            'dev.galasa:dev.galasa:0.34.0'
     implementation 'dev.galasa:dev.galasa.framework:0.38.0'
-    implementation 'commons-logging:commons-logging:1.2'
+    implementation 'commons-logging:commons-logging:1.3.4'
     implementation 'org.osgi:org.osgi.core:6.0.0'
     implementation 'org.osgi:org.osgi.service.component.annotations:1.3.0'
     compileOnly    'javax.validation:validation-api:2.0.1.Final'

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.ivt.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.ivt.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     implementation 'dev.galasa:dev.galasa:0.34.0'
     
-    implementation 'commons-logging:commons-logging:1.2'
+    implementation 'commons-logging:commons-logging:1.3.4'
     
     implementation 'org.assertj:assertj-core:3.11.1'
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/build.gradle
@@ -13,12 +13,8 @@ dependencies {
     implementation  'commons-io:commons-io:2.16.1'
     implementation  'com.google.code.gson:gson:2.10.1'
     implementation  'jakarta.xml.bind:jakarta.xml.bind-api:3.0.0'
-    implementation (group: 'commons-codec', name: 'commons-codec'){
-      version{
-        strictly "[1.15]"
-      }
-   }
-   implementation project (':galasa-managers-common-parent:dev.galasa.common')
+    implementation  'commons-codec:commons-codec:1.15'
+    implementation project (':galasa-managers-common-parent:dev.galasa.common')
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -70,7 +70,7 @@ external:
 
   - group: commons-logging
     artifact: commons-logging
-    version: 1.2
+    version: 1.3.4
     obr: false
     bom: true
     mvp: true

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
         api 'commons-io:commons-io:2.16.1' // If updating, also update in galasa-boot build.gradle.
 
-        api 'commons-logging:commons-logging:1.2'
+        api 'commons-logging:commons-logging:1.3.4'
 
         api 'dev.galasa:com.auth0.jwt:4.4.1'
         api 'dev.galasa:dev.galasa.wrapping.io.grpc.java:0.38.0'


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2028