### PR TITLE
Add api platform to galasa.manager plugin

### DIFF
--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
@@ -5,23 +5,23 @@ plugins {
 }
 
 dependencies {
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
+    api platform('dev.galasa:dev.galasa.platform:0.38.0')
+    api 'dev.galasa:dev.galasa'
 
-    api            'dev.galasa:dev.galasa'
+    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
     implementation 'dev.galasa:dev.galasa.framework'
     implementation 'commons-logging:commons-logging'
     implementation 'org.osgi:org.osgi.core'
     implementation 'org.osgi:org.osgi.service.component.annotations'
-    compileOnly    'javax.validation:validation-api'
+    compileOnly 'javax.validation:validation-api'
 
     testImplementation platform('dev.galasa:dev.galasa.platform:0.38.0')
-
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core:4.6.1' // Platform has 3.1.0
     testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.assertj:assertj-core:3.16.1'
     testImplementation 'dev.galasa:galasa-testharness'
-    testCompileOnly    'javax.validation:validation-api'
+    testCompileOnly 'javax.validation:validation-api'
 }
 
 jacoco {

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
@@ -7,8 +7,7 @@ plugins {
 dependencies {
     api platform('dev.galasa:dev.galasa.platform:0.38.0')
     api 'dev.galasa:dev.galasa'
-
-    implementation platform('dev.galasa:dev.galasa.platform:0.38.0')
+    
     implementation 'dev.galasa:dev.galasa.framework'
     implementation 'commons-logging:commons-logging'
     implementation 'org.osgi:org.osgi.core'


### PR DESCRIPTION
## Why?

We are seeing some failures in the Isolated/MVP tests where the version provided by the platform is not being found. All of these dependencies seem to be `api` scope rather than `implementation`, so its possible this is because the platform is itself being passed to the bundles as `implementation` (only visible within the bundle). Changing it to `api` should make it visible to any bundle that uses that bundle.
As all managers inherit from the galasa.manager gradle plugin, this change was only required there.