### PR TITLE
Bump commons-logging to 1.3.4 and override commons-logging for the httpclient-osgi bundle

### DIFF
--- a/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
+++ b/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'dev.galasa:dev.galasa.framework:0.38.0'
     implementation 'dev.galasa:dev.galasa:0.34.0'
 
-    implementation 'commons-logging:commons-logging:1.2'
+    implementation 'commons-logging:commons-logging:1.3.4'
     implementation 'org.osgi:org.osgi.core:6.0.0'
     implementation 'org.osgi:org.osgi.service.component.annotations:1.3.0'
     implementation 'javax.validation:validation-api:2.0.1.Final'

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/build.gradle
@@ -12,7 +12,7 @@ configurations {
 }
 
 dependencies {
-    implementation ('org.apache.httpcomponents:httpclient-osgi:4.5.13')
+    implementation ('dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0')
     implementation ('org.apache.httpcomponents:httpcore-osgi:4.4.14')
     implementation ('com.google.code.gson:gson:2.10.1')
     implementation (project(':dev.galasa.extensions.common'))

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/build.gradle
@@ -10,11 +10,11 @@ description = 'Galasa CPS access over http - Provides the CPS stores via the pub
 version = '0.38.0'
 
 dependencies {
-    implementation ('org.apache.httpcomponents:httpclient-osgi:4.5.13')
+    implementation ('dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0')
     implementation ('org.apache.httpcomponents:httpcore-osgi:4.4.14')
     implementation ('com.google.code.gson:gson:2.10.1')
 
-    testFixturesImplementation 'org.apache.httpcomponents:httpclient-osgi:4.5.13'
+    testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0'
     testFixturesImplementation 'org.apache.httpcomponents:httpcore-osgi:4.4.14'
     testFixturesImplementation 'dev.galasa:dev.galasa.framework:0.38.0'
     testFixturesImplementation 'javax.validation:validation-api:2.0.1.Final'

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/build.gradle
@@ -12,7 +12,7 @@ configurations {
 }
 
 dependencies {
-    implementation ('org.apache.httpcomponents:httpclient-osgi:4.5.13')
+    implementation ('dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0')
     implementation ('org.apache.httpcomponents:httpcore-osgi:4.4.14')
     implementation ('com.google.code.gson:gson:2.10.1')
     implementation (project(':dev.galasa.extensions.common'))

--- a/modules/framework/galasa-parent/dev.galasa.framework.log4j2.bridge/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.log4j2.bridge/build.gradle
@@ -6,7 +6,6 @@ plugins {
 description = 'Galasa log4j2 Bridge'
 
 version = "0.38.0"
-version = "0.38.0"
 
 dependencies {
     implementation platform('dev.galasa:dev.galasa.platform:0.38.0')

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     api            project(':galasa-managers-comms-parent:dev.galasa.ipnetwork.manager')
     implementation project(':galasa-managers-unix-parent:dev.galasa.linux.manager')
     implementation project(':galasa-managers-windows-parent:dev.galasa.windows.manager')
-    implementation 'org.apache.httpcomponents:httpclient-osgi'
+    implementation 'dev.galasa:dev.galasa.wrapping.httpclient-osgi'
     implementation 'com.google.code.gson:gson'
     implementation 'io.prometheus:simpleclient'
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/build.gradle
@@ -7,7 +7,7 @@ description = 'HTTP Manager'
 version = '0.38.0'
 
 dependencies {
-    api             'org.apache.httpcomponents:httpclient-osgi'
+    api             'dev.galasa:dev.galasa.wrapping.httpclient-osgi'
     implementation  project (':galasa-managers-common-parent:dev.galasa.common')
     implementation  'org.apache.httpcomponents:httpcore-osgi'
     implementation  'org.apache.httpcomponents:httpmime'

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -68,6 +68,10 @@ external:
     mvp: true
     isolated: true
 
+  # commons-logging is not included in the OBR because it is exported in
+  # the log4j2.bridge bundle and that bundle is directly installed into 
+  # the Felix framework at runtime.
+  # Adding it into the OBR causes run logs to no longer be captured correctly!
   - group: commons-logging
     artifact: commons-logging
     version: 1.3.4

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -71,7 +71,7 @@ external:
   - group: commons-logging
     artifact: commons-logging
     version: 1.3.4
-    obr: true
+    obr: false
     bom: true
     mvp: true
     isolated: true

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -70,8 +70,8 @@ external:
 
   - group: commons-logging
     artifact: commons-logging
-    version: 1.2
-    obr: false
+    version: 1.3.4
+    obr: true
     bom: true
     mvp: true
     isolated: true
@@ -97,6 +97,13 @@ external:
     bom: true
     mvp: true
     isolated: true
+
+  - artifact: dev.galasa.wrapping.httpclient-osgi
+    version: 0.38.0
+    obr: true
+    bom: true
+    isolated: true
+    mvp: true
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.io.grpc.java
@@ -280,14 +287,6 @@ external:
     obr: true
     mvp: true
     isolated: true
-
-  - group: org.apache.httpcomponents
-    artifact: httpclient-osgi
-    version: 4.5.13
-    obr: true
-    bom: true
-    isolated: true
-    mvp: true
 
   - group: org.apache.httpcomponents
     artifact: httpcore-osgi

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -42,13 +42,14 @@ dependencies {
 
         api 'commons-io:commons-io:2.16.1' // If updating, also update in galasa-boot build.gradle.
 
-        api 'commons-logging:commons-logging:1.2'
+        api 'commons-logging:commons-logging:1.3.4'
 
         api 'dev.galasa:com.jcraft.jsch:0.1.55'
         api 'dev.galasa:dev.galasa:0.34.0'
         api 'dev.galasa:dev.galasa.framework:'+version
         api 'dev.galasa:dev.galasa.wrapping.com.auth0.jwt:'+version
         api 'dev.galasa:dev.galasa.wrapping.gson:'+version
+        api 'dev.galasa:dev.galasa.wrapping.httpclient-osgi:'+version
         api 'dev.galasa:dev.galasa.wrapping.io.grpc.java:'+version
         api 'dev.galasa:dev.galasa.wrapping.io.kubernetes.client-java:'+version
         api 'dev.galasa:dev.galasa.wrapping.protobuf-java:'+version

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -90,10 +90,10 @@ dependencies {
         api 'org.apache.felix:org.apache.felix.scr:2.1.14' // If updating, also update in galasa-boot build.gradle.
 
         api 'org.apache.httpcomponents:httpclient:4.5.14'
-        api 'org.apache.httpcomponents:httpclient-osgi:4.5.13'
-        api 'org.apache.httpcomponents:httpcore:4.4.11'
+        api 'org.apache.httpcomponents:httpclient-osgi:4.5.14'
+        api 'org.apache.httpcomponents:httpcore:4.4.16'
         api 'org.apache.httpcomponents:httpcore-osgi:4.4.14'
-        api 'org.apache.httpcomponents:httpmime:4.5.8'
+        api 'org.apache.httpcomponents:httpmime:4.5.14'
 
         api 'org.apache.logging.log4j:log4j-api:2.24.1' // If updating, also update in galasa-boot build.gradle.
         api 'org.apache.logging.log4j:log4j-core:2.24.1' // If updating, also update in galasa-boot build.gradle.

--- a/modules/wrapping/dev.galasa.wrapping.httpclient-osgi/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.httpclient-osgi/pom.xml
@@ -1,0 +1,112 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.galasa</groupId>
+        <artifactId>dev.galasa.wrapping.parent</artifactId>
+        <version>0.38.0</version>
+    </parent>
+
+    <artifactId>dev.galasa.wrapping.httpclient-osgi</artifactId>
+    <version>0.38.0</version>
+    <packaging>bundle</packaging>
+
+    <name>Galasa wrapped version of org.apache.httpcomponents:httpclient-osgi</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+
+            <!--
+            This dependency has a dependency on:
+            commons-logging:commons-logging:jar:1.2:compile
+
+            Which has several vulnerabilities. We will add an explicit dependency on
+            a later version.
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient-cache</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <supportedProjectTypes>bundle</supportedProjectTypes>
+                    <instructions>
+                        <Bundle-SymbolicName>dev.galasa.wrapping.httpclient-osgi</Bundle-SymbolicName>
+                        <Embed-Dependency>*;scope=compile</Embed-Dependency>
+                        <Import-Package>
+                            javax.crypto,
+                            javax.crypto.spec,
+                            javax.naming,
+                            javax.naming.directory,
+                            javax.naming.ldap,
+                            javax.net,
+                            javax.net.ssl,
+                            javax.security.auth.x500,
+                            org.apache.commons.logging,
+                            org.apache.http,
+                            org.apache.http.config,
+                            org.apache.http.concurrent,
+                            org.apache.http.entity,
+                            org.apache.http.io,
+                            org.apache.http.message,
+                            org.apache.http.params,
+                            org.apache.http.pool,
+                            org.apache.http.protocol,
+                            org.apache.http.ssl,
+                            org.apache.http.util,
+                            org.apache.http.impl,
+                            org.apache.http.impl.entity,
+                            org.apache.http.impl.io,
+                            org.apache.http.impl.pool
+                        </Import-Package>
+                        <Export-Package>
+                            org.apache.http*
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/wrapping/dev.galasa.wrapping.httpclient-osgi/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.httpclient-osgi/pom.xml
@@ -50,17 +50,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.5.14</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-cache</artifactId>
-            <version>4.5.14</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>fluent-hc</artifactId>
-            <version>4.5.14</version>
         </dependency>
     </dependencies>
 
@@ -114,10 +103,8 @@
                             org.apache.http.conn.ssl,
                             org.apache.http.conn.util,
                             org.apache.http.client,
-                            org.apache.http.client.cache,
                             org.apache.http.client.config,
                             org.apache.http.client.entity,
-                            org.apache.http.client.fluent,
                             org.apache.http.client.methods,
                             org.apache.http.client.params,
                             org.apache.http.client.protocol,
@@ -130,7 +117,6 @@
                             org.apache.http.impl.conn.tsccm,
                             org.apache.http.impl.execchain,
                             org.apache.http.impl.client,
-                            org.apache.http.impl.client.cache,
                             org.apache.http.osgi.services
                         </Export-Package>
                     </instructions>

--- a/modules/wrapping/dev.galasa.wrapping.httpclient-osgi/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.httpclient-osgi/pom.xml
@@ -102,7 +102,36 @@
                             org.apache.http.impl.pool
                         </Import-Package>
                         <Export-Package>
-                            org.apache.http*
+                            org.apache.http.auth,
+                            org.apache.http.auth.params,
+                            org.apache.http.cookie,
+                            org.apache.http.cookie.params,
+                            org.apache.http.conn,
+                            org.apache.http.conn.params,
+                            org.apache.http.conn.routing,
+                            org.apache.http.conn.scheme,
+                            org.apache.http.conn.socket,
+                            org.apache.http.conn.ssl,
+                            org.apache.http.conn.util,
+                            org.apache.http.client,
+                            org.apache.http.client.cache,
+                            org.apache.http.client.config,
+                            org.apache.http.client.entity,
+                            org.apache.http.client.fluent,
+                            org.apache.http.client.methods,
+                            org.apache.http.client.params,
+                            org.apache.http.client.protocol,
+                            org.apache.http.client.utils,
+                            org.apache.http.entity.mime,
+                            org.apache.http.entity.mime.content,
+                            org.apache.http.impl.auth,
+                            org.apache.http.impl.cookie,
+                            org.apache.http.impl.conn,
+                            org.apache.http.impl.conn.tsccm,
+                            org.apache.http.impl.execchain,
+                            org.apache.http.impl.client,
+                            org.apache.http.impl.client.cache,
+                            org.apache.http.osgi.services
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/modules/wrapping/pom.xml
+++ b/modules/wrapping/pom.xml
@@ -38,6 +38,7 @@
 		<module>dev.galasa.wrapping.com.auth0.jwt</module>
 		<module>com.jcraft.jsch</module>
 		<module>dev.galasa.wrapping.gson</module>
+        <module>dev.galasa.wrapping.httpclient-osgi</module>
 		<module>dev.galasa.wrapping.io.grpc.java</module>
 		<module>dev.galasa.wrapping.io.kubernetes.client-java</module>
 		<module>dev.galasa.wrapping.protobuf-java</module>


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2028

## Changes
- Bumped commons-logging to 1.3.4
- Replaced httpclient-osgi bundle with a custom wrapped bundle in order to override the version of commons-logging in that bundle since it was constrained to use commons-logging between 1.1.0 and 1.3.0 (this previously caused wiring errors when bumping commons-logging to 1.3.4)