### PR TITLE
galasabld now builds with linux arm64 architecture

### DIFF
--- a/modules/buildutils/Makefile
+++ b/modules/buildutils/Makefile
@@ -3,7 +3,8 @@ all: clean test \
 	bin/galasabld-windows-amd64 \
 	bin/galasabld-darwin-amd64 \
 	bin/galasabld-linux-s390x \
-	bin/galasabld-darwin-arm64
+	bin/galasabld-darwin-arm64 \
+	bin/galasabld-linux-arm64
 
 src : ./Makefile \
 	./cmd/galasabld/main.go \
@@ -17,6 +18,9 @@ test: src
 
 bin/galasabld-linux-amd64 : src
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/galasabld-linux-amd64 ./cmd/galasabld
+
+bin/galasabld-linux-arm64 : src
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/galasabld-linux-arm64 ./cmd/galasabld
 
 bin/galasabld-windows-amd64 : src
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o bin/galasabld-windows-amd64 ./cmd/galasabld

--- a/modules/buildutils/test-locally.sh
+++ b/modules/buildutils/test-locally.sh
@@ -162,31 +162,36 @@ function test_versions_manipulation() {
     success "Tested the galasabld versioning commands as best we can"
 }
 
-function calculate_galasabld_executable {
-    h2 "Calculate the name of the galasabld executable for this machine/os"
-
-    raw_os=$(uname -s) # eg: "Darwin"
+function get_architecture() {
+    h2 "Retrieving system architecture."
+        raw_os=$(uname -s) # eg: "Darwin"
     os=""
     case $raw_os in
-        Darwin*) 
-            os="darwin" 
-            ;;
-        Windows*)
-            os="windows"
+        Darwin*)
+            os="darwin"
             ;;
         Linux*)
             os="linux"
             ;;
-        *) 
-            error "Failed to recognise which operating system is in use. $raw_os"
+        *)
+            error "Unsupported operating system is in use. $raw_os"
             exit 1
     esac
 
     architecture=$(uname -m)
-    printf "${architecture}"
-    if [ $architecture == "x86_64" ]; then
-        architecture="amd64"
-    fi
+    case $architecture in
+        aarch64)
+            architecture="arm64"
+            ;;
+        amd64)
+            architecture="x86_64"
+    esac
+}
+
+function calculate_galasabld_executable {
+    h2 "Calculate the name of the galasabld executable for this machine/os"
+
+    get_architecture
 
     export GALASABLD=${BASEDIR}/bin/galasabld-${os}-${architecture}
     info "galasabld binary is ${GALASABLD}"

--- a/modules/obr/build-locally.sh
+++ b/modules/obr/build-locally.sh
@@ -172,30 +172,37 @@ log_file=${LOGS_DIR}/${project}.txt
 info "Log will be placed at ${log_file}"
 date > ${log_file}
 
-#------------------------------------------------------------------------------------
-function get_galasabld_binary_location {
-    # What's the architecture-variable name of the build tool we want for this local build ?
-    export ARCHITECTURE=$(uname -m) # arm64 or amd64
-    if [ $ARCHITECTURE == "x86_64" ]; then
-        export ARCHITECTURE="amd64"
-    fi
-
-    raw_os=$(uname -s) # eg: "Darwin"
+function get_architecture() {
+    h2 "Retrieving system architecture."
+        raw_os=$(uname -s) # eg: "Darwin"
     os=""
     case $raw_os in
         Darwin*)
             os="darwin"
             ;;
-        Windows*)
-            os="windows"
-            ;;
         Linux*)
             os="linux"
             ;;
         *)
-            error "Failed to recognise which operating system is in use. $raw_os"
+            error "Unsupported operating system is in use. $raw_os"
             exit 1
     esac
+
+    architecture=$(uname -m)
+    case $architecture in
+        aarch64)
+            architecture="arm64"
+            ;;
+        amd64)
+            architecture="x86_64"
+    esac
+}
+
+#------------------------------------------------------------------------------------
+function get_galasabld_binary_location {
+    # What's the architecture-variable name of the build tool we want for this local build ?
+    get_architecture
+    export ARCHITECTURE=${architecture}
     export GALASA_BUILD_TOOL_NAME=galasabld-${os}-${ARCHITECTURE}
 
     # Favour the galasabld tool if it's on the path, else use a locally-built version or fail if not available.


### PR DESCRIPTION
Running a docker container on a mac requires the galasabld tool to support the linux-arm64 architecture.