### PR TITLE
more things either avoiding having a version in, or it being set by the script.

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     testImplementation(testFixtures(project(':dev.galasa.extensions.common')))
 
-    testFixturesImplementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    testFixturesImplementation platform('dev.galasa:dev.galasa.platform:'+version)
     testFixturesImplementation(testFixtures(project(':dev.galasa.extensions.common')))
 
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.httpclient-osgi'

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation ('org.apache.httpcomponents:httpcore-osgi')
     implementation ('com.google.code.gson:gson')
 
-    testFixturesImplementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    testFixturesImplementation platform('dev.galasa:dev.galasa.platform:'+version)
 
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.httpclient-osgi'
     testFixturesImplementation 'org.apache.httpcomponents:httpcore-osgi'

--- a/modules/extensions/set-version.sh
+++ b/modules/extensions/set-version.sh
@@ -140,3 +140,13 @@ cp $temp_dir/release.yaml $BASEDIR/release.yaml
 # There is a bundle in the extensions which needs a bump also.
 cat $BASEDIR/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle | sed "s/dev.galasa:dev.galasa:.*'/dev.galasa:dev.galasa:$component_version'/1" > $temp_dir/galasa.extensions.gradle
 cp $temp_dir/galasa.extensions.gradle $BASEDIR/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
+
+
+# The platform in the extensions gradle plugin src needs setting.
+cat $BASEDIR/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle | sed "s/'dev[.]galasa[:]dev[.]galasa[.]platform[:].*'/'dev.galasa:dev.galasa.platform:$component_version'/1" > $temp_dir/galasa.extensions.gradle
+cp $temp_dir/galasa.extensions.gradle $BASEDIR/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
+
+
+# The top-level build.gradle has this: id 'dev.galasa.githash' version '$version' apply false
+cat $BASEDIR/galasa-extensions-parent/build.gradle | sed  "s/id 'dev[.]galasa[.]githash' version '.*'/id 'dev.galasa.githash' version '$component_version'/1" > $temp_dir/top-build.gradle
+cp $temp_dir/top-build.gradle $BASEDIR/galasa-extensions-parent/build.gradle

--- a/modules/framework/galasa-parent/build.gradle
+++ b/modules/framework/galasa-parent/build.gradle
@@ -31,7 +31,7 @@ tasks.withType(Sign) {
 dependencies {
     // We need the swagger generator to generate API documentation from the openapi.yaml file
     // https://mvnrepository.com/artifact/io.swagger.codegen.v3/swagger-codegen-cli
-    compileOnly platform('dev.galasa:dev.galasa.platform:0.39.0')
+    compileOnly platform('dev.galasa:dev.galasa.platform:'+version)
     compileOnly 'io.swagger.codegen.v3:swagger-codegen-cli'
 }
 

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.api.server.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.api.server.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    implementation platform('dev.galasa:dev.galasa.platform:'+version)
 
     implementation 'javax.servlet:javax.servlet-api'
     implementation 'org.osgi:org.osgi.core'

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    implementation platform('dev.galasa:dev.galasa.platform:'+version)
 
     implementation 'commons-logging:commons-logging'
     implementation 'org.osgi:org.osgi.core'

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':dev.galasa.framework.api.beans')
     implementation 'dev.galasa:dev.galasa.wrapping.com.auth0.jwt'
 
-    testFixturesImplementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    testFixturesImplementation platform('dev.galasa:dev.galasa.platform:'+version)
     testFixturesImplementation 'javax.servlet:javax.servlet-api'
     testFixturesImplementation 'org.assertj:assertj-core:3.16.1'
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.gson'

--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     testImplementation(testFixtures(project(':dev.galasa.framework.api.common')))
 
-    testFixturesImplementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    testFixturesImplementation platform('dev.galasa:dev.galasa.platform:'+version)
     testFixturesImplementation 'javax.servlet:javax.servlet-api'
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
     testFixturesImplementation 'org.assertj:assertj-core:3.16.1'

