### PR TITLE
Bump jakarta.xml.bind-api to 4.0.2

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -26,16 +26,9 @@ external:
     mvp: true
     isolated: true
 
-  - group: com.sun.activation
-    artifact: jakarta.activation
-    version: 2.0.0
-    obr: true
-    mvp: true
-    isolated: true
-
   - group: com.sun.xml.bind
     artifact: jaxb-osgi
-    version: 3.0.0
+    version: 4.0.5
     obr: true
 
   - group: commons-codec
@@ -196,9 +189,16 @@ external:
     mvp: true
     isolated: true
 
+  - group: jakarta.activation
+    artifact: jakarta.activation-api
+    version: 2.1.3
+    obr: true
+    mvp: true
+    isolated: true
+
   - group: jakarta.xml.bind
     artifact: jakarta.xml.bind-api
-    version: 3.0.0
+    version: 4.0.2
     obr: true
     mvp: true
     isolated: true

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 
         api 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.41'
 
-        api 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.0'
+        api 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
 
         api 'javax.jms:javax.jms-api:2.0.1'
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2028

## Changes
- Removes a vulnerability flagged in jakarta.activation-javadoc.jar by upgrading jakarta.xml.bind-api to 4.0.2, which no longer uses jakarta.activation 2.0.0.
  - Also bumped jaxb-osgi from 3.0.0 to 4.0.5 since 4.0.5 uses jakarta.xml.bind-api 4.0.2