### PR TITLE
removed compat lib. Moved classes so they don't clash with maven core class names

### DIFF
--- a/modules/maven/galasa-maven-plugin/pom.xml
+++ b/modules/maven/galasa-maven-plugin/pom.xml
@@ -90,7 +90,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-compat</artifactId>
+			<artifactId>maven-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildBundleTestCatalog.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildBundleTestCatalog.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.io.File;
 import java.lang.annotation.Annotation;
@@ -147,7 +147,7 @@ public class BuildBundleTestCatalog extends AbstractMojo {
                 // *** Have to do reflection here, becuase of the different classpaths
                 if (annotationBuilderInterface.isAssignableFrom(klass)) {
                     try {
-                        Object instance = klass.newInstance();
+                        Object instance = klass.getDeclaredConstructor().newInstance();
                         catalogTestBuilders.put(instance,
                                 klass.getMethod("appendTestCatalog", JsonObject.class, JsonObject.class, Class.class));
                         catalogSenvBuilders.put(instance,

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildGherkinTestCatalog.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildGherkinTestCatalog.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.io.File;
 import java.nio.file.Files;

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildGherkinZip.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildGherkinZip.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildOBRResources.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildOBRResources.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.io.File;
 import java.io.FileReader;

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildObrEmbeddedRepository.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildObrEmbeddedRepository.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.io.File;
 import java.io.FileReader;

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/DeployTestCatalog.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/DeployTestCatalog.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.net.URL;
 import org.apache.maven.artifact.Artifact;

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/ErrorRaiserMavenImpl.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/ErrorRaiserMavenImpl.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.text.MessageFormat;
 

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/MergeTestCatalogs.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/MergeTestCatalogs.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.io.BufferedInputStream;
 import java.io.File;

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/StoreGitCommitHash.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/StoreGitCommitHash.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.io.File;
 import java.io.IOException;

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/TestCatalogArtifactMavenImpl.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/TestCatalogArtifactMavenImpl.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/WrappedLogMaven.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/WrappedLogMaven.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import org.apache.maven.plugin.logging.Log;
 

--- a/modules/maven/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/galasa/DeployTestCatalogTest.java
+++ b/modules/maven/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/galasa/DeployTestCatalogTest.java
@@ -3,10 +3,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.net.URL;
 import org.junit.Test;
+
 import org.apache.maven.project.MavenProject;
 
 public class DeployTestCatalogTest { 

--- a/modules/maven/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/galasa/ErrorRaiserMavenImplTest.java
+++ b/modules/maven/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/galasa/ErrorRaiserMavenImplTest.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/modules/maven/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/galasa/MockArtifact.java
+++ b/modules/maven/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/galasa/MockArtifact.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 
 import java.io.File;
 import java.util.Collection;

--- a/modules/maven/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/galasa/MockMavenLog.java
+++ b/modules/maven/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/galasa/MockMavenLog.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.maven.plugin;
+package dev.galasa.maven.plugin.galasa;
 import java.util.*;
 import static org.assertj.core.api.Assertions.*;
 import org.apache.maven.plugin.logging.Log;

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -235,8 +235,8 @@ dependencies {
         api 'org.apache.logging.log4j:log4j-core:2.24.1' // If updating, also update in galasa-boot build.gradle.
         api 'org.apache.logging.log4j:log4j-slf4j-impl:2.24.1'
 
+        api 'org.apache.maven:maven-core:3.9.9'
         api 'org.apache.maven:maven-artifact:3.9.6'
-        api 'org.apache.maven:maven-compat:3.9.9'
         api 'org.apache.maven:maven-plugin-api:3.6.2'
         api 'org.apache.maven:maven-repository-metadata:3.3.9'
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
See story maven-compat 3.6.2 needs upgrading
[#2091](https://github.com/galasa-dev/projectmanagement/issues/2091)

- Removed maven compat as a dependency for the maven plugins (So maven v2 is no longer going to work). Given maven 3.0 was issued in 2010 I don't see this as a problem.
- Moved all the implementation classes down a level, so they don't clash with maven-core classes