--- a/modules/framework/set-version.sh
+++ b/modules/framework/set-version.sh
@@ -175,3 +175,7 @@ cp $temp_dir/galasa.api.server.gradle ${BASEDIR}/galasa-parent/buildSrc/src/main
 
 cat ${BASEDIR}/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle | sed "s/   implementation platform('dev[.]galasa[:]dev[.]galasa[.]platform[:].*')/   implementation platform('dev.galasa:dev.galasa.platform:$component_version')/1" > $temp_dir/galasa.framework.gradle
 cp  $temp_dir/galasa.framework.gradle ${BASEDIR}/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle
+
+# The top-level build.gradle has this: id 'dev.galasa.githash' version '$version' apply false
+cat $BASEDIR/galasa-parent/build.gradle | sed  "s/id 'dev[.]galasa[.]githash' version '.*'/id 'dev.galasa.githash' version '$component_version'/1" > $temp_dir/top-build.gradle
+cp $temp_dir/top-build.gradle $BASEDIR/galasa-parent/build.gradle

--- a/modules/framework/set-version.sh
+++ b/modules/framework/set-version.sh
@@ -154,7 +154,7 @@ cp $temp_dir/release.yaml ${BASEDIR}/release.yaml
 
 
 ## Update the openapi file
-cat ${BASEDIR}/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml | sed "s/^[ ]*version[ ]*:.*/  version : \"$component_version\"/1" > $temp_dir/openapi.yaml
+cat ${BASEDIR}/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml | sed "s/^[ ]*version[ ]*[:].*/  version : \"$component_version\"/1" > $temp_dir/openapi.yaml
 cp $temp_dir/openapi.yaml ${BASEDIR}/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
 
 ## and the openapi bundle
@@ -168,3 +168,10 @@ cp $temp_dir/release.yaml ${BASEDIR}/release.yaml
 
 cat ${BASEDIR}/test-api-locally.md | sed "s/^[ ]*export[ ]+GALASA_OBR_VERSION[ ]*=[ ]*.*$/export GALASA_OBR_VERSION=\"$component_version\"/1" > $temp_dir/test-api-locally.md 
 cp $temp_dir/test-api-locally.md  ${BASEDIR}/test-api-locally.md 
+
+cat ${BASEDIR}/galasa-parent/buildSrc/src/main/groovy/galasa.api.server.gradle | sed "s/    implementation platform('dev[.]galasa[:]dev[.]galasa[.]platform[:].*')/    implementation platform('dev.galasa:dev.galasa.platform:$component_version')/1" > $temp_dir/galasa.api.server.gradle
+cp $temp_dir/galasa.api.server.gradle ${BASEDIR}/galasa-parent/buildSrc/src/main/groovy/galasa.api.server.gradle
+
+
+cat ${BASEDIR}/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle | sed "s/   implementation platform('dev[.]galasa[:]dev[.]galasa[.]platform[:].*')/   implementation platform('dev.galasa:dev.galasa.platform:$component_version')/1" > $temp_dir/galasa.framework.gradle
+cp  $temp_dir/galasa.framework.gradle ${BASEDIR}/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle

--- a/modules/gradle/dev.galasa.gradle.impl/build.gradle
+++ b/modules/gradle/dev.galasa.gradle.impl/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    implementation platform('dev.galasa:dev.galasa.platform:'+version)
     implementation 'org.apache.felix:org.apache.felix.bundlerepository'
     implementation 'org.reflections:reflections'
     implementation 'com.google.code.gson:gson'

--- a/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    implementation platform('dev.galasa:dev.galasa.platform:'+version)
     implementation 'com.google.code.gson:gson'
     implementation 'commons-codec:commons-codec'
 	implementation 'commons-io:commons-io'

--- a/modules/gradle/dev.galasa.plugin.common.test/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.test/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    implementation platform('dev.galasa:dev.galasa.platform:'+version)
     implementation 'junit:junit'
     implementation 'com.google.code.gson:gson'
     implementation 'commons-codec:commons-codec'

--- a/modules/gradle/dev.galasa.plugin.common/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    implementation platform('dev.galasa:dev.galasa.platform:'+version)
     implementation 'com.google.code.gson:gson'
     implementation 'org.apache.httpcomponents:httpcore'
     implementation 'org.apache.httpcomponents:httpclient'

