### PR TITLE
Iss2052 - Implement platform in maven

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -85,6 +85,14 @@ jobs:
         run: |
           cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
 
+      - name: Download platform from this workflow
+        id: download-platform
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+
       - name: Download gradle artifacts from this workflow
         id: download-gradle
         continue-on-error: true

--- a/.github/workflows/pr-maven.yaml
+++ b/.github/workflows/pr-maven.yaml
@@ -12,6 +12,10 @@ on:
         description: 'True if this module has been changed and should be rebuilt'
         required: true
         type: string
+      platform-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the platform'
+        required: true
+        type: string
       gradle-artifact-id:
         description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
         required: true
@@ -87,6 +91,14 @@ jobs:
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.
 
+      - name: Download platform from this workflow
+        id: download-platform
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+
       - name: Download gradle artifacts from this workflow
         id: download-gradle
         continue-on-error: true
@@ -97,6 +109,15 @@ jobs:
 
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
+
+      - name: Download platform from last successful workflow
+        if: ${{ steps.download-platform.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.platform-artifact-id }}
 
       - name: Download gradle artifacts from last successful workflow
         if: ${{ steps.download-gradle.outcome == 'failure' }}

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -108,6 +108,7 @@ jobs:
     with:
       changed: ${{ needs.get-changed-modules.outputs.maven_changed }}
       gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+      platform-artifact-id: ${{ needs.find-artifacts.outputs.platform_artifacts_id }}
 
   pr-build-framework:
     name: Build the 'framework' module

--- a/modules/maven/galasa-maven-plugin/pom.xml
+++ b/modules/maven/galasa-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>0.34.0</version>
+	<version>0.38.0</version>
 
 	<name>Galasa Maven Plugin</name>
 	<description>Maven plugin for build Galasa artifacts such as the OBR, Test Catalog</description>
@@ -61,118 +61,19 @@
 		<dependencies>
 			<dependency>
 				<groupId>dev.galasa</groupId>
-				<artifactId>dev.galasa.plugin.common</artifactId>
-				<version>0.33.0</version>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+          		<scope>import</scope>
 			</dependency>
-
-			<dependency>
-				<groupId>dev.galasa</groupId>
-				<artifactId>dev.galasa.plugin.common.impl</artifactId>
-				<version>0.33.0</version>
-			</dependency>
-
-			<dependency>
-				<groupId>dev.galasa</groupId>
-				<artifactId>dev.galasa.plugin.common.test</artifactId>
-				<version>0.33.0</version>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.maven.plugin-tools</groupId>
-				<artifactId>maven-plugin-annotations</artifactId>
-				<version>3.11.0</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.maven</groupId>
-				<artifactId>maven-plugin-api</artifactId>
-				<version>3.6.2</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.maven.shared</groupId>
-				<artifactId>maven-shared-utils</artifactId>
-				<version>3.4.2</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.maven</groupId>
-				<artifactId>maven-artifact</artifactId>
-				<version>3.6.2</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.maven</groupId>
-				<artifactId>maven-compat</artifactId>
-				<version>3.9.6</version>
-			</dependency>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.13.1</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.maven.plugin-testing</groupId>
-				<artifactId>maven-plugin-testing-harness</artifactId>
-				<scope>test</scope>
-				<version>3.3.0</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-codec</groupId>
-				<artifactId>commons-codec</artifactId>
-				<version>1.16.1</version>
-			</dependency>
-
-			<dependency>
-				<groupId>commons-io</groupId>
-				<artifactId>commons-io</artifactId>
-				<version>2.15.1</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>org.apache.felix.bundlerepository</artifactId>
-				<version>2.0.10</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.reflections</groupId>
-				<artifactId>reflections</artifactId>
-				<version>0.9.11</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.google.code.gson</groupId>
-				<artifactId>gson</artifactId>
-				<version>2.10.1</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.assertj</groupId>
-				<artifactId>assertj-core</artifactId>
-				<version>3.25.3</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpcore</artifactId>
-				<version>4.4.16</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpclient</artifactId>
-				<version>4.5.14</version>
-			</dependency>
-
 		</dependencies>
 	</dependencyManagement>
-
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
@@ -185,6 +86,7 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-artifact</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
@@ -193,10 +95,12 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-testing</groupId>
 			<artifactId>maven-plugin-testing-harness</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
@@ -206,27 +110,23 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.felix</groupId>
 			<artifactId>org.apache.felix.bundlerepository</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
+			<version>3.25.3</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
@@ -250,6 +150,7 @@
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.plugin.common.test</artifactId>
+			<scope>test</scope>
 		</dependency>
  	</dependencies>
 
