### PR TITLE
Platformed the kafka wrapper and upgraded versions of kafka-* to 3.9.0

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -121,6 +121,9 @@ dependencies {
         api 'org.apache.httpcomponents:httpcore-osgi:4.4.14'
         api 'org.apache.httpcomponents:httpmime:4.5.14'
 
+        api 'org.apache.kafka:kafka-clients:3.9.0'
+        api 'org.apache.kafka:kafka-server-common:3.9.0'
+
         api 'org.apache.logging.log4j:log4j-api:2.24.1' // If updating, also update in galasa-boot build.gradle.
         api 'org.apache.logging.log4j:log4j-core:2.24.1' // If updating, also update in galasa-boot build.gradle.
         api 'org.apache.logging.log4j:log4j-slf4j-impl:2.24.1'

--- a/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
@@ -19,17 +19,14 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-server-common</artifactId>
-			<version>3.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.30</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2052 and https://github.com/galasa-dev/projectmanagement/issues/2060

- Uses the platform to get the versions of dependencies
- Upgrades the kafka-client dependency to 3.9.0 to remove vulnerability found
- Also upgraded kafka-server-common to keep it in line