### PR TITLE
Remove dev.galasa.platform from the release.yaml

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -71,12 +71,6 @@ external:
     isolated: true
 
   - group: dev.galasa
-    artifact: dev.galasa.platform
-    obr: false
-    mvp: true
-    isolated: true
-
-  - group: dev.galasa
     artifact: dev.galasa.wrapping.com.jcraft.jsch
     obr: true
     mvp: true


### PR DESCRIPTION
## Why?

dev.galasa.platform still needs to be part of the Isolated/MVP zips but being in the release.yaml should only be for artifacts that are built and put into the zip as a jar. dev.galasa.platform being here in the release.yaml (which is used to generate a pom.xml for the Isolated/MVP zips) has caused this error:
```
Could not find artifact dev.galasa:dev.galasa.platform:jar:0.38.0 in galasa.runtime.repo (https://development.galasa.dev/main/maven-repo/obr)
```

dev.galasa.platform can be included in Isolated/MVP instead as a POM artifact correctly by adding this section into the Isolated and MVP's pom.templates:
```
        <dependency>
            <groupId>dev.galasa</groupId>
            <artifactId>dev.galasa.platform</artifactId>
            <version>{{.Release}}</version>
            <type>pom</type>
        </dependency>
```

