### PR TITLE
gherkin tests don't stop immediately if framework.continue.on.test.failure is set to true

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -21,6 +21,7 @@ import dev.galasa.ResultArchiveStoreContentType;
 import dev.galasa.framework.beans.Property;
 import dev.galasa.framework.internal.runner.ITestRunnerEventsProducer;
 import dev.galasa.framework.spi.AbstractManager;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
@@ -361,6 +362,20 @@ public class BaseTestRunner {
             throw new TestRunException("Unable to initialise the heartbeat. "+ex.getMessage(), ex);
         }
         return heartbeat;
+    }
+
+    protected boolean getContinueOnTestFailureFromCPS() {
+        boolean continueOnTestFailure = false ;
+        try {
+            IConfigurationPropertyStoreService cps = getCPS();
+            String checkContinue = AbstractManager.nulled(cps.getProperty("continue.on.test", "failure"));
+            if (checkContinue != null) {
+                continueOnTestFailure = Boolean.parseBoolean(checkContinue);
+            }
+        } catch(ConfigurationPropertyStoreException ex) {
+            logger.error("Failed to get the CPS property 'framework.continue.on.test.failure'", ex);
+        }
+        return continueOnTestFailure ;
     }
 }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -20,8 +20,10 @@ import dev.galasa.framework.internal.runner.MavenRepositoryListBuilder;
 import dev.galasa.framework.internal.runner.TestRunnerDataProvider;
 import dev.galasa.framework.maven.repository.spi.IMavenRepository;
 import dev.galasa.framework.spi.AbstractManager;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.FrameworkResourceUnavailableException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IGherkinExecutable;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.language.GalasaTest;
@@ -276,15 +278,19 @@ public class GherkinTestRunner extends BaseTestRunner {
         managers.provisionStop();
     }
 
