### PR TITLE
Bump guava to 33.2.1-jre

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/bnd.bnd
+++ b/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/bnd.bnd
@@ -47,9 +47,9 @@ Embed-Transitive: true
 Embed-Dependency: *;scope=compile
 -includeresource: byte-buddy-*.jar; lib:=true,\
     commons-exec-*.jar; lib:=true,\
-    error_prone_annotations-2.5.1.jar; lib:=true,\
+    error_prone_annotations-2.26.1.jar; lib:=true,\
     guava-*.jar; lib:=true,\
-    j2objc-annotations-1.3.jar; lib:=true,\
+    j2objc-annotations-3.0.0.jar; lib:=true,\
     jsr305-3.0.2.jar; lib:=true,\
     okhttp-4.10.0.jar; lib:=true,\
     okio-jvm-*.jar; lib:=true,\

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -26,7 +26,7 @@ dependencies {
         api 'com.google.code.gson:gson:2.10.1'
         // api 'com.google.protobuf:protobuf-java:4.28.3' - dangerous. Protobuf versions are all explicit elsewhere right now.
 
-        api 'com.google.guava:guava:30.1.1-jre'
+        api 'com.google.guava:guava:33.2.1-jre'
 
         api 'com.ibm.db2.jcc:db2jcc:db2jcc4'
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2028

## Changes
- Bumped guava 30.1.1-jre to 33.2.1-jre in the selenium manager to resolve vulnerabilities