### PR TITLE
Workflow cleanup

### DIFF
--- a/.github/workflows/buildutils.yaml
+++ b/.github/workflows/buildutils.yaml
@@ -7,11 +7,6 @@ name: Buildutils Main Build
 
 on:
   workflow_call:
-    inputs:
-      changed:
-        description: 'True if this module has been changed and should be rebuilt'
-        required: true
-        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -20,19 +15,8 @@ env:
 
 jobs:
 
-  log-unchanged:
-    name: Buildutils is unchanged
-    if: ${{ inputs.changed == 'false' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Log this module is unchanged
-        run: |
-          echo "The buildutils module is unchanged"
-
   build-push-galasabld:
     name: Build and push galasabld artifacts
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -95,7 +79,6 @@ jobs:
 
   build-push-galasabld-ibm:
     name: Build and push galasabld-ibm artefact
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     needs: [build-push-galasabld]
 
@@ -145,7 +128,6 @@ jobs:
 
   build-push-openapi2beans:
     name: Build and push openapi2beans artifacts
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     
     steps:
@@ -208,7 +190,6 @@ jobs:
 
   build-push-buildutils-executables:
     name: Build and push buildutils repository executables
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -8,10 +8,6 @@ name: Extensions Main Build
 on:
   workflow_call:
     inputs:
-      changed:
-        description: 'True if this module has been changed and should be rebuilt'
-        required: true
-        type: string
       jacoco_enabled:
         description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
         required: false
@@ -22,45 +18,14 @@ on:
         required: false
         default: 'true'
         type: string
-      platform-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the platform'
-        required: true
-        type: string
-      wrapping-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
-        required: true
-        type: string
-      gradle-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
-        required: true
-        type: string
-      maven-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
-        required: true
-        type: string
-      framework-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the framework module'
-        required: true
-        type: string
 
 env:
   BRANCH: ${{ github.ref_name }}
     
 jobs:
 
-  log-unchanged:
-    name: Extensions is unchanged
-    if: ${{ inputs.changed == 'false' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Log this module is unchanged
-        run: |
-          echo "The extensions module is unchanged"
-
   log-github-ref:
     name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Log GitHub ref of workflow
@@ -69,7 +34,6 @@ jobs:
 
   build-extensions:
     name: Build Extensions source code and Docker image for development Maven registry
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -87,9 +51,6 @@ jobs:
         with:
           gradle-version: 8.9
           cache-disabled: true
-
-      # For any modules that were changed in this push,
-      # download their artifacts from this workflow run.
 
       - name: Download platform from this workflow
         id: download-platform
@@ -130,54 +91,6 @@ jobs:
         with:
           name: framework
           path: modules/artifacts
-
-      # For any modules that weren't changed in this push,
-      # download artifacts from the last successful workflow.
-
-      - name: Download platform from last successful workflow
-        if: ${{ steps.download-platform.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.platform-artifact-id }}
-
-      - name: Download wrapping artifacts from last successful workflow
-        if: ${{ steps.download-wrapping.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: wrapping
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.wrapping-artifact-id }}
-
-      - name: Download gradle artifacts from last successful workflow
-        if: ${{ steps.download-gradle.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: gradle
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.gradle-artifact-id }}
-
-      - name: Download maven artifacts from last successful workflow
-        if: ${{ steps.download-maven.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: maven
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.maven-artifact-id }}
-
-      - name: Download framework artifacts from last successful workflow
-        if: ${{ steps.download-framework.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: framework
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.framework-artifact-id }}
 
       - name: Build Extensions source code with gradle
         working-directory: modules/extensions

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -8,10 +8,6 @@ name: Framework Main Build
 on:
   workflow_call:
     inputs:
-      changed:
-        description: 'True if this module has been changed and should be rebuilt'
-        required: true
-        type: string
       jacoco_enabled:
         description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
         required: false
@@ -22,22 +18,6 @@ on:
         required: false
         default: 'true'
         type: string
-      platform-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the platform'
-        required: true
-        type: string
-      wrapping-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
-        required: true
-        type: string
-      gradle-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
-        required: true
-        type: string
-      maven-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
-        required: true
-        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -46,19 +26,8 @@ env:
     
 jobs:
 
-  log-unchanged:
-    name: Framework is unchanged
-    if: ${{ inputs.changed == 'false' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Log this module is unchanged
-        run: |
-          echo "The framework module is unchanged"
-
   log-github-ref:
     name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Log GitHub ref of workflow
@@ -67,7 +36,6 @@ jobs:
 
   build-framework:
     name: Build Framework using openapi2beans and gradle
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -93,9 +61,6 @@ jobs:
           PACKAGE: "dev.galasa.framework.api.beans.generated"
         run: |
           docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/openapi2beans:main generate --yaml var/workspace/${{ env.YAML_LOCATION }} --output var/workspace/${{ env.OUTPUT_LOCATION }} --package ${{ env.PACKAGE }}
-
-      # For any modules that were changed in this push,
-      # download their artifacts from this workflow run.
 
       - name: Download platform from this workflow
         id: download-platform
@@ -128,45 +93,6 @@ jobs:
         with:
           name: maven
           path: modules/artifacts
-
-      # For any modules that weren't changed in this push,
-      # download artifacts from the last successful workflow.
-
-      - name: Download platform from last successful workflow
-        if: ${{ steps.download-platform.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.platform-artifact-id }}
-
-      - name: Download wrapping artifacts from last successful workflow
-        if: ${{ steps.download-wrapping.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: wrapping
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.wrapping-artifact-id }}
-
-      - name: Download gradle artifacts from last successful workflow
-        if: ${{ steps.download-gradle.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: gradle
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.gradle-artifact-id }}
-
-      - name: Download maven artifacts from last successful workflow
-        if: ${{ steps.download-maven.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: maven
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.maven-artifact-id }}
 
       - name: Build Framework source code
         working-directory: modules/framework
@@ -202,7 +128,6 @@ jobs:
 
   build-rest-api-documentation:
     name: Build REST API documentation using openapi2beans and gradle
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -8,10 +8,6 @@ name: Gradle Main Build
 on:
   workflow_call:
     inputs:
-      changed:
-        description: 'True if this module has been changed and should be rebuilt'
-        required: true
-        type: string
       jacoco_enabled:
         description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
         required: false
@@ -22,29 +18,14 @@ on:
         required: false
         default: 'true'
         type: string
-      platform-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the platform'
-        required: true
-        type: string
 
 env:
   BRANCH: ${{ github.ref_name }}
 
 jobs:
 
-  log-unchanged:
-    name: Gradle is unchanged
-    if: ${{ inputs.changed == 'false' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Log this module is unchanged
-        run: |
-          echo "The gradle module is unchanged"
-
   log-github-ref:
     name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Log GitHub ref of workflow
@@ -53,7 +34,6 @@ jobs:
 
   build-gradle:
     name: Build 'gradle' source code
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -78,16 +58,6 @@ jobs:
         with:
           name: platform
           path: modules/artifacts
-
-      # If the above failed because the platform hasn't changed in this PR...
-      - name: Download platform from last successful workflow
-        if: ${{ steps.download-platform.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.platform-artifact-id }}
 
       - name: Build Gradle source code
         working-directory: modules/gradle

--- a/.github/workflows/managers.yaml
+++ b/.github/workflows/managers.yaml
@@ -8,10 +8,6 @@ name: Managers Main Build
 on:
   workflow_call:
     inputs:
-      changed:
-        description: 'True if this module has been changed and should be rebuilt'
-        required: true
-        type: string
       jacoco_enabled:
         description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
         required: false
@@ -22,45 +18,14 @@ on:
         required: false
         default: 'true'
         type: string
-      platform-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the platform'
-        required: true
-        type: string
-      wrapping-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
-        required: true
-        type: string
-      gradle-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
-        required: true
-        type: string
-      maven-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
-        required: true
-        type: string
-      framework-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the framework module'
-        required: true
-        type: string
 
 env:
   BRANCH: ${{ github.ref_name }}
 
 jobs:
 
-  log-unchanged:
-    name: Managers is unchanged
-    if: ${{ inputs.changed == 'false' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Log this module is unchanged
-        run: |
-          echo "The managers module is unchanged"
-
   log-github-ref:
     name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Log GitHub ref of workflow
@@ -69,7 +34,6 @@ jobs:
 
   build-managers:
     name: Build Managers source code and Docker image for development Maven registry
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -87,9 +51,6 @@ jobs:
         with:
           gradle-version: 8.9
           cache-disabled: true
-
-      # For any modules that were changed in this push,
-      # download their artifacts from this workflow run.
 
       - name: Download platform from this workflow
         id: download-platform
@@ -130,54 +91,6 @@ jobs:
         with:
           name: framework
           path: modules/artifacts
-
-      # For any modules that weren't changed in this push,
-      # download artifacts from the last successful workflow.
-
-      - name: Download platform from last successful workflow
-        if: ${{ steps.download-platform.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.platform-artifact-id }}
-
-      - name: Download wrapping artifacts from last successful workflow
-        if: ${{ steps.download-wrapping.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: wrapping
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.wrapping-artifact-id }}
-  
-      - name: Download gradle artifacts from last successful workflow
-        if: ${{ steps.download-gradle.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: gradle
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.gradle-artifact-id }}
-
-      - name: Download maven artifacts from last successful workflow
-        if: ${{ steps.download-maven.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: maven
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.maven-artifact-id }}
-
-      - name: Download framework artifacts from last successful workflow
-        if: ${{ steps.download-framework.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: framework
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.framework-artifact-id }}
 
       - name: Build Managers source code
         working-directory: modules/managers

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -8,10 +8,6 @@ name: Maven Main Build
 on:
   workflow_call:
     inputs:
-      changed:
-        description: 'True if this module has been changed and should be rebuilt'
-        required: true
-        type: string
       jacoco_enabled:
         description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
         required: false
@@ -22,29 +18,14 @@ on:
         required: false
         default: 'true'
         type: string
-      gradle-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
-        required: true
-        type: string
 
 env:
   BRANCH: ${{ github.ref_name }}
 
 jobs:
 
-  log-unchanged:
-    name: Maven is unchanged
-    if: ${{ inputs.changed == 'false' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Log this module is unchanged
-        run: |
-          echo "The maven module is unchanged"
-
   log-github-ref:
     name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Log GitHub ref of workflow
@@ -53,7 +34,6 @@ jobs:
 
   build-maven:
     name: Build Maven source code and Docker image for development Maven registry
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -105,9 +85,6 @@ jobs:
         run: |
           cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
 
-      # For any modules that were changed in this push,
-      # download their artifacts from this workflow run.
-
       - name: Download gradle artifacts from this workflow
         id: download-gradle
         continue-on-error: true
@@ -115,18 +92,6 @@ jobs:
         with:
           name: gradle
           path: modules/artifacts
-
-      # For any modules that weren't changed in this push,
-      # download artifacts from the last successful workflow.
-
-      - name: Download gradle artifacts from last successful workflow
-        if: ${{ steps.download-gradle.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: gradle
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.gradle-artifact-id }}
 
       - name: Build Maven source code
         working-directory: modules/maven

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -7,39 +7,6 @@ name: OBR Main Build
 
 on:
   workflow_call:
-    inputs:
-      changed:
-        description: 'True if this module has been changed and should be rebuilt'
-        required: true
-        type: string
-      platform-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the platform'
-        required: true
-        type: string
-      wrapping-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
-        required: true
-        type: string
-      gradle-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
-        required: true
-        type: string
-      maven-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
-        required: true
-        type: string
-      framework-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the framework module'
-        required: true
-        type: string
-      extensions-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the extensions module'
-        required: true
-        type: string
-      managers-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the managers module'
-        required: true
-        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -49,19 +16,8 @@ env:
 
 jobs:
 
-  log-unchanged:
-    name: OBR is unchanged
-    if: ${{ inputs.changed == 'false' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Log this module is unchanged
-        run: |
-          echo "The obr module is unchanged"
-
   log-github-ref:
     name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Log GitHub ref of workflow
@@ -70,7 +26,6 @@ jobs:
           
   build-obr:
     name: Build OBR using galasabld image and maven
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -125,9 +80,6 @@ jobs:
       - name: Display Galasa BOM pom.xml
         run: |
           cat modules/obr/galasa-bom/pom.xml
-
-      # For any modules that were changed in this push,
-      # download their artifacts from this workflow run.
 
       - name: Download platform from this workflow
         id: download-platform
@@ -185,72 +137,6 @@ jobs:
           name: managers
           path: modules/artifacts
 
-      # For any modules that weren't changed in this push,
-      # download artifacts from the last successful workflow.
-
-      - name: Download platform from last successful workflow
-        if: ${{ steps.download-platform.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.platform-artifact-id }}
-
-      - name: Download wrapping artifacts from last successful workflow
-        if: ${{ steps.download-wrapping.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: wrapping
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.wrapping-artifact-id }}
-
-      - name: Download gradle artifacts from last successful workflow
-        if: ${{ steps.download-gradle.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: gradle
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.gradle-artifact-id }}
-
-      - name: Download maven artifacts from last successful workflow
-        if: ${{ steps.download-maven.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: maven
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.maven-artifact-id }}
-
-      - name: Download framework artifacts from last successful workflow
-        if: ${{ steps.download-framework.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: framework
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.framework-artifact-id }}
-
-      - name: Download extensions artifacts from last successful workflow
-        if: ${{ steps.download-extensions.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: extensions
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.extensions-artifact-id }}
-
-      - name: Download managers artifacts from last successful workflow
-        if: ${{ steps.download-managers.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: managers
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.managers-artifact-id }}
-        
       - name: Build Galasa BOM with maven
         working-directory: modules/obr
         run: |
@@ -358,7 +244,6 @@ jobs:
 
   build-obr-javadocs:
     name: Build OBR javadocs using galasabld image and maven
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -413,9 +298,6 @@ jobs:
       - name: Display Galasa Javadoc pom.xml 
         run: |
           cat modules/obr/javadocs/pom.xml
-
-      # For any modules that were changed in this push,
-      # download their artifacts from this workflow run.
 
       - name: Download platform from this workflow
         id: download-platform
@@ -472,73 +354,6 @@ jobs:
         with:
           name: managers
           path: modules/artifacts
-
-      # For any modules that weren't changed in this push,
-      # download artifacts from the last successful workflow.
-
-      # Commented out for now as there are no historical runs with Platform artifacts.
-      - name: Download platform from last successful workflow
-        if: ${{ steps.download-platform.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.platform-artifact-id }}
-
-      - name: Download wrapping artifacts from last successful workflow
-        if: ${{ steps.download-wrapping.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: wrapping
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.wrapping-artifact-id }}
-
-      - name: Download gradle artifacts from last successful workflow
-        if: ${{ steps.download-gradle.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: gradle
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.gradle-artifact-id }}
-
-      - name: Download maven artifacts from last successful workflow
-        if: ${{ steps.download-maven.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: maven
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.maven-artifact-id }}
-
-      - name: Download framework artifacts from last successful workflow
-        if: ${{ steps.download-framework.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: framework
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.framework-artifact-id }}
-
-      - name: Download extensions artifacts from last successful workflow
-        if: ${{ steps.download-extensions.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: extensions
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.extensions-artifact-id }}
-
-      - name: Download managers artifacts from last successful workflow
-        if: ${{ steps.download-managers.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: managers
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.managers-artifact-id }}
         
       - name: Build javadoc site using maven
         working-directory: modules/obr/javadocs
@@ -620,7 +435,6 @@ jobs:
 
   build-obr-generic:
     name: Build OBR embedded and boot images using galasabld and maven
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     needs: [build-obr, build-obr-javadocs]
 
@@ -676,9 +490,6 @@ jobs:
       - name: Display Galasa OBR generic pom.xml
         run: |
           cat modules/obr/obr-generic/pom.xml
-
-      # For any modules that were changed in this push,
-      # download their artifacts from this workflow run.
 
       - name: Download platform from this workflow
         id: download-platform
@@ -743,73 +554,6 @@ jobs:
         with:
           name: obr
           path: modules/artifacts
-
-      # For any modules that weren't changed in this push,
-      # download artifacts from the last successful workflow.
-
-      # Commented out for now as there are no historical runs with Platform artifacts.
-      - name: Download platform from last successful workflow
-        if: ${{ steps.download-platform.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.platform-artifact-id }}
-
-      - name: Download wrapping artifacts from last successful workflow
-        if: ${{ steps.download-wrapping.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: wrapping
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.wrapping-artifact-id }}
-
-      - name: Download gradle artifacts from last successful workflow
-        if: ${{ steps.download-gradle.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: gradle
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.gradle-artifact-id }}
-
-      - name: Download maven artifacts from last successful workflow
-        if: ${{ steps.download-maven.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: maven
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.maven-artifact-id }}
-
-      - name: Download framework artifacts from last successful workflow
-        if: ${{ steps.download-framework.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: framework
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.framework-artifact-id }}
-
-      - name: Download extensions artifacts from last successful workflow
-        if: ${{ steps.download-extensions.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: extensions
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.extensions-artifact-id }}
-
-      - name: Download managers artifacts from last successful workflow
-        if: ${{ steps.download-managers.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: managers
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.managers-artifact-id }}
         
       - name: Build Galasa OBR generic pom.xml with maven
         working-directory: modules/obr/obr-generic
@@ -902,7 +646,6 @@ jobs:
 
   trigger-next-workflows:
     name: Trigger next workflows in the build chain
-    if: ${{ inputs.changed == 'true' }}
     needs: [build-obr, build-obr-generic, build-obr-javadocs]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/platform.yaml
+++ b/.github/workflows/platform.yaml
@@ -8,10 +8,6 @@ name: Platform Main Build
 on:
   workflow_call:
     inputs:
-      changed:
-        description: 'True if this module has been changed and should be rebuilt'
-        required: true
-        type: string
       jacoco_enabled:
         description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
         required: false
@@ -28,19 +24,8 @@ env:
 
 jobs:
 
-  log-unchanged:
-    name: Platform is unchanged
-    if: ${{ inputs.changed == 'false' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Log this module is unchanged
-        run: |
-          echo "The gradle module is unchanged"
-
   log-github-ref:
     name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Log GitHub ref of workflow
@@ -49,7 +34,6 @@ jobs:
 
   build-platform:
     name: Build Platform
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -11,121 +11,54 @@ on:
 
 jobs:
 
-  find-artifacts:
-    name: Get Workflow Run IDs with artifacts to download for each module
-    runs-on: ubuntu-latest
-
-    outputs: 
-      platform_artifacts_id: ${{ steps.find-artifacts.outputs.platform_artifacts_id }}
-      wrapping_artifacts_id: ${{ steps.find-artifacts.outputs.wrapping_artifacts_id }}
-      gradle_artifacts_id: ${{ steps.find-artifacts.outputs.gradle_artifacts_id }}
-      maven_artifacts_id: ${{ steps.find-artifacts.outputs.maven_artifacts_id }}
-      framework_artifacts_id: ${{ steps.find-artifacts.outputs.framework_artifacts_id }}
-      extensions_artifacts_id: ${{ steps.find-artifacts.outputs.extensions_artifacts_id }}
-      managers_artifacts_id: ${{ steps.find-artifacts.outputs.managers_artifacts_id }}
-      obr_artifacts_id: ${{ steps.find-artifacts.outputs.obr_artifacts_id }}
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Get last successful workflow run with artifacts for each module
-        id: find-artifacts
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ./tools/get-last-successful-workflow-run-for-artifacts.sh --repo ${{ github.repository }}
-
   build-platform:
     name: Build the 'platform' module
     uses: ./.github/workflows/platform.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}
         
   build-buildutils:
     name: Build the 'buildutils' module
     uses: ./.github/workflows/buildutils.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}
 
   build-wrapping:
     name: Build the 'wrapping' module
-    needs: [find-artifacts, build-platform]
+    needs: [build-platform]
     uses: ./.github/workflows/wrapping.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}
-      platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
 
   build-gradle:
     name: Build the 'gradle' module
-    needs: [find-artifacts, build-platform]
+    needs: [build-platform]
     uses: ./.github/workflows/gradle.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}
-      platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
 
   build-maven:
     name: Build the 'maven' module
-    needs: [find-artifacts, build-gradle]
+    needs: [build-gradle]
     uses: ./.github/workflows/maven.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}
-      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
 
   build-framework:
     name: Build the 'framework' module
-    needs: [find-artifacts, build-buildutils, build-wrapping, build-maven]
+    needs: [build-buildutils, build-wrapping, build-maven]
     uses: ./.github/workflows/framework.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}
-      platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
-      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
-      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
-      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
 
   build-extensions:
     name: Build the 'extensions' module
-    needs: [find-artifacts, build-framework]
+    needs: [build-framework]
     uses: ./.github/workflows/extensions.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}
-      platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
-      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
-      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
-      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
-      framework-artifact-id: ${{ needs.find-artifacts.outputs.framework_artifacts_id }}
 
   build-managers:
     name: Build the 'managers' module
-    needs: [find-artifacts, build-framework]
+    needs: [build-framework]
     uses: ./.github/workflows/managers.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}
-      platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
-      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
-      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
-      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
-      framework-artifact-id: ${{ needs.find-artifacts.outputs.framework_artifacts_id }}
 
   build-obr:
     name: Build the 'obr' module
-    needs: [find-artifacts, build-extensions, build-managers]
+    needs: [build-extensions, build-managers]
     uses: ./.github/workflows/obr.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}
-      platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
-      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
-      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
-      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
-      framework-artifact-id: ${{ needs.find-artifacts.outputs.framework_artifacts_id }}
-      extensions-artifact-id: ${{ needs.find-artifacts.outputs.extensions_artifacts_id }}
-      managers-artifact-id: ${{ needs.find-artifacts.outputs.managers_artifacts_id }}

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -31,15 +31,12 @@ jobs:
     name: Build the 'buildutils' module
     uses: ./.github/workflows/buildutils.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}
 
   build-wrapping:
     name: Build the 'wrapping' module
     uses: ./.github/workflows/wrapping.yaml
     secrets: inherit
     with:
-      changed: ${{ true }}
       jacoco_enabled: ${{ inputs.jacoco_enabled }}
       sign_artifacts: ${{ inputs.sign_artifacts }}
 
@@ -48,7 +45,6 @@ jobs:
     uses: ./.github/workflows/gradle.yaml
     secrets: inherit
     with:
-      changed: ${{ true }}
       jacoco_enabled: ${{ inputs.jacoco_enabled }}
       sign_artifacts: ${{ inputs.sign_artifacts }}
 
@@ -58,7 +54,6 @@ jobs:
     uses: ./.github/workflows/maven.yaml
     secrets: inherit
     with:
-      changed: ${{ true }}
       jacoco_enabled: ${{ inputs.jacoco_enabled }}
       sign_artifacts: ${{ inputs.sign_artifacts }}
 
@@ -68,7 +63,6 @@ jobs:
     uses: ./.github/workflows/framework.yaml
     secrets: inherit
     with:
-      changed: ${{ true }}
       jacoco_enabled: ${{ inputs.jacoco_enabled }}
       sign_artifacts: ${{ inputs.sign_artifacts }}
 
@@ -78,7 +72,6 @@ jobs:
     uses: ./.github/workflows/extensions.yaml
     secrets: inherit
     with:
-      changed: ${{ true }}
       jacoco_enabled: ${{ inputs.jacoco_enabled }}
       sign_artifacts: ${{ inputs.sign_artifacts }}
 
@@ -88,7 +81,6 @@ jobs:
     uses: ./.github/workflows/managers.yaml
     secrets: inherit
     with:
-      changed: ${{ true }}
       jacoco_enabled: ${{ inputs.jacoco_enabled }}
       sign_artifacts: ${{ inputs.sign_artifacts }}
 
@@ -97,5 +89,3 @@ jobs:
     needs: [build-extensions, build-managers]
     uses: ./.github/workflows/obr.yaml
     secrets: inherit
-    with:
-      changed: ${{ true }}

--- a/.github/workflows/wrapping.yaml
+++ b/.github/workflows/wrapping.yaml
@@ -8,10 +8,6 @@ name: Wrapping Main Build
 on:
   workflow_call:
     inputs:
-      changed:
-        description: 'True if this module has been changed and should be rebuilt'
-        required: true
-        type: string
       jacoco_enabled:
         description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
         required: false
@@ -22,29 +18,14 @@ on:
         required: false
         default: 'true'
         type: string
-      platform-artifact-id:
-        description: 'The Workflow Run ID of the last workflow containing artifacts for the platform'
-        required: true
-        type: string
 
 env:
   BRANCH: ${{ github.ref_name }}
 
 jobs:
 
-  log-unchanged:
-    name: Wrapping is unchanged
-    if: ${{ inputs.changed == 'false' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Log this module is unchanged
-        run: |
-          echo "The wrapping module is unchanged"
-
   log-github-ref:
     name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
     
     steps:
@@ -54,7 +35,6 @@ jobs:
 
   build-wrapping:
     name: Build Wrapping source code and Docker image for development Maven registry
-    if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -74,16 +54,6 @@ jobs:
         with:
           name: platform
           path: modules/artifacts
-    
-      # If the above failed because the platform hasn't changed in this PR...
-      - name: Download platform from last successful workflow
-        if: ${{ steps.download-platform.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.platform-artifact-id }}
 
       # Copy secrets into files to use in workflow
       - name: Make secrets directory


### PR DESCRIPTION
## Why?

Now that we have decided to rebuild all modules as part of the Main builds regardless of if the module has changed, I have cleaned up the workflows and removed logic that is not needed:
- Logic to decide whether to build a module or skip it ,
- Download artifacts from the last previously successful main build if not available from the current main build

These are no longer required so the workflows can be simpler and shorter.