### PR TITLE
Iss 2052 - Use Platform for the OBR

### DIFF
--- a/modules/obr/dev.galasa.uber.obr/pom.template
+++ b/modules/obr/dev.galasa.uber.obr/pom.template
@@ -51,12 +51,24 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 {{range .Artifacts}}
         <dependency>
             <groupId>{{.GroupId}}</groupId>
-            <artifactId>{{.ArtifactId}}</artifactId>
-            <version>{{.Version}}</version>
+            <artifactId>{{.ArtifactId}}</artifactId>{{if .Version}}
+            <version>{{.Version}}</version>{{end}}
         </dependency>
     {{end}}
 	</dependencies>

--- a/modules/obr/galasa-bom/pom.template
+++ b/modules/obr/galasa-bom/pom.template
@@ -40,18 +40,28 @@
         <url>https://github.com/galasa-dev/projectmanagement/issues</url>
         <system>GitHub</system>
     </issueManagement>
-    
-	<dependencyManagement>
-        <dependencies>
+
+    <dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+    <dependencies>
 {{range .Artifacts}}
         <dependency>
             <groupId>{{.GroupId}}</groupId>
-            <artifactId>{{.ArtifactId}}</artifactId>
-            <version>{{.Version}}</version>
+            <artifactId>{{.ArtifactId}}</artifactId>{{if .Version}}
+            <version>{{.Version}}</version>{{end}}
         </dependency>
     {{end}}
-        </dependencies>
-	</dependencyManagement>
+    </dependencies>
 
 	<build>
 		<pluginManagement>

--- a/modules/obr/javadocs/pom.template
+++ b/modules/obr/javadocs/pom.template
@@ -23,18 +23,29 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 {{range .Artifacts}}
         <dependency>
             <groupId>{{.GroupId}}</groupId>
-            <artifactId>{{.ArtifactId}}</artifactId>
-            <version>{{.Version}}</version>
+            <artifactId>{{.ArtifactId}}</artifactId>{{if .Version}}
+            <version>{{.Version}}</version>{{end}}
         </dependency>
     {{end}}
         <dependency>
 			<groupId>javax.validation</groupId>
 			<artifactId>validation-api</artifactId>
-			<version>2.0.1.Final</version>
 		</dependency>
 	</dependencies>
 

--- a/modules/obr/obr-generic/pom.template
+++ b/modules/obr/obr-generic/pom.template
@@ -14,6 +14,18 @@
 
 	<description>Builds a a repository for including in the embedded image</description>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>dev.galasa</groupId>
@@ -25,7 +37,6 @@
 		<dependency>
 			<groupId>javax.validation</groupId>
 			<artifactId>validation-api</artifactId>
-			<version>2.0.1.Final</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -20,7 +20,6 @@ external:
   bundles:
   - group: com.google.code.gson
     artifact: gson
-    version: 2.10.1
     obr: true
     bom: true
     mvp: true
@@ -28,12 +27,10 @@ external:
 
   - group: com.sun.xml.bind
     artifact: jaxb-osgi
-    version: 4.0.5
     obr: true
 
   - group: commons-codec
     artifact: commons-codec
-    version: 1.16.1
     obr: true
     bom: true
     mvp: true
@@ -41,14 +38,12 @@ external:
 
   - group: commons-collections
     artifact: commons-collections
-    version: 3.2.2
     obr: true
     mvp: true
     isolated: true
 
   - group: commons-io
     artifact: commons-io
-    version: 2.16.1
     obr: true
     bom: true
     mvp: true
@@ -56,7 +51,6 @@ external:
 
   - group: commons-lang
     artifact: commons-lang
-    version: 2.6
     obr: true
     mvp: true
     isolated: true
@@ -67,7 +61,6 @@ external:
   # Adding it into the OBR causes run logs to no longer be captured correctly!
   - group: commons-logging
     artifact: commons-logging
-    version: 1.3.4
     obr: false
     bom: true
     mvp: true
@@ -75,35 +68,30 @@ external:
 
   - group: dev.galasa
     artifact: dev.galasa.platform
-    version: 0.38.0
     obr: false
     mvp: true
     isolated: true
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.com.jcraft.jsch
-    version: 0.38.0
     obr: true
     mvp: true
     isolated: true
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.com.auth0.jwt
-    version: 0.38.0
     obr: true
     mvp: true
     isolated: true
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.gson
-    version: 0.38.0
     obr: true
     bom: true
     mvp: true
     isolated: true
 
   - artifact: dev.galasa.wrapping.httpclient-osgi
-    version: 0.38.0
     obr: true
     bom: true
     isolated: true
