### PR TITLE
Remove bundles from the MVP/Isolated that aren't needed

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.beans/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.beans/build.gradle
@@ -17,8 +17,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
-ext.includeInIsolated     = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = false
 ext.includeInBOM          = true
 ext.includeInCodeCoverage = true
 ext.includeInJavadoc      = true

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/build.gradle
@@ -54,8 +54,8 @@ publishing {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
-ext.includeInIsolated     = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = false
 ext.includeInBOM          = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/modules/framework/release.yaml
+++ b/modules/framework/release.yaml
@@ -156,10 +156,10 @@ api:
   - artifact: dev.galasa.framework.api.beans
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          true
     javadoc:      true
-    isolated:     true
+    isolated:     false
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.bootstrap
@@ -210,10 +210,10 @@ api:
   - artifact: dev.galasa.framework.api.openapi
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          true
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.framework.api.openapi.servlet

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt/build.gradle
@@ -21,9 +21,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager.ivt/build.gradle
@@ -18,8 +18,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager.ivt/build.gradle
@@ -19,8 +19,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
-ext.includeInIsolated     = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = false
 ext.includeInBOM          = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager.ivt/build.gradle
@@ -19,9 +19,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/build.gradle
@@ -18,9 +18,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/build.gradle
@@ -17,9 +17,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager.ivt/build.gradle
@@ -16,8 +16,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager.ivt/build.gradle
@@ -15,8 +15,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/build.gradle
@@ -16,9 +16,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager.ivt/build.gradle
@@ -16,9 +16,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/build.gradle
@@ -17,9 +17,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/build.gradle
@@ -16,9 +16,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/release.yaml
+++ b/modules/managers/release.yaml
@@ -36,10 +36,10 @@ managers:
   - artifact: dev.galasa.cicsts.ceci.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.cicsts.ceda.manager
@@ -54,10 +54,10 @@ managers:
   - artifact: dev.galasa.cicsts.ceda.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.cicsts.cemt.manager
@@ -72,10 +72,10 @@ managers:
   - artifact: dev.galasa.cicsts.cemt.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.cicsts.manager
@@ -90,10 +90,10 @@ managers:
   - artifact: dev.galasa.cicsts.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.cicsts.resource.manager
@@ -126,10 +126,10 @@ managers:
   - artifact: dev.galasa.docker.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.kubernetes.manager
@@ -189,10 +189,10 @@ managers:
   - artifact: dev.galasa.http.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.ipnetwork.manager
@@ -234,10 +234,10 @@ managers:
   - artifact: dev.galasa.artifact.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.core.manager
@@ -252,10 +252,10 @@ managers:
   - artifact: dev.galasa.core.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.textscan.manager
@@ -279,10 +279,10 @@ managers:
   - artifact: dev.galasa.db2.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.eclipseruntime.manager
@@ -423,10 +423,10 @@ managers:
   - artifact: dev.galasa.selenium.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.vtp.manager
@@ -495,10 +495,10 @@ managers:
   - artifact: dev.galasa.zos.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.zos3270.common
@@ -522,10 +522,10 @@ managers:
   - artifact: dev.galasa.zos3270.manager.ivt
     version: 0.38.0
     obr:          true
-    mvp:          true
+    mvp:          false
     bom:          false
     javadoc:      false
-    isolated:     true
+    isolated:     false
     codecoverage: false
 
   - artifact: dev.galasa.zosbatch.rseapi.manager

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -79,8 +79,6 @@ external:
   - group: dev.galasa
     artifact: dev.galasa.wrapping.com.auth0.jwt
     obr: true
-    mvp: true
-    isolated: true
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.gson
@@ -129,8 +127,6 @@ external:
   - group: dev.galasa
     artifact: dev.galasa.wrapping.kafka.clients
     obr: true
-    mvp: true
-    isolated: true
 
   - group: io.prometheus
     artifact: simpleclient


### PR DESCRIPTION
## Why?

The MVP/Isolated zips of Galasa are a component provided to users so they can run local Galasa tests using just the built bundles provided in the `maven` directory, if they were hypothetically offline and unable to access Maven Central. 
Both the Isolated and MVP zip have had bundles included that shouldn't be as they aren't necessary to the functionality.
This PR removes all *.ivt bundles as users should not be interested in running the Galasa IVTs themselves, and the kafka.clients and com.auth0 wrappers as they are only used for remote runs.
Trimming these bundles from the MVP zip will also hopefully help the scan results be cleaner as there is less content included.