### PR TITLE
Update galasabld slackpost workflows to work with the mono repo

### DIFF
--- a/.github/workflows/buildutils.yaml
+++ b/.github/workflows/buildutils.yaml
@@ -275,4 +275,4 @@ jobs:
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run : |
-          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "buildutils" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "buildutils" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -221,4 +221,4 @@ jobs:
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run : |
-          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "extensions" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "extensions" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -270,4 +270,4 @@ jobs:
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run : |
-          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "framework" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "framework" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -130,4 +130,4 @@ jobs:
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run : |
-          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "gradle" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "gradle" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/managers.yaml
+++ b/.github/workflows/managers.yaml
@@ -232,4 +232,4 @@ jobs:
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run : |
-          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "managers" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "managers" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -172,4 +172,4 @@ jobs:
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run : |
-          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "maven" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "maven" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -945,4 +945,4 @@ jobs:
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run : |
-          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "obr" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "obr" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/platform.yaml
+++ b/.github/workflows/platform.yaml
@@ -101,4 +101,4 @@ jobs:
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run : |
-          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "platform" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "platform" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/wrapping.yaml
+++ b/.github/workflows/wrapping.yaml
@@ -137,4 +137,4 @@ jobs:
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run : |
-          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "wrapping" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "wrapping" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/modules/buildutils/pkg/cmd/slackpostWorkflows.go
+++ b/modules/buildutils/pkg/cmd/slackpostWorkflows.go
@@ -22,14 +22,16 @@ var (
 		Long:  "",
 		Run:   slackpostWorkflowsExecute,
 	}
-	repo				string
-	workflowName        	string
-	workflowRunNumber  	string
-	ref          		string
+	repo              string
+	module            string
+	workflowName      string
+	workflowRunNumber string
+	ref               string
 )
- 
+
 func init() {
 	slackpostWorkflowsCmd.PersistentFlags().StringVar(&repo, "repo", "", "The name of the repository of the workflow that failed")
+	slackpostWorkflowsCmd.PersistentFlags().StringVar(&module, "module", "", "The name of the module in the workflow that failed") // Used for the 'galasa' repo where there are multiple modules
 	slackpostWorkflowsCmd.PersistentFlags().StringVar(&workflowName, "workflowName", "", "The name of the workflow that failed")
 	slackpostWorkflowsCmd.PersistentFlags().StringVar(&workflowRunNumber, "workflowRunNum", "", "The number of the workflow run that failed")
 	slackpostWorkflowsCmd.PersistentFlags().StringVar(&ref, "ref", "", "The name of the branch/ref that was being built")
@@ -41,16 +43,21 @@ func init() {
 
 	slackpostCmd.AddCommand(slackpostWorkflowsCmd)
 }
- 
+
 func slackpostWorkflowsExecute(cmd *cobra.Command, args []string) {
 	fmt.Printf("Galasa Build - Slack Failed GitHub Workflow Report - version %v\n", rootCmd.Version)
 
 	linkToWorkflowRun := fmt.Sprintf("https://github.com/galasa-dev/%s/actions/runs/%s", repo, workflowRunNumber)
 
-	content := fmt.Sprintf("Galasa GitHub workflow failure:\n\nThe '%s' workflow failed for the '%s' repository when building the '%s' ref. Please see %s for details.", workflowName, repo, ref, linkToWorkflowRun)
+	moduleString := ""
+	if repo == "galasa" {
+		moduleString = fmt.Sprintf(" in the '%s' module", module)
+	}
+
+	content := fmt.Sprintf("Galasa GitHub workflow failure:\n\nThe '%s' workflow failed for the '%s' repository%s when building the '%s' ref. Please see %s for details.", workflowName, repo, moduleString, ref, linkToWorkflowRun)
 
 	client := http.Client{
-	Timeout: time.Second * 30,
+		Timeout: time.Second * 30,
 	}
 
 	body := fmt.Sprintf("{\"text\":\"%s\"}", content)


### PR DESCRIPTION
## Why?

Since changing to the mono repo the failed build notifications into the Slack channel would post an incorrect URL.