### PR TITLE
wrapped kafka client to be versioned in same way as rest of galasa. re-named and 3.7.0 -> 3.7.1

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.events.kafka/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.events.kafka/build.gradle
@@ -8,7 +8,7 @@ description = 'Galasa Events Plug-In - Kafka'
 version = '0.38.0'
 
 dependencies {
-    implementation 'dev.galasa:kafka.clients:3.7.0'
+    implementation 'dev.galasa:dev.galasa.wrapping.kafka.clients:0.38.0'
 
     testImplementation(testFixtures(project(':dev.galasa.extensions.common')))
 }

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -133,8 +133,8 @@ external:
     isolated: true
 
   - group: dev.galasa
-    artifact: kafka.clients
-    version: 3.7.0
+    artifact: dev.galasa.wrapping.kafka.clients
+    version: 0.38.0
     obr: true
     mvp: true
     isolated: true

--- a/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
@@ -9,8 +9,8 @@
 		<version>0.38.0</version>
 	</parent>
 
-	<artifactId>kafka.clients</artifactId>
-	<version>3.7.0</version>
+	<artifactId>dev.galasa.wrapping.kafka.clients</artifactId>
+	<version>0.38.0</version>
 	<packaging>bundle</packaging>
 
 	<name>Galasa wrapped version of the kafka-client package</name>
@@ -19,12 +19,12 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.7.0</version>
+			<version>3.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-server-common</artifactId>
-			<version>3.7.0</version>
+			<version>3.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -42,7 +42,7 @@
 				<configuration>
 					<supportedProjectTypes>bundle</supportedProjectTypes>
 					<instructions>
-						<Bundle-SymbolicName>kafka.clients</Bundle-SymbolicName>
+						<Bundle-SymbolicName>dev.galasa.wrapping.kafka.clients</Bundle-SymbolicName>
 						<Embed-Dependency>*;scope=compile</Embed-Dependency>
 						<Import-Package>
 						    org.ietf.jgss,

--- a/modules/wrapping/pom.xml
+++ b/modules/wrapping/pom.xml
@@ -43,7 +43,7 @@
 		<module>dev.galasa.wrapping.protobuf-java</module>
 		<module>dev.galasa.wrapping.jta</module>
         <module>dev.galasa.wrapping.velocity-engine-core</module>
-		<module>kafka.clients</module>
+		<module>dev.galasa.wrapping.kafka.clients</module>
 	</modules>
 
 	<scm>


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ? 
- Need to version the kafka bundle in the same way we version the other wrapped bundles + galasa bundles. All at same level. So need to rename bundle and set version of it.
- Bump the version of the kafka client up to avoid a vulnerability.