### PR TITLE
Remove references to the implementation platform that are not needed

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
@@ -15,12 +15,10 @@ dependencies {
     implementation project(':dev.galasa.framework.api.common')
     implementation project(':dev.galasa.framework.api.users')
     implementation project(':dev.galasa.framework.auth.spi')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
-    implementation 'org.apache.commons:commons-lang3'
     implementation 'dev.galasa:dev.galasa.wrapping.com.auth0.jwt'
-
     implementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
+    implementation 'org.apache.commons:commons-lang3'
+
     compileOnly 'org.apache.tomcat:annotations-api'
 
     testImplementation(testFixtures(project(':dev.galasa.framework.api.common')))

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.bootstrap/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.bootstrap/build.gradle
@@ -10,7 +10,6 @@ version = '0.38.0'
 dependencies {
     implementation project(':dev.galasa.framework')
     implementation project(':dev.galasa.framework.api.common')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
 
     testImplementation 'org.apache.commons:commons-lang3'
     testImplementation project(':dev.galasa.framework').sourceSets.test.output

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/build.gradle
@@ -12,12 +12,9 @@ version = '0.38.0'
 dependencies {
     implementation project(':dev.galasa.framework')
     implementation project(':dev.galasa.framework.api.beans')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
     implementation 'dev.galasa:dev.galasa.wrapping.com.auth0.jwt'
 
     testFixturesImplementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
     testFixturesImplementation 'javax.servlet:javax.servlet-api'
     testFixturesImplementation 'org.assertj:assertj-core:3.16.1'
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.gson'

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/build.gradle
@@ -11,9 +11,8 @@ dependencies {
     implementation project(':dev.galasa.framework')
     implementation project(':dev.galasa.framework.api.beans')
     implementation project(':dev.galasa.framework.api.common')
-    testImplementation(testFixtures(project(':dev.galasa.framework.api.common')))
-    testImplementation platform('dev.galasa:dev.galasa.platform:0.38.0')
 
+    testImplementation(testFixtures(project(':dev.galasa.framework.api.common')))
     testImplementation 'org.assertj:assertj-core:3.23.1'
     // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
     // to use 3.23.1 caused unit test failures. Fixes for this to be completed in a future story.

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi.servlet/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi.servlet/build.gradle
@@ -15,7 +15,6 @@ configurations {
 dependencies {
     implementation project(':dev.galasa.framework')
     implementation project(':dev.galasa.framework.api.common')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
     implementation 'org.yaml:snakeyaml'
 
     openApiSpec project(':dev.galasa.framework.api.openapi')

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/build.gradle
@@ -13,11 +13,7 @@ version '0.38.0'
 dependencies {
     implementation project(':dev.galasa.framework')
     implementation project(':dev.galasa.framework.api.common')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
     implementation 'org.apache.commons:commons-collections4'
-
-    testImplementation platform('dev.galasa:dev.galasa.platform:0.38.0')
 
     testImplementation 'org.apache.commons:commons-lang3'
     testImplementation project(':dev.galasa.framework').sourceSets.test.output

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/build.gradle
@@ -15,11 +15,7 @@ dependencies {
     implementation project(':dev.galasa.framework.api.beans')
     implementation project(':dev.galasa.framework.api.common')
     implementation project(':dev.galasa.framework.api.cps')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
     implementation 'org.apache.commons:commons-collections4'
-
-    testImplementation platform('dev.galasa:dev.galasa.platform:0.38.0')
 
     testImplementation 'org.apache.commons:commons-lang3'
     testImplementation project(':dev.galasa.framework').sourceSets.test.output

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.testcatalog/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.testcatalog/build.gradle
@@ -9,8 +9,6 @@ version = "0.38.0"
 
 dependencies {
     implementation project(':dev.galasa.framework')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-    
     implementation 'commons-io:commons-io'
 }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/build.gradle
@@ -14,11 +14,9 @@ dependencies {
     implementation project(':dev.galasa.framework.api.beans')
     implementation project(':dev.galasa.framework.api.common')
     implementation project(':dev.galasa.framework.auth.spi')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
+    implementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
     implementation 'org.apache.commons:commons-lang3'
 
-    implementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
     compileOnly 'org.apache.tomcat:annotations-api'
     
     testImplementation(testFixtures(project(':dev.galasa.framework.api.common')))

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/build.gradle
@@ -8,12 +8,9 @@ description = 'Framework API'
 version = '0.38.0'
 
 dependencies {
-
     implementation project(':dev.galasa.framework')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
-    implementation 'org.osgi:org.osgi.service.cm'
     implementation 'org.apache.felix:org.apache.felix.bundlerepository'
+    implementation 'org.osgi:org.osgi.service.cm'
 
     testImplementation project(':dev.galasa.framework').sourceSets.test.output
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
@@ -14,17 +14,15 @@ version = '0.38.0'
 dependencies {
     implementation project(':dev.galasa.framework')
     implementation project(':dev.galasa.framework.api.common')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
-    implementation 'org.apache.commons:commons-lang3'
     implementation 'dev.galasa:dev.galasa.wrapping.com.auth0.jwt'
     implementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
+    implementation 'org.apache.commons:commons-lang3'
+
     compileOnly 'org.apache.tomcat:annotations-api'
 
     testImplementation(testFixtures(project(':dev.galasa.framework.api.common')))
 
     testFixturesImplementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
     testFixturesImplementation 'javax.servlet:javax.servlet-api'
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
     testFixturesImplementation 'org.assertj:assertj-core:3.16.1'

--- a/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
@@ -10,19 +10,14 @@ version '0.38.0'
 dependencies {
     implementation project(':dev.galasa')
     implementation project(':dev.galasa.framework')
-
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
-    implementation 'commons-io:commons-io'
+    implementation 'com.github.docker-java:docker-java-core'
+    implementation 'com.github.docker-java:docker-java-transport-httpclient5'
     implementation 'commons-codec:commons-codec'
-    implementation 'org.apache.commons:commons-compress'
-
+    implementation 'commons-io:commons-io'
     implementation 'io.prometheus:simpleclient'
     implementation 'io.prometheus:simpleclient_httpserver'
     implementation 'io.prometheus:simpleclient_hotspot'
-
-    implementation 'com.github.docker-java:docker-java-core'
-    implementation 'com.github.docker-java:docker-java-transport-httpclient5'
+    implementation 'org.apache.commons:commons-compress'
     implementation 'org.bouncycastle:bcpkix-jdk18on'
     implementation 'org.bouncycastle:bcprov-jdk18on'
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
@@ -8,13 +8,10 @@ description = 'Galasa Kubernetes Controller'
 version '0.38.0'
 
 dependencies {
-
     implementation project(':dev.galasa')
     implementation project(':dev.galasa.framework')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-    
-    implementation 'io.prometheus:simpleclient'
     implementation 'dev.galasa:dev.galasa.wrapping.io.kubernetes.client-java'
+    implementation 'io.prometheus:simpleclient'
 
     testImplementation project(':dev.galasa.framework').sourceSets.test.output
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.log4j2.bridge/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.log4j2.bridge/build.gradle
@@ -8,8 +8,6 @@ description = 'Galasa log4j2 Bridge'
 version = "0.38.0"
 
 dependencies {
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
     implementation 'org.apache.logging.log4j:log4j-api'
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
@@ -9,8 +9,6 @@ version = '0.38.0'
 
 dependencies {
     compileOnly project(':dev.galasa.framework.maven.repository.spi')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
     implementation 'org.apache.maven:maven-repository-metadata'
     implementation 'org.codehaus.plexus:plexus-utils'
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.metrics/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.metrics/build.gradle
@@ -9,8 +9,6 @@ version = '0.38.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
     implementation 'io.prometheus:simpleclient'
     implementation 'io.prometheus:simpleclient_httpserver'
     implementation 'io.prometheus:simpleclient_hotspot'

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/build.gradle
@@ -9,8 +9,6 @@ version = '0.38.0'
 
 dependencies {
     implementation project (':dev.galasa.framework')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-    
     implementation 'io.prometheus:simpleclient'
     implementation 'io.prometheus:simpleclient_httpserver'
     implementation 'io.prometheus:simpleclient_hotspot'

--- a/modules/framework/galasa-parent/dev.galasa.framework/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework/build.gradle
@@ -10,24 +10,20 @@ description = 'Galasa Framework'
 version = "0.38.0"
 
 dependencies {
-
     api project (':dev.galasa')
-    implementation project (':dev.galasa.framework.maven.repository.spi')
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
 
+    implementation project (':dev.galasa.framework.maven.repository.spi')
+    implementation 'commons-io:commons-io'
+    implementation 'dev.galasa:dev.galasa.wrapping.gson'
+    implementation 'org.apache.bcel:bcel'
+    implementation 'org.apache.commons:commons-lang3'
+    implementation 'org.apache.felix:org.apache.felix.bundlerepository'
     implementation 'org.apache.logging.log4j:log4j-api'
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
-    implementation 'org.apache.commons:commons-lang3'
-    implementation 'org.apache.felix:org.apache.felix.bundlerepository'
-
-    implementation 'org.apache.bcel:bcel'
-    implementation 'commons-io:commons-io'
-    implementation 'dev.galasa:dev.galasa.wrapping.gson'
     implementation 'org.yaml:snakeyaml'
 
     testImplementation project (':dev.galasa')
-
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/framework/galasa-parent/galasa-boot/build.gradle
+++ b/modules/framework/galasa-parent/galasa-boot/build.gradle
@@ -43,9 +43,7 @@ jar {
 }
 
 dependencies {
-
     implementation project (':dev.galasa.framework.maven.repository')
-    implementation platform ('dev.galasa:dev.galasa.platform:0.38.0')
     implementation 'org.apache.felix:org.apache.felix.scr'
 
     embedImplementation project (':dev.galasa.framework.maven.repository.spi')


### PR DESCRIPTION
## Why?

These framework bundles either use the `galasa.api.server` or `galasa.framework` plugin which both have a reference to the `implementation platform('dev.galasa:dev.galasa.platform:0.38.0')`. These bundles don't need to also include this line as they get it from the plugins.

I have also alphabetised the dependencies so it's easier to do a side by side comparison with other files like the platform and release.yaml.