### PR TITLE
Only delete run document after all referenced documents are deleted

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStore.java
@@ -415,7 +415,7 @@ public class TestCouchdbAuthStore {
         assertThat(thrown).isNotNull();
         assertThat(thrown.getMessage()).contains("GAL6104E",
                 "Failed to delete auth token from the CouchDB tokens database");
-        assertThat(thrown.getMessage()).contains("GAL6007E", "Expected status code(s) [200, 202] but received 500");
+        assertThat(thrown.getMessage()).contains("GAL6007E", "Expected status code(s) [200, 202, 404] but received 500");
     }
 
     @Test

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/src/main/java/dev/galasa/extensions/common/couchdb/CouchdbStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/src/main/java/dev/galasa/extensions/common/couchdb/CouchdbStore.java
@@ -139,20 +139,31 @@ public abstract class CouchdbStore {
      * sending a
      * GET /{db}/{docid} request to the CouchDB server.
      *
-     * @param <T>           The object type to be returned
-     * @param dbName        the name of the database to retrieve the document from
-     * @param documentId    the CouchDB ID for the document to retrieve
-     * @param classOfObject the class of the JSON object to retrieve from the
-     *                      CouchDB Document
+     * @param <T>                 the object type to be returned
+     * @param dbName              the name of the database to retrieve the document from
+     * @param documentId          the CouchDB ID for the document to retrieve
+     * @param classOfObject       the class of the JSON object to retrieve from the
+     *                            CouchDB Document
+     * @param expectedStatusCodes the HTTP response codes to be accepted, defaults to only accept 200 if not supplied
      * @return an object of the class provided in classOfObject
      * @throws CouchdbException if there was a problem accessing the CouchDB store
      *                          or its response
      */
-    public <T> T getDocumentFromDatabase(String dbName, String documentId, Class<T> classOfObject)
+    public <T> T getDocumentFromDatabase(String dbName, String documentId, Class<T> classOfObject, int... expectedStatusCodes)
             throws CouchdbException {
+        T response = null;
         HttpGet getDocumentRequest = httpRequestFactory.getHttpGetRequest(storeUri + "/" + dbName + "/" + documentId);
 
-        return gson.fromJson(sendHttpRequest(getDocumentRequest, HttpStatus.SC_OK), classOfObject);
+        // If no expected status codes were supplied, assume a 200 response is expected
+        if (expectedStatusCodes == null || expectedStatusCodes.length == 0) {
+            expectedStatusCodes = new int[] { HttpStatus.SC_OK };
+        }
+
+        String responseEntity = sendHttpRequest(getDocumentRequest, expectedStatusCodes);
+        if (responseEntity != null) {
+            response = gson.fromJson(responseEntity, classOfObject);
+        }
+        return response;
     }
 
     public ViewResponse getDocumentsFromDatabaseViewByKey(String dbName, String viewName, String queryKey, boolean includeDocs)
@@ -237,7 +248,7 @@ public abstract class CouchdbStore {
             URIBuilder builder = new URIBuilder(deleteRequestUrl);
             builder.addParameter("rev", documentRevision);
             HttpDelete deleteDocumentRequest = httpRequestFactory.getHttpDeleteRequest(builder.toString());
-            sendHttpRequest(deleteDocumentRequest, HttpStatus.SC_OK, HttpStatus.SC_ACCEPTED);
+            sendHttpRequest(deleteDocumentRequest, HttpStatus.SC_OK, HttpStatus.SC_ACCEPTED, HttpStatus.SC_NOT_FOUND);
         } catch (URISyntaxException e) {
             String errorMessage = ERROR_URI_IS_INVALID.getMessage(deleteRequestUrl);
             throw new CouchdbException(errorMessage, e);
@@ -251,13 +262,13 @@ public abstract class CouchdbStore {
      * @param httpRequest             the HTTP request to send to the CouchDB server
      * @param expectedHttpStatusCodes the expected Status code to get from the
      *                                CouchDb server upon the request being actioned
-     * @return a string representation of the response.
+     * @return a string representation of the response, or null if the requested value was not found.
      * @throws CouchdbException if there was a problem accessing the CouchDB store
      *                          or its response
      */
     protected String sendHttpRequest(HttpUriRequest httpRequest, int... expectedHttpStatusCodes)
             throws CouchdbException {
-        String responseEntity = "";
+        String responseEntity = null;
         try (CloseableHttpResponse response = httpClient.execute(httpRequest)) {
             StatusLine statusLine = response.getStatusLine();
             int actualStatusCode = statusLine.getStatusCode();
@@ -272,8 +283,13 @@ public abstract class CouchdbStore {
                 throw new CouchdbException(errorMessage);
             }
 
+            // If we're expecting a 404 not found response, return null
             HttpEntity entity = response.getEntity();
-            responseEntity = EntityUtils.toString(entity);
+            if (actualStatusCode != HttpStatus.SC_NOT_FOUND) {
+                responseEntity = EntityUtils.toString(entity);
+            } else {
+                EntityUtils.consumeQuietly(entity);
+            }
 
         } catch (ParseException | IOException e) {
             String errorMessage = ERROR_FAILURE_OCCURRED_WHEN_CONTACTING_COUCHDB

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/operations/CouchdbDeleteRunServiceTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/operations/CouchdbDeleteRunServiceTest.java
@@ -212,4 +212,105 @@ public class CouchdbDeleteRunServiceTest extends BaseCouchdbOperationTest {
             runId
         );
     }
+
+    @Test
+    public void testDiscardRunWithFailedArtifactDeletionDoesNotDeleteRunDocumentOk() throws Exception {
+        // Given...
+        String runId = "ABC123";
+        TestStructureCouchdb mockRun1 = createRunTestStructure(runId, "run1");
+
+        IdRev mockIdRev = new IdRev();
+        String revision = "this-is-a-revision";
+        mockIdRev._id = "this-is-an-id";
+        mockIdRev._rev = revision;
+
+        String artifactId1 = "artifact1";
+        List<String> mockArtifactIds = List.of(artifactId1);
+
+        mockRun1.setArtifactRecordIds(mockArtifactIds);
+
+        String baseUri = "http://my.uri";
+        String artifactsDbUri = baseUri + "/" + CouchdbRasStore.ARTIFACTS_DB;
+        List<HttpInteraction> interactions = List.of(                        
+            // Start discarding the run's artifact records
+            new GetDocumentByIdFromCouchdbInteraction(artifactsDbUri + "/" + artifactId1, HttpStatus.SC_OK, mockIdRev),
+            new DeleteDocumentFromCouchdbInteraction(artifactsDbUri + "/" + artifactId1 + "?rev=" + revision, HttpStatus.SC_INTERNAL_SERVER_ERROR)
+
+            // The parent run document should not be deleted if any of its referenced artifacts were not deleted,
+            // so don't include an interaction to delete the run document here
+        );
+
+        MockLogFactory mockLogFactory = new MockLogFactory();
+        MockAsyncCloseableHttpClient httpClient = new MockAsyncCloseableHttpClient(interactions);
+        CouchdbRasStore mockRasStore = fixtures.createCouchdbRasStore(mockLogFactory, httpClient);
+        CouchdbDeleteRunService deleteRunOperation = new CouchdbDeleteRunService(mockRasStore);
+
+        // When...
+        ResultArchiveStoreException thrown = catchThrowableOfType(() -> {
+            deleteRunOperation.discardRun(mockRun1);
+        }, ResultArchiveStoreException.class);
+
+        // Then...
+        // The assertions in the interactions should not have failed
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("Failed to discard run", runId);
+        assertThat(thrown.getCause().getMessage()).contains(
+            "GAL6007E",
+            "Internal server error",
+            "Unexpected response received from CouchDB server"
+        );
+    }
+
+    @Test
+    public void testDiscardRunWithNotFoundDocumentsContinuesToDeleteRunOk() throws Exception {
+        // Given...
+        String runId = "ABC123";
+        TestStructureCouchdb mockRun1 = createRunTestStructure(runId, "run1");
+
+        IdRev mockIdRev = new IdRev();
+        String revision = "this-is-a-revision";
+        mockIdRev._id = "this-is-an-id";
+        mockIdRev._rev = revision;
+
+        String artifactId1 = "artifact1";
+        String artifactId2 = "artifact2";
+        List<String> mockArtifactIds = List.of(artifactId1, artifactId2);
+
+        String logId1 = "log1"; 
+        String logId2 = "log2"; 
+        List<String> mockLogRecordIds = List.of(logId1, logId2);
+
+        mockRun1.setArtifactRecordIds(mockArtifactIds);
+        mockRun1.setLogRecordIds(mockLogRecordIds);
+
+        String baseUri = "http://my.uri";
+        String runDbUri = baseUri + "/" + CouchdbRasStore.RUNS_DB + "/" + runId;
+        String artifactsDbUri = baseUri + "/" + CouchdbRasStore.ARTIFACTS_DB;
+        String logsDbUri = baseUri + "/" + CouchdbRasStore.LOG_DB;
+        List<HttpInteraction> interactions = List.of(            
+            // Start discarding the run's log records
+            new GetDocumentByIdFromCouchdbInteraction(logsDbUri + "/" + logId1, HttpStatus.SC_NOT_FOUND, mockIdRev),
+            new GetDocumentByIdFromCouchdbInteraction(logsDbUri + "/" + logId2, HttpStatus.SC_OK, mockIdRev),
+            new DeleteDocumentFromCouchdbInteraction(logsDbUri + "/" + logId2 + "?rev=" + revision, HttpStatus.SC_OK),
+            
+            // Start discarding the run's artifact records
+            new GetDocumentByIdFromCouchdbInteraction(artifactsDbUri + "/" + artifactId1, HttpStatus.SC_OK, mockIdRev),
+            new DeleteDocumentFromCouchdbInteraction(artifactsDbUri + "/" + artifactId1 + "?rev=" + revision, HttpStatus.SC_OK),
+            new GetDocumentByIdFromCouchdbInteraction(artifactsDbUri + "/" + artifactId2, HttpStatus.SC_NOT_FOUND, mockIdRev),
+
+            // Delete the record of the run
+            new DeleteDocumentFromCouchdbInteraction(runDbUri + "?rev=" + mockRun1._rev, HttpStatus.SC_OK)
+        );
+
+        MockLogFactory mockLogFactory = new MockLogFactory();
+        MockAsyncCloseableHttpClient httpClient = new MockAsyncCloseableHttpClient(interactions);
+        CouchdbRasStore mockRasStore = fixtures.createCouchdbRasStore(mockLogFactory, httpClient);
+        CouchdbDeleteRunService deleteRunOperation = new CouchdbDeleteRunService(mockRasStore);
+
+        // When...
+        deleteRunOperation.discardRun(mockRun1);
+
+        // Then...
+        // The assertions in the interactions should not have failed
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ResponseBuilder.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ResponseBuilder.java
@@ -96,7 +96,7 @@ public class ResponseBuilder {
     private String validateRequestOrigin(HttpServletRequest req) {
         String requestOrigin = req.getHeader(ORIGIN_HEADER);
         if (requestOrigin == null || !isOriginAllowed(requestOrigin)) {
-            logger.error("Request origin is not set or is not permitted to receive responses");
+            logger.info("Request origin is not set or is not permitted to receive responses");
             requestOrigin = null;
         }
         return requestOrigin;


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/galasa/pull/108

With the async requests, deleting runs currently deletes the parent run document at the same time as it deletes referenced artifact and log documents. If the deletion of a document fails (e.g. couchdb or the API server goes down) and the parent run document has already been deleted, it may cause some artifact documents to be orphaned.

## Changes
- Make sure that the parent run document is only deleted **after** all referenced artifact and log documents have been deleted
- Ignore 404 Not Found errors when deleting documents since we should only error out if any server errors occur
- Change request origin not set log message from error to info since it doesn't actually represent an error