@@ -111,108 +99,92 @@ external:
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.io.grpc.java
-    version: 0.38.0
     obr: true
     mvp: true
     isolated: true
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.io.kubernetes.client-java
-    version: 0.38.0
     obr: true
     mvp: true
     isolated: true
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.protobuf-java
-    version: 0.38.0
     obr: true
     mvp: true
     isolated: true
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.jta
-    version: 0.38.0
     obr: true
     mvp: true
     isolated: true
 
   - artifact: dev.galasa.wrapping.velocity-engine-core
-    version: 0.38.0
     obr: true
     mvp: true
     isolated: true
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.kafka.clients
-    version: 0.38.0
     obr: true
     mvp: true
     isolated: true
 
   - group: io.prometheus
     artifact: simpleclient
-    version: 0.16.0
     obr: true
     mvp: true
     isolated: true
 
   - group: io.prometheus
     artifact: simpleclient_common
-    version: 0.16.0
     obr: true
     isolated: true
 
   - group: io.prometheus
     artifact: simpleclient_hotspot
-    version: 0.16.0
     obr: true
     isolated: true
 
   - group: io.prometheus
     artifact: simpleclient_httpserver
-    version: 0.16.0
     obr: true
     isolated: true
 
   - group: io.prometheus
     artifact: simpleclient_tracer_common
-    version: 0.16.0
     obr: true
     mvp: true
     isolated: true
 
   - group: io.prometheus
     artifact: simpleclient_tracer_otel
-    version: 0.16.0
     obr: true
     mvp: true
     isolated: true
 
   - group: io.prometheus
     artifact: simpleclient_tracer_otel_agent
-    version: 0.16.0
     obr: true
     mvp: true
     isolated: true
 
   - group: jakarta.activation
     artifact: jakarta.activation-api
-    version: 2.1.3
     obr: true
     mvp: true
     isolated: true
 
   - group: jakarta.xml.bind
     artifact: jakarta.xml.bind-api
-    version: 4.0.2
     obr: true
     mvp: true
     isolated: true
 
   - group: javax.validation
     artifact: validation-api
-    version: 2.0.1.Final
     obr: true
     bom: true
     mvp: true
@@ -220,28 +192,24 @@ external:
 
   - group: org.apache.bcel
     artifact: bcel
-    version: 6.7.0
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.commons
     artifact: commons-collections4
-    version: 4.4
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.commons
     artifact: commons-compress
-    version: 1.26.0
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.commons
     artifact: commons-lang3
-    version: 3.17.0
     obr: true
     bom: true
     mvp: true
@@ -249,59 +217,50 @@ external:
 
   - group: org.apache.derby
     artifact: derbyclient
-    version: 10.14.2.0
     obr: true
 
   - group: org.apache.felix
     artifact: org.apache.felix.configadmin
-    version: 1.9.16
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.felix
     artifact: org.apache.felix.fileinstall
-    version: 3.6.4
     obr: true
     isolated: true
 
   - group: org.apache.felix
     artifact: org.apache.felix.gogo.command
-    version: 1.1.0
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.felix
     artifact: org.apache.felix.gogo.runtime
-    version: 1.1.2
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.felix
     artifact: org.apache.felix.gogo.shell
-    version: 1.1.2
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.felix
     artifact: org.apache.felix.http.jetty
-    version: 5.0.0
     obr: true
     isolated: true
 
   - group: org.apache.felix
     artifact: org.apache.felix.http.servlet-api
-    version: 2.1.0
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.httpcomponents
     artifact: httpcore-osgi
-    version: 4.4.14
     obr: true
     bom: true
     isolated: true
@@ -309,21 +268,18 @@ external:
 
   - group: org.apache.logging.log4j
     artifact: log4j-api
-    version: 2.24.1
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.logging.log4j
     artifact: log4j-core
-    version: 2.24.1
     obr: true
     mvp: true
     isolated: true
 
   - group: org.apache.logging.log4j
     artifact: log4j-slf4j-impl
-    version: 2.24.1
     obr: true
     mvp: true
     isolated: true
@@ -338,22 +294,18 @@ external:
 
   - group: org.bouncycastle
     artifact: bcpkix-jdk18on
-    version: 1.79
     obr: true
 
   - group: org.bouncycastle
     artifact: bcprov-jdk18on
-    version: 1.79
     obr: true
 
   - group: org.bouncycastle
     artifact: bcutil-jdk18on
-    version: 1.79
     obr: true
 
   - group: org.osgi
     artifact: org.osgi.service.component.annotations
-    version: 1.3.0
     bom: true
 
   - group: org.slf4j
@@ -365,7 +317,6 @@ external:
 
   - group: org.yaml
     artifact: snakeyaml
-    version: 2.0
     obr: true
     isolated: true
     mvp: true

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 
         api 'com.ibm.mq:com.ibm.mq.allclient:9.2.3.0'
 
