### PR TITLE
Add org.osgi.service.component.annotations to MVP packaging

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -340,6 +340,7 @@ external:
     artifact: org.osgi.service.component.annotations
     version: 1.3.0
     bom: true
+    mvp: true
     # Added since Isolated selects bundles based on this line,
     # and not just all bundles appearing in this file,
     # but might not be needed in Isolated.


### PR DESCRIPTION
## Why?
The CompilationLocalJava11UbuntuMvp regression test is failing to build, throwing the following error:
```
* What went wrong:
Execution failed for task ':dev.galasa.simbank.manager:compileJava'.
> Could not resolve all files for configuration ':dev.galasa.simbank.manager:compileClasspath'.
   > Could not find org.osgi:org.osgi.service.component.annotations:1.3.0.
     Searched in the following locations:
       - file:/home/galasa83/galasaconfig/isolatedrepo/maven/org/osgi/org.osgi.service.component.annotations/1.3.0/org.osgi.service.component.annotations-1.3.0.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project :dev.galasa.simbank.manager
         project :dev.galasa.simbank.manager > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
```

This PR adds the missing `org.osgi.service.component.annotations` to the MVP packaging to fix the above error.
