### PR TITLE
Revert the assertj-core dependency in the obr

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -321,7 +321,7 @@ external:
 
   - group: org.assertj
     artifact: assertj-core
-    version: 3.16.1
+    version: 3.11.1
     obr: true
     bom: true
     mvp: true


### PR DESCRIPTION
## Why?

Continuing from PR #54 

This originally broke things for me locally, but now everything seems fine.