### PR TITLE
Iss2085 - Simplify workflows for forked repositories

### DIFF
--- a/.github/workflows/pr-maven.yaml
+++ b/.github/workflows/pr-maven.yaml
@@ -47,46 +47,6 @@ jobs:
           java-version: '17'
           distribution: 'semeru'
           cache: 'maven'
-      
-      # Copy secrets into files to use in workflow
-      # - name: Make secrets directory
-      #   run : |
-      #     mkdir /home/runner/work/secrets
-
-      # - name: Copy settings.xml
-      #   env:
-      #     MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-      #   run : |
-      #     echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
-
-      # - name: Copy GPG passphrase
-      #   env:
-      #     GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      #   run : |
-      #     echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
-
-      # - name: Copy GPG key
-      #   env:
-      #     GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
-      #   run : |
-      #     echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
-            
-      #   # Set up Maven GPG directory
-      # - name: Make GPG home directory
-      #   run: |
-      #     mkdir /home/runner/work/gpg
-        
-      # - name: Change directory permissions
-      #   run: |
-      #     chmod '700' /home/runner/work/gpg
-  
-      # - name: Import GPG
-      #   run: |
-      #     gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
-        
-      # - name: Copy custom settings.xml
-      #   run: |
-      #     cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
 
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.

--- a/.github/workflows/pr-maven.yaml
+++ b/.github/workflows/pr-maven.yaml
@@ -49,44 +49,44 @@ jobs:
           cache: 'maven'
       
       # Copy secrets into files to use in workflow
-      - name: Make secrets directory
-        run : |
-          mkdir /home/runner/work/secrets
+      # - name: Make secrets directory
+      #   run : |
+      #     mkdir /home/runner/work/secrets
 
-      - name: Copy settings.xml
-        env:
-          MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-        run : |
-          echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+      # - name: Copy settings.xml
+      #   env:
+      #     MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+      #   run : |
+      #     echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
 
-      - name: Copy GPG passphrase
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run : |
-          echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+      # - name: Copy GPG passphrase
+      #   env:
+      #     GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      #   run : |
+      #     echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
 
-      - name: Copy GPG key
-        env:
-          GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
-        run : |
-          echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+      # - name: Copy GPG key
+      #   env:
+      #     GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+      #   run : |
+      #     echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
             
-        # Set up Maven GPG directory
-      - name: Make GPG home directory
-        run: |
-          mkdir /home/runner/work/gpg
+      #   # Set up Maven GPG directory
+      # - name: Make GPG home directory
+      #   run: |
+      #     mkdir /home/runner/work/gpg
         
-      - name: Change directory permissions
-        run: |
-          chmod '700' /home/runner/work/gpg
+      # - name: Change directory permissions
+      #   run: |
+      #     chmod '700' /home/runner/work/gpg
   
-      - name: Import GPG
-        run: |
-          gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+      # - name: Import GPG
+      #   run: |
+      #     gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
         
-      - name: Copy custom settings.xml
-        run: |
-          cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+      # - name: Copy custom settings.xml
+      #   run: |
+      #     cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
 
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.
@@ -137,7 +137,7 @@ jobs:
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/maven/repo \
           --batch-mode --errors --fail-at-end \
-          --settings /home/runner/work/gpg/settings.xml
+          --settings settings.xml
 
       - name: Upload maven artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-obr.yaml
+++ b/.github/workflows/pr-obr.yaml
@@ -60,41 +60,6 @@ jobs:
         run: |
           echo $GITHUB_SHA > ./obr.githash
 
-      # - name: Make secrets directory
-      #   run : |
-      #       mkdir /home/runner/work/secrets
-
-      # - name: Copy settings.xml
-      #   env:
-      #       MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-      #   run : |
-      #       echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
-      
-      # - name: Copy GPG passphrase
-      #   env:
-      #       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      #   run : |
-      #       echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
-      
-      # - name: Copy GPG key
-      #   env:
-      #       GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
-      #   run : |
-      #       echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
-            
-      # - name: Make GPG home directory and change permissions
-      #   run: |
-      #       mkdir /home/runner/work/gpg
-      #       chmod '700' /home/runner/work/gpg
-        
-      # - name: Import GPG
-      #   run: |
-      #       gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
-        
-      # - name: Copy custom settings.xml
-      #   run: |
-      #       cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
-
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.
 
@@ -363,41 +328,6 @@ jobs:
           java-version: '17'
           distribution: 'semeru'
           cache: 'maven'
