### PR TITLE
Iss2052 - Replace versions in bnd files with platform

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.testcatalog/bnd.bnd
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.testcatalog/bnd.bnd
@@ -1,5 +1,5 @@
 -snapshot ${tstamp}
 Bundle-Name: Galasa API Test Catalog microservices
 Import-Package: !javax.validation.constraints,\
-                org.apache.commons.io;version="[2,3)",\
+                org.apache.commons.io;version="${@}",\
                 *

--- a/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/bnd.bnd
+++ b/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/bnd.bnd
@@ -14,19 +14,19 @@ Embed-Transitive: true
 Embed-Dependency: *;scope=compile
 -includeresource: docker-java-core-*.jar; lib:=true,\
     docker-java-transport-httpclient5-*.jar; lib:=true,\
-    docker-java-api-3.2.14.jar; lib:=true,\
-    docker-java-transport-3.2.14.jar; lib:=true,\
-    httpclient5-5.0.3.jar; lib:=true,\
-    slf4j-api-1.7.36.jar; lib:=true,\
+    docker-java-api-*.jar; lib:=true,\
+    docker-java-transport-*.jar; lib:=true,\
+    httpclient5-*.jar; lib:=true,\
+    slf4j-api-*.jar; lib:=true,\
     commons-io-*.jar; lib:=true,\
     commons-lang3-*.jar; lib:=true,\
     jackson-databind-*.jar; lib:=true,\
     guava-*.jar; lib:=true,\
-    jna-5.12.1.jar; lib:=true,\
+    jna-*.jar; lib:=true,\
     jackson-annotations-*.jar; lib:=true,\
     jackson-core-*.jar; lib:=true,\
     bcpkix-jdk18on-*.jar; lib:=true,\
     bcprov-jdk18on-*.jar; lib:=true,\
-    httpcore5-5.0.2.jar; lib:=true,\
+    httpcore5-*.jar; lib:=true,\
     commons-codec-*.jar; lib:=true
 -fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=warning

--- a/modules/framework/galasa-parent/dev.galasa.framework/bnd.bnd
+++ b/modules/framework/galasa-parent/dev.galasa.framework/bnd.bnd
@@ -2,9 +2,9 @@
 Bundle-Name Galasa Framework
 Export-Package !dev.galasa.framework.internal*;!dev.galasa.framework.maven;dev.galasa.framework;dev.galasa.framework.*;
 Import-Package !javax.validation*,\
-               org.apache.commons.io;version="[2,3)",\
-               org.apache.commons.io.filefilter;version="[2,3)",\
-               org.apache.commons.io.monitor;version="[2,3)",\
+               org.apache.commons.io;version="${@}",\
+               org.apache.commons.io.filefilter;version="${@}",\
+               org.apache.commons.io.monitor;version="${@}",\
                org.apache.bcel.*;resolution:=optional,\
                org.apache.felix.*;resolution:=optional,\
                dev.galasa.framework.maven.repository.spi;resolution:=optional,\

--- a/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/bnd.bnd
+++ b/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/bnd.bnd
@@ -62,6 +62,6 @@ Embed-Dependency: *;scope=compile
     selenium-java-*.jar; lib:=true,\
     selenium-opera-driver-*.jar; lib:=true,\
     selenium-remote-driver-*.jar; lib:=true,\
-    selenium-safari-driver-3.141.59.jar; lib:=true,\
+    selenium-safari-driver-*.jar; lib:=true,\
     selenium-support-*.jar; lib:=true
 -fixupmessages: Classes found in the wrong directory: ...;is:=ignore

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -18,7 +18,9 @@ dependencies {
         api 'com.fasterxml.jackson.core:jackson-core:2.16.0' // used by wrapper.
         api 'com.fasterxml.jackson.core:jackson-databind:2.16.0' // used by wrapper.
 
+        api 'com.github.docker-java:docker-java-api:3.2.14' // bnd.bnd only
         api 'com.github.docker-java:docker-java-core:3.2.14'
+        api 'com.github.docker-java:docker-java-transport:3.2.14' // bnd.bnd only
         api 'com.github.docker-java:docker-java-transport-httpclient5:3.2.14'
 
         api 'com.google.android:annotations:4.1.1.4'
@@ -149,6 +151,8 @@ dependencies {
 
         api 'net.bytebuddy:byte-buddy:1.8.15'
 
+        api 'net.java.dev.jna:jna:5.12.1' // bnd.bnd only
+
         api 'org.apache.bcel:bcel:6.7.0'
 
         api 'org.codehaus.plexus:plexus-utils:3.0.24'
@@ -176,6 +180,10 @@ dependencies {
         api 'org.apache.httpcomponents:httpcore:4.4.16'
         api 'org.apache.httpcomponents:httpcore-osgi:4.4.14' // If updating, also update in obr/release.yaml.
         api 'org.apache.httpcomponents:httpmime:4.5.14'
+
+        api 'org.apache.httpcomponents.httpclient:httpclient5:5.0.3' // bnd.bnd only
+
+        api 'org.apache.httpcomponents.core5:httpcore5:5.0.2' // bnd.bnd only
 
         api 'org.apache.kafka:kafka-clients:3.9.0'
         api 'org.apache.kafka:kafka-server-common:3.9.0'
@@ -235,6 +243,7 @@ dependencies {
         api 'org.seleniumhq.selenium:selenium-java:3.141.59'
         api 'org.seleniumhq.selenium:selenium-opera-driver:3.141.59'
         api 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
+        api 'org.seleniumhq.selenium:selenium-safari-driver:3.141.59' // bnd.bnd only
         api 'org.seleniumhq.selenium:selenium-support:3.141.59'
 
         api 'org.slf4j:slf4j-api:1.7.36'


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2052

Replacing hard coded versions in bnd.bnd files with a wildcard or `${@}` means that the version or version range is picked up from the build process, which takes the version from the platform.
In this PR I have only replaced versions with `*` if either the dependency appears only once in the Galasa source in this bnd file (and so the dependency has also been added to the platform), or if it matches the version in the platform. Any dependencies with clashing versions to the platform have been left to look at in a future uplift story.