### PR TITLE
Bump protoc and protobuf to 4.28.3

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.25.5"
+    artifact = "com.google.protobuf:protoc:4.28.3"
   }
   plugins {
     grpc {

--- a/modules/wrapping/dev.galasa.wrapping.io.grpc.java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.io.grpc.java/pom.xml
@@ -63,7 +63,6 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>3.25.5</version>
 		</dependency>
 
 
@@ -95,7 +94,7 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-javalite</artifactId>
-			<version>3.25.5</version>
+			<version>4.28.3</version>
 		</dependency>
 
 


### PR DESCRIPTION
## Why?
Fixes Dex gRPC client errors due to a recent platform change https://github.com/galasa-dev/galasa/commit/ac93c8e9b0278706be165b6bf4764e5543231e73