### PR TITLE
Add selenium dependencies for isolated and MVP into release.yaml

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -20,6 +20,12 @@ release:
 
 external:
   bundles:
+  # Transitive dependency of selenium 4.27.0 required for isolated and MVP
+  - group: com.google.auto.service
+    artifact: auto-service-annotations
+    mvp: true
+    isolated: true
+
   - group: com.google.code.gson
     artifact: gson
     version: 2.10.1
@@ -73,6 +79,12 @@ external:
     version: 1.3.4
     obr: false
     bom: true
+    mvp: true
+    isolated: true
+
+  # Transitive dependency of selenium 4.27.0 required for isolated and MVP
+  - group: dev.failsafe
+    artifact: failsafe
     mvp: true
     isolated: true
 
@@ -137,6 +149,62 @@ external:
     obr: true
     mvp: false      # Only used in Kafka extension - not needed.
     isolated: false # Only used in Kafka extension - not needed.
+
+  # io.opentelemetry dependencies are transitive dependencies of selenium 4.27.0 required for isolated and MVP
+  - group: io.opentelemetry
+    artifact: opentelemetry-api
+    mvp: true
+    isolated: true
+
+  - group: io.opentelemetry
+    artifact: opentelemetry-context
+    mvp: true
+    isolated: true
+
+  - group: io.opentelemetry
+    artifact: opentelemetry-exporter-logging
+    mvp: true
+    isolated: true
+
+  - group: io.opentelemetry
+    artifact: opentelemetry-sdk
+    mvp: true
+    isolated: true
+
+  - group: io.opentelemetry
+    artifact: opentelemetry-sdk-common
+    mvp: true
+    isolated: true
+
+  - group: io.opentelemetry
+    artifact: opentelemetry-sdk-extension-autoconfigure
+    mvp: true
+    isolated: true
+
+  - group: io.opentelemetry
+    artifact: opentelemetry-sdk-extension-autoconfigure-spi
+    mvp: true
+    isolated: true
+
+  - group: io.opentelemetry
+    artifact: opentelemetry-sdk-logs
+    mvp: true
+    isolated: true
+
+  - group: io.opentelemetry
+    artifact: opentelemetry-sdk-metrics
+    mvp: true
+    isolated: true
+
+  - group: io.opentelemetry
+    artifact: opentelemetry-sdk-trace
+    mvp: true
+    isolated: true
+
+  - group: io.opentelemetry.semconv
+    artifact: opentelemetry-semconv
+    mvp: true
+    isolated: true
 
   - group: io.prometheus
     artifact: simpleclient
@@ -336,6 +404,12 @@ external:
     mvp: false      # Only used for Docker controller - not needed.
     isolated: false # Only used for Docker controller - not needed.
 
+  # Transitive dependency of selenium 4.27.0 required for isolated and MVP
+  - group: org.jspecify
+    artifact: jspecify
+    mvp: true
+    isolated: true
+
   - group: org.osgi
     artifact: org.osgi.service.component.annotations
     version: 1.3.0
@@ -344,6 +418,67 @@ external:
     # Added since Isolated selects bundles based on this line,
     # and not just all bundles appearing in this file,
     # but might not be needed in Isolated.
+    isolated: true
+
+  # org.seleniumhq.selenium dependencies are dependencies on selenium 4.27.0 required for isolated and MVP
+  - group: org.seleniumhq.selenium
+    artifact: selenium-api
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-chrome-driver
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-chromium-driver
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-devtools-v85
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-edge-driver
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-firefox-driver
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-http
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-ie-driver
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-json
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-manager
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-os
+    mvp: true
+    isolated: true
+
+  - group: org.seleniumhq.selenium
+    artifact: selenium-remote-driver
+    mvp: true
     isolated: true
 
   - group: org.slf4j


### PR DESCRIPTION
## Why?
The compilation inttests are failing because they cannot resolve several selenium-related dependencies using the isolated and mvp maven repos since the dependencies are not in those zips. The Gradle build error seen in the compilation tests is shown below.

This PR adds the missing dependencies into the isolated and MVP packaging and also moves the existing selenium dependencies from the isolated pom.template files into the release.yaml to reduce duplication and keep all the related dependencies in the same place.

```
* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find com.google.auto.service:auto-service-annotations:1.1.1.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/com/google/auto/service/auto-service-annotations/1.1.1/auto-service-annotations-1.1.1.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-chrome-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-edge-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-firefox-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-ie-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find org.seleniumhq.selenium:selenium-chromium-driver:4.27.0.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/org/seleniumhq/selenium/selenium-chromium-driver/4.27.0/selenium-chromium-driver-4.27.0.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-chrome-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-edge-driver:4.27.0
   > Could not find org.seleniumhq.selenium:selenium-json:4.27.0.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/org/seleniumhq/selenium/selenium-json/4.27.0/selenium-json-4.27.0.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-chrome-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-firefox-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find org.seleniumhq.selenium:selenium-manager:4.27.0.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/org/seleniumhq/selenium/selenium-manager/4.27.0/selenium-manager-4.27.0.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-chrome-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-edge-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-firefox-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-ie-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find org.seleniumhq.selenium:selenium-devtools-v85:4.27.0.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/org/seleniumhq/selenium/selenium-devtools-v85/4.27.0/selenium-devtools-v85-4.27.0.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-firefox-driver:4.27.0
   > Could not find org.seleniumhq.selenium:selenium-http:4.27.0.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/org/seleniumhq/selenium/selenium-http/4.27.0/selenium-http-4.27.0.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-firefox-driver:4.27.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/io/opentelemetry/semconv/opentelemetry-semconv/1.25.0-alpha/opentelemetry-semconv-1.25.0-alpha.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find io.opentelemetry:opentelemetry-api:1.44.1.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/io/opentelemetry/opentelemetry-api/1.44.1/opentelemetry-api-1.44.1.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find io.opentelemetry:opentelemetry-context:1.44.1.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/io/opentelemetry/opentelemetry-context/1.44.1/opentelemetry-context-1.44.1.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find io.opentelemetry:opentelemetry-exporter-logging:1.44.1.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/io/opentelemetry/opentelemetry-exporter-logging/1.44.1/opentelemetry-exporter-logging-1.44.1.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find io.opentelemetry:opentelemetry-sdk-common:1.44.1.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/io/opentelemetry/opentelemetry-sdk-common/1.44.1/opentelemetry-sdk-common-1.44.1.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.44.1.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/1.44.1/opentelemetry-sdk-extension-autoconfigure-spi-1.44.1.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.44.1.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.44.1/opentelemetry-sdk-extension-autoconfigure-1.44.1.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find io.opentelemetry:opentelemetry-sdk-trace:1.44.1.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/io/opentelemetry/opentelemetry-sdk-trace/1.44.1/opentelemetry-sdk-trace-1.44.1.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find io.opentelemetry:opentelemetry-sdk:1.44.1.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/io/opentelemetry/opentelemetry-sdk/1.44.1/opentelemetry-sdk-1.44.1.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find org.seleniumhq.selenium:selenium-os:4.27.0.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/org/seleniumhq/selenium/selenium-os/4.27.0/selenium-os-4.27.0.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-remote-driver:4.27.0
   > Could not find org.jspecify:jspecify:1.0.0.
     Searched in the following locations:
       - file:/home/galasa73/galasaconfig/isolatedrepo/maven/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.39.0 > dev.galasa:dev.galasa.platform:0.39.0
         project : > dev.galasa:dev.galasa.selenium.manager:0.39.0 > org.seleniumhq.selenium:selenium-edge-driver:4.27.0 > org.seleniumhq.selenium:selenium-api:4.27.0
```