### PR TITLE
reversing the adding of protobuf into the gradle java platform

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -24,7 +24,7 @@ dependencies {
         api 'com.github.docker-java:docker-java-transport-httpclient5:3.2.14'
 
         api 'com.google.code.gson:gson:2.10.1'
-        api 'com.google.protobuf:protobuf-java:4.28.3'
+        // api 'com.google.protobuf:protobuf-java:4.28.3' - dangerous. Protobuf versions are all explicit elsewhere right now.
 
         api 'com.google.guava:guava:30.1.1-jre'
 

--- a/modules/wrapping/dev.galasa.wrapping.protobuf-java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.protobuf-java/pom.xml
@@ -19,6 +19,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
+            <version>4.28.3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Is seems that putting protobuf into the gradle java platform caused some unexpected issues with the code which talks to Dex. 

This is a reversing of that change, to revert it to what it was previously.
