### PR TITLE
Adding in Tolerations to the Galasa TestPodScheduler

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -21,7 +21,7 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 public class Settings implements Runnable {
 
     private final Log         logger                      = LogFactory.getLog(getClass());
-    
+
     private final K8sController controller;
 
     private String            namespace;
@@ -35,6 +35,8 @@ public class Settings implements Runnable {
     private int               engineMemoryLimit           = 200;
     private String            nodeArch                    = "";
     private String            nodePreferredAffinity       = "";
+    private String            nodeTolerations             = "";
+
     private String            encryptionKeysSecretName;
 
     private HashSet<String>   requiredCapabilities        = new HashSet<>();
@@ -48,7 +50,7 @@ public class Settings implements Runnable {
 
     private final CoreV1Api   api;
     private String            oldConfigMapResourceVersion = "";
-    
+
     public Settings(K8sController controller, CoreV1Api api) throws K8sControllerException {
         this.api = api;
         this.controller = controller;
@@ -152,6 +154,8 @@ public class Settings implements Runnable {
         this.engineMemoryLimit = updateProperty(configMapData, "engine_memory_limit", engineMemory + 100, this.engineMemoryLimit);
         this.nodeArch = updateProperty(configMapData, "node_arch", "", this.nodeArch);
         this.nodePreferredAffinity = updateProperty(configMapData, "galasa_node_preferred_affinity", "", this.nodePreferredAffinity);
+        this.nodeTolerations = updateProperty(configMapData, "galasa_node_tolerations", "", this.nodeTolerations);
+
         this.encryptionKeysSecretName = updateProperty(configMapData, "encryption_keys_secret_name", "", this.encryptionKeysSecretName);
 
         int poll = getPropertyFromData(configMapData, "run_poll", 20);
@@ -174,7 +178,7 @@ public class Settings implements Runnable {
             for (String requestor : requestors) {
                 newRequestorsByScheduleid.add(requestor);
             }
-    
+
             if (!requestorsByScheduleID.equals(newRequestorsByScheduleid)) {
                 logger.info("Setting Requestors by Schedule from '" + requestorsByScheduleID + "' to '"
                         + newRequestorsByScheduleid + "'");
@@ -203,7 +207,7 @@ public class Settings implements Runnable {
                     }
                 }
             }
-    
+
             boolean changed = false;
             if (newRequiredCapabilties.size() != requiredCapabilities.size()
                     || newCapableCapabilties.size() != capableCapabilities.size()) {
@@ -222,7 +226,7 @@ public class Settings implements Runnable {
                     }
                 }
             }
-    
+
             if (changed) {
                 capableCapabilities.clear();
                 requiredCapabilities.clear();
@@ -230,7 +234,7 @@ public class Settings implements Runnable {
                 requiredCapabilities.addAll(newRequiredCapabilties);
                 logger.info("Engine set with Required Capabilities - " + requiredCapabilities);
                 logger.info("Engine set with Capabable Capabilities - " + capableCapabilities);
-    
+
                 StringBuilder report = new StringBuilder();
                 for (String cap : requiredCapabilities) {
                     if (report.length() > 0) {
@@ -301,6 +305,11 @@ public class Settings implements Runnable {
     public String getNodePreferredAffinity() {
         return this.nodePreferredAffinity;
     }
+
+    public String getNodeTolerations() {
+        return this.nodeTolerations;
+    }
+
 
     public String getEngineImage() {
         return this.engineImage;

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -277,6 +277,16 @@ public class TestPodScheduler implements Runnable {
         return newPod;
     }
 
+
+    /*
+    * Tolerations are supplied as a string in the form:
+    * "node-label1=Operator1:Condition1,node-label2=Operator2:Condition2"
+    *
+    * For example: "galasa-engines=Exists:NoSchedule"
+    *
+    * The following method parses the String comma separated list of node
+    * tolerations and returns a list of K8s V1Tolerations.
+    */
     private List<V1Toleration> createNodeTolerations(String nodeTolerations) {
         List<V1Toleration> tolerationsList = new ArrayList<>();
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -268,8 +268,10 @@ public class TestPodScheduler implements Runnable {
 
             if(tolerationsList.length > 0) {
                 for(int i = 0; i < tolerationsList.length; i++){
-                    String[] selection = nodePreferredAffinity.split("=");
+                    String[] selection = tolerationsList[i].split("=");
+
                     if (selection.length == 2) {
+
                         String[] operatorAndEffect = selection[1].split(":");
 
                         if(operatorAndEffect.length == 2) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -270,7 +270,7 @@ public class TestPodScheduler implements Runnable {
                 for(int i = 0; i < tolerationsList.length; i++){
                     String[] selection = nodePreferredAffinity.split("=");
                     if (selection.length == 2) {
-                        String[] operatorAndEffect = selection.split(":");
+                        String[] operatorAndEffect = selection[1].split(":");
 
                         if(operatorAndEffect.length == 2) {
                             V1Toleration toleration = new V1Toleration();

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -294,7 +294,6 @@ public class TestPodScheduler implements Runnable {
             }
         }
 
-
         podSpec.setVolumes(createTestPodVolumes());
         podSpec.addContainersItem(createTestContainer(runName, engineName, isTraceEnabled));
         return newPod;


### PR DESCRIPTION
The Galasa test pod scheduler can handle Node Affinities, for our usage in CICS we also need it to be able to handle Node Tolerations, so that we can make a node exclusively run our Galasa test pods.

I have added a property to the Settings.java file for Node Tolerations based on how the Node Affinity property is handled. This should allow you to specify multiple node tolerations in your Ecosystem Config as a list:

```
  galasa_node_tolerations: "node-label=Operator:Condition,node-label2=Operator2:Condition2..."
```
for example:
```
  galasa_node_tolerations: "galasa-engines=Exists:NoSchedule"
```

I have added code to the TestPodScheduler that will process the text as a list and add them as tolerations items in the podspec before creating the pod. 