### PR TITLE
ShutdownHooks not signalling to main processes because shared-state variable was not volatile

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.metrics/src/main/java/dev/galasa/framework/metrics/MetricsServer.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.metrics/src/main/java/dev/galasa/framework/metrics/MetricsServer.java
@@ -45,8 +45,9 @@ public class MetricsServer implements IMetricsServer {
     private final ArrayList<IMetricsProvider> metricsProviders                    = new ArrayList<>();
     private ScheduledExecutorService          scheduledExecutorService;
 
-    private boolean                           shutdown                            = false;
-    private boolean                           shutdownComplete                    = false;
+    // Note: These two flags are shared-state between two threads, so must be marked volatile.
+    private volatile boolean shutdown         = false;
+    private volatile boolean shutdownComplete = false;
 
     private long                              successfulPollsSinceLastHealthCheck = 0;
 
@@ -69,175 +70,178 @@ public class MetricsServer implements IMetricsServer {
 
         // *** Add shutdown hook to allow for orderly shutdown
         Runtime.getRuntime().addShutdownHook(new ShutdownHook());
-
-        // *** Initialise the framework services
-        FrameworkInitialisation frameworkInitialisation = null;
         try {
-            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
-        } catch (Exception e) {
-            throw new FrameworkException("Unable to initialise the Framework Services", e);
-        }
-        IFramework framework = frameworkInitialisation.getFramework();
 
-        IConfigurationPropertyStoreService cps = framework.getConfigurationPropertyService("framework");
-        IDynamicStatusStoreService dss = framework.getDynamicStatusStoreService("framework");
-
-        // *** Now start the Metrics Server framework
-
-        logger.info("Starting Metrics Server");
-
-        // *** Calculate servername
-
-        this.hostname = "unknown";
-        try {
-            this.hostname = InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            logger.error("Unable to obtain the host name", e);
-        }
-        this.serverName = AbstractManager.nulled(cps.getProperty("server", "name"));
-        if (this.serverName == null) {
-            this.serverName = AbstractManager.nulled(System.getenv("framework.server.name"));
-            if (this.serverName == null) {
-                String[] split = this.hostname.split("\\.");
-                if (split.length >= 1) {
-                    this.serverName = split[0];
-                }
-            }
-        }
-        if (serverName == null) {
-            this.serverName = "unknown";
-        }
-        this.serverName = this.serverName.toLowerCase();
-        this.hostname = this.hostname.toLowerCase();
-        this.serverName = this.serverName.replaceAll("\\.", "-");
-
-        // *** Setup defaults and properties
-
-        int numberOfRunThreads = 5;
-        int metricsPort = 9010;
-        int healthPort = 9011;
-
-        String threads = AbstractManager.nulled(cps.getProperty("metrics", "threads"));
-        if (threads != null) {
-            numberOfRunThreads = Integer.parseInt(threads);
-        }
-
-        String port = AbstractManager.nulled(cps.getProperty("metrics", "port"));
-        if (port != null) {
-            metricsPort = Integer.parseInt(port);
-        }
-
-        port = AbstractManager.nulled(cps.getProperty("metrics.health", "port"));
-        if (port != null) {
-            healthPort = Integer.parseInt(port);
-        }
-
-        // *** Setup scheduler
-        scheduledExecutorService = new ScheduledThreadPoolExecutor(numberOfRunThreads);
-
-        // *** Start the metrics server
-        if (metricsPort > 0) {
+            // *** Initialise the framework services
+            FrameworkInitialisation frameworkInitialisation = null;
             try {
-                this.metricsServer = new HTTPServer(metricsPort);
-                logger.info("Metrics server running on port " + metricsPort);
-            } catch (IOException e) {
-                throw new FrameworkException("Unable to start the metrics server", e);
+                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+            } catch (Exception e) {
+                throw new FrameworkException("Unable to initialise the Framework Services", e);
             }
-        } else {
-            logger.info("Metrics server disabled");
-        }
+            IFramework framework = frameworkInitialisation.getFramework();
 
-        // *** Create metrics
-        // DefaultExports.initialize() - problem within the the exporter at the moment
-        // TODO
+            IConfigurationPropertyStoreService cps = framework.getConfigurationPropertyService("framework");
+            IDynamicStatusStoreService dss = framework.getDynamicStatusStoreService("framework");
 
-        this.successfulPollsCounter = Counter.build().name("galasa_metric_successfull_polls")
-                .help("The number of successfull metrics pools").register();
+            // *** Now start the Metrics Server framework
 
-        // *** Create Health Server
-        if (healthPort > 0) {
-            this.healthServer = new MetricsServerHealth(this, healthPort);
-            logger.info("Health monitoring on port " + healthPort);
-        } else {
-            logger.info("Health monitoring disabled");
-        }
+            logger.info("Starting Metrics Server");
 
-        // *** Locate all the Metrics providers in the framework
-        try {
-            final ServiceReference<?>[] mpServiceReference = bundleContext
-                    .getAllServiceReferences(IMetricsProvider.class.getName(), null);
-            if ((mpServiceReference == null) || (mpServiceReference.length == 0)) {
-                logger.info("No additional Metrics providers have been found");
-            } else {
-                for (final ServiceReference<?> mpReference : mpServiceReference) {
-                    final IMetricsProvider mpStoreRegistration = (IMetricsProvider) bundleContext
-                            .getService(mpReference);
-                    try {
-                        if (mpStoreRegistration.initialise(framework, this)) {
-                            logger.info("Found Metrics Provider " + mpStoreRegistration.getClass().getName());
-                            metricsProviders.add(mpStoreRegistration);
-                        } else {
-                            logger.info("Metrics Provider " + mpStoreRegistration.getClass().getName()
-                                    + " opted out of this Metrics run");
-                        }
-                    } catch (Exception e) {
-                        logger.error("Failed initialisation of Metrics Provider "
-                                + mpStoreRegistration.getClass().getName() + " ignoring", e);
+            // *** Calculate servername
+
+            this.hostname = "unknown";
+            try {
+                this.hostname = InetAddress.getLocalHost().getHostName();
+            } catch (UnknownHostException e) {
+                logger.error("Unable to obtain the host name", e);
+            }
+            this.serverName = AbstractManager.nulled(cps.getProperty("server", "name"));
+            if (this.serverName == null) {
+                this.serverName = AbstractManager.nulled(System.getenv("framework.server.name"));
+                if (this.serverName == null) {
+                    String[] split = this.hostname.split("\\.");
+                    if (split.length >= 1) {
+                        this.serverName = split[0];
                     }
                 }
             }
-        } catch (Exception e) {
-            throw new FrameworkException("Problem during Metrics Server initialisation", e);
-        }
+            if (serverName == null) {
+                this.serverName = "unknown";
+            }
+            this.serverName = this.serverName.toLowerCase();
+            this.hostname = this.hostname.toLowerCase();
+            this.serverName = this.serverName.replaceAll("\\.", "-");
 
-        // *** Start the providers
-        for (IMetricsProvider provider : metricsProviders) {
-            provider.start();
-        }
-        
-        logger.info("Metrics Server has started");
+            // *** Setup defaults and properties
 
-        // *** Loop until we are asked to shutdown
-        long heartbeatExpire = 0;
-        while (!shutdown) {
-            if (System.currentTimeMillis() >= heartbeatExpire) {
-                updateHeartbeat(dss);
-                heartbeatExpire = System.currentTimeMillis() + 20000;
+            int numberOfRunThreads = 5;
+            int metricsPort = 9010;
+            int healthPort = 9011;
+
+            String threads = AbstractManager.nulled(cps.getProperty("metrics", "threads"));
+            if (threads != null) {
+                numberOfRunThreads = Integer.parseInt(threads);
             }
 
+            String port = AbstractManager.nulled(cps.getProperty("metrics", "port"));
+            if (port != null) {
+                metricsPort = Integer.parseInt(port);
+            }
+
+            port = AbstractManager.nulled(cps.getProperty("metrics.health", "port"));
+            if (port != null) {
+                healthPort = Integer.parseInt(port);
+            }
+
+            // *** Setup scheduler
+            scheduledExecutorService = new ScheduledThreadPoolExecutor(numberOfRunThreads);
+
+            // *** Start the metrics server
+            if (metricsPort > 0) {
+                try {
+                    this.metricsServer = new HTTPServer(metricsPort);
+                    logger.info("Metrics server running on port " + metricsPort);
+                } catch (IOException e) {
+                    throw new FrameworkException("Unable to start the metrics server", e);
+                }
+            } else {
+                logger.info("Metrics server disabled");
+            }
+
+            // *** Create metrics
+            // DefaultExports.initialize() - problem within the the exporter at the moment
+            // TODO
+
+            this.successfulPollsCounter = Counter.build().name("galasa_metric_successfull_polls")
+                    .help("The number of successfull metrics pools").register();
+
+            // *** Create Health Server
+            if (healthPort > 0) {
+                this.healthServer = new MetricsServerHealth(this, healthPort);
+                logger.info("Health monitoring on port " + healthPort);
+            } else {
+                logger.info("Health monitoring disabled");
+            }
+
+            // *** Locate all the Metrics providers in the framework
             try {
-                Thread.sleep(500);
+                final ServiceReference<?>[] mpServiceReference = bundleContext
+                        .getAllServiceReferences(IMetricsProvider.class.getName(), null);
+                if ((mpServiceReference == null) || (mpServiceReference.length == 0)) {
+                    logger.info("No additional Metrics providers have been found");
+                } else {
+                    for (final ServiceReference<?> mpReference : mpServiceReference) {
+                        final IMetricsProvider mpStoreRegistration = (IMetricsProvider) bundleContext
+                                .getService(mpReference);
+                        try {
+                            if (mpStoreRegistration.initialise(framework, this)) {
+                                logger.info("Found Metrics Provider " + mpStoreRegistration.getClass().getName());
+                                metricsProviders.add(mpStoreRegistration);
+                            } else {
+                                logger.info("Metrics Provider " + mpStoreRegistration.getClass().getName()
+                                        + " opted out of this Metrics run");
+                            }
+                        } catch (Exception e) {
+                            logger.error("Failed initialisation of Metrics Provider "
+                                    + mpStoreRegistration.getClass().getName() + " ignoring", e);
+                        }
+                    }
+                }
             } catch (Exception e) {
-                throw new FrameworkException("Interrupted sleep", e);
+                throw new FrameworkException("Problem during Metrics Server initialisation", e);
             }
-        }
 
-        // *** shutdown the scheduler
-        this.scheduledExecutorService.shutdown();
-        try {
-            this.scheduledExecutorService.awaitTermination(30, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            logger.error("Unable to shutdown the scheduler");
-        }
+            // *** Start the providers
+            for (IMetricsProvider provider : metricsProviders) {
+                provider.start();
+            }
+            
+            logger.info("Metrics Server has started");
 
-        // *** shutdown the providers
-        for (IMetricsProvider provider : metricsProviders) {
-            logger.info("Requesting Metrics Management Provider " + provider.getClass().getName() + " shutdown");
-            provider.shutdown();
-        }
+            // *** Loop until we are asked to shutdown
+            long heartbeatExpire = 0;
+            while (!shutdown) {
+                if (System.currentTimeMillis() >= heartbeatExpire) {
+                    updateHeartbeat(dss);
+                    heartbeatExpire = System.currentTimeMillis() + 20000;
+                }
 
-        // *** Stop the metics server
-        if (metricsPort > 0) {
-            this.metricsServer.stop();
-        }
+                try {
+                    Thread.sleep(500);
+                } catch (Exception e) {
+                    throw new FrameworkException("Interrupted sleep", e);
+                }
+            }
 
-        // *** Stop the health server
-        if (healthPort > 0) {
-            this.healthServer.shutdown();
-        }
+            // *** shutdown the scheduler
+            this.scheduledExecutorService.shutdown();
+            try {
+                this.scheduledExecutorService.awaitTermination(30, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                logger.error("Unable to shutdown the scheduler");
+            }
 
-        logger.info("Metrics Server shutdown");
-        shutdownComplete = true;
+            // *** shutdown the providers
+            for (IMetricsProvider provider : metricsProviders) {
+                logger.info("Requesting Metrics Management Provider " + provider.getClass().getName() + " shutdown");
+                provider.shutdown();
+            }
+
+            // *** Stop the metics server
+            if (metricsPort > 0) {
+                this.metricsServer.close();
+            }
+
+            // *** Stop the health server
+            if (healthPort > 0) {
+                this.healthServer.shutdown();
+            }
+        } finally {
+            logger.info("Metrics Server shutdown");
+            // This allows the shutdown hook to exit.
+            shutdownComplete = true;
+        }
         return;
     }
 
@@ -281,6 +285,8 @@ public class MetricsServer implements IMetricsServer {
         @Override
         public void run() {
             MetricsServer.this.logger.info("Shutdown request received");
+            
+            // Tell the main thread to shut down via this shared variable.
             MetricsServer.this.shutdown = true;
 
             while (!shutdownComplete) {
@@ -289,7 +295,7 @@ public class MetricsServer implements IMetricsServer {
                 } catch (InterruptedException e) {
                     MetricsServer.this.logger.info("Shutdown wait was interrupted", e);
                     Thread.currentThread().interrupt();
-                    return;
+                    break;
                 }
             }
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
@@ -49,8 +49,12 @@ public class ResourceManagement implements IResourceManagement {
     private final ArrayList<IResourceManagementProvider> resourceManagementProviders        = new ArrayList<>();
     private ScheduledExecutorService                     scheduledExecutorService;
 
-    private boolean                                      shutdown                           = false;
-    private boolean                                      shutdownComplete                   = false;
+    // This flag is set by one thread, and read by another, so we always want the variable to be in memory rather than 
+    // in some code-optimised register.
+    private volatile boolean                             shutdown                           = false;
+
+    // Same for this flag too. Multi-threaded access.
+    private volatile boolean                             shutdownComplete                   = false;
 
     private Instant                                      lastSuccessfulRun                  = Instant.now();
 
@@ -73,182 +77,190 @@ public class ResourceManagement implements IResourceManagement {
         // *** Add shutdown hook to allow for orderly shutdown
         Runtime.getRuntime().addShutdownHook(new ShutdownHook());
 
-        // *** Initialise the framework services
-        FrameworkInitialisation frameworkInitialisation = null;
         try {
-            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
-        } catch (Exception e) {
-            throw new FrameworkException("Unable to initialise the Framework Services", e);
-        }
-        IFramework framework = frameworkInitialisation.getFramework();
-
-        IConfigurationPropertyStoreService cps = framework.getConfigurationPropertyService("framework");
-        IDynamicStatusStoreService dss = framework.getDynamicStatusStoreService("framework");
-
-        // *** Now start the Resource Management framework
-
-        logger.info("Starting Resource Management");
-
-        // *** Calculate servername
-
-        this.hostname = "unknown";
-        try {
-            this.hostname = InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            logger.error("Unable to obtain the host name", e);
-        }
-        this.serverName = AbstractManager.nulled(cps.getProperty("server", "name"));
-        if (this.serverName == null) {
-            this.serverName = AbstractManager.nulled(System.getenv("framework.server.name"));
-            if (this.serverName == null) {
-                String[] split = this.hostname.split("\\.");
-                if (split.length >= 1) {
-                    this.serverName = split[0];
-                }
-            }
-        }
-        if (serverName == null) {
-            this.serverName = "unknown";
-        }
-        this.serverName = this.serverName.toLowerCase();
-        this.hostname = this.hostname.toLowerCase();
-        this.serverName = this.serverName.replaceAll("\\.", "-");
-
-        // *** Setup defaults and properties
-
-        int numberOfRunThreads = 5;
-        int metricsPort = 9010;
-        int healthPort = 9011;
-
-        String threads = AbstractManager.nulled(cps.getProperty("resource.management", "threads"));
-        if (threads != null) {
-            numberOfRunThreads = Integer.parseInt(threads);
-        }
-
-        String port = AbstractManager.nulled(cps.getProperty("resource.management.metrics", "port"));
-        if (port != null) {
-            metricsPort = Integer.parseInt(port);
-        }
-
-        port = AbstractManager.nulled(cps.getProperty("resource.management.health", "port"));
-        if (port != null) {
-            healthPort = Integer.parseInt(port);
-        }
-
-        // *** Setup scheduler
-        scheduledExecutorService = new ScheduledThreadPoolExecutor(numberOfRunThreads);
-
-        // *** Start the metrics server
-        if (metricsPort > 0) {
+            // *** Initialise the framework services
+            FrameworkInitialisation frameworkInitialisation = null;
             try {
-                this.metricsServer = new HTTPServer(metricsPort);
-                logger.info("Metrics server running on port " + metricsPort);
-            } catch (IOException e) {
-                throw new FrameworkException("Unable to start the metrics server", e);
+                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+            } catch (Exception e) {
+                throw new FrameworkException("Unable to initialise the Framework Services", e);
             }
-        } else {
-            logger.info("Metrics server disabled");
-        }
+            IFramework framework = frameworkInitialisation.getFramework();
 
-        // *** Create metrics
-        // DefaultExports.initialize() - problem within the the exporter at the moment
-        // TODO
+            IConfigurationPropertyStoreService cps = framework.getConfigurationPropertyService("framework");
+            IDynamicStatusStoreService dss = framework.getDynamicStatusStoreService("framework");
 
-        this.successfulRunsCounter = Counter.build().name("galasa_resource_management_successfull_runs")
-                .help("The number of successfull resource management runs").register();
+            // *** Now start the Resource Management framework
 
-        // *** Create Health Server
-        if (healthPort > 0) {
-            this.healthServer = new ResourceManagementHealth(this, healthPort);
-            logger.info("Health monitoring on port " + healthPort);
-        } else {
-            logger.info("Health monitoring disabled");
-        }
+            logger.info("Starting Resource Management");
 
-        // *** Locate all the Resource Management providers in the framework
-        try {
-            final ServiceReference<?>[] rmpServiceReference = bundleContext
-                    .getAllServiceReferences(IResourceManagementProvider.class.getName(), null);
-            if ((rmpServiceReference == null) || (rmpServiceReference.length == 0)) {
-                logger.info("No additional Resource Manager providers have been found");
-            } else {
-                for (final ServiceReference<?> rmpReference : rmpServiceReference) {
-                    final IResourceManagementProvider rmpStoreRegistration = (IResourceManagementProvider) bundleContext
-                            .getService(rmpReference);
-                    try {
-                        if (rmpStoreRegistration.initialise(framework, this)) {
-                            logger.info(
-                                    "Found Resource Management Provider " + rmpStoreRegistration.getClass().getName());
-                            resourceManagementProviders.add(rmpStoreRegistration);
-                        } else {
-                            logger.info("Resource Management Provider " + rmpStoreRegistration.getClass().getName()
-                                    + " opted out of this Resource Management run");
-                        }
-                    } catch (Exception e) {
-                        logger.error("Failed initialisation of Resource Management Provider "
-                                + rmpStoreRegistration.getClass().getName() + " ignoring", e);
+            // *** Calculate servername
+
+            this.hostname = "unknown";
+            try {
+                this.hostname = InetAddress.getLocalHost().getHostName();
+            } catch (UnknownHostException e) {
+                logger.error("Unable to obtain the host name", e);
+            }
+            this.serverName = AbstractManager.nulled(cps.getProperty("server", "name"));
+            if (this.serverName == null) {
+                this.serverName = AbstractManager.nulled(System.getenv("framework.server.name"));
+                if (this.serverName == null) {
+                    String[] split = this.hostname.split("\\.");
+                    if (split.length >= 1) {
+                        this.serverName = split[0];
                     }
                 }
             }
-        } catch (Exception e) {
-            throw new FrameworkException("Problem during Resource Manager initialisation", e);
-        }
+            if (serverName == null) {
+                this.serverName = "unknown";
+            }
+            this.serverName = this.serverName.toLowerCase();
+            this.hostname = this.hostname.toLowerCase();
+            this.serverName = this.serverName.replaceAll("\\.", "-");
 
-        // *** Start the providers
-        for (IResourceManagementProvider provider : resourceManagementProviders) {
-            provider.start();
-        }
+            // *** Setup defaults and properties
 
-        // *** Start the Run watch thread
-        ResourceManagementRunWatch runWatch = new ResourceManagementRunWatch(framework, this);
+            int numberOfRunThreads = 5;
+            int metricsPort = 9010;
+            int healthPort = 9011;
 
-        logger.info("Resource Manager has started");
-
-        // *** Loop until we are asked to shutdown
-        long heartbeatExpire = 0;
-        while (!shutdown) {
-            if (System.currentTimeMillis() >= heartbeatExpire) {
-                updateHeartbeat(dss);
-                heartbeatExpire = System.currentTimeMillis() + 20000;
+            String threads = AbstractManager.nulled(cps.getProperty("resource.management", "threads"));
+            if (threads != null) {
+                numberOfRunThreads = Integer.parseInt(threads);
             }
 
+            String port = AbstractManager.nulled(cps.getProperty("resource.management.metrics", "port"));
+            if (port != null) {
+                metricsPort = Integer.parseInt(port);
+            }
+
+            port = AbstractManager.nulled(cps.getProperty("resource.management.health", "port"));
+            if (port != null) {
+                healthPort = Integer.parseInt(port);
+            }
+
+            // *** Setup scheduler
+            scheduledExecutorService = new ScheduledThreadPoolExecutor(numberOfRunThreads);
+
+            // *** Start the metrics server
+            if (metricsPort > 0) {
+                try {
+                    this.metricsServer = new HTTPServer(metricsPort);
+                    logger.info("Metrics server running on port " + metricsPort);
+                } catch (IOException e) {
+                    throw new FrameworkException("Unable to start the metrics server", e);
+                }
+            } else {
+                logger.info("Metrics server disabled");
+            }
+
+            // *** Create metrics
+            // DefaultExports.initialize() - problem within the the exporter at the moment
+            // TODO
+
+            this.successfulRunsCounter = Counter.build().name("galasa_resource_management_successfull_runs")
+                    .help("The number of successfull resource management runs").register();
+
+            // *** Create Health Server
+            if (healthPort > 0) {
+                this.healthServer = new ResourceManagementHealth(this, healthPort);
+                logger.info("Health monitoring on port " + healthPort);
+            } else {
+                logger.info("Health monitoring disabled");
+            }
+
+            // *** Locate all the Resource Management providers in the framework
             try {
-                Thread.sleep(500);
+                final ServiceReference<?>[] rmpServiceReference = bundleContext
+                        .getAllServiceReferences(IResourceManagementProvider.class.getName(), null);
+                if ((rmpServiceReference == null) || (rmpServiceReference.length == 0)) {
+                    logger.info("No additional Resource Manager providers have been found");
+                } else {
+                    for (final ServiceReference<?> rmpReference : rmpServiceReference) {
+                        final IResourceManagementProvider rmpStoreRegistration = (IResourceManagementProvider) bundleContext
+                                .getService(rmpReference);
+                        try {
+                            if (rmpStoreRegistration.initialise(framework, this)) {
+                                logger.info(
+                                        "Found Resource Management Provider " + rmpStoreRegistration.getClass().getName());
+                                resourceManagementProviders.add(rmpStoreRegistration);
+                            } else {
+                                logger.info("Resource Management Provider " + rmpStoreRegistration.getClass().getName()
+                                        + " opted out of this Resource Management run");
+                            }
+                        } catch (Exception e) {
+                            logger.error("Failed initialisation of Resource Management Provider "
+                                    + rmpStoreRegistration.getClass().getName() + " ignoring", e);
+                        }
+                    }
+                }
             } catch (Exception e) {
-                throw new FrameworkException("Interrupted sleep", e);
+                throw new FrameworkException("Problem during Resource Manager initialisation", e);
             }
+
+            // *** Start the providers
+            for (IResourceManagementProvider provider : resourceManagementProviders) {
+                provider.start();
+            }
+
+            // *** Start the Run watch thread
+            ResourceManagementRunWatch runWatch = new ResourceManagementRunWatch(framework, this);
+
+            logger.info("Resource Manager has started");
+
+        
+
+            // *** Loop until we are asked to shutdown
+            long heartbeatExpire = 0;
+            while (!shutdown) {
+                if (System.currentTimeMillis() >= heartbeatExpire) {
+                    updateHeartbeat(dss);
+                    heartbeatExpire = System.currentTimeMillis() + 20000;
+                }
+
+                try {
+                    Thread.sleep(500);
+                } catch (Exception e) {
+                    throw new FrameworkException("Interrupted sleep", e);
+                }
+            }
+
+            // *** shutdown the scheduler
+            logger.error("Asking the scheduler to shut down.");
+            this.scheduledExecutorService.shutdown();
+            try {
+                this.scheduledExecutorService.awaitTermination(30, TimeUnit.SECONDS);
+                logger.error("The scheduler shut down ok.");
+            } catch (Exception e) {
+                logger.error("Unable to shutdown the scheduler");
+            }
+
+            // *** Ask the run watch to terminate
+            runWatch.shutdown();
+
+            // *** shutdown the providers
+            for (IResourceManagementProvider provider : resourceManagementProviders) {
+                logger.info("Requesting Resource Management Provider " + provider.getClass().getName() + " shutdown");
+                provider.shutdown();
+            }
+
+            // *** Stop the metics server
+            if (metricsPort > 0) {
+                this.metricsServer.close();
+            }
+
+            // *** Stop the health server
+            if (healthPort > 0) {
+                this.healthServer.shutdown();
+            }
+
+        } finally {
+            logger.info("Resource Management shutdown is complete.");
+
+            // Let the ShutDownHook know that the main thread has shut things down via this shared-state boolean.
+            shutdownComplete = true;
         }
-
-        // *** shutdown the scheduler
-        this.scheduledExecutorService.shutdown();
-        try {
-            this.scheduledExecutorService.awaitTermination(30, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            logger.error("Unable to shutdown the scheduler");
-        }
-
-        // *** Ask the run watch to terminate
-        runWatch.shutdown();
-
-        // *** shutdown the providers
-        for (IResourceManagementProvider provider : resourceManagementProviders) {
-            logger.info("Requesting Resource Management Provider " + provider.getClass().getName() + " shutdown");
-            provider.shutdown();
-        }
-
-        // *** Stop the metics server
-        if (metricsPort > 0) {
-            this.metricsServer.stop();
-        }
-
-        // *** Stop the health server
-        if (healthPort > 0) {
-            this.healthServer.shutdown();
-        }
-
-        logger.info("Resource Management shutdown");
-        shutdownComplete = true;
-        return;
     }
 
     private void updateHeartbeat(IDynamicStatusStoreService dss) {
@@ -296,6 +308,8 @@ public class ResourceManagement implements IResourceManagement {
         @Override
         public void run() {
             ResourceManagement.this.logger.info("Shutdown request received");
+            
+            // Tell the main thread to shut down via this shared variable.
             ResourceManagement.this.shutdown = true;
 
             while (!shutdownComplete) {
@@ -304,7 +318,7 @@ public class ResourceManagement implements IResourceManagement {
                 } catch (InterruptedException e) {
                     ResourceManagement.this.logger.info("Shutdown wait was interrupted", e);
                     Thread.currentThread().interrupt();
-                    return;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Processes are not stopping correctly. Even when they get a signal to stop.

See issue: [Resource management pod not restarting on failure #2064](https://github.com/galasa-dev/projectmanagement/issues/2064)

- Same coding pattern used in 5 places !
- Solution isn't overly clean, want to see if it makes a difference.
- A signal should allow the service to shut down now
- Seems to work for the API server, Ctrl-C where I could never do that before.
