### PR TITLE
Fix engine controller deprecated warnings and overhead error

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -226,12 +226,13 @@ public class TestPodScheduler implements Runnable {
 
         V1PodSpec podSpec = new V1PodSpec();
         newPod.setSpec(podSpec);
+        podSpec.setOverhead(null);
         podSpec.setRestartPolicy("Never");
 
         String nodeArch = this.settings.getNodeArch();
         if (!nodeArch.isEmpty()) {
             HashMap<String, String> nodeSelector = new HashMap<>();
-            nodeSelector.put("beta.kubernetes.io/arch", nodeArch);
+            nodeSelector.put("kubernetes.io/arch", nodeArch);
             podSpec.setNodeSelector(nodeSelector);
         }
 


### PR DESCRIPTION
## Why?
Due to changes in https://github.com/galasa-dev/galasa/pull/23, when the engine controller tries to start a pod using the new kubernetes client-java library, it throws the following error:

```
io.kubernetes.client.openapi.ApiException: Message:
HTTP response code: 403
HTTP response body: {
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "pods \"galasa-prod1-k8s-standard-engine-c14777\" is forbidden: pod rejected: Pod Overhead set without corresponding RuntimeClass defined Overhead",
  "reason": "Forbidden",
  "details": {
    "name": "galasa-prod1-k8s-standard-engine-c14777",
    "kind": "pods"
  },
  "code": 403
}
HTTP response headers: {audit-id=[d1475f86-87be-489a-b12d-af172f633a5b], cache-control=[no-cache, private], content-length=[381], content-type=[application/json], date=[Tue, 19 Nov 2024 13:35:08 GMT], warning=[299 - 
"spec.nodeSelector[beta.kubernetes.io/arch]: deprecated since v1.14; use \"kubernetes.io/arch\" instead"], x-kubernetes-pf-flowschema-uid=[d0974127-47d2-4a27-ac04-bc8ea80c046c], x-kubernetes-pf-prioritylevel-uid=[d3d5b117-371a-4b80-8e15-4d09facd3ff6]}
	at io.kubernetes.client.openapi.ApiClient.handleResponse(ApiClient.java:1130) ~[-1732022199253:?]
	at io.kubernetes.client.openapi.ApiClient.execute(ApiClient.java:1043) ~[-1732022199253:?]
	at io.kubernetes.client.openapi.apis.CoreV1Api.createNamespacedPodWithHttpInfo(CoreV1Api.java:10875) ~[-1732022199253:?]
	at io.kubernetes.client.openapi.apis.CoreV1Api$APIcreateNamespacedPodRequest.execute(CoreV1Api.java:10971) ~[-1732022199253:?]
	at dev.galasa.framework.k8s.controller.TestPodScheduler.startPod(TestPodScheduler.java:184) [-1732022199296:?]
	at dev.galasa.framework.k8s.controller.TestPodScheduler.run(TestPodScheduler.java:142) [-1732022199296:?]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) [?:?]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.base/java.lang.Thread.run(Thread.java:833) [?:?]
19/11/2024 13:35:08.901 INFO  d.g.f.k.c.TestPodScheduler - Waiting 2 seconds before trying to create pod again
```

So explicitly setting the pod overhead to null to prevent an empty map from being set and updated the architecture annotation from `beta.kubernetes.io/arch` to `kubernetes.io/arch` as mentioned in the above message.