### PR TITLE
Fix: Don't use platform to generate the galasa-bom

### DIFF
--- a/modules/obr/galasa-bom/pom.template
+++ b/modules/obr/galasa-bom/pom.template
@@ -42,26 +42,16 @@
     </issueManagement>
 
     <dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>dev.galasa</groupId>
-				<artifactId>dev.galasa.platform</artifactId>
-				<version>0.38.0</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
-    <dependencies>
+        <dependencies>
 {{range .Artifacts}}
         <dependency>
             <groupId>{{.GroupId}}</groupId>
-            <artifactId>{{.ArtifactId}}</artifactId>{{if .Version}}
-            <version>{{.Version}}</version>{{end}}
+            <artifactId>{{.ArtifactId}}</artifactId>
+            <version>{{.Version}}</version>
         </dependency>
     {{end}}
-    </dependencies>
+        </dependencies>
+	</dependencyManagement>
 
 	<build>
 		<pluginManagement>

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -20,6 +20,7 @@ external:
   bundles:
   - group: com.google.code.gson
     artifact: gson
+    version: 2.10.1
     obr: true
     bom: true
     mvp: true
@@ -44,6 +45,7 @@ external:
 
   - group: commons-io
     artifact: commons-io
+    version: 2.16.1
     obr: true
     bom: true
     mvp: true
@@ -61,6 +63,7 @@ external:
   # Adding it into the OBR causes run logs to no longer be captured correctly!
   - group: commons-logging
     artifact: commons-logging
+    version: 1.3.4
     obr: false
     bom: true
     mvp: true
@@ -86,12 +89,14 @@ external:
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.gson
+    version: 0.38.0
     obr: true
     bom: true
     mvp: true
     isolated: true
 
   - artifact: dev.galasa.wrapping.httpclient-osgi
+    version: 0.38.0
     obr: true
     bom: true
     isolated: true
@@ -185,6 +190,7 @@ external:
 
   - group: javax.validation
     artifact: validation-api
+    version: 2.0.1.Final
     obr: true
     bom: true
     mvp: true
@@ -210,6 +216,7 @@ external:
 
   - group: org.apache.commons
     artifact: commons-lang3
+    version: 3.17.0
     obr: true
     bom: true
     mvp: true
@@ -261,6 +268,7 @@ external:
 
   - group: org.apache.httpcomponents
     artifact: httpcore-osgi
+    version: 4.4.14
     obr: true
     bom: true
     isolated: true
@@ -306,6 +314,7 @@ external:
 
   - group: org.osgi
     artifact: org.osgi.service.component.annotations
+    version: 1.3.0
     bom: true
 
   - group: org.slf4j

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -23,7 +23,8 @@ dependencies {
         api 'com.github.docker-java:docker-java-core:3.2.14'
         api 'com.github.docker-java:docker-java-transport-httpclient5:3.2.14'
 
-        api 'com.google.code.gson:gson:2.10.1'
+        api 'com.google.code.gson:gson:2.10.1' // If updating, also update in obr/release.yaml.
+
         // api 'com.google.protobuf:protobuf-java:4.28.3' - dangerous. Protobuf versions are all explicit elsewhere right now.
 
         api 'com.google.guava:guava:33.2.1-jre'
@@ -44,28 +45,26 @@ dependencies {
 
         api 'commons-collections:commons-collections:3.2.2'
 
-        api 'commons-io:commons-io:2.16.1' // If updating, also update in galasa-boot build.gradle.
+        api 'commons-io:commons-io:2.16.1' // If updating, also update in galasa-boot build.gradlen and in obr/release.yaml.
 
         api 'commons-lang:commons-lang:2.6'
 
-        api 'commons-logging:commons-logging:1.3.4'
+        api 'commons-logging:commons-logging:1.3.4' // If updating, also update in obr/release.yaml.
 
-        api 'dev.galasa:dev.galasa.wrapping.com.jcraft.jsch:'+version
         api 'dev.galasa:dev.galasa:'+version
         api 'dev.galasa:dev.galasa.framework:'+version
         api 'dev.galasa:dev.galasa.platform:'+version
         api 'dev.galasa:dev.galasa.wrapping.com.auth0.jwt:'+version
-        api 'dev.galasa:dev.galasa.wrapping.gson:'+version
-        api 'dev.galasa:dev.galasa.wrapping.httpclient-osgi:'+version
+        api 'dev.galasa:dev.galasa.wrapping.com.jcraft.jsch:'+version
+        api 'dev.galasa:dev.galasa.wrapping.gson:'+version // If updating, also update in obr/release.yaml.
+        api 'dev.galasa:dev.galasa.wrapping.httpclient-osgi:'+version // If updating, also update in obr/release.yaml.
         api 'dev.galasa:dev.galasa.wrapping.io.grpc.java:'+version
         api 'dev.galasa:dev.galasa.wrapping.io.kubernetes.client-java:'+version
+        api 'dev.galasa:dev.galasa.wrapping.jta:'+version
         api 'dev.galasa:dev.galasa.wrapping.kafka.clients:'+version
         api 'dev.galasa:dev.galasa.wrapping.protobuf-java:'+version
         api 'dev.galasa:dev.galasa.wrapping.velocity-engine-core:'+version
         api 'dev.galasa:galasa-testharness:0.18.0'
-        api 'dev.galasa:dev.galasa.wrapping.jta:'+version
-        api 'dev.galasa:dev.galasa.wrapping.velocity-engine-core:'+version
-        api 'dev.galasa:dev.galasa.wrapping.protobuf-java:'+version
 
         // Most bundles before implementing the Platform used 0.6.0 other than dev.galasa.framework.k8s.controller.
         // Upgrading all to 0.16.0 by using the Platform.
@@ -87,7 +86,7 @@ dependencies {
 
         api 'javax.servlet:javax.servlet-api:3.1.0'
 
-        api 'javax.validation:validation-api:2.0.1.Final'
+        api 'javax.validation:validation-api:2.0.1.Final' // If updating, also update in obr/release.yaml.
 
         api 'junit:junit:4.13.1'
 
@@ -100,7 +99,7 @@ dependencies {
         api 'org.apache.commons:commons-collections4:4.4'
         api 'org.apache.commons:commons-compress:1.26.0'
         api 'org.apache.commons:commons-exec:1.3'
-        api 'org.apache.commons:commons-lang3:3.17.0'
+        api 'org.apache.commons:commons-lang3:3.17.0' // If updating, also update in obr/release.yaml.
         
         api 'org.apache.derby:derbyclient:10.14.2.0'
 
@@ -118,7 +117,7 @@ dependencies {
         api 'org.apache.httpcomponents:httpclient:4.5.14'
         api 'org.apache.httpcomponents:httpclient-osgi:4.5.14'
         api 'org.apache.httpcomponents:httpcore:4.4.16'
-        api 'org.apache.httpcomponents:httpcore-osgi:4.4.14'
+        api 'org.apache.httpcomponents:httpcore-osgi:4.4.14' // If updating, also update in obr/release.yaml.
         api 'org.apache.httpcomponents:httpmime:4.5.14'
 
         api 'org.apache.kafka:kafka-clients:3.9.0'
@@ -154,7 +153,7 @@ dependencies {
 
         api 'org.osgi:org.osgi.core:6.0.0'
         api 'org.osgi:org.osgi.service.cm:1.6.0'
-        api 'org.osgi:org.osgi.service.component.annotations:1.3.0'
+        api 'org.osgi:org.osgi.service.component.annotations:1.3.0' // If updating, also update in obr/release.yaml.
 
         api 'org.reflections:reflections:0.9.11'
 


### PR DESCRIPTION
## Why?

The galasa-bom is a component used by Galasa user's to get versions of dependencies for their test projects (generated by `galasactl project create`). Using the platform to generate the galasa-bom subsequently broke the `project create` command so I have reverted the changes to the galasa-bom where the platform was involved (found in this [PR](https://github.com/galasa-dev/galasa/pull/70/files#diff-326cccbabfee54a9f05abac16cfef22e42b4eb13a834ae0e717a29d2a2a3cc54))
The OBR's release.yaml now requires all dependencies with `bom: true` to list their version explicitly again. So I have added a comment in the platform to highlight the second location for uplifts in future.