### PR TITLE
querying a list of roles should return a list of complete role information not just the role metadata

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1938,7 +1938,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RBACRole'
+                type: array
+                description: A list of the roles in the system.
+                items: 
+                  $ref: '#/components/schemas/RBACRole'
         '404':
           $ref: '#/components/responses/NotFound'
         '401':
@@ -2430,6 +2433,7 @@ components:
       properties:
         role:
           $ref: '#/components/schemas/RBACRole'
+
     RBACRole:
       type: object
       properties:

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1938,7 +1938,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RBACRolesSummary'
+                $ref: '#/components/schemas/RBACRole'
         '404':
           $ref: '#/components/responses/NotFound'
         '401':
@@ -2430,11 +2430,6 @@ components:
       properties:
         role:
           $ref: '#/components/schemas/RBACRole'
-    RBACRolesSummary:
-      type: array
-      description: A summary of the roles available on the system
-      items:
-        $ref: '#/components/schemas/RBACRoleMetadata'
     RBACRole:
       type: object
       properties:

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.rbac/src/main/java/dev/galasa/framework/api/rbac/internal/routes/RoleTransform.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.rbac/src/main/java/dev/galasa/framework/api/rbac/internal/routes/RoleTransform.java
@@ -51,8 +51,8 @@ public class RoleTransform {
         return metadata;
     }
 
-    public List<RBACRoleMetadata> createRolesSummary(Collection<Role> roles, String baseUrl) {
-        List<RBACRoleMetadata> rolesSummaryBeans = new ArrayList<RBACRoleMetadata>();
+    public List<RBACRole> createRolesBeans(Collection<Role> roles, String baseUrl) {
+        List<RBACRole> rolesBeans = new ArrayList<RBACRole>();
         for( Role role : roles ) {
 
             String url ;
@@ -62,10 +62,10 @@ public class RoleTransform {
                 url = baseUrl+"/"+role.getId();
             }
 
-            RBACRoleMetadata roleMetadataBean = createRoleMetadata(role, url);
-            rolesSummaryBeans.add(roleMetadataBean);
+            RBACRole roleBean = createRoleBean(role, url);
+            rolesBeans.add(roleBean);
         }
-        return rolesSummaryBeans;
+        return rolesBeans;
     }
     
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.rbac/src/main/java/dev/galasa/framework/api/rbac/internal/routes/RolesRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.rbac/src/main/java/dev/galasa/framework/api/rbac/internal/routes/RolesRoute.java
@@ -14,7 +14,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.api.beans.generated.RBACRole;
-import dev.galasa.framework.api.beans.generated.RBACRoleMetadata;
 import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.rbac/src/main/java/dev/galasa/framework/api/rbac/internal/routes/RolesRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.rbac/src/main/java/dev/galasa/framework/api/rbac/internal/routes/RolesRoute.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import dev.galasa.framework.api.beans.generated.RBACRole;
 import dev.galasa.framework.api.beans.generated.RBACRoleMetadata;
 import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.QueryParameters;
@@ -49,11 +50,11 @@ public class RolesRoute extends AbstractRBACRoute {
     ) throws FrameworkException {
         logger.info("handleGetRequest() entered. Getting roles");
 
-        Collection<Role> roles = getRBACService().getRolesMapById().values();
+        Collection<Role> roles = getRBACService().getRolesSortedByName();
 
         String baseUrl = request.getRequestURL().toString();
 
-        List<RBACRoleMetadata> roleBeans = roleTransform.createRolesSummary(roles, baseUrl);
+        List<RBACRole> roleBeans = roleTransform.createRolesBeans(roles, baseUrl);
     
         HttpServletResponse httpResponse = getResponseBuilder().buildResponse(request, response, "application/json",
             gson.toJson(roleBeans), HttpServletResponse.SC_OK);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.rbac/src/test/java/dev/galasa/framework/api/rbac/internal/routes/RolesRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.rbac/src/test/java/dev/galasa/framework/api/rbac/internal/routes/RolesRouteTest.java
@@ -71,13 +71,28 @@ public class RolesRouteTest {
         JsonArray expectedJson = new JsonArray();
 
         {
+            JsonObject roleObj = new JsonObject();
+            roleObj.addProperty("kind", "GalasaRole");
+            roleObj.addProperty("apiVersion","galasa-dev/v1alpha1");
+
             JsonObject role1MetadataObj = new JsonObject();
             role1MetadataObj.addProperty("url","http://mock.galasa.server/myRole1Id");
             role1MetadataObj.addProperty("name","myRole1Name");
             role1MetadataObj.addProperty("id","myRole1Id");
             role1MetadataObj.addProperty("description","Description of myRole1Name");
 
-            expectedJson.add(role1MetadataObj);
+            roleObj.add( "metadata", role1MetadataObj);
+
+            JsonArray actionsList = new JsonArray();
+            actionsList.add("action1Id");
+            actionsList.add("action2Id");
+
+            JsonObject dataObj = new JsonObject();
+            dataObj.add("actions",actionsList);
+
+            roleObj.add("data",dataObj);
+
+            expectedJson.add(roleObj);
         }
 
         assertThat(servletResponse.getStatus()).isEqualTo(200);


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Part of the [rbac foundation story](https://github.com/galasa-dev/projectmanagement/issues/2071)

- Instead of returning a list of metadata when you query a list of roles, you get all the role information.