### PR TITLE
Remove the MQ manager from being an optional resource for the framework bundle

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/bnd.bnd
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/bnd.bnd
@@ -1,9 +1,7 @@
 -snapshot: ${tstamp}
 Bundle-Name: MQ Manager
 Export-Package: !dev.galasa.mq.internal*,\
-        dev.galasa.mq*,\
-        javax.jms*,\
-        javax.management*
+        dev.galasa.mq*
 Import-Package: !javax.validation.constraints,\
         dev.galasa,\
         dev.galasa.framework.spi,\

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/build.gradle
@@ -5,7 +5,7 @@ plugins {
 description = 'MQ Manager'
 
 dependencies {
-    implementation 'javax.jms:javax.jms-api'
+    api 'javax.jms:javax.jms-api'
     implementation 'com.ibm.mq:com.ibm.mq.allclient'
 	implementation 'commons-codec:commons-codec'
   


### PR DESCRIPTION
## Why?
When the framework bundle is installed, the MQ manager incorrectly appears as an optional resource. This has led to several regression test failures as the MQ manager is not included in our MVP packaging. This PR fixes this erroneous behaviour so that the MQ manager is not listed as an optional resource when the framework is installed.