### PR TITLE
version of test-harness bundle should be same as release.

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -90,7 +90,7 @@ dependencies {
         api 'dev.galasa:dev.galasa.wrapping.protobuf-java:'+version
         api 'dev.galasa:dev.galasa.wrapping.velocity-engine-core:'+version
         api 'dev.galasa:galasa-boot:'+version
-        api 'dev.galasa:galasa-testharness:0.18.0'
+        api 'dev.galasa:galasa-testharness:'+version
 
         api 'io.etcd:jetcd-api:0.8.3'
         api 'io.etcd:jetcd-common:0.8.3'


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?

Browsing the code I noted that the test-harness bundle wasn't at 0.39.0 when it should be.
