### PR TITLE
Iss2084 - Add CLI dependencies to the Platform

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -74,6 +74,7 @@ dependencies {
         api 'dev.galasa:dev.galasa:'+version
         api 'dev.galasa:dev.galasa.framework:'+version
         api 'dev.galasa:dev.galasa.framework.api.beans:'+version
+        api 'dev.galasa:dev.galasa.framework.api.openapi:'+version
         api 'dev.galasa:dev.galasa.platform:'+version
         api 'dev.galasa:dev.galasa.plugin.common:'+version
         api 'dev.galasa:dev.galasa.plugin.common.impl:'+version
@@ -88,6 +89,7 @@ dependencies {
         api 'dev.galasa:dev.galasa.wrapping.kafka.clients:'+version
         api 'dev.galasa:dev.galasa.wrapping.protobuf-java:'+version
         api 'dev.galasa:dev.galasa.wrapping.velocity-engine-core:'+version
+        api 'dev.galasa:galasa-boot:'+version
         api 'dev.galasa:galasa-testharness:0.18.0'
 
         api 'io.etcd:jetcd-api:0.8.3'
@@ -240,6 +242,8 @@ dependencies {
 
         api 'org.mockito:mockito-core:3.1.0'
         api 'org.mockito:mockito-junit-jupiter:5.3.1'
+
+        api 'org.openapitools:openapi-generator-cli:6.6.0'
 
         api 'org.osgi:org.osgi.core:6.0.0'
         api 'org.osgi:org.osgi.service.cm:1.6.0'


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2084

Add dependencies used by the CLI into the Platform so the CLI can get versions from here.