@@ -273,8 +174,8 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-    		        <artifactId>maven-compiler-plugin</artifactId>
-            		<version>3.13.0</version>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.13.0</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-platform'
     id 'maven-publish'
+    id 'signing'
 }
 
 version = "0.38.0"
@@ -9,9 +10,6 @@ javaPlatform {
     allowDependencies()
 }
 
-
-
-        
 dependencies {
     constraints {
         api 'com.auth0:java-jwt:4.4.0' // used by wrapper.
@@ -45,7 +43,7 @@ dependencies {
 
         api 'commons-collections:commons-collections:3.2.2'
 
-        api 'commons-io:commons-io:2.16.1' // If updating, also update in galasa-boot build.gradlen and in obr/release.yaml.
+        api 'commons-io:commons-io:2.16.1' // If updating, also update in galasa-boot build.gradle and in obr/release.yaml.
 
         api 'commons-lang:commons-lang:2.6'
 
@@ -54,6 +52,9 @@ dependencies {
         api 'dev.galasa:dev.galasa:'+version
         api 'dev.galasa:dev.galasa.framework:'+version
         api 'dev.galasa:dev.galasa.platform:'+version
+        api 'dev.galasa:dev.galasa.plugin.common:'+version
+        api 'dev.galasa:dev.galasa.plugin.common.impl:'+version
+        api 'dev.galasa:dev.galasa.plugin.common.test:'+version
         api 'dev.galasa:dev.galasa.wrapping.com.auth0.jwt:'+version
         api 'dev.galasa:dev.galasa.wrapping.com.jcraft.jsch:'+version
         api 'dev.galasa:dev.galasa.wrapping.gson:'+version // If updating, also update in obr/release.yaml.
@@ -127,7 +128,16 @@ dependencies {
         api 'org.apache.logging.log4j:log4j-core:2.24.1' // If updating, also update in galasa-boot build.gradle.
         api 'org.apache.logging.log4j:log4j-slf4j-impl:2.24.1'
 
+        api 'org.apache.maven:maven-artifact:3.9.6'
+        api 'org.apache.maven:maven-compat:3.6.2'
+        api 'org.apache.maven:maven-plugin-api:3.6.2'
         api 'org.apache.maven:maven-repository-metadata:3.3.9'
+
+        api 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0'
+
+        api 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.11.0'
+
+        api 'org.apache.maven.shared:maven-shared-utils:3.4.2'
 
         api 'org.apache.tomcat:annotations-api:6.0.53'
 
@@ -174,6 +184,17 @@ dependencies {
     }
 }
 
+signing {
+    def signingKeyId = findProperty("signingKeyId")
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    sign publishing.publications
+}
+
+tasks.withType(Sign) {
+    onlyIf { isMainOrRelease.toBoolean() }
+}
 
 publishing {
     publications {

--- a/modules/platform/dev.galasa.platform/gradle.properties
+++ b/modules/platform/dev.galasa.platform/gradle.properties
@@ -1,0 +1,1 @@
+isMainOrRelease=false

--- a/tools/get-changed-modules-pull-request.sh
+++ b/tools/get-changed-modules-pull-request.sh
@@ -140,9 +140,13 @@ function get_changed_modules_and_set_in_environment() {
         if [[ "$module" == "platform" ]]; then
             echo "PLATFORM_CHANGED=true" >> $GITHUB_OUTPUT
             # Also rebuild modules that depend on the Platform...
+            echo "WRAPPING_CHANGED=true" >> $GITHUB_OUTPUT
             echo "GRADLE_CHANGED=true" >> $GITHUB_OUTPUT
+            echo "MAVEN_CHANGED=true" >> $GITHUB_OUTPUT
             echo "FRAMEWORK_CHANGED=true" >> $GITHUB_OUTPUT
+            # echo "EXTENSIONS_CHANGED=true" >> $GITHUB_OUTPUT # Not done yet
             echo "MANAGERS_CHANGED=true" >> $GITHUB_OUTPUT
+            echo "OBR_CHANGED=true" >> $GITHUB_OUTPUT
             continue
         fi
         if [[ "$module" == "buildutils" ]]; then


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2052

- Remove explicit versions in the galasa-maven-plugin pom.xml and draw from the platform 
- Add extra dependencies into the platform
- Add signing for the platform to its build.gradle (to get ready for the 0.38.0 release)
- Add gradle.properties which provides the value of `isMainOrRelease` when building locally (value is provided from the GH workflows in remote builds)
- Adjust get-changed-modules-pull-request.sh script to rebuild all modules that use the platform, whenever there are changes to the platform

Testing done locally:
- [x] Galasa repo built
- [x] CLI repo built and generated tests ran locally
- [x] Isolated pom.xml build locally
- [x] API Server starts locally
- [x] CoreManagerIVT ran locally