-      
-      # - name: Make secrets directory
-      #   run : |
-      #       mkdir /home/runner/work/secrets
-
-      # - name: Copy settings.xml 
-      #   env:
-      #     MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-      #   run : |
-      #     echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
-
-      # - name: Copy GPG passphrase
-      #   env:
-      #     GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      #   run : |
-      #     echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
-
-      # - name: Copy GPG key
-      #   env:
-      #     GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
-      #   run : |
-      #     echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
-          
-      # - name: Make GPG home directory and change permissions
-      #   run: |
-      #     mkdir /home/runner/work/gpg
-      #     chmod '700' /home/runner/work/gpg
-
-      # - name: Import GPG
-      #   run: |
-      #     gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
-      
-      # - name: Copy custom settings.xml
-      #   run: |
-      #     cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
 
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.

--- a/.github/workflows/pr-obr.yaml
+++ b/.github/workflows/pr-obr.yaml
@@ -60,40 +60,40 @@ jobs:
         run: |
           echo $GITHUB_SHA > ./obr.githash
 
-      - name: Make secrets directory
-        run : |
-            mkdir /home/runner/work/secrets
+      # - name: Make secrets directory
+      #   run : |
+      #       mkdir /home/runner/work/secrets
 
-      - name: Copy settings.xml
-        env:
-            MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-        run : |
-            echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+      # - name: Copy settings.xml
+      #   env:
+      #       MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+      #   run : |
+      #       echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
       
-      - name: Copy GPG passphrase
-        env:
-            GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run : |
-            echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+      # - name: Copy GPG passphrase
+      #   env:
+      #       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      #   run : |
+      #       echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
       
-      - name: Copy GPG key
-        env:
-            GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
-        run : |
-            echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+      # - name: Copy GPG key
+      #   env:
+      #       GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+      #   run : |
+      #       echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
             
-      - name: Make GPG home directory and change permissions
-        run: |
-            mkdir /home/runner/work/gpg
-            chmod '700' /home/runner/work/gpg
+      # - name: Make GPG home directory and change permissions
+      #   run: |
+      #       mkdir /home/runner/work/gpg
+      #       chmod '700' /home/runner/work/gpg
         
-      - name: Import GPG
-        run: |
-            gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+      # - name: Import GPG
+      #   run: |
+      #       gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
         
-      - name: Copy custom settings.xml
-        run: |
-            cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+      # - name: Copy custom settings.xml
+      #   run: |
+      #       cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
 
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.
@@ -262,7 +262,7 @@ jobs:
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/repo \
           --batch-mode --errors --fail-at-end \
-          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-bom-build.log
+          --settings settings.xml 2>&1 | tee galasa-bom-build.log
         
       - name: Upload Galasa BOM build log
         if: failure()
@@ -297,7 +297,7 @@ jobs:
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/repo \
           --batch-mode --errors --fail-at-end \
-          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-obr-build.log
+          --settings settings.xml 2>&1 | tee galasa-obr-build.log
 
       - name: Upload Galasa OBR build log
         if: failure()
@@ -364,40 +364,40 @@ jobs:
           distribution: 'semeru'
           cache: 'maven'
       
-      - name: Make secrets directory
-        run : |
-            mkdir /home/runner/work/secrets
+      # - name: Make secrets directory
+      #   run : |
+      #       mkdir /home/runner/work/secrets
 
-      - name: Copy settings.xml 
-        env:
-          MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-        run : |
-          echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+      # - name: Copy settings.xml 
+      #   env:
+      #     MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+      #   run : |
+      #     echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
 
-      - name: Copy GPG passphrase
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run : |
-          echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+      # - name: Copy GPG passphrase
+      #   env:
+      #     GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      #   run : |
+      #     echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
 
-      - name: Copy GPG key
-        env:
-          GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
-        run : |
-          echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+      # - name: Copy GPG key
+      #   env:
+      #     GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+      #   run : |
+      #     echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
           
-      - name: Make GPG home directory and change permissions
-        run: |
-          mkdir /home/runner/work/gpg
-          chmod '700' /home/runner/work/gpg
+      # - name: Make GPG home directory and change permissions
+      #   run: |
+      #     mkdir /home/runner/work/gpg
+      #     chmod '700' /home/runner/work/gpg
 
-      - name: Import GPG
-        run: |
-          gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+      # - name: Import GPG
+      #   run: |
+      #     gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
       
-      - name: Copy custom settings.xml
-        run: |
-          cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+      # - name: Copy custom settings.xml
+      #   run: |
+      #     cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
 
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.
@@ -568,7 +568,7 @@ jobs:
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/javadocs/docker/repo \
           -Dmaven.javadoc.failOnError=false \
           --batch-mode --errors --fail-at-end \
-          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
+          --settings ${{ github.workspace }}/modules/obr/settings.xml 2>&1 | tee build.log
 
       - name: Upload Javadoc site build log
         if: failure()

--- a/.github/workflows/pr-wrapping.yaml
+++ b/.github/workflows/pr-wrapping.yaml
@@ -66,43 +66,6 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ inputs.artifact-id }}
 
