### PR TITLE
Add authentication to GHCR into OBR workflow new job

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -696,7 +696,7 @@ jobs:
 
   trigger-next-workflows:
     name: Trigger next workflows in the build chain
-    needs: [build-obr, build-obr-generic, build-obr-javadocs]
+    needs: [build-obr, build-obr-generic, build-obr-javadocs, build-obr-galasabld-image]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -265,6 +265,13 @@ jobs:
           name: galasabld
           path: modules/artifacts/galasabld
 
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+
       - name: Extract metadata for OBR artifacts and galasabld executable image
         id: metadata-obr-galasabld
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7


### PR DESCRIPTION
## Why?

From build failure https://github.com/galasa-dev/galasa/actions/runs/12282232008/job/34274037660 realised the authentication to GHCR step had not been added into the new job.