--- a/modules/gradle/set-version.sh
+++ b/modules/gradle/set-version.sh
@@ -111,7 +111,10 @@ function upgrade_build_gradle {
     # of the this component lives.
     # For example: version = "0.29.0"
     
-    cat $source_path | sed "s/version[ ]*=.*/version = \"$component_version\"/1" > $temp_dir/build.gradle
+    cat $source_path \
+    | sed "s/version[ ]*=.*/version = \"$component_version\"/1" > $temp_dir/build.gradle \
+    | sed "s/'dev[.]galasa[.]githash' version '.*'/'dev.galasa.githash' version '$component_version'/1" \
+    > $temp_dir/build.gradle
     rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to replace master version in file $source_path" ; exit 1 ; fi
 
     cp $temp_dir/build.gradle $source_path
@@ -120,4 +123,21 @@ function upgrade_build_gradle {
     success "Upgraded build.gradle file OK."
 }
 
+
+function upgrade_readme {
+
+    h2 "upgrading the readme for gradle module"
+
+    cat $BASEDIR/README.md \
+    | sed "s/id 'dev[.]galasa[.]tests' version '.*'/id 'dev.galasa.tests' version '$component_version'/1" \
+    | sed "s/id 'dev[.]galasa[.]obr' version '.*'/id 'dev.galasa.obr' version '$component_version'/1" \
+    | sed "s/id 'dev[.]galasa[.]testcatalog' version '.*'/id 'dev.galasa.testcatalog' version '$component_version'/1" \
+    > $temp_dir/README.md
+    cp $temp_dir/README.md $BASEDIR/README.md
+
+    success "gradle module upgraded OK."
+}
+
 upgrade_build_gradle
+
+upgrade_readme

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.ivt.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.ivt.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    implementation platform('dev.galasa:dev.galasa.platform:'+version)
 
     implementation 'dev.galasa:dev.galasa'
     

--- a/modules/managers/set-version.sh
+++ b/modules/managers/set-version.sh
@@ -146,5 +146,25 @@ function upgrade_build_gradle {
     success "Upgraded build.gradle file OK."
 }
 
+function upgrade_manager_gradle_plugin() {
+    h2 "Upgrading the gradle manager plugin in the managers module"
+
+    cat $BASEDIR/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle \
+    | sed "s/'dev[.]galasa[:]dev[.]galasa[.]platform:.*'/'dev.galasa:dev.galasa.platform:$component_version'/g" \
+    > $temp_dir/manager-gradle-plugin
+    cp $temp_dir/manager-gradle-plugin $BASEDIR/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
+    success "OK"
+}
+
+function upgrade_kube_manager_ivt_readme() {
+    cat $BASEDIR/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager.ivt/README.md \
+    | sed "s/mvn[:]dev[.]galasa\/dev[.]galasa[.]uber[.]obr\/.*\/obr/mvn:dev.galasa\/dev.galasa.uber.obr\/$component_version\/obr/g" \
+    > $temp_dir/manager-gradle-plugin
+    cp $temp_dir/manager-gradle-plugin $BASEDIR/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager.ivt/README.md
+    success "OK"
+}
+
 upgrade_build_gradle
 upgrade_dependencies_on_framework
+upgrade_manager_gradle_plugin
+upgrade_kube_manager_ivt_readme

--- a/modules/maven/set-version.sh
+++ b/modules/maven/set-version.sh
@@ -160,4 +160,5 @@ mvn versions:set -DnewVersion=$component_version
 mvn versions:commit
 
 replace_line_following ${BASEDIR}/galasa-maven-plugin/pom.xml ${BASEDIR}/galasa-maven-plugin/pom.xml $temp_dir "^.*dev.galasa.plugin.common.*$" "version" "				<version>$component_version</version>"
+replace_line_following ${BASEDIR}/galasa-maven-plugin/pom.xml ${BASEDIR}/galasa-maven-plugin/pom.xml $temp_dir "^.*dev.galasa.platform.*$" "version" "				<version>$component_version</version>"
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Part of this story: https://github.com/galasa-dev/projectmanagement/issues/2053

- Some imports of the platform can be variablised if they are not in a gradle plugin in bldsrc
- Some versions are set by the set-version.sh script