-      # Copy secrets into files to use in workflow
-      # - name: Make secrets directory
-      #   run : |
-      #     mkdir /home/runner/work/secrets
-      # - name: Copy settings.xml
-      #   env:
-      #     MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-      #   run : |
-      #     echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
-      # - name: Copy GPG passphrase
-      #   env:
-      #     GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      #   run : |
-      #     echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
-      # - name: Copy GPG key
-      #   env:
-      #     GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
-      #   run : |
-      #     echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
-          
-      # Set up Maven GPG directory
-      # - name: Make GPG home directory
-      #   run: |
-      #     mkdir /home/runner/work/gpg
-      
-      # - name: Change directory permissions
-      #   run: |
-      #     chmod '700' /home/runner/work/gpg
-
-      # - name: Import GPG
-      #   run: |
-      #     gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
-      
-      # - name: Copy custom settings.xml
-      #   run: |
-      #     cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
-      
       - name: Building Wrapping source code
         working-directory: modules/wrapping
         run: |

--- a/.github/workflows/pr-wrapping.yaml
+++ b/.github/workflows/pr-wrapping.yaml
@@ -67,41 +67,41 @@ jobs:
           run-id: ${{ inputs.artifact-id }}
 
       # Copy secrets into files to use in workflow
-      - name: Make secrets directory
-        run : |
-          mkdir /home/runner/work/secrets
-      - name: Copy settings.xml
-        env:
-          MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-        run : |
-          echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
-      - name: Copy GPG passphrase
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run : |
-          echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
-      - name: Copy GPG key
-        env:
-          GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
-        run : |
-          echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+      # - name: Make secrets directory
+      #   run : |
+      #     mkdir /home/runner/work/secrets
+      # - name: Copy settings.xml
+      #   env:
+      #     MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+      #   run : |
+      #     echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+      # - name: Copy GPG passphrase
+      #   env:
+      #     GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      #   run : |
+      #     echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+      # - name: Copy GPG key
+      #   env:
+      #     GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+      #   run : |
+      #     echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
           
       # Set up Maven GPG directory
-      - name: Make GPG home directory
-        run: |
-          mkdir /home/runner/work/gpg
+      # - name: Make GPG home directory
+      #   run: |
+      #     mkdir /home/runner/work/gpg
       
-      - name: Change directory permissions
-        run: |
-          chmod '700' /home/runner/work/gpg
+      # - name: Change directory permissions
+      #   run: |
+      #     chmod '700' /home/runner/work/gpg
 
-      - name: Import GPG
-        run: |
-          gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+      # - name: Import GPG
+      #   run: |
+      #     gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
       
-      - name: Copy custom settings.xml
-        run: |
-          cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+      # - name: Copy custom settings.xml
+      #   run: |
+      #     cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
       
       - name: Building Wrapping source code
         working-directory: modules/wrapping
@@ -112,7 +112,7 @@ jobs:
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/wrapping/repo \
           --batch-mode --errors --fail-at-end \
-          --settings /home/runner/work/gpg/settings.xml
+          --settings settings.xml
 
       - name: Upload wrapping artifacts
         uses: actions/upload-artifact@v4

--- a/modules/maven/settings.xml
+++ b/modules/maven/settings.xml
@@ -1,0 +1,35 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+	<profiles>
+        <profile>
+            <id>galasa</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>galasa.source.repo</id>
+                    <url>${galasa.source.repo}</url>
+                </repository>
+                <repository>
+                    <id>central</id>
+                    <url>${galasa.central.repo}</url>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>galasa.source.repo</id>
+                    <url>${galasa.source.repo}</url>
+                </pluginRepository>
+                <pluginRepository>
+                    <id>central</id>
+                    <url>${galasa.central.repo}</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+	</profiles>
+
+</settings>

--- a/modules/wrapping/settings.xml
+++ b/modules/wrapping/settings.xml
@@ -1,0 +1,35 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+	<profiles>
+        <profile>
+            <id>galasa</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>galasa.source.repo</id>
+                    <url>${galasa.source.repo}</url>
+                </repository>
+                <repository>
+                    <id>central</id>
+                    <url>${galasa.central.repo}</url>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>galasa.source.repo</id>
+                    <url>${galasa.source.repo}</url>
+                </pluginRepository>
+                <pluginRepository>
+                    <id>central</id>
+                    <url>${galasa.central.repo}</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+	</profiles>
+
+</settings>


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2085

Delete sections in Pull Request workflows that reference GPG secrets as they are not needed, as GPG signing is disabled for PR builds. Use a different settings.xml for these which simply has the repositories and no reference to GPG info. This means forked repositories can run the PR workflows without needing to set these secrets up.