### PR TITLE
obr build-locally.sh script should default to using the local maven repo

### DIFF
--- a/modules/obr/build-locally.sh
+++ b/modules/obr/build-locally.sh
@@ -68,7 +68,8 @@ Options are:
 Environment Variables:
 SOURCE_MAVEN :
     Used to indicate where parts of the OBR can be obtained.
-    Optional. Defaults to https://development.galasa.dev/main/maven-repo/obr/
+    Optional. Could be set to something like: https://development.galasa.dev/main/maven-repo/obr/
+    Defaults to file://~/.m2/repository
 
 LOGS_DIR :
     Controls where logs are placed.
@@ -135,7 +136,11 @@ h1 "Building ${project}"
 
 # Over-rode SOURCE_MAVEN if you want to build from a different maven repo...
 if [[ -z ${SOURCE_MAVEN} ]]; then
-    export SOURCE_MAVEN=https://development.galasa.dev/main/maven-repo/obr/
+    cd ~/.m2/repository
+    local_maven_repo_folder=$(pwd)
+    cd - 
+    export SOURCE_MAVEN="file://$local_maven_repo_folder"
+    # export SOURCE_MAVEN=https://development.galasa.dev/main/maven-repo/obr/
     info "SOURCE_MAVEN repo defaulting to ${SOURCE_MAVEN}."
     info "Set this environment variable if you want to over-ride this value."
 else

--- a/tools/build-locally.sh
+++ b/tools/build-locally.sh
@@ -157,10 +157,6 @@ function build_module() {
     chain=$2
     h1 "Building... module:'$module' chain:'$chain'"
 
-    cd ~/.m2/repository
-    local_maven_repo_folder=$(pwd)
-    cd - 
-
     # platform
     if [[ "$module" == "platform" ]]; then
         h2 "Building $module"
@@ -261,7 +257,6 @@ function build_module() {
     if [[ "$module" == "obr" ]]; then
         h2 "Building $module"
         cd ${PROJECT_DIR}/modules/$module
-        export SOURCE_MAVEN="file:/$local_maven_repo_folder"
         info "Using SOURCE_MAVEN of $SOURCE_MAVEN"
         ${PROJECT_DIR}/modules/$module/build-locally.sh --detectsecrets false
         rc=$? ;  if [[ "${rc}" != "0" ]]; then error "Failed to build module $module. rc=$rc" ; exit 1 ; fi


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
I noticed that the obr build was drawing material from the hosted download site.

It should have everything it needs from ~/.m2 now for local builds of this repo.