### PR TITLE
Add IVT bundles back into the MVP zip

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt/build.gradle
@@ -21,9 +21,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = false
+ext.includeInMVP          = true
 ext.includeInBOM          = false
-ext.includeInIsolated     = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager.ivt/build.gradle
@@ -18,8 +18,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = false
+ext.includeInMVP          = true
 ext.includeInBOM          = false
-ext.includeInIsolated     = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager.ivt/build.gradle
@@ -19,8 +19,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = false
-ext.includeInIsolated     = false
+ext.includeInMVP          = true
 ext.includeInBOM          = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager.ivt/build.gradle
@@ -19,9 +19,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = false
+ext.includeInMVP          = true
 ext.includeInBOM          = false
-ext.includeInIsolated     = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/build.gradle
@@ -17,9 +17,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = false
+ext.includeInMVP          = true
 ext.includeInBOM          = false
-ext.includeInIsolated     = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager.ivt/build.gradle
@@ -16,8 +16,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = false
+ext.includeInMVP          = true
 ext.includeInBOM          = false
-ext.includeInIsolated     = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager.ivt/build.gradle
@@ -15,8 +15,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = false
+ext.includeInMVP          = true
 ext.includeInBOM          = false
-ext.includeInIsolated     = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/build.gradle
@@ -21,8 +21,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = false
+ext.includeInMVP          = true
 ext.includeInBOM          = false
-ext.includeInIsolated     = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/build.gradle
@@ -17,9 +17,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = false
+ext.includeInMVP          = true
 ext.includeInBOM          = false
-ext.includeInIsolated     = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/build.gradle
@@ -16,9 +16,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = false
+ext.includeInMVP          = true
 ext.includeInBOM          = false
-ext.includeInIsolated     = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 


### PR DESCRIPTION
## Why?
Since #88 which removed the IVT bundles from the MVP zip, so that we ship less bundles to customers that they aren't going to use - the Mvp integration tests have been failing as the test looks only inside the zip for its artifacts and so it can't find the *.ivt bundle it is supposed to be running. Adding the IVT bundles back into the MVP zip until we can figure out a solution. 