### PR TITLE
set-version.sh in OBR works cleanly now

### DIFF
--- a/modules/obr/dev.galasa.uber.obr/pom.template
+++ b/modules/obr/dev.galasa.uber.obr/pom.template
@@ -56,7 +56,7 @@
 			<dependency>
 				<groupId>dev.galasa</groupId>
 				<artifactId>dev.galasa.platform</artifactId>
-				<version>0.39.0</version>
+				<version>{{.Release}}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -78,7 +78,7 @@
 			<plugin>
 				<groupId>dev.galasa</groupId>
 				<artifactId>galasa-maven-plugin</artifactId>
-				<version>0.39.0</version>
+				<version>{{.Release}}</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/modules/obr/galasa-bom/pom.template
+++ b/modules/obr/galasa-bom/pom.template
@@ -59,7 +59,7 @@
 				<plugin>
 					<groupId>dev.galasa</groupId>
 					<artifactId>galasa-maven-plugin</artifactId>
-					<version>0.39.0</version>
+					<version>{{.Release}}</version>
 				</plugin>
             </plugins>
         </pluginManagement>

--- a/modules/obr/javadocs/pom.template
+++ b/modules/obr/javadocs/pom.template
@@ -28,7 +28,7 @@
 			<dependency>
 				<groupId>dev.galasa</groupId>
 				<artifactId>dev.galasa.platform</artifactId>
-				<version>0.39.0</version>
+				<version>{{.Release}}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/modules/obr/obr-generic/pom.template
+++ b/modules/obr/obr-generic/pom.template
@@ -19,7 +19,7 @@
 			<dependency>
 				<groupId>dev.galasa</groupId>
 				<artifactId>dev.galasa.platform</artifactId>
-				<version>0.39.0</version>
+				<version>{{.Release}}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/modules/obr/set-version.sh
+++ b/modules/obr/set-version.sh
@@ -170,6 +170,7 @@ function update_dependency_versions {
     success "Dependency versions updated OK."
 }
 
+
 temp_dir=$BASEDIR/temp/versions
 rm -fr $temp_dir
 mkdir -p $temp_dir
@@ -179,4 +180,3 @@ update_release_yaml ${BASEDIR}/release.yaml $temp_dir/release.yaml $temp_dir "^.
 update_release_yaml ${BASEDIR}/release.yaml $temp_dir/release.yaml $temp_dir "^.*artifact[:] dev[.]galasa[.]wrapping[.]httpclient-osgi.*$" "    "
 
 update_dependency_versions $temp_dir
-


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Part of [Infrastructure: Tool to update the release version dynamically wherever it is referenced. #2053](https://github.com/galasa-dev/projectmanagement/issues/2053)

To sort out the set-version.sh script for the OBR module.