### PR TITLE
Update all uses of galasa plugins to 0.38.0

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -562,7 +562,7 @@ jobs:
           mvn -f pom.xml process-sources -X \
           -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
-          dev.galasa:galasa-maven-plugin:0.15.0:obrembedded \
+          dev.galasa:galasa-maven-plugin:0.38.0:obrembedded \
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
         

--- a/modules/extensions/galasa-extensions-parent/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'biz.aQute.bnd.builder' version '5.3.0' apply false
-    id 'dev.galasa.githash' version '0.15.0' apply false
+    id 'dev.galasa.githash' version '0.38.0' apply false
     id 'maven-publish'
     id 'signing'
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.testcatalog/settings.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.testcatalog/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = "dev.galasa.framework.api.testcatalog"
-bundleVersion = 0.16.0

--- a/modules/obr/dev.galasa.uber.obr/pom.template
+++ b/modules/obr/dev.galasa.uber.obr/pom.template
@@ -78,7 +78,7 @@
 			<plugin>
 				<groupId>dev.galasa</groupId>
 				<artifactId>galasa-maven-plugin</artifactId>
-				<version>0.34.0</version>
+				<version>0.38.0</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/modules/obr/galasa-bom/pom.template
+++ b/modules/obr/galasa-bom/pom.template
@@ -59,7 +59,7 @@
 				<plugin>
 					<groupId>dev.galasa</groupId>
 					<artifactId>galasa-maven-plugin</artifactId>
-					<version>0.34.0</version>
+					<version>0.38.0</version>
 				</plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Why?

- Upgrading all remaining references to Galasa artifacts to 0.38.0 now that all artifacts are to be kept up to date with the latest level.
- Even though the plugins themselves have had their versions upgraded to 0.38.0 along with the rest of Galasa, building locally was pulling older versions into the local maven repo for galasa-maven-plugin, dev.galasa.plugin.common and dev.galasa.plugin.common.impl as there are uses of the plugins which use these versions.
- The updates in this PR mean only 0.38.0 is used for all Galasa artifacts in this repo and there should be no Galasa bundles mentioned that are back level.