### PR TITLE
Revert assertj-core dependencies to their original versions

### DIFF
--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.api.server.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.api.server.gradle
@@ -17,5 +17,5 @@ dependencies {
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.awaitility:awaitility'
-    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.assertj:assertj-core:3.16.1'
 }

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle
@@ -14,5 +14,5 @@ dependencies {
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.awaitility:awaitility'
-    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.assertj:assertj-core:3.16.1'
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testFixturesImplementation platform('dev.galasa:dev.galasa.platform:0.38.0')
 
     testFixturesImplementation 'javax.servlet:javax.servlet-api'
-    testFixturesImplementation 'org.assertj:assertj-core'
+    testFixturesImplementation 'org.assertj:assertj-core:3.16.1'
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.gson'
     testFixturesImplementation(project(':dev.galasa.framework'))
     testFixturesImplementation(project(':dev.galasa.framework.api.beans'))

--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     testFixturesImplementation 'javax.servlet:javax.servlet-api'
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
-    testFixturesImplementation 'org.assertj:assertj-core'
+    testFixturesImplementation 'org.assertj:assertj-core:3.16.1'
     testFixturesImplementation(project(':dev.galasa.framework'))
     testFixturesImplementation(project(':dev.galasa.framework.api.beans'))
     testFixturesImplementation(testFixtures(project(':dev.galasa.framework.api.common')))

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core:4.6.1' // Platform has 3.1.0
     testImplementation 'org.awaitility:awaitility'
-    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.assertj:assertj-core:3.16.1'
     testImplementation 'dev.galasa:galasa-testharness'
     testCompileOnly    'javax.validation:validation-api'
 }

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.ivt.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.ivt.gradle
@@ -10,5 +10,5 @@ dependencies {
     
     implementation 'commons-logging:commons-logging'
     
-    implementation 'org.assertj:assertj-core'
+    implementation 'org.assertj:assertj-core:3.11.1'
 }

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -104,7 +104,8 @@ dependencies {
 
         api 'org.apache.velocity:velocity-engine-core:2.3'
 
-        api 'org.assertj:assertj-core:3.16.1'
+        // Removing from the platform! Breaks the tests.
+        // api 'org.assertj:assertj-core:3.16.1'
         // 3.23.1 found in dev.galasa.framework.api.cps but breaks Extensions unit tests when used in other bundles.
         // So using 3.16.1 as the default and 3.23.1 as override in dev.galasa.framework.api.cps.
 


### PR DESCRIPTION
## Why?

Utilising the platform's suggested version for the `org.assertj:assertj-core` dependency has broken the integration tests due to unsatisfied requirement errors at runtime.

`assertj-core` is one of our dependencies with several versions included throughout Galasa's codebase that need to be properly sorted out, leaving only one remaining version we depend on, but for now reverting the changes made to use the platform's suggested version should get us back in a healthy state where our tests can run.

Reverting changes made to assertj-core's version from these PRs:
- https://github.com/galasa-dev/galasa/pull/11
- https://github.com/galasa-dev/galasa/pull/31