### PR TITLE
log an error when a test fails so failures are easy to spot in run logs for users

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
@@ -125,7 +125,7 @@ public class GenericMethodWrapper {
                 if (this.testStructureMethod.getException() != null) {
                     exception = "\n" + this.testStructureMethod.getException();
                 }
-                logger.info(TestClassWrapper.LOG_ENDING + TestClassWrapper.LOG_START_LINE + TestClassWrapper.LOG_ASTERS
+                logger.error(TestClassWrapper.LOG_ENDING + TestClassWrapper.LOG_START_LINE + TestClassWrapper.LOG_ASTERS
                         + TestClassWrapper.LOG_START_LINE + "*** " + this.result.getName() + " - Test method "
                         + testClass.getName() + "#" + excecutionMethod.getName() + methodType
                         + TestClassWrapper.LOG_START_LINE + TestClassWrapper.LOG_ASTERS + exception);


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
See [Incorrect log message when ending a test if it's failed.
#2046](https://github.com/galasa-dev/projectmanagement/issues/2046)