### PR TITLE
Fix release orchestrator - it was missing platform build

### DIFF
--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build the 'platform' module
     uses: ./.github/workflows/platform.yaml
     secrets: inherit
-        
+
   build-buildutils:
     name: Build the 'buildutils' module
     uses: ./.github/workflows/buildutils.yaml

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -27,6 +27,11 @@ on:
 
 jobs:
 
+  build-platform:
+    name: Build the 'platform' module
+    uses: ./.github/workflows/platform.yaml
+    secrets: inherit
+
   build-buildutils:
     name: Build the 'buildutils' module
     uses: ./.github/workflows/buildutils.yaml
@@ -34,6 +39,7 @@ jobs:
 
   build-wrapping:
     name: Build the 'wrapping' module
+    needs: [build-platform]
     uses: ./.github/workflows/wrapping.yaml
     secrets: inherit
     with:
@@ -42,6 +48,7 @@ jobs:
 
   build-gradle:
     name: Build the 'gradle' module
+    needs: [build-platform]
     uses: ./.github/workflows/gradle.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
## Why?

First run of the new release workflow since the platform was introduced failed as the platform build hadn't been added into the release workflow: https://github.com/galasa-dev/galasa/actions/runs/12178752446