### PR TITLE
Move httpcomponents jars from poms in isolated and into the obr's release.yaml

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -258,12 +258,27 @@ external:
     isolated: true
 
   - group: org.apache.httpcomponents
+    artifact: httpclient
+    mvp: true
+    isolated: true
+
+  - group: org.apache.httpcomponents
     artifact: httpcore-osgi
     version: 4.4.14
     obr: true
     bom: true
     isolated: true
     mvp: true
+
+  - group: org.apache.httpcomponents
+    artifact: httpcore
+    mvp: true
+    isolated: true
+
+  - group: org.apache.httpcomponents
+    artifact: httpmime
+    mvp: true
+    isolated: true
 
   - group: org.apache.logging.log4j
     artifact: log4j-api


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/isolated/pull/81.

To make it easier to bump versions in the future, this PR adds the httpcomponents dependencies into the OBR module's release.yaml so that their jars can be embedded into the isolated and mvp packaging.