### PR TITLE
Fix occasional test failures when backoff time is 1000ms

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/src/test/java/dev/galasa/extensions/common/couchdb/RetryableCouchdbUpdateOperationProcessorTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/src/test/java/dev/galasa/extensions/common/couchdb/RetryableCouchdbUpdateOperationProcessorTest.java
@@ -113,7 +113,7 @@ public class RetryableCouchdbUpdateOperationProcessorTest {
         BackoffTimeCalculator backoffTimeCalculator = new BackoffTimeCalculator(){};
         for(int i=0; i<100; i++) {
             long millis = backoffTimeCalculator.getBackoffDelayMillis();
-            assertThat(millis).isGreaterThan(1000L);
+            assertThat(millis).isGreaterThanOrEqualTo(1000L);
             assertThat(millis).isLessThanOrEqualTo(4000L);
         }
     }


### PR DESCRIPTION
## Why?
Occasionally, a unit test in the extensions module fails because it adds 1000 to a random number between 0 and 3000, but the test expects the resulting value to be >1000.

This PR updates the assertion to accept resulting values >=1000 to stop these occasional failures from happening.