+        api 'com.sun.xml.bind:jaxb-osgi:4.0.5'
+
         api 'com.squareup.okhttp3:okhttp:4.9.2'
 
         api 'com.squareup.okio:okio-jvm:3.0.0'
@@ -40,29 +42,42 @@ dependencies {
 
         api 'commons-codec:commons-codec:1.16.1'
 
+        api 'commons-collections:commons-collections:3.2.2'
+
         api 'commons-io:commons-io:2.16.1' // If updating, also update in galasa-boot build.gradle.
+
+        api 'commons-lang:commons-lang:2.6'
 
         api 'commons-logging:commons-logging:1.3.4'
 
         api 'dev.galasa:dev.galasa.wrapping.com.jcraft.jsch:'+version
         api 'dev.galasa:dev.galasa:0.34.0'
         api 'dev.galasa:dev.galasa.framework:'+version
+        api 'dev.galasa:dev.galasa.platform:'+version
         api 'dev.galasa:dev.galasa.wrapping.com.auth0.jwt:'+version
         api 'dev.galasa:dev.galasa.wrapping.gson:'+version
         api 'dev.galasa:dev.galasa.wrapping.httpclient-osgi:'+version
         api 'dev.galasa:dev.galasa.wrapping.io.grpc.java:'+version
         api 'dev.galasa:dev.galasa.wrapping.io.kubernetes.client-java:'+version
+        api 'dev.galasa:dev.galasa.wrapping.kafka.clients:'+version
         api 'dev.galasa:dev.galasa.wrapping.protobuf-java:'+version
+        api 'dev.galasa:dev.galasa.wrapping.velocity-engine-core:'+version
         api 'dev.galasa:galasa-testharness:0.18.0'
         api 'dev.galasa:dev.galasa.wrapping.jta:'+version
 
         // Most bundles before implementing the Platform used 0.6.0 other than dev.galasa.framework.k8s.controller.
         // Upgrading all to 0.16.0 by using the Platform.
         api 'io.prometheus:simpleclient:0.16.0'
+        api 'io.prometheus:simpleclient_common:0.16.0'
         api 'io.prometheus:simpleclient_httpserver:0.16.0'
         api 'io.prometheus:simpleclient_hotspot:0.16.0'
+        api 'io.prometheus:simpleclient_tracer_common:0.16.0'
+        api 'io.prometheus:simpleclient_tracer_otel:0.16.0'
+        api 'io.prometheus:simpleclient_tracer_otel_agent:0.16.0'
 
         api 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.41'
+
+        api 'jakarta.activation:jakarta.activation-api:2.1.3'
 
         api 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
 
@@ -84,9 +99,18 @@ dependencies {
         api 'org.apache.commons:commons-compress:1.26.0'
         api 'org.apache.commons:commons-exec:1.3'
         api 'org.apache.commons:commons-lang3:3.17.0'
+        
+        api 'org.apache.derby:derbyclient:10.14.2.0'
 
         api 'org.apache.felix:org.apache.felix.bundlerepository:2.0.10' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.felix:org.apache.felix.configadmin:1.9.16'
         api 'org.apache.felix:org.apache.felix.framework:7.0.5' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.felix:org.apache.felix.fileinstall:3.6.4'
+        api 'org.apache.felix:org.apache.felix.gogo.command:1.1.0'
+        api 'org.apache.felix:org.apache.felix.gogo.runtime:1.1.2'
+        api 'org.apache.felix:org.apache.felix.gogo.shell:1.1.2'
+        api 'org.apache.felix:org.apache.felix.http.jetty:5.0.0'
+        api 'org.apache.felix:org.apache.felix.http.servlet-api:2.1.0'
         api 'org.apache.felix:org.apache.felix.scr:2.1.14' // If updating, also update in galasa-boot build.gradle.
 
         api 'org.apache.httpcomponents:httpclient:4.5.14'
@@ -114,6 +138,7 @@ dependencies {
 
         api 'org.bouncycastle:bcpkix-jdk18on:1.79'
         api 'org.bouncycastle:bcprov-jdk18on:1.79'
+        api 'org.bouncycastle:bcutil-jdk18on:1.79'
 
         api 'org.jetbrains.kotlin:kotlin-osgi-bundle:1.4.0'
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2052

- Add extra dependencies into the dev.galasa.platform.
- Remove hard coded versions from the OBR's release.yaml.
- Add `dependencyManagement` section to the pom.templates in the OBR module which are used by the `galasabld` program to create pom.xmls containing all artifacts listed in the release.yaml. This means the pom.xmls will now have the `dependencyManagement` section which provides the versions, and the `dependency` parts of the pom.xmls will have no version.
- assertj-core has been ignored as it's been difficult to get working with the platform so another story covers this in future.
- slf4j-api has been ignored as it's got a different version in the release.yaml than the platform so will address bringing these in line in future.