### PR TITLE
Temporarily remove org.slf4j import causing wiring errors

### DIFF
--- a/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
@@ -43,7 +43,6 @@
 						<Embed-Dependency>*;scope=compile</Embed-Dependency>
 						<Import-Package>
 						    org.ietf.jgss,
-							org.slf4j,
 							javax.management,
 							javax.net.ssl,
 							javax.security.*


### PR DESCRIPTION
## Why?
Fixes an OSGi wiring error caused by an unresolved org.slf4j import, which might not be required, in order to get the Galasa API server working again.