### PR TITLE
openapi2beans now builds with linux arm64 architecture

### DIFF
--- a/modules/buildutils/openapi2beans/Makefile
+++ b/modules/buildutils/openapi2beans/Makefile
@@ -8,7 +8,8 @@ all: tests docs openapi2beans
 openapi2beans: \
 	bin/openapi2beans-linux-x86_64 \
 	bin/openapi2beans-darwin-x86_64 \
-	bin/openapi2beans-darwin-arm64 
+	bin/openapi2beans-darwin-arm64 \
+	bin/openapi2beans-linux-arm64
 
 
 tests: openapi2beans-source build/coverage.txt


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?

Running a docker container on a mac requires the openapi2beans tool to support the linux-arm64 architecture.
