### PR TITLE
framework settings.gradle doesn't need a bundleVersion variable set.

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/settings.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = "dev.galasa.framework"
 
-bundleVersion = 0.39.0
+


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ? 

Part of [Infrastructure: Tool to update the release version dynamically wherever it is referenced. #2053](https://github.com/galasa-dev/projectmanagement/issues/2053)

Trying to reduce the number of literal versions we have in the code so it's easier to change versions in an automated manner.

I tried this without, and the bundle metadata appears to have the correct version set inside anyway, regardless of whether this version reference is there or not.

CLI local tests work with this change, and I think they would have failed if something major was wrong after this.
