### PR TITLE
Fix broken job in OBR main workflow

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -252,6 +252,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            modules/obr
+
       - name: Download galasabld executables
         id: download-galasabld
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Why?

Noticed a build failure [here](https://github.com/galasa-dev/galasa/actions/runs/12281409979/job/34271262205) because the job was missing the checkout-code action, so it couldn't find the Dockerfile. Sparse checkout so it only checks out the code it needs.