+
+
     private void runGherkinTest(GherkinTest testObject, ITestRunManagers managers) throws TestRunException {
         if (!isRunOK) {
             return;
         }
 
+        boolean isContinueOnTestFailure = getContinueOnTestFailureFromCPS();
+
         updateStatus(TestRunLifecycleStatus.RUNNING, null);
         try {
             logger.info("Running the test class");
-            testObject.runTestMethods(managers);
+            testObject.runTestMethods(managers,isContinueOnTestFailure);
         } finally {
             updateStatus(TestRunLifecycleStatus.RUNDONE, null);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -81,19 +81,7 @@ public class TestClassWrapper {
         this.testClass = testClass;
         this.testStructure = testStructure;
 
-
-        // Check that we are supposed to continue on test failure
-        IConfigurationPropertyStoreService cps = this.testRunner.getCPS();
-        String checkContinue = AbstractManager.nulled(cps.getProperty("continue.on.test", "failure"));
-        if (checkContinue != null) {
-            this.continueOnTestFailure = Boolean.parseBoolean(checkContinue);
-        } else {
-            if (this.testClass.isAnnotationPresent(ContinueOnTestFailure.class)) {
-                this.continueOnTestFailure = true;
-            } else {
-                this.continueOnTestFailure = false;
-            }
-        }
+        this.continueOnTestFailure = this.testRunner.getContinueOnTestFailureFromCPS();
     }
 
     /**

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinTest.java
@@ -123,7 +123,7 @@ public class GherkinTest {
         this.result = result;
     }
 
-    public void runTestMethods(ITestRunManagers managers) throws TestRunException {
+    public void runTestMethods(ITestRunManagers managers, boolean isContinueOnTestFailure ) throws TestRunException {
         String report = this.testStructure.gherkinReport(LOG_START_LINE);
         logger.trace("Test Class structure:-" + report);
 
@@ -143,7 +143,14 @@ public class GherkinTest {
                 method.invoke(managers, this.feature.getVariables().getVariablesOriginal());
             }
             
-            if(method.fullStop()) {
+            boolean isExecutionHalting = method.fullStop();
+            if (isContinueOnTestFailure) {
+                if (isExecutionHalting) {
+                    logger.info("Test method has failed, but the CPS property 'framework.continue.on.test.failure' has been set, so we carry on going...");
+                    isExecutionHalting = false ;
+                }
+            }
+            if( isExecutionHalting ) {
                 break;
             }
         }
@@ -181,7 +188,6 @@ public class GherkinTest {
         String postReport = this.testStructure.gherkinReport(LOG_START_LINE);
         logger.trace("Finishing Test Class structure:-" + postReport);
     }
-
 
     private List<String> getGherkinFeatureTextLines(IRun run, IFileLineReader fileReader) throws TestRunException {
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestGherkinTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestGherkinTestRunner.java
@@ -5,24 +5,26 @@
  */
 package dev.galasa.framework;
 
-import static org.assertj.core.api.Assertions.*;
+// import static org.assertj.core.api.Assertions.*;
 
-import java.lang.annotation.Annotation;
-import java.util.*;
-import java.nio.file.Path;
+// import java.lang.annotation.Annotation;
+// import java.util.*;
+// import java.nio.file.Path;
 
-import javax.validation.constraints.NotNull;
+// import javax.validation.constraints.NotNull;
 
-import org.apache.felix.bundlerepository.Repository;
-import org.apache.felix.bundlerepository.Resolver;
-import org.apache.felix.bundlerepository.Resource;
+// import org.apache.felix.bundlerepository.Repository;
+// import org.apache.felix.bundlerepository.Resolver;
+// import org.apache.felix.bundlerepository.Resource;
 import org.junit.Test;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.InvalidSyntaxException;
-import dev.galasa.framework.maven.repository.spi.IMavenRepository;
-import dev.galasa.framework.mocks.*;
-import dev.galasa.framework.spi.*;
-import dev.galasa.framework.spi.teststructure.TestStructure;
+// import org.osgi.framework.Bundle;
+// import org.osgi.framework.InvalidSyntaxException;
+
+// import dev.galasa.framework.internal.runner.ITestRunnerEventsProducer;
+// import dev.galasa.framework.maven.repository.spi.IMavenRepository;
+// import dev.galasa.framework.mocks.*;
+// import dev.galasa.framework.spi.*;
+// import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class TestGherkinTestRunner {
     
@@ -31,6 +33,7 @@ public class TestGherkinTestRunner {
         new GherkinTestRunner();
     }
 
+    // This is a guiding test. It's not running just yet, but it's a start down that path.
     // @Test
     // public void TestCanGetThroughGoldenPathOK() throws Exception {
 
@@ -49,16 +52,11 @@ public class TestGherkinTestRunner {
     //     MockFileSystem mockFileSystem = new MockFileSystem();
 
     //     StringBuffer featureText = new StringBuffer();
-    //     featureText.append("Feature: FruitLogger");
-    //     featureText.append("\n");
-    //     featureText.append(" Scenario: Log the cost of fruit-0");
-    //     featureText.append("\n");
-    //     featureText.append("  THEN Write to log \"An apple costs 1\"");
-    //     featureText.append("\n");
-    //     featureText.append("Scenario: Log the cost of fruit-1");
-    //     featureText.append("\n");
-    //     featureText.append("  THEN Write to log \"An melon costs 2\"");
-    //     featureText.append("\n");
+    //     featureText.append("Feature: FruitLogger\n");
+    //     featureText.append(" Scenario: Log the cost of fruit-0\n");
+    //     featureText.append("  THEN Write to log \"An apple costs 1\"\n");
+    //     featureText.append("Scenario: Log the cost of fruit-1\n");
+    //     featureText.append("  THEN Write to log \"An melon costs 2\"\n");
     //     Path gherkinTestFilePath = mockFileSystem.getPath(GHERKIN_TEST_FILE_PATH);
     //     mockFileSystem.createFile(gherkinTestFilePath);
     //     mockFileSystem.setFileContents(gherkinTestFilePath, featureText.toString() );
@@ -95,8 +93,6 @@ public class TestGherkinTestRunner {
 
     //     MockShutableFramework framework = new MockShutableFramework(ras,dss,TEST_RUN_NAME, run, frameworkRuns );
     //     IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
-
-
 
     //     IMavenRepository mockMavenRepo = new MockMavenRepository();
 
@@ -166,6 +162,8 @@ public class TestGherkinTestRunner {
         
     //     MockTestRunManagers mockTestRunManagers = new MockTestRunManagers(IGNORE_TEST_CLASS_FALSE, testResult );
         
+    //     ITestRunnerEventsProducer mockEventPublisher = new MockTestRunnerEventsProducer();
+
     //     MockTestRunnerDataProvider testRunData = new MockTestRunnerDataProvider(
     //         cps,
     //         dss,
@@ -176,7 +174,8 @@ public class TestGherkinTestRunner {
     //         mockAnnotationExtractor,
     //         mockBundleManager,
     //         mockTestRunManagers,
-    //         mockFileSystem
+    //         mockFileSystem,
+    //         mockEventPublisher
     //     );
 
     //     // When...

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockShutableFramework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockShutableFramework.java
@@ -96,6 +96,12 @@ public class MockShutableFramework implements IShuttableFramework {
         return new Properties();
     }
 
+    @Override
+    public @NotNull IConfigurationPropertyStoreService getConfigurationPropertyService(@NotNull String namespace)
+            throws ConfigurationPropertyStoreException {
+               throw new UnsupportedOperationException("Unimplemented method 'getConfigurationPropertyService'");
+    }
+
     // ----------------- un-implemented methods follow -------------------
 
     @Override
@@ -106,12 +112,6 @@ public class MockShutableFramework implements IShuttableFramework {
     @Override
     public boolean isInitialised() {
                throw new UnsupportedOperationException("Unimplemented method 'isInitialised'");
-    }
-
-    @Override
-    public @NotNull IConfigurationPropertyStoreService getConfigurationPropertyService(@NotNull String namespace)
-            throws ConfigurationPropertyStoreException {
-               throw new UnsupportedOperationException("Unimplemented method 'getConfigurationPropertyService'");
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
See issue [Infrastructure: Tool to update the release version dynamically wherever it is referenced. #2053](https://github.com/galasa-dev/projectmanagement/issues/2053)

- Code to get the CPS property is common between java and gherkin test runners.
- Logic to not fail immediately added to gherkin test runner, in similar way it's on the java one. No appetite for combining runners more for this change alone.
- Unit test code not advanced enough to enable still. Must do better at some point soon.
- Having enabled this it's now obvious we should be counting methods and reporting on successful `@Test` methods than just successful test class executions. A feature which fails at the first scenario looks exactly the same as one which fails at the 3rd or last.
- I also notice that junit/gson/html results don't list the methods/scenarios, so that's not great either. This needs raising separately.
