### PR TITLE
set the version into the build workflows so the build logic knows which version it is building

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -7,6 +7,12 @@ name: OBR Main Build
 
 on:
   workflow_call:
+    inputs:
+      galasa-version:
+        # The version of Galasa we are building. eg:0.123.0
+        # Access this value using ${{inputs.galasa-version}}
+        type: string
+        required: true
 
 env:
   REGISTRY: ghcr.io
@@ -559,10 +565,12 @@ jobs:
         working-directory: modules/obr/obr-generic
         run: |
           set -o pipefail
+          # Note: using the maven plugin version ${{inputs.galasa-version}} which we should have
+          # downloaded in the maven artifacts.
           mvn -f pom.xml process-sources -X \
           -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
-          dev.galasa:galasa-maven-plugin:0.39.0:obrembedded \
+          dev.galasa:galasa-maven-plugin:${{inputs.galasa-version}}:obrembedded \
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
         

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -11,6 +11,21 @@ on:
 
 jobs:
 
+  set-build-properties:
+    # Use the version.properties file to source the galasa-version output variable.
+    # This variable can be referenced by other jobs in this flow using 
+    # ${{needs.set-build-properties.outputs.galasa-version}}
+    runs-on: ubuntu-latest
+    outputs:
+      galasa-version: ${{ steps.set-build-properties.outputs.GALASA_VERSION }}
+    steps:
+      - id: checkout-code
+        uses: actions/checkout@v4 
+
+      - id: set-build-properties
+        run: |
+          cat build.properties >> $GITHUB_OUTPUT
+
   detect-secrets:
     runs-on: ubuntu-latest 
     steps:
@@ -167,7 +182,7 @@ jobs:
 
   pr-build-obr:
     name: Build the 'obr' module
-    needs: [get-changed-modules, find-artifacts, pr-build-extensions, pr-build-managers]
+    needs: [get-changed-modules, find-artifacts, pr-build-extensions, pr-build-managers, set-build-properties]
     uses: ./.github/workflows/pr-obr.yaml
     secrets: inherit
     with:

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -167,7 +167,7 @@ jobs:
 
   pr-build-obr:
     name: Build the 'obr' module
-    needs: [get-changed-modules, find-artifacts, pr-build-extensions, pr-build-managers, set-build-properties]
+    needs: [get-changed-modules, find-artifacts, pr-build-extensions, pr-build-managers]
     uses: ./.github/workflows/pr-obr.yaml
     secrets: inherit
     with:

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - id: checkout-code
         uses: actions/checkout@v4 
+        with:
+          sparse-checkout: |
+            build.properties
+          sparse-checkout-cone-mode: false
 
       - id: set-build-properties
         run: |

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - id: set-build-properties
         run: |
-          cat build.properties >> $GITHUB_OUTPUT
+          cat build.properties | grep "=" >> $GITHUB_OUTPUT
 
   detect-secrets:
     runs-on: ubuntu-latest 

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -11,25 +11,6 @@ on:
 
 jobs:
 
-  set-build-properties:
-    # Use the version.properties file to source the galasa-version output variable.
-    # This variable can be referenced by other jobs in this flow using 
-    # ${{needs.set-build-properties.outputs.galasa-version}}
-    runs-on: ubuntu-latest
-    outputs:
-      galasa-version: ${{ steps.set-build-properties.outputs.GALASA_VERSION }}
-    steps:
-      - id: checkout-code
-        uses: actions/checkout@v4 
-        with:
-          sparse-checkout: |
-            build.properties
-          sparse-checkout-cone-mode: false
-
-      - id: set-build-properties
-        run: |
-          cat build.properties | grep "=" >> $GITHUB_OUTPUT
-
   detect-secrets:
     runs-on: ubuntu-latest 
     steps:

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   set-build-properties:
-    # Use the version.properties file to source the 'galasa-version' output variable.
+    # Use the version.properties file to source the galasa-version output variable.
     # This variable can be referenced by other jobs in this flow using 
     # ${{needs.set-build-properties.outputs.galasa-version}}
     runs-on: ubuntu-latest
@@ -21,6 +21,10 @@ jobs:
     steps:
       - id: checkout-code
         uses: actions/checkout@v4 
+        with:
+          sparse-checkout: |
+            build.properties
+          sparse-checkout-cone-mode: false
 
       - id: set-build-properties
         run: |

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -11,6 +11,21 @@ on:
 
 jobs:
 
+  set-build-properties:
+    # Use the version.properties file to source the 'galasa-version' output variable.
+    # This variable can be referenced by other jobs in this flow using 
+    # ${{needs.set-build-properties.outputs.galasa-version}}
+    runs-on: ubuntu-latest
+    outputs:
+      galasa-version: ${{ steps.set-build-properties.outputs.GALASA_VERSION }}
+    steps:
+      - id: checkout-code
+        uses: actions/checkout@v4 
+
+      - id: set-build-properties
+        run: |
+          cat build.properties >> $GITHUB_OUTPUT
+
   build-platform:
     name: Build the 'platform' module
     uses: ./.github/workflows/platform.yaml
@@ -59,6 +74,8 @@ jobs:
 
   build-obr:
     name: Build the 'obr' module
-    needs: [build-extensions, build-managers]
+    needs: [build-extensions, build-managers, set-build-properties ]
     uses: ./.github/workflows/obr.yaml
     secrets: inherit
