### PR TITLE
Iss2082 - Build image for release process with OBR and a galasabld executable

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -246,7 +246,8 @@ jobs:
   # to deploy artifacts to the Sonatype staging repo.
   build-obr-galasabld-image:
     name: Build Docker image with OBR artifacts and galasabld executable
-    if: ${{ github.repository_owner == 'galasa-dev' && ( github.ref_name == 'release' || github.ref_name == 'prerelease' ) }}
+    # Skip for forks.
+    if: ${{ github.repository_owner == 'galasa-dev' }}
     needs: build-obr
     runs-on: ubuntu-latest
 

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -240,7 +240,43 @@ jobs:
       - name: Wait for OBR application health in ArgoCD
         run: |
           docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:obr-${{ env.BRANCH }} --health --server argocd.galasa.dev
-    
+
+  # For the release process build an image containing
+  # the OBR artifacts and a galasabld executable used
+  # to deploy artifacts to the Sonatype staging repo.
+  build-obr-galasabld-image:
+    name: Build Docker image with OBR artifacts and galasabld executable
+    if: ${{ github.repository_owner == 'galasa-dev' && ( github.ref_name == 'release' || github.ref_name == 'prerelease' ) }}
+    needs: build-obr
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download galasabld executables
+        id: download-galasabld
+        uses: actions/download-artifact@v4
+        with:
+          name: galasabld
+          path: modules/artifacts/galasabld
+
+      - name: Extract metadata for OBR artifacts and galasabld executable image
+        id: metadata-obr-galasabld
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/obr-with-galasabld-executable
+
+      - name: Build image with OBR artifacts and galasabld executable
+        id: build-obr-galasabld
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/artifacts/galasabld
+          file: modules/obr/dockerfiles/dockerfile.obrgalasabld
+          push: true
+          tags: ${{ steps.metadata-obr-galasabld.outputs.tags }}
+          labels: ${{ steps.metadata-obr-galasabld.outputs.labels }}
+          build-args: |
+            dockerRepository=${{ env.REGISTRY }}
+            tag=${{ env.BRANCH }}
+            platform=linux-amd64
 
   build-obr-javadocs:
     name: Build OBR javadocs using galasabld image and maven

--- a/modules/obr/dockerfiles/dockerfile.obrgalasabld
+++ b/modules/obr/dockerfiles/dockerfile.obrgalasabld
@@ -5,6 +5,6 @@ ARG tag
 FROM ${dockerRepository}/galasa-dev/obr-maven-artefacts:${tag}
 
 ARG platform
-COPY bin/galasabld-${platform} /bin/galasabld
+COPY galasabld-${platform} /bin/galasabld
 
 ENTRYPOINT ["/bin/galasabld"]

--- a/modules/obr/dockerfiles/dockerfile.obrgalasabld
+++ b/modules/obr/dockerfiles/dockerfile.obrgalasabld
@@ -1,9 +1,15 @@
+# During the release process, we need to be able to execute `galasabld`
+# commands from within an image that contains all the 'dev.galasa' artifacts.
+# This is not a hosted image - but it runs a pipeline which copies the
+# artifacts from the image's filesystem to a Sonatype staging repo over HTTP.
 ARG dockerRepository
 ARG tag
 
-# During a release, we need to be able to execute galasabld commands from inside the OBR image
+# 1. This Docker image contains all dev.galasa Maven artifacts from the
+# build of the Galasa repo within the '/usr/local/apache2/htdocs' directory.
 FROM ${dockerRepository}/galasa-dev/obr-maven-artefacts:${tag}
 
+# 2. The `galasabld` exectuable is installed here.
 ARG platform
 COPY galasabld-${platform} /bin/galasabld
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2082

As part of the release, to release the dev.galasa artifacts to the staging repo, we call a script -> which calls a Tekton pipeline -> which runs the `galasabld maven deploy tool`. To do this, we need the Docker image that runs in the pipeline to have two things installed: 1. all of the OBR artifacts and 2. the galasabld executable. This image should be built as part of the release process. Currently it's not and so it was built manually for the 0.38.0 release.