### PR TITLE
Create code_of_conduct.md

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,1 @@
+All participants agree to abide by The Linux Foundation Code of Conduct available at http://events.linuxfoundation.org/code-of-conduct.


### PR DESCRIPTION
This is to start bringing the community guidelines up to scratch in the Galasa-dev project. This is the same code_of_conduct used in the Zowe project as part of the Linux Foundation. https://github.com/zowe/zowe-on-the-go/blob/master/CODE_OF_CONDUCT.md