+    with:
+      galasa-version: "${{needs.set-build-properties.outputs.galasa-version}}"

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - id: set-build-properties
         run: |
-          cat build.properties >> $GITHUB_OUTPUT
+          cat build.properties | grep "=" >> $GITHUB_OUTPUT
 
   build-platform:
     name: Build the 'platform' module

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - id: set-build-properties
         run: |
-          cat build.properties >> $GITHUB_OUTPUT
+          cat build.properties | grep "=" >> $GITHUB_OUTPUT
 
   build-platform:
     name: Build the 'platform' module

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -27,6 +27,21 @@ on:
 
 jobs:
 
+  set-build-properties:
+    # Use the version.properties file to source the 'galasa-version' output variable.
+    # This variable can be referenced by other jobs in this flow using 
+    # ${{needs.set-build-properties.outputs.galasa-version}}
+    runs-on: ubuntu-latest
+    outputs:
+      galasa-version: ${{ steps.set-build-properties.outputs.GALASA_VERSION }}
+    steps:
+      - id: checkout-code
+        uses: actions/checkout@v4 
+
+      - id: set-build-properties
+        run: |
+          cat build.properties >> $GITHUB_OUTPUT
+
   build-platform:
     name: Build the 'platform' module
     uses: ./.github/workflows/platform.yaml
@@ -93,6 +108,8 @@ jobs:
 
   build-obr:
     name: Build the 'obr' module
-    needs: [build-extensions, build-managers]
+    needs: [build-extensions, build-managers, set-build-properties]
     uses: ./.github/workflows/obr.yaml
     secrets: inherit
+    with:
+      galasa-version: "${{needs.set-build-properties.outputs.galasa-version}}"

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
 
   set-build-properties:
-    # Use the version.properties file to source the 'galasa-version' output variable.
+    # Use the version.properties file to source the galasa-version output variable.
     # This variable can be referenced by other jobs in this flow using 
     # ${{needs.set-build-properties.outputs.galasa-version}}
     runs-on: ubuntu-latest
@@ -37,6 +37,10 @@ jobs:
     steps:
       - id: checkout-code
         uses: actions/checkout@v4 
+        with:
+          sparse-checkout: |
+            build.properties
+          sparse-checkout-cone-mode: false
 
       - id: set-build-properties
         run: |

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,3 @@
+# This file is used to source the version of artifacts created by the github build workflows.
+# It gets maintained by the set-version.sh script, so don't change it manually without using that script.
+GALASA_VERSION=0.39.0

--- a/tools/set-version.sh
+++ b/tools/set-version.sh
@@ -128,7 +128,7 @@ function set_version_in_readme() {
 function set_version_in_build_properties() {
     h2 "Setting the version number in the build.properties"
     mkdir -p ${REPO_ROOT_DIR}/temp
-    cat ${REPO_ROOT_DIR}/build.properties | sed "s/^GALASA_VERSION=.*$/GALASA_VERSION ${component_version}/g" > ${REPO_ROOT_DIR}/temp/build.properties
+    cat ${REPO_ROOT_DIR}/build.properties | sed "s/^GALASA_VERSION=.*$/GALASA_VERSION=${component_version}/g" > ${REPO_ROOT_DIR}/temp/build.properties
     cp ${REPO_ROOT_DIR}/temp/build.properties ${REPO_ROOT_DIR}/build.properties
     success "set version in build.properties file OK"
 }

--- a/tools/set-version.sh
+++ b/tools/set-version.sh
@@ -117,8 +117,28 @@ function set_version_in_all_modules() {
     success "OK - All modules have had their versions set to $component_version"
 }
 
+function set_version_in_readme() {
+    h2 "Setting the version number in the README.md"
+    mkdir -p ${REPO_ROOT_DIR}/temp
+    cat ${REPO_ROOT_DIR}/README.md | sed "s/\`set-version.sh --version .*\`/\`set-version.sh --version ${component_version}\`/g" > ${REPO_ROOT_DIR}/temp/readme.md
+    cp ${REPO_ROOT_DIR}/temp/readme.md ${REPO_ROOT_DIR}/README.md
+    success "set version in README.md OK"
+}
+
+function set_version_in_build_properties() {
+    h2 "Setting the version number in the build.properties"
+    mkdir -p ${REPO_ROOT_DIR}/temp
+    cat ${REPO_ROOT_DIR}/build.properties | sed "s/^GALASA_VERSION=.*$/GALASA_VERSION ${component_version}/g" > ${REPO_ROOT_DIR}/temp/build.properties
+    cp ${REPO_ROOT_DIR}/temp/build.properties ${REPO_ROOT_DIR}/build.properties
+    success "set version in build.properties file OK"
+}
+
 h1 "Setting version of this repository to $component_version"
 set_version_in_all_modules
 check_for_error "Failed to set version in all modules"
+
+set_version_in_readme
+set_version_in_build_properties
+
 success "OK"
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Part of this story: https://github.com/galasa-dev/projectmanagement/issues/2053

- Version master sits in the `/build.properties` file where GALASA_VERSION is set.
- The workflows ~~all~~ which need it go get this file (using sparse checkout), and convert the value into the `galasa-version` variable
- This can then be passed down into sub-flows
- The set-version.sh script sets the version into the `/build.properties` file.