### PR TITLE
jakarta-transation -> dev.galasa.wrapping.jta and versioned to 0.38.0

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/build.gradle
@@ -8,7 +8,7 @@ version = '0.38.0'
 
 dependencies {
     implementation 'com.ibm.db2.jcc:db2jcc'
-    implementation 'dev.galasa:jta'
+    implementation 'dev.galasa:dev.galasa.wrapping.jta'
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -120,8 +120,8 @@ external:
     isolated: true
 
   - group: dev.galasa
-    artifact: jta
-    version: 2.0.1
+    artifact: dev.galasa.wrapping.jta
+    version: 0.38.0
     obr: true
     mvp: true
     isolated: true

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -53,7 +53,7 @@ dependencies {
         api 'dev.galasa:dev.galasa.wrapping.io.kubernetes.client-java:'+version
         api 'dev.galasa:dev.galasa.wrapping.protobuf-java:'+version
         api 'dev.galasa:galasa-testharness:0.18.0'
-        api 'dev.galasa:jta:2.0.1'
+        api 'dev.galasa:dev.galasa.wrapping.jta:'+version
 
         // Most bundles before implementing the Platform used 0.6.0 other than dev.galasa.framework.k8s.controller.
         // Upgrading all to 0.16.0 by using the Platform.

--- a/modules/wrapping/dev.galasa.wrapping.jta/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.jta/pom.xml
@@ -9,8 +9,8 @@
 		<version>0.38.0</version>
 	</parent>
 
-	<artifactId>jta</artifactId>
-	<version>2.0.1</version>
+	<artifactId>dev.galasa.wrapping.jta</artifactId>
+	<version>0.38.0</version>
 	<packaging>bundle</packaging>
 
 	<name>galasa wrapped version of JTA</name>
@@ -39,7 +39,7 @@
 				<configuration>
 					<supportedProjectTypes>bundle</supportedProjectTypes>
 					<instructions>
-						<Bundle-SymbolicName>jakarta.transaction</Bundle-SymbolicName>
+						<Bundle-SymbolicName>dev.galasa.wrapping.jta</Bundle-SymbolicName>
 						<Embed-Dependency>*;scope=compile</Embed-Dependency>
 						<Export-Package>javax.transaction,
 							javax.transaction.*,

--- a/modules/wrapping/pom.xml
+++ b/modules/wrapping/pom.xml
@@ -41,7 +41,7 @@
 		<module>dev.galasa.wrapping.io.grpc.java</module>
 		<module>dev.galasa.wrapping.io.kubernetes.client-java</module>
 		<module>dev.galasa.wrapping.protobuf-java</module>
-		<module>jakarta.transaction</module>
+		<module>dev.galasa.wrapping.jta</module>
 		<module>kafka.clients</module>
 	</modules>
 


### PR DESCRIPTION
# Why ?
To get everything to the same level, we need to re-name the jta wrapping bundle.