### PR TITLE
Fixing incorrect output of set-version script which broke the API

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -80,7 +80,7 @@ external:
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.com.auth0.jwt
-    version: 0.39.0
+    obr: true
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.gson
@@ -99,7 +99,7 @@ external:
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.io.grpc.java
-    version: 0.39.0
+    obr: true
     mvp: true
     isolated: true
 


### PR DESCRIPTION
## Why?

The set-version script assumes that the version line is directly underneath the artifact line in the release.yaml and so removed the com.auth0.jwt and io.grpc.java wrappers from the OBR, breaking the API server.