### PR TITLE
0.38.0 prerelease fixes

### DIFF
--- a/modules/extensions/galasa-extensions-parent/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/build.gradle
@@ -175,7 +175,7 @@ publishing {
                 licenses {
                     license {
                         name = 'Eclipse Public License - v 2.0'
-                        url = 'https://www.eclipse.org/legal/epl-2.0/t'
+                        url = 'https://www.eclipse.org/legal/epl-2.0'
                     }
                 }
                 url = 'https://galasa.dev'
@@ -188,9 +188,9 @@ publishing {
                     }
                 }
                 scm {
-                    connection = 'scm:git:git:://github.com/galasa-dev/extensions'
-                    developerConnection = 'scm:git:git:://github.com/galasa-dev/extensions'
-                    url = 'https://github.com/galasa-dev/extensions'
+                    connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    url = 'https://github.com/galasa-dev/galasa'
                 }
                 issueManagement {
                     system = 'GitHub'

--- a/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -94,9 +94,9 @@ publishing {
                     }
                 }
                 scm {
-                    connection = 'scm:git:git:://github.com/galasa-dev/framework'
-                    developerConnection = 'scm:git:git:://github.com/galasa-dev/framework'
-                    url = 'https://github.com/galasa-dev/framework'
+                    connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    url = 'https://github.com/galasa-dev/galasa'
                 }
                 issueManagement {
                     system = 'GitHub'

--- a/modules/framework/galasa-parent/build.gradle
+++ b/modules/framework/galasa-parent/build.gradle
@@ -328,9 +328,9 @@ publishing {
                     }
                 }
                 scm {
-                    connection = 'scm:git:git:://github.com/galasa-dev/framework'
-                    developerConnection = 'scm:git:git:://github.com/galasa-dev/framework'
-                    url = 'https://github.com/galasa-dev/framework'
+                    connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    url = 'https://github.com/galasa-dev/galasa'
                 }
                 issueManagement {
                     system = 'GitHub'

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -94,9 +94,9 @@ publishing {
                     }
                 }
                 scm {
-                    connection = 'scm:git:git:://github.com/galasa-dev/framework'
-                    developerConnection = 'scm:git:git:://github.com/galasa-dev/framework'
-                    url = 'https://github.com/galasa-dev/framework'
+                    connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    url = 'https://github.com/galasa-dev/galasa'
                 }
                 issueManagement {
                     system = 'GitHub'

--- a/modules/gradle/build.gradle
+++ b/modules/gradle/build.gradle
@@ -82,9 +82,9 @@ publishing {
                         }
                     }
                     scm {
-                        connection = 'scm:git:git:://github.com/galasa-dev/gradle'
-                        developerConnection = 'scm:git:git:://github.com/galasa-dev/gradle'
-                        url = 'https://github.com/galasa-dev/gradle'
+                        connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                        developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                        url = 'https://github.com/galasa-dev/galasa'
                     }
                     issueManagement {
                         system = 'GitHub'

--- a/modules/gradle/dev.galasa.gradle.impl/build.gradle
+++ b/modules/gradle/dev.galasa.gradle.impl/build.gradle
@@ -134,9 +134,9 @@ publishing {
                         }
                     }
                     scm {
-                        connection = 'scm:git:git:://github.com/galasa-dev/gradle'
-                        developerConnection = 'scm:git:git:://github.com/galasa-dev/gradle'
-                        url = 'https://github.com/galasa-dev/gradle'
+                        connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                        developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                        url = 'https://github.com/galasa-dev/galasa'
                     }
                     issueManagement {
                         system = 'GitHub'

--- a/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
@@ -84,9 +84,9 @@ publishing {
                         }
                     }
                     scm {
-                        connection = 'scm:git:git:://github.com/galasa-dev/gradle'
-                        developerConnection = 'scm:git:git:://github.com/galasa-dev/gradle'
-                        url = 'https://github.com/galasa-dev/gradle'
+                        connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                        developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                        url = 'https://github.com/galasa-dev/galasa'
                     }
                     issueManagement {
                         system = 'GitHub'

--- a/modules/gradle/dev.galasa.plugin.common.test/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.test/build.gradle
@@ -84,9 +84,9 @@ publishing {
                         }
                     }
                     scm {
-                        connection = 'scm:git:git:://github.com/galasa-dev/gradle'
-                        developerConnection = 'scm:git:git:://github.com/galasa-dev/gradle'
-                        url = 'https://github.com/galasa-dev/gradle'
+                        connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                        developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                        url = 'https://github.com/galasa-dev/galasa'
                     }
                     issueManagement {
                         system = 'GitHub'

--- a/modules/gradle/dev.galasa.plugin.common/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common/build.gradle
@@ -106,9 +106,9 @@ publishing {
                         }
                     }
                     scm {
-                        connection = 'scm:git:git:://github.com/galasa-dev/gradle'
-                        developerConnection = 'scm:git:git:://github.com/galasa-dev/gradle'
-                        url = 'https://github.com/galasa-dev/gradle'
+                        connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                        developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                        url = 'https://github.com/galasa-dev/galasa'
                     }
                     issueManagement {
                         system = 'GitHub'

--- a/modules/managers/galasa-managers-parent/build.gradle
+++ b/modules/managers/galasa-managers-parent/build.gradle
@@ -234,7 +234,7 @@ publishing {
                 licenses {
                     license {
                         name = 'Eclipse Public License - v 2.0'
-                        url = 'https://www.eclipse.org/legal/epl-2.0/t'
+                        url = 'https://www.eclipse.org/legal/epl-2.0'
                     }
                 }
                 url = 'https://galasa.dev'
@@ -247,9 +247,9 @@ publishing {
                     }
                 }
                 scm {
-                    connection = 'scm:git:git:://github.com/galasa-dev/managers'
-                    developerConnection = 'scm:git:git:://github.com/galasa-dev/managers'
-                    url = 'https://github.com/galasa-dev/managers'
+                    connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    url = 'https://github.com/galasa-dev/galasa'
                 }
                 issueManagement {
                     system = 'GitHub'

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -96,9 +96,9 @@ publishing {
                     }
                 }
                 scm {
-                    connection = 'scm:git:git:://github.com/galasa-dev/framework'
-                    developerConnection = 'scm:git:git:://github.com/galasa-dev/framework'
-                    url = 'https://github.com/galasa-dev/framework'
+                    connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    url = 'https://github.com/galasa-dev/galasa'
                 }
                 issueManagement {
                     system = 'GitHub'

--- a/modules/maven/galasa-maven-plugin/pom.xml
+++ b/modules/maven/galasa-maven-plugin/pom.xml
@@ -30,9 +30,9 @@
 	</developers>
 
 	<scm>
-		<url>https://github.com/galasa-dev/maven</url>
-		<connection>scm:git:git:://github.com/galasa-dev/maven</connection>
-		<developerConnection>scm:git:git:://github.com/galasa-dev/maven</developerConnection>
+		<url>https://github.com/galasa-dev/galasa</url>
+		<connection>scm:git:git:://github.com/galasa-dev/galasa</connection>
+		<developerConnection>scm:git:git:://github.com/galasa-dev/galasa</developerConnection>
 	</scm>
 
 	<issueManagement>

--- a/modules/obr/dev.galasa.uber.obr/pom.template
+++ b/modules/obr/dev.galasa.uber.obr/pom.template
@@ -30,9 +30,9 @@
     </developers>
     
     <scm>
-        <url>https://github.com/galasa-dev/framework</url>
-        <connection>scm:git:git:://github.com/galasa-dev/framework</connection>
-        <developerConnection>scm:git:git:://github.com/galasa-dev/framework</developerConnection>
+        <url>https://github.com/galasa-dev/galasa</url>
+        <connection>scm:git:git:://github.com/galasa-dev/galasa</connection>
+        <developerConnection>scm:git:git:://github.com/galasa-dev/galasa</developerConnection>
     </scm>
 
     <issueManagement>

--- a/modules/obr/galasa-bom/pom.template
+++ b/modules/obr/galasa-bom/pom.template
@@ -31,9 +31,9 @@
     </developers>
 
     <scm>
-        <url>https://github.com/galasa-dev/framework</url>
-        <connection>scm:git:git:://github.com/galasa-dev/framework</connection>
-        <developerConnection>scm:git:git:://github.com/galasa-dev/framework</developerConnection>
+        <url>https://github.com/galasa-dev/galasa</url>
+        <connection>scm:git:git:://github.com/galasa-dev/galasa</connection>
+        <developerConnection>scm:git:git:://github.com/galasa-dev/galasa</developerConnection>
     </scm>
 
     <issueManagement>

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -282,24 +282,38 @@ publishing {
         myPlatform(MavenPublication) {
             from components.javaPlatform
 
-            groupId = 'dev.galasa'
-            artifactId = 'dev.galasa.platform'
-            version = "0.38.0"
+            pom {
+                name = 'Gradle Java Platform for Galasa bundles'
+                groupId = 'dev.galasa'
+                artifactId = 'dev.galasa.platform'
+                version = '0.38.0'
+                description = 'Provides versions to dependencies'
+                licenses {
+                    license {
+                        name = 'Eclipse Public License - v 2.0'
+                        url = 'https://www.eclipse.org/legal/epl-2.0'
+                    }
+                }
+                url = 'https://galasa.dev'
+                developers {
+                    developer {
+                        name = 'Galasa Developer'
+                        email = 'galasadelivery@ibm.com'
+                        organization = 'IBM'
+                        organizationUrl = 'https://www.ibm.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    developerConnection = 'scm:git:git:://github.com/galasa-dev/galasa'
+                    url = 'https://github.com/galasa-dev/galasa'
+                }
+                issueManagement {
+                    system = 'GitHub'
+                    url = 'https://github.com/galasa-dev/projectmanagement/issues'
+                }
+            }
         }
-
-        // mavenBom(MavenPublication) {
-        //     from components.java
-
-        //     groupId = 'com.example'
-        //     artifactId = 'my-dependencies-bom'
-        //     version = '1.0.0'
-
-        //     // Optional: Customize the generated POM file if needed
-        //     pom {
-        //         name = 'My Dependencies BOM'
-        //         description = 'A BOM of dependency versions for Java projects'
-        //     }
-        // }
     }
 
     repositories {

--- a/modules/wrapping/pom.xml
+++ b/modules/wrapping/pom.xml
@@ -48,9 +48,9 @@
 	</modules>
 
 	<scm>
-		<url>https://github.com/galasa-dev/wrapping</url>
-		<connection>scm:git:git:://github.com/galasa-dev/wrapping</connection>
-		<developerConnection>scm:git:git:://github.com/galasa-dev/wrapping</developerConnection>
+		<url>https://github.com/galasa-dev/galasa</url>
+		<connection>scm:git:git:://github.com/galasa-dev/galasa</connection>
+		<developerConnection>scm:git:git:://github.com/galasa-dev/galasa</developerConnection>
 	</scm>
 
 	<issueManagement>


### PR DESCRIPTION
## Why?

1. Added missing developer attribution, licenses, scm and issue management sections to dev.galasa.platform pom.xml which are needed for publishing to Maven Central
2. Updated all scm management links to the Galasa mono repo link from the previous individual repos
3. Fixed typo in the licenses link that took you to a 404