### PR TITLE
Add servlet filter for rate limiting API server requests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,6 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-12-13T15:57:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,6 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
+  "generated_at": "2024-12-13T15:57:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -785,7 +786,7 @@
         "hashed_secret": "a5c1ad5f1dc7d24152e39cb14dfa99775fa1884d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 143,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/modules/framework/dev-instructions.md
+++ b/modules/framework/dev-instructions.md
@@ -262,6 +262,12 @@ function setup_galasa_dev() {
   # The GALASA_DEX_GRPC_HOSTNAME environment variable must match the "addr" value
   # within the "grpc" section in your local Dex server's configuration 
   export GALASA_DEX_GRPC_HOSTNAME="127.0.0.1:5557"
+
+  export GALASA_GLOBAL_REQUEST_CAPACITY=10000
+  export GALASA_GLOBAL_RATE_LIMIT=10000
+
+  export GALASA_IP_REQUEST_CAPACITY=5000
+  export GALASA_IP_RATE_LIMIT=5000
 }
 
 setup_galasa_dev

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/EnvironmentVariables.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/EnvironmentVariables.java
@@ -35,7 +35,6 @@ public class EnvironmentVariables {
      */
     public static final String GALASA_ALLOWED_ORIGINS = "GALASA_ALLOWED_ORIGINS";
 
-
     /**
      * Represents the maximum number of requests that can be sent to the API server after a refreshed rate limit
      */

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/EnvironmentVariables.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/EnvironmentVariables.java
@@ -34,4 +34,25 @@ public class EnvironmentVariables {
      * A comma-separated list of allowed origins that the API server is permitted to respond to.
      */
     public static final String GALASA_ALLOWED_ORIGINS = "GALASA_ALLOWED_ORIGINS";
+
+
+    /**
+     * Represents the maximum number of requests that can be sent to the API server after a refreshed rate limit
+     */
+    public static final String GALASA_GLOBAL_REQUEST_CAPACITY = "GALASA_GLOBAL_REQUEST_CAPACITY";
+
+    /**
+     * Represents the rate at which requests can be sent to the API server over time
+     */
+    public static final String GALASA_GLOBAL_RATE_LIMIT = "GALASA_GLOBAL_RATE_LIMIT";
+
+    /**
+     * Represents the maximum number of requests that can be sent to the API server after a refreshed rate limit per IP address
+     */
+    public static final String GALASA_IP_REQUEST_CAPACITY = "GALASA_IP_REQUEST_CAPACITY";
+
+    /**
+     * Represents the rate at which requests can be sent to the API server over time per IP address
+     */
+    public static final String GALASA_IP_RATE_LIMIT = "GALASA_IP_RATE_LIMIT";
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -46,8 +46,9 @@ public enum ServletErrorMessage {
     GAL5401_UNAUTHORIZED                              (5401,"E: Unauthorized. Please ensure you have provided a valid 'Authorization' header with a valid bearer token and try again."),
     GAL5404_UNRESOLVED_ENDPOINT_ERROR                 (5404,"E: Error occurred when trying to identify the endpoint ''{0}''. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."),
     GAL5405_METHOD_NOT_ALLOWED                        (5405,"E: Error occurred when trying to access the endpoint ''{0}''. The method ''{1}'' is not allowed."),
-    GAL5406_UNSUPPORTED_CONTENT_TYPE_REQUESTED        (5406, "E: Unsupported ''Accept'' header value set. Supported response types are: [{0}]. Ensure the ''Accept'' header in your request contains a valid value and try again"),
+    GAL5406_UNSUPPORTED_CONTENT_TYPE_REQUESTED        (5406,"E: Unsupported ''Accept'' header value set. Supported response types are: [{0}]. Ensure the ''Accept'' header in your request contains a valid value and try again"),
     GAL5411_NO_REQUEST_BODY                           (5411,"E: Error occurred when trying to access the endpoint ''{0}''. The request body is empty."),
+    GAL5429_TOO_MANY_REQUESTS                         (5429,"E: Rate limit exceeded. The Galasa API server may be experiencing heavy load at the moment or too many requests have been sent in a short amount of time. Try again later."),
 
     //CPS Namespaces...
     GAL5015_INTERNAL_CPS_ERROR                        (5015,"E: Error occurred when trying to access the Configuration Property Store. Report the problem to your Galasa Ecosystem owner."),

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockHttpServletRequest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockHttpServletRequest.java
@@ -41,6 +41,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
     private String method = "GET"; 
     private String contextPath = "/api";
     private String contentType = "application/json";
+    private String clientIpAddress;
 
     private MockHttpSession session;
 
@@ -88,6 +89,15 @@ public class MockHttpServletRequest implements HttpServletRequest {
     public MockHttpServletRequest(String pathInfo, String content, String method, Map<String, String> headerMap) {
         this(pathInfo,content,method);
         this.headerMap = headerMap;
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        return this.clientIpAddress;
+    }
+
+    public void setRemoteAddr(String newAddress) {
+        clientIpAddress = newAddress;
     }
 
     @Override
@@ -246,11 +256,6 @@ public class MockHttpServletRequest implements HttpServletRequest {
     @Override
     public int getServerPort() {
         throw new UnsupportedOperationException("Unimplemented method 'getServerPort'");
-    }
-
-    @Override
-    public String getRemoteAddr() {
-        throw new UnsupportedOperationException("Unimplemented method 'getRemoteAddr'");
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/build.gradle
@@ -7,10 +7,12 @@ description = 'Framework API'
 
 dependencies {
     implementation project(':dev.galasa.framework')
+    implementation project(':dev.galasa.framework.api.common')
     implementation 'org.apache.felix:org.apache.felix.bundlerepository'
     implementation 'org.osgi:org.osgi.service.cm'
 
     testImplementation project(':dev.galasa.framework').sourceSets.test.output
+    testImplementation(testFixtures(project(':dev.galasa.framework.api.common')))
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/IRateLimiter.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/IRateLimiter.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api;
+
+public interface IRateLimiter {
+    boolean tryToAcquireToken();
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/RateLimitFilter.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/RateLimitFilter.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+import dev.galasa.framework.api.common.Environment;
+import dev.galasa.framework.api.common.MimeType;
+import dev.galasa.framework.api.common.ResponseBuilder;
+import dev.galasa.framework.api.common.ServletError;
+import dev.galasa.framework.api.common.SystemEnvironment;
+import dev.galasa.framework.api.internal.IpRateLimiter;
+import dev.galasa.framework.api.internal.TokenBucketRateLimiter;
+import dev.galasa.framework.spi.utils.ITimeService;
+import dev.galasa.framework.spi.utils.SystemTimeService;
+
+import static dev.galasa.framework.api.common.ServletErrorMessage.*;
+import static dev.galasa.framework.api.common.EnvironmentVariables.*;
+
+/**
+ * A servlet filter that implements rate limiting for the Galasa API server.
+ *
+ * This filter uses a global rate limiter to prevent clients from exhausting the API server's
+ * resources, causing it to become unresponsive. The global rate limit serves as an upper-limit
+ * safety net to keep the API server running under heavy load.
+ *
+ * The filter also applies a rate limit to clients based on their IP addresses so that
+ * a client is not able to exceed the global rate limit alone, preventing other clients from being able
+ * to use the API server. This IP-based rate limit should be stricter than the global rate limit
+ * so that API server resources are shared fairly amongst clients.
+ *
+ * Both the global and individual rate limits are configurable through environment variables.
+ */
+@Component(service = Filter.class, scope = ServiceScope.PROTOTYPE, property = {
+        "osgi.http.whiteboard.filter.pattern=/*" }, name = "Galasa Rate Limit Filter")
+public class RateLimitFilter implements Filter {
+
+    // Mark IPs stale after 1 minute
+    public static final long IP_IDLE_TIMEOUT_MILLIS = 60 * 1000L;
+
+    // The javax HttpServletResponse class is missing the 429 status code from its constants
+    private static final int TOO_MANY_REQUESTS_CODE = 429;
+
+    private final Log logger = LogFactory.getLog(getClass());
+
+    protected ITimeService timeService = new SystemTimeService();
+    protected ResponseBuilder responseBuilder = new ResponseBuilder();
+
+    private IRateLimiter globalRateLimiter;
+    protected ConcurrentHashMap<String, IpRateLimiter> rateLimitersPerIp = new ConcurrentHashMap<>();
+
+    private int ipRateLimitRequestCapacity;
+    private int ipRefillRatePerSecond;
+
+    protected Environment env = new SystemEnvironment();
+
+    protected ScheduledExecutorService cleanupScheduler = Executors.newScheduledThreadPool(1);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        logger.info("Rate limit filter initialising");
+
+        try {
+            this.ipRateLimitRequestCapacity = Integer.parseInt(env.getenv(GALASA_IP_REQUEST_CAPACITY));
+            this.ipRefillRatePerSecond = Integer.parseInt(env.getenv(GALASA_IP_RATE_LIMIT));
+            logger.info("Request capacity per IP set to: " + ipRateLimitRequestCapacity);
+            logger.info("Request rate limit per IP set to: " + ipRefillRatePerSecond);
+
+            int globalRefillRatePerSecond = Integer.parseInt(env.getenv(GALASA_GLOBAL_RATE_LIMIT));
+            int globalRequestCapacity = Integer.parseInt(env.getenv(GALASA_GLOBAL_REQUEST_CAPACITY));
+            globalRateLimiter = new TokenBucketRateLimiter(globalRequestCapacity, globalRefillRatePerSecond, timeService);
+            logger.info("Global request capacity set to: " + globalRequestCapacity);
+            logger.info("Global request rate limit set to: " + globalRefillRatePerSecond);
+
+        } catch (NumberFormatException e) {
+            String formattedEnvVariablesStr = String.join(
+                ", ",
+                List.of(GALASA_GLOBAL_RATE_LIMIT, GALASA_GLOBAL_REQUEST_CAPACITY, GALASA_IP_REQUEST_CAPACITY, GALASA_IP_RATE_LIMIT)
+            );
+
+            String errorMsg = "Failed to initialise rate limit filter. One or more of the following environment variables have not been set valid values: ["
+                + formattedEnvVariablesStr + "]";
+            logger.error(errorMsg);
+            throw new ServletException(errorMsg);
+        }
+
+        // Schedule periodic cleanup of stale IPs
+        cleanupScheduler.scheduleAtFixedRate(this::cleanUpStaleIps, 1, 1, TimeUnit.MINUTES);
+        logger.info("Rate limit filter initialised");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        logger.info("RateLimitFilter - doFilter() entered");
+        HttpServletRequest servletRequest = (HttpServletRequest) request;
+        HttpServletResponse servletResponse = (HttpServletResponse) response;
+
+        String clientIp = servletRequest.getRemoteAddr();
+
+        // Check the global rate limit hasn't been exceeded
+        logger.info("Checking whether the global rate limit has been exceeded");
+        if (!globalRateLimiter.tryToAcquireToken()) {
+            logger.info("Global rate limit has been exceeded");
+            sendRateLimitExceededResponse(servletRequest, servletResponse);
+        } else {
+            logger.info("Global rate limit has not been exceeded, checking IP-based rate limit");
+
+            // Check that the user's own rate limit hasn't been exceeded (based on their IP)
+            rateLimitersPerIp.computeIfAbsent(clientIp, ip -> {
+                IRateLimiter tokenBucketLimiter = new TokenBucketRateLimiter(ipRateLimitRequestCapacity, ipRefillRatePerSecond, timeService);
+                return new IpRateLimiter(tokenBucketLimiter, timeService);
+            });
+
+            IpRateLimiter ipRateLimiter = rateLimitersPerIp.get(clientIp);
+            ipRateLimiter.updateLastAccessTime();
+
+            if (!ipRateLimiter.tryToAcquireToken()) {
+                logger.info("IP-based rate limit has been exceeded");
+                sendRateLimitExceededResponse(servletRequest, servletResponse);
+            } else {
+                // Allow the request through the filter
+                logger.info("IP-based rate limit has not been exceeded");
+                chain.doFilter(request, response);
+            }
+        }
+        logger.info("RateLimitFilter - doFilter() exiting");
+    }
+
+    @Override
+    public void destroy() {
+        logger.info("Shutting down rate limit filter");
+
+        cleanupScheduler.shutdown();
+
+        logger.info("Rate limit filter shut down OK");
+    }
+
+    private void sendRateLimitExceededResponse(HttpServletRequest servletRequest, HttpServletResponse servletResponse) {
+        String errorString = new ServletError(GAL5429_TOO_MANY_REQUESTS).toJsonString();
+        responseBuilder.buildResponse(servletRequest, servletResponse, MimeType.APPLICATION_JSON.toString(), errorString, TOO_MANY_REQUESTS_CODE);
+    }
+
+    // Package-level to allow unit testing
+    void cleanUpStaleIps() {
+        logger.info("Cleaning up stale IPs from rate limit checks");
+        List<String> ipsToRemove = new ArrayList<>();
+        for (Entry<String, IpRateLimiter> entry : rateLimitersPerIp.entrySet()) {
+            if (Duration.between(entry.getValue().getLastAccessTime(), timeService.now()).toMillis() >= IP_IDLE_TIMEOUT_MILLIS) {
+                ipsToRemove.add(entry.getKey());
+            }
+        }
+
+        for (String ipToRemove : ipsToRemove) {
+            rateLimitersPerIp.remove(ipToRemove);
+        }
+
+        int ipsToRemoveCount = ipsToRemove.size();
+        if (ipsToRemoveCount > 0) {
+            logger.info("Removed " + ipsToRemoveCount + " stale IP(s) OK");
+        } else {
+            logger.info("No stale IPs to remove");
+        }
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/IpRateLimiter.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/IpRateLimiter.java
@@ -10,6 +10,10 @@ import java.time.Instant;
 import dev.galasa.framework.api.IRateLimiter;
 import dev.galasa.framework.spi.utils.ITimeService;
 
+/**
+ * A rate limiter wrapper used for IP-based rate limiting to keep track of the last time
+ * a client sent a request to the API server.
+ */
 public class IpRateLimiter implements IRateLimiter {
     private final IRateLimiter rateLimiter;
     private ITimeService timeService;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/IpRateLimiter.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/IpRateLimiter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.internal;
+
+import java.time.Instant;
+
+import dev.galasa.framework.api.IRateLimiter;
+import dev.galasa.framework.spi.utils.ITimeService;
+
+public class IpRateLimiter implements IRateLimiter {
+    private final IRateLimiter rateLimiter;
+    private ITimeService timeService;
+    private Instant lastAccessTime;
+
+    public IpRateLimiter(IRateLimiter rateLimiter, ITimeService timeService) {
+        this.rateLimiter = rateLimiter;
+        this.timeService = timeService;
+        this.lastAccessTime = timeService.now();
+    }
+
+    @Override
+    public boolean tryToAcquireToken() {
+        return rateLimiter.tryToAcquireToken();
+    }
+
+    public synchronized void updateLastAccessTime() {
+        this.lastAccessTime = timeService.now();
+    }
+
+    public synchronized Instant getLastAccessTime() {
+        return this.lastAccessTime;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/TokenBucketRateLimiter.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/TokenBucketRateLimiter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.internal;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import dev.galasa.framework.api.IRateLimiter;
+import dev.galasa.framework.spi.utils.ITimeService;
+
+/**
+ * A rate limiter that applies the Token Bucket algorithm to rate-limit API requests. It works by
+ * maintaining a "bucket" that can store a fixed number of "tokens". A token represents a permit
+ * to execute a request.
+ * 
+ * When a request is made to the API server, the bucket is checked for available tokens and if
+ * the bucket is not empty, then the request will take one token from the bucket.
+ * 
+ * If the bucket is empty (i.e. the rate limit has been exceeded), then the request will be denied.
+ * 
+ * This bucket of tokens is constantly refilled over time based on a given refill rate so that more
+ * requests can be made gradually.
+ */
+public class TokenBucketRateLimiter implements IRateLimiter {
+    private final int bucketCapacity;
+    private final int refillRateSeconds;
+    private int tokens;
+
+    private Instant lastRefillTIme;
+    private ITimeService timeService;
+
+    public TokenBucketRateLimiter(int bucketCapacity, int refillRate, ITimeService timeService) {
+        this.bucketCapacity = bucketCapacity;
+        this.timeService = timeService;
+        this.refillRateSeconds = refillRate;
+        this.tokens = bucketCapacity;
+        this.lastRefillTIme = timeService.now();
+    }
+
+    public synchronized boolean tryToAcquireToken() {
+        boolean isTokenAcquired = false;
+        refillBucket();
+        if (tokens > 0) {
+            tokens--;
+            isTokenAcquired = true;
+        }
+        return isTokenAcquired;
+    }
+
+    private void refillBucket() {
+        Instant now = timeService.now();
+        Duration timeSinceLastRefill = Duration.between(lastRefillTIme, now);
+
+        // Check if any tokens should be added to the bucket based on the refill rate
+        int tokensToAdd = (int) (timeSinceLastRefill.toSeconds() * refillRateSeconds);
+        if (tokensToAdd > 0) {
+            tokens = Math.min(bucketCapacity, tokens + tokensToAdd);
+
+            // Update the last refill time so that we don't over-fill the bucket next time
+            lastRefillTIme = now;
+        }
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/RateLimitFilterTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/RateLimitFilterTest.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api;
+
+import static dev.galasa.framework.api.common.EnvironmentVariables.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+
+import dev.galasa.framework.api.common.BaseServletTest;
+import dev.galasa.framework.api.common.Environment;
+import dev.galasa.framework.api.common.ResponseBuilder;
+import dev.galasa.framework.api.common.mocks.MockEnvironment;
+import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
+import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
+import dev.galasa.framework.api.common.mocks.MockTimeService;
+import dev.galasa.framework.api.internal.IpRateLimiter;
+import dev.galasa.framework.api.mocks.MockScheduledExecutorService;
+import dev.galasa.framework.spi.utils.ITimeService;
+
+public class RateLimitFilterTest extends BaseServletTest {
+
+    class MockRateLimitFilter extends RateLimitFilter {
+
+        private MockScheduledExecutorService mockCleanupScheduler;
+
+        public MockRateLimitFilter(Environment env, ITimeService timeService) {
+            super.env = env;
+            super.timeService = timeService;
+            super.responseBuilder = new ResponseBuilder(env);
+
+            this.mockCleanupScheduler = new MockScheduledExecutorService();
+            super.cleanupScheduler = mockCleanupScheduler;
+        }
+
+        public MockScheduledExecutorService getMockCleanupScheduler() {
+            return mockCleanupScheduler;
+        }
+
+        public ConcurrentHashMap<String, IpRateLimiter> getRateLimitersPerIp() {
+            return super.rateLimitersPerIp;
+        }
+    }
+
+    class MockFilterChain implements FilterChain {
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
+            HttpServletResponse servletResponse = (HttpServletResponse) response;
+            servletResponse.setStatus(200);
+        }
+    }
+
+    private MockEnvironment setupMockEnv(
+        int globalRequestCapacity,
+        int globalRateLimit,
+        int ipRequestCapacity,
+        int ipRateLimit
+    ) {
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setenv(GALASA_GLOBAL_REQUEST_CAPACITY, String.valueOf(globalRequestCapacity));
+        mockEnv.setenv(GALASA_GLOBAL_RATE_LIMIT, String.valueOf(globalRateLimit));
+
+        mockEnv.setenv(GALASA_IP_REQUEST_CAPACITY, String.valueOf(ipRequestCapacity));
+        mockEnv.setenv(GALASA_IP_RATE_LIMIT, String.valueOf(ipRateLimit));
+
+        return mockEnv;
+    }
+
+    private HttpServletResponse sendMockRequestToFilter(RateLimitFilter rateLimitFilter, String clientIpAddress) throws IOException, ServletException {
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/ras/runs");
+        mockRequest.setRemoteAddr(clientIpAddress);
+
+        HttpServletResponse mockResponse = new MockHttpServletResponse();
+        FilterChain mockChain = new MockFilterChain();
+
+        rateLimitFilter.doFilter(mockRequest, mockResponse, mockChain);
+        return mockResponse;
+    }
+
+    @Test
+    public void testInitWithMissingEnvVariablesThrowsError() throws Exception {
+        // Given...
+        MockEnvironment mockEnv = new MockEnvironment();
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        RateLimitFilter rateLimitFilter = new MockRateLimitFilter(mockEnv, mockTimeService);
+
+        // When...
+        ServletException thrown = catchThrowableOfType(() -> {
+            rateLimitFilter.init(null);
+        }, ServletException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("Failed to initialise rate limit filter");
+    }
+
+    @Test
+    public void testFilterAllowsRequestWithinRateLimitOk() throws Exception {
+        // Given...
+        String client1IpAddress = "client1.ip.address";
+        int globalRequestCapacity = 10;
+        int globalRateLimit = 10;
+        int ipRequestCapacity = 5;
+        int ipRateLimit = 5;
+        MockEnvironment mockEnv = setupMockEnv(globalRequestCapacity, globalRateLimit, ipRequestCapacity, ipRateLimit);
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        RateLimitFilter rateLimitFilter = new MockRateLimitFilter(mockEnv, mockTimeService);
+
+        // When...
+        rateLimitFilter.init(null);
+        HttpServletResponse mockResponse = sendMockRequestToFilter(rateLimitFilter, client1IpAddress);
+
+        // Then...
+        // The request should have been allowed through the filter
+        assertThat(mockResponse.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void testFilterRejectsRequestExceedingGlobalRateLimit() throws Exception {
+        // Given...
+        String client1IpAddress = "client1.ip.address";
+
+        // Only allow one request per second globally
+        int globalRequestCapacity = 1;
+        int globalRateLimit = 1;
+        int ipRequestCapacity = 5;
+        int ipRateLimit = 5;
+        MockEnvironment mockEnv = setupMockEnv(globalRequestCapacity, globalRateLimit, ipRequestCapacity, ipRateLimit);
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        RateLimitFilter rateLimitFilter = new MockRateLimitFilter(mockEnv, mockTimeService);
+
+        // When...
+        rateLimitFilter.init(null);
+        HttpServletResponse mockResponse = sendMockRequestToFilter(rateLimitFilter, client1IpAddress);
+
+        // The first request should have been allowed through the filter
+        assertThat(mockResponse.getStatus()).isEqualTo(200);
+
+        // Send another request without advancing time
+        mockResponse = sendMockRequestToFilter(rateLimitFilter, client1IpAddress);
+
+        // Then...
+        // The second request should have exceeded the rate limit
+        ServletOutputStream outputStream = mockResponse.getOutputStream();
+        assertThat(mockResponse.getStatus()).isEqualTo(429);
+        checkErrorStructure(outputStream.toString(), 5429, "GAL5429E", "Rate limit exceeded.");
+    }
+
+    @Test
+    public void testFilterRejectsRequestExceedingIpRateLimit() throws Exception {
+        // Given...
+        String client1IpAddress = "client1.ip.address";
+        int globalRequestCapacity = 10;
+        int globalRateLimit = 10;
+
+        // Only allow one request per second per IP
+        int ipRequestCapacity = 1;
+        int ipRateLimit = 1;
+        MockEnvironment mockEnv = setupMockEnv(globalRequestCapacity, globalRateLimit, ipRequestCapacity, ipRateLimit);
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        RateLimitFilter rateLimitFilter = new MockRateLimitFilter(mockEnv, mockTimeService);
+
+        // When...
+        rateLimitFilter.init(null);
+        HttpServletResponse mockResponse = sendMockRequestToFilter(rateLimitFilter, client1IpAddress);
+
+        // The first request should have been allowed through the filter
+        assertThat(mockResponse.getStatus()).isEqualTo(200);
+
+        // Send another request without advancing time
+        mockResponse = sendMockRequestToFilter(rateLimitFilter, client1IpAddress);
+
+        // Then...
+        // The second request should have exceeded the rate limit
+        ServletOutputStream outputStream = mockResponse.getOutputStream();
+        assertThat(mockResponse.getStatus()).isEqualTo(429);
+        checkErrorStructure(outputStream.toString(), 5429, "GAL5429E", "Rate limit exceeded.");
+    }
+
+    @Test
+    public void testFilterRejectsIpRateLimitedRequestAllowsRequestsFromOtherClients() throws Exception {
+        // Given...
+        String client1IpAddress = "client1.ip.address";
+        String client2IpAddress = "client2.ip.address";
+        String client3IpAddress = "client3.ip.address";
+        int globalRequestCapacity = 10;
+        int globalRateLimit = 10;
+
+        // Only allow one request per second per IP
+        int ipRequestCapacity = 1;
+        int ipRateLimit = 1;
+        MockEnvironment mockEnv = setupMockEnv(globalRequestCapacity, globalRateLimit, ipRequestCapacity, ipRateLimit);
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        RateLimitFilter rateLimitFilter = new MockRateLimitFilter(mockEnv, mockTimeService);
+
+        // When...
+        rateLimitFilter.init(null);
+        HttpServletResponse mockResponse = sendMockRequestToFilter(rateLimitFilter, client1IpAddress);
+
+        // The first request should have been allowed through the filter
+        assertThat(mockResponse.getStatus()).isEqualTo(200);
+        mockResponse = sendMockRequestToFilter(rateLimitFilter, client1IpAddress);
+
+        // The second request should have exceeded the rate limit for this IP address
+        ServletOutputStream outputStream = mockResponse.getOutputStream();
+        assertThat(mockResponse.getStatus()).isEqualTo(429);
+        checkErrorStructure(outputStream.toString(), 5429, "GAL5429E", "Rate limit exceeded.");
+
+        // Requests from different IP addresses should be allowed through regardless of other client rate limits
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client2IpAddress).getStatus()).isEqualTo(200);
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client3IpAddress).getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void testCleanUpStaleIpsRemovesOldIpEntriesAfterIdleTimeout() throws Exception {
+        // Given...
+        String client1IpAddress = "client1.ip.address";
+        String client2IpAddress = "client2.ip.address";
+        int globalRequestCapacity = 10;
+        int globalRateLimit = 10;
+        int ipRequestCapacity = 1;
+        int ipRateLimit = 1;
+        MockEnvironment mockEnv = setupMockEnv(globalRequestCapacity, globalRateLimit, ipRequestCapacity, ipRateLimit);
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        MockRateLimitFilter rateLimitFilter = new MockRateLimitFilter(mockEnv, mockTimeService);
+        ConcurrentHashMap<String, IpRateLimiter> rateLimitersPerIp = rateLimitFilter.getRateLimitersPerIp();
+
+        // When...
+        rateLimitFilter.init(null);
+
+        // Send requests from different IP addresses to build up the recorded IP address rate limiters
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client1IpAddress).getStatus()).isEqualTo(200);
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client2IpAddress).getStatus()).isEqualTo(200);
+
+        assertThat(rateLimitersPerIp).hasSize(2);
+        assertThat(rateLimitersPerIp).containsKey(client1IpAddress);
+        assertThat(rateLimitersPerIp).containsKey(client2IpAddress);
+
+        // Advance time to exceed the IP idle timeout
+        mockTimeService.sleepMillis(10 * RateLimitFilter.IP_IDLE_TIMEOUT_MILLIS);
+
+        // Run the cleanup job
+        rateLimitFilter.cleanUpStaleIps();
+
+        // Then...
+        assertThat(rateLimitersPerIp).isEmpty();
+    }
+
+    @Test
+    public void testCleanUpStaleIpsRemovesOldIpEntriesAtIdleTimeoutBoundary() throws Exception {
+        // Given...
+        String client1IpAddress = "client1.ip.address";
+        String client2IpAddress = "client2.ip.address";
+        int globalRequestCapacity = 10;
+        int globalRateLimit = 10;
+        int ipRequestCapacity = 1;
+        int ipRateLimit = 1;
+        MockEnvironment mockEnv = setupMockEnv(globalRequestCapacity, globalRateLimit, ipRequestCapacity, ipRateLimit);
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        MockRateLimitFilter rateLimitFilter = new MockRateLimitFilter(mockEnv, mockTimeService);
+        ConcurrentHashMap<String, IpRateLimiter> rateLimitersPerIp = rateLimitFilter.getRateLimitersPerIp();
+
+        // When...
+        rateLimitFilter.init(null);
+
+        // Send requests from different IP addresses to build up the recorded IP address rate limiters
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client1IpAddress).getStatus()).isEqualTo(200);
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client2IpAddress).getStatus()).isEqualTo(200);
+
+        assertThat(rateLimitersPerIp).hasSize(2);
+        assertThat(rateLimitersPerIp).containsKey(client1IpAddress);
+        assertThat(rateLimitersPerIp).containsKey(client2IpAddress);
+
+        // Advance time to be the same as the IP idle timeout
+        mockTimeService.sleepMillis(RateLimitFilter.IP_IDLE_TIMEOUT_MILLIS);
+
+        // Run the cleanup job
+        rateLimitFilter.cleanUpStaleIps();
+
+        // Then...
+        assertThat(rateLimitersPerIp).isEmpty();
+    }
+
+    @Test
+    public void testCleanUpStaleIpsDoesNotRemoveRecentIpEntries() throws Exception {
+        // Given...
+        String client1IpAddress = "client1.ip.address";
+        String client2IpAddress = "client2.ip.address";
+        int globalRequestCapacity = 10;
+        int globalRateLimit = 10;
+        int ipRequestCapacity = 1;
+        int ipRateLimit = 1;
+        MockEnvironment mockEnv = setupMockEnv(globalRequestCapacity, globalRateLimit, ipRequestCapacity, ipRateLimit);
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        MockRateLimitFilter rateLimitFilter = new MockRateLimitFilter(mockEnv, mockTimeService);
+        ConcurrentHashMap<String, IpRateLimiter> rateLimitersPerIp = rateLimitFilter.getRateLimitersPerIp();
+
+        // When...
+        rateLimitFilter.init(null);
+
+        // Send requests from different IP addresses to build up the recorded IP address rate limiters
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client1IpAddress).getStatus()).isEqualTo(200);
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client2IpAddress).getStatus()).isEqualTo(200);
+
+        assertThat(rateLimitersPerIp).hasSize(2);
+        assertThat(rateLimitersPerIp).containsKey(client1IpAddress);
+        assertThat(rateLimitersPerIp).containsKey(client2IpAddress);
+
+        // Advance time to be just before the IP idle timeout
+        mockTimeService.sleepMillis(RateLimitFilter.IP_IDLE_TIMEOUT_MILLIS - 1);
+
+        // Run the cleanup job
+        rateLimitFilter.cleanUpStaleIps();
+
+        // Then...
+        assertThat(rateLimitersPerIp).hasSize(2);
+        assertThat(rateLimitersPerIp).containsKey(client1IpAddress);
+        assertThat(rateLimitersPerIp).containsKey(client2IpAddress);
+    }
+
+    @Test
+    public void testCleanUpStaleIpsDoesNotRemoveAllIpEntries() throws Exception {
+        // Given...
+        String client1IpAddress = "client1.ip.address";
+        String client2IpAddress = "client2.ip.address";
+        String client3IpAddress = "client3.ip.address";
+        int globalRequestCapacity = 10;
+        int globalRateLimit = 10;
+        int ipRequestCapacity = 1;
+        int ipRateLimit = 1;
+        MockEnvironment mockEnv = setupMockEnv(globalRequestCapacity, globalRateLimit, ipRequestCapacity, ipRateLimit);
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        MockRateLimitFilter rateLimitFilter = new MockRateLimitFilter(mockEnv, mockTimeService);
+        ConcurrentHashMap<String, IpRateLimiter> rateLimitersPerIp = rateLimitFilter.getRateLimitersPerIp();
+
+        // When...
+        rateLimitFilter.init(null);
+
+        // Send requests from different IP addresses to build up the recorded IP address rate limiters
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client1IpAddress).getStatus()).isEqualTo(200);
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client2IpAddress).getStatus()).isEqualTo(200);
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client3IpAddress).getStatus()).isEqualTo(200);
+
+        assertThat(rateLimitersPerIp).hasSize(3);
+        assertThat(rateLimitersPerIp).containsKey(client1IpAddress);
+        assertThat(rateLimitersPerIp).containsKey(client2IpAddress);
+        assertThat(rateLimitersPerIp).containsKey(client3IpAddress);
+
+        // Advance time to be just before the IP idle timeout
+        mockTimeService.sleepMillis(RateLimitFilter.IP_IDLE_TIMEOUT_MILLIS - 1);
+
+        // Send a more recent request from the client1 IP address
+        assertThat(sendMockRequestToFilter(rateLimitFilter, client1IpAddress).getStatus()).isEqualTo(200);
+
+        // Advance time to exceed the IP idle timeout without timing out the recent request
+        mockTimeService.sleepMillis(RateLimitFilter.IP_IDLE_TIMEOUT_MILLIS - 1);
+
+        // Run the cleanup job
+        rateLimitFilter.cleanUpStaleIps();
+
+        // Then...
+        // Only the client2 IP address should have been marked stale
+        assertThat(rateLimitersPerIp).hasSize(1);
+        assertThat(rateLimitersPerIp).containsKey(client1IpAddress);
+    }
+
+    @Test
+    public void testDestroyFilterShutsDownCleanupThread() throws Exception {
+        // Given...
+        MockEnvironment mockEnv = new MockEnvironment();
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        MockRateLimitFilter rateLimitFilter = new MockRateLimitFilter(mockEnv, mockTimeService);
+
+        // When...
+        rateLimitFilter.destroy();
+
+        // Then...
+        MockScheduledExecutorService mockCleanupScheduler = rateLimitFilter.getMockCleanupScheduler();
+        assertThat(mockCleanupScheduler.isShutdown()).isTrue();
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/internal/TokenBucketRateLimiterTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/internal/TokenBucketRateLimiterTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.internal;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+import dev.galasa.framework.api.common.mocks.MockTimeService;
+
+public class TokenBucketRateLimiterTest {
+
+    @Test
+    public void testTryToAcquireTokenWithoutExceedingLimitReturnsTrue() throws Exception {
+        // Given...
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        int bucketCapacity = 10;
+        int refillRate = 10;
+        TokenBucketRateLimiter rateLimiter = new TokenBucketRateLimiter(bucketCapacity, refillRate, mockTimeService);
+
+        // When...
+        boolean isTokenAcquired = rateLimiter.tryToAcquireToken();
+
+        // Then...
+        assertThat(isTokenAcquired).isTrue();
+    }
+
+    @Test
+    public void testTryToAcquireTokenExceedingLimitReturnsFalse() throws Exception {
+        // Given...
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        int bucketCapacity = 1;
+        int refillRate = 1;
+        TokenBucketRateLimiter rateLimiter = new TokenBucketRateLimiter(bucketCapacity, refillRate, mockTimeService);
+
+        // When/Then...
+        // The second call should return false since the bucket only stores one token
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isFalse();
+    }
+
+    @Test
+    public void testTryToAcquireTokenMultipleRequestsWithoutExceedingLimitReturnsTrue() throws Exception {
+        // Given...
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        int bucketCapacity = 5;
+        int refillRate = 2;
+        TokenBucketRateLimiter rateLimiter = new TokenBucketRateLimiter(bucketCapacity, refillRate, mockTimeService);
+
+        // When/Then...
+        // The bucket has five tokens, so five calls should all return true
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+    }
+
+    @Test
+    public void testRateLimiterRefillsTokensOverTime() throws Exception {
+        // Given...
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        int bucketCapacity = 3;
+
+        // Set the refill rate to one token per second
+        int refillRate = 1;
+        TokenBucketRateLimiter rateLimiter = new TokenBucketRateLimiter(bucketCapacity, refillRate, mockTimeService);
+
+        // When...
+        // Three calls are made to use up all tokens in the bucket 
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+
+        // All tokens have been used, so the next call should return false
+        assertThat(rateLimiter.tryToAcquireToken()).isFalse();
+
+        // Advance time by one second
+        mockTimeService.sleepMillis(1 * 1000L);
+
+        // The bucket should have been refilled with one new token
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isFalse();
+
+        // Advance time by two seconds
+        mockTimeService.sleepMillis(2 * 1000L);
+
+        // The bucket should have been refilled with two new tokens
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isFalse();
+    }
+
+    @Test
+    public void testRateLimiterDoesNotOverfillTokensBucket() throws Exception {
+        // Given...
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        int bucketCapacity = 3;
+
+        // Set the refill rate to one token per second
+        int refillRate = 1;
+        TokenBucketRateLimiter rateLimiter = new TokenBucketRateLimiter(bucketCapacity, refillRate, mockTimeService);
+
+        // When...
+        // Three calls are made to use up all tokens in the bucket 
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+
+        // All tokens have been used, so the next call should return false
+        assertThat(rateLimiter.tryToAcquireToken()).isFalse();
+
+        // Advance time by three seconds
+        mockTimeService.sleepMillis(3 * 1000L);
+
+        // The bucket should have been refilled with three new token
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isFalse();
+
+        // Advance time by 1 minute
+        mockTimeService.sleepMillis(60 * 1000L);
+
+        // The bucket should only have been refilled with three tokens
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isTrue();
+        assertThat(rateLimiter.tryToAcquireToken()).isFalse();
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockScheduledExecutorService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockScheduledExecutorService.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.mocks;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class MockScheduledExecutorService implements ScheduledExecutorService {
+
+    private boolean isShutdown = false;
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        // Do nothing...
+        return null;
+    }
+
+    @Override
+    public void shutdown() {
+        this.isShutdown = true;
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return this.isShutdown;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        throw new UnsupportedOperationException("Unimplemented method 'shutdownNow'");
+    }
+
+    @Override
+    public boolean isTerminated() {
+        throw new UnsupportedOperationException("Unimplemented method 'isTerminated'");
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        throw new UnsupportedOperationException("Unimplemented method 'awaitTermination'");
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        throw new UnsupportedOperationException("Unimplemented method 'submit'");
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        throw new UnsupportedOperationException("Unimplemented method 'submit'");
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        throw new UnsupportedOperationException("Unimplemented method 'submit'");
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        throw new UnsupportedOperationException("Unimplemented method 'invokeAll'");
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        throw new UnsupportedOperationException("Unimplemented method 'invokeAll'");
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        throw new UnsupportedOperationException("Unimplemented method 'invokeAny'");
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        throw new UnsupportedOperationException("Unimplemented method 'invokeAny'");
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        throw new UnsupportedOperationException("Unimplemented method 'schedule'");
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        throw new UnsupportedOperationException("Unimplemented method 'schedule'");
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        throw new UnsupportedOperationException("Unimplemented method 'scheduleWithFixedDelay'");
+    }
+}


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2072

Currently, the API server is prone to being overloaded with requests, causing the API server to crash as a result. Adding configurable rate limiting will allow service admins to protect the API server from such overloads.

## Changes
- Added rate limit servlet filter that checks that global and per-IP rate limits have not been exceeded before passing the request down
  - The rate limit filter uses the token bucket rate limiting algorithm
  - To avoid a build up of stored IP addresses and rate limiters, a cleanup job has been added to periodically remove stale IP addresses and corresponding rate limiters
- Added environment variables to allow the API server's global and per-IP rate limits to be configurable