### PR TITLE
Bump okio-jvm to 3.6.0

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -46,7 +46,7 @@ dependencies {
         api 'com.squareup.okhttp3:okhttp:4.9.2'
         api 'com.squareup.okhttp3:logging-interceptor:4.12.0'
 
-        api 'com.squareup.okio:okio-jvm:3.0.0'
+        api 'com.squareup.okio:okio-jvm:3.6.0'
 
         api 'commons-cli:commons-cli:1.4' // If updating, also update in galasa-boot build.gradle.
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2066

## Changes
- Bumped okio-jvm from 3.0.0 to [3.6.0](https://mvnrepository.com/artifact/com.squareup.okio/okio-jvm/3.6.0)
  - 3.9.1 is the latest version but we're already using 3.6.0 elsewhere, so bringing the platform in line with our existing latest version instead of introducing another version