### PR TITLE
Use httpd:alpine image in maven repo dockerfiles

### DIFF
--- a/modules/buildutils/dockerfiles/dockerfile.buildutils
+++ b/modules/buildutils/dockerfiles/dockerfile.buildutils
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:2.4.59
+FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:alpine
 
 RUN rm -v /usr/local/apache2/htdocs/*
 COPY dockerfiles/httpdconf/httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/modules/framework/dockerfiles/dockerfile.restapidocsite
+++ b/modules/framework/dockerfiles/dockerfile.restapidocsite
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:2.4.59
+FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:alpine
 
 RUN rm -v /usr/local/apache2/htdocs/*
 

--- a/modules/obr/codecoveragetemplates/Dockerfile
+++ b/modules/obr/codecoveragetemplates/Dockerfile
@@ -1,6 +1,6 @@
 ARG dockerRepository
 
-FROM ${dockerRepository}/library/httpd:2.4
+FROM ${dockerRepository}/library/httpd:alpine
 ARG branch
 
 RUN rm -v /usr/local/apache2/htdocs/*

--- a/modules/obr/dockerfiles/dockerfile.javadocsite
+++ b/modules/obr/dockerfiles/dockerfile.javadocsite
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:2.4.59
+FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:alpine
 
 RUN rm -v /usr/local/apache2/htdocs/*
 COPY dockerfiles/httpdconf/httpd.conf /usr/local/apache2/conf/httpd.conf


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2057

httpd:2.4.59 contains several vulnerabilities, so switching over to use httpd:alpine instead.