### PR TITLE
Add missing version for BOM dependency

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -32,6 +32,7 @@ external:
 
   - group: commons-codec
     artifact: commons-codec
+    version: 1.16.1
     obr: true
     bom: true
     mvp: true


### PR DESCRIPTION
## Why?

Continuing from #76 - missed this dependency.