### PR TITLE
Framework storing login time while creating a new Galasa access token

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
@@ -331,7 +331,7 @@ public class AuthTokensRoute extends BaseRoute {
             authStoreService.createUser(loginId, clientName);
         } else {
 
-            // Only update the document if the user has not created a Galasa Access Token
+            // Only update the document if the user has not created a new Galasa Access Token
             // or is using the web-ui
             if(!isNewAccessTokenBeingCreated || clientName.equals(WEB_UI_CLIENT)){
                 IFrontEndClient client = user.getClient(clientName);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRouteTest.java
@@ -938,7 +938,7 @@ public class AuthTokensRouteTest extends BaseServletTest {
         boolean isWebUiJustLoggedIn = true ;
 
         // When...
-        route.recordUserJustLoggedIn(isWebUiJustLoggedIn,dummyJwt, mockTimeService, mockEnv);
+        route.recordUserJustLoggedIn(isWebUiJustLoggedIn,dummyJwt, mockTimeService, mockEnv, false);
 
         // Then...
         IUser userGotBack = authStoreService.getUserByLoginId("requestorId");
@@ -1006,7 +1006,7 @@ public class AuthTokensRouteTest extends BaseServletTest {
             mockEnv);
 
         // When...
-        route.recordUserJustLoggedIn(isWebUiJustLoggedIn,dummyJwt, mockTimeService,mockEnv);
+        route.recordUserJustLoggedIn(isWebUiJustLoggedIn,dummyJwt, mockTimeService,mockEnv, false);
 
         // Then...
         IUser userGotBack = authStoreService.getUserByLoginId("requestorId");
@@ -1056,7 +1056,7 @@ public class AuthTokensRouteTest extends BaseServletTest {
         boolean isWebUiJustLoggedIn = true ;
 
         // When...
-        route.recordUserJustLoggedIn(isWebUiJustLoggedIn,dummyJwt, mockTimeService, mockEnv);
+        route.recordUserJustLoggedIn(isWebUiJustLoggedIn,dummyJwt, mockTimeService, mockEnv, true);
 
         // Then...
         IUser userGotBack = authStoreService.getUserByLoginId("requestorId");


### PR DESCRIPTION
# Why?

- Refer to https://github.com/galasa-dev/projectmanagement/issues/1975

- This change was needed as the current setup was storing the last login time of a user even when they allocated a new Galasa Access Token. We should only be storing client and last login time when uses actually uses the `galasactl`
