### PR TITLE
Store auth state in DSS instead of server sessions

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStore.java
@@ -81,8 +81,12 @@ public class Etcd3DynamicStatusStore implements IDynamicStatusStore {
      * @param dssUri - http:// uri for th etcd cluster.
      */
     public Etcd3DynamicStatusStore(URI dssUri) {
-        client = Client.builder().endpoints(dssUri).build();
-        kvClient = client.getKVClient();
+        this(Client.builder().endpoints(dssUri).build());
+    }
+
+    public Etcd3DynamicStatusStore(Client client) {
+        this.client = client;
+        this.kvClient = client.getKVClient();
         this.watchClient = client.getWatchClient();
         this.leaseClient = client.getLeaseClient();
     }
@@ -499,6 +503,7 @@ public class Etcd3DynamicStatusStore implements IDynamicStatusStore {
     @Override
     public void shutdown() throws DynamicStatusStoreException {
         watchClient.close();
+        leaseClient.close();
         kvClient.close();
         client.close();
     }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStore.java
@@ -35,6 +35,7 @@ import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.KV;
 import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.Lease;
 import io.etcd.jetcd.Txn;
 import io.etcd.jetcd.Watch;
 import io.etcd.jetcd.Watch.Listener;
@@ -43,6 +44,7 @@ import io.etcd.jetcd.kv.DeleteResponse;
 import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.kv.PutResponse;
 import io.etcd.jetcd.kv.TxnResponse;
+import io.etcd.jetcd.lease.LeaseGrantResponse;
 import io.etcd.jetcd.op.Cmp;
 import io.etcd.jetcd.op.CmpTarget;
 import io.etcd.jetcd.op.Op;
@@ -65,6 +67,7 @@ public class Etcd3DynamicStatusStore implements IDynamicStatusStore {
     private final Client                            client;
     private final KV                                kvClient;
     private final Watch                             watchClient;
+    private final Lease                             leaseClient;
 
     private final HashMap<UUID, PassthroughWatcher> watchers = new HashMap<>();
 
@@ -81,6 +84,7 @@ public class Etcd3DynamicStatusStore implements IDynamicStatusStore {
         client = Client.builder().endpoints(dssUri).build();
         kvClient = client.getKVClient();
         this.watchClient = client.getWatchClient();
+        this.leaseClient = client.getLeaseClient();
     }
 
     /**
@@ -130,6 +134,36 @@ public class Etcd3DynamicStatusStore implements IDynamicStatusStore {
             throw new DynamicStatusStoreException("", e);
         }
 
+    }
+
+    /**
+     * Put a key-value pair into the DSS that expires after a given amount of time in seconds
+     * 
+     * @param key the key to be stored
+     * @param value the value to be associated with the given key
+     * @param timeToLiveSecs the amount of time in seconds for the key-value pair to be available for before expiring
+     * @throws DynamicStatusStoreException if there was an error accessing etcd
+     */
+    @Override
+    public void put(@NotNull String key, @NotNull String value, @NotNull long timeToLiveSecs) throws DynamicStatusStoreException {
+
+        // Create a new lease with the given time-to-live (TTL)
+        CompletableFuture<LeaseGrantResponse> leaseResponse = leaseClient.grant(timeToLiveSecs);
+        try {
+            LeaseGrantResponse lease = leaseResponse.get();
+            PutOption putOption = PutOption.builder()
+                .withLeaseId(lease.getID())
+                .build();
+            
+            // Set the key-value pair, applying the lease to it so the key expires after the given amount of time
+            ByteSequence bsKey = ByteSequence.from(key, UTF_8);
+            ByteSequence bsValue = ByteSequence.from(value, UTF_8);
+            kvClient.put(bsKey, bsValue, putOption).get();
+
+        } catch (InterruptedException | ExecutionException e) {
+            Thread.currentThread().interrupt();
+            throw new DynamicStatusStoreException("Could not set key-value pair with time-to-live", e);
+        }
     }
 
     /**

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3DynamicStatusStoreTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3DynamicStatusStoreTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.etcd.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import dev.galasa.cps.etcd.internal.Etcd3DynamicStatusStore;
+import dev.galasa.etcd.internal.mocks.MockEtcdClient;
+import dev.galasa.etcd.internal.mocks.MockEtcdLeaseClient;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class Etcd3DynamicStatusStoreTest {
+
+    @Test
+    public void testPutPropertyWithTimeToLiveCreatesExpectedLeaseOk() throws Exception {
+        // Given...
+        Map<String, String> mockProps = new HashMap<>();
+
+        MockEtcdLeaseClient mockLeaseClient = new MockEtcdLeaseClient();
+        MockEtcdClient mockClient = new MockEtcdClient(mockProps);
+        mockClient.setLeaseClient(mockLeaseClient);
+
+        Etcd3DynamicStatusStore store = new Etcd3DynamicStatusStore(mockClient);
+
+        String keyToAdd = "key1";
+        String valueToAdd = "value1";
+        long timeToLiveSecs = 5;
+
+        // When...
+        store.put(keyToAdd, valueToAdd, timeToLiveSecs);
+
+        // Then...
+        assertThat(mockProps).hasSize(1);
+        assertThat(mockProps.get(keyToAdd)).isEqualTo(valueToAdd);
+        assertThat(mockLeaseClient.getLeases()).hasSize(1);
+        assertThat(mockLeaseClient.getLeases().get(0).getTTL()).isEqualTo(timeToLiveSecs);
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdClient.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdClient.java
@@ -20,6 +20,8 @@ import io.etcd.jetcd.Watch;
 public class MockEtcdClient implements Client {
 
     private KV kvClient;
+    private Lease leaseClient = new MockEtcdLeaseClient();
+    private Watch watchClient = new MockEtcdWatchClient();
     private boolean isClientShutDown = false;
 
     public MockEtcdClient(Map<String, String> kvContents) {
@@ -32,12 +34,26 @@ public class MockEtcdClient implements Client {
     }
 
     @Override
+    public Lease getLeaseClient() {
+        return leaseClient;
+    }
+
+    @Override
+    public Watch getWatchClient() {
+        return watchClient;
+    }
+
+    @Override
     public void close() {
         isClientShutDown = true;
     }
 
     public boolean isClientShutDown() {
         return isClientShutDown;
+    }
+
+    public void setLeaseClient(Lease leaseClient) {
+        this.leaseClient = leaseClient;
     }
 
     @Override
@@ -56,11 +72,6 @@ public class MockEtcdClient implements Client {
     }
 
     @Override
-    public Lease getLeaseClient() {
-        throw new UnsupportedOperationException("Unimplemented method 'getLeaseClient'");
-    }
-
-    @Override
     public Lock getLockClient() {
         throw new UnsupportedOperationException("Unimplemented method 'getLockClient'");
     }
@@ -69,10 +80,4 @@ public class MockEtcdClient implements Client {
     public Maintenance getMaintenanceClient() {
         throw new UnsupportedOperationException("Unimplemented method 'getMaintenanceClient'");
     }
-
-    @Override
-    public Watch getWatchClient() {
-        throw new UnsupportedOperationException("Unimplemented method 'getWatchClient'");
-    }
-    
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdKvClient.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdKvClient.java
@@ -94,6 +94,11 @@ public class MockEtcdKvClient implements KV {
         return CompletableFuture.completedFuture(null);
     }
 
+    @Override
+    public CompletableFuture<PutResponse> put(ByteSequence key, ByteSequence value, PutOption options) {
+        return put(key, value);
+    }
+
 
     @Override
     public CompletableFuture<DeleteResponse> delete(ByteSequence key, DeleteOption options) {
@@ -137,11 +142,6 @@ public class MockEtcdKvClient implements KV {
     @Override
     public CompletableFuture<DeleteResponse> delete(ByteSequence key) {
         throw new UnsupportedOperationException("Unimplemented method 'delete'");
-    }
-
-    @Override
-    public CompletableFuture<PutResponse> put(ByteSequence key, ByteSequence value, PutOption options) {
-        throw new UnsupportedOperationException("Unimplemented method 'put'");
     }
 
     @Override

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdLeaseClient.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdLeaseClient.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.etcd.internal.mocks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import io.etcd.jetcd.Lease;
+import io.etcd.jetcd.lease.LeaseGrantResponse;
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse;
+import io.etcd.jetcd.lease.LeaseRevokeResponse;
+import io.etcd.jetcd.lease.LeaseTimeToLiveResponse;
+import io.etcd.jetcd.options.LeaseOption;
+import io.etcd.jetcd.support.CloseableClient;
+import io.grpc.stub.StreamObserver;
+
+public class MockEtcdLeaseClient implements Lease {
+
+    private List<LeaseGrantResponse> leases = new ArrayList<>();
+
+    @Override
+    public CompletableFuture<LeaseGrantResponse> grant(long ttl) {
+        LeaseGrantResponse mockLeaseResponse = new LeaseGrantResponse(
+            io.etcd.jetcd.api.LeaseGrantResponse.newBuilder()
+            .setID(123)
+            .setTTL(ttl)
+            .build()
+        );
+        leases.add(mockLeaseResponse);
+        return CompletableFuture.completedFuture(mockLeaseResponse);
+    }
+
+    public List<LeaseGrantResponse> getLeases() {
+        return leases;
+    }
+
+    @Override
+    public CompletableFuture<LeaseGrantResponse> grant(long ttl, long timeout, TimeUnit unit) {
+        throw new UnsupportedOperationException("Unimplemented method 'grant'");
+    }
+
+    @Override
+    public CompletableFuture<LeaseRevokeResponse> revoke(long leaseId) {
+        throw new UnsupportedOperationException("Unimplemented method 'revoke'");
+    }
+
+    @Override
+    public CompletableFuture<LeaseKeepAliveResponse> keepAliveOnce(long leaseId) {
+        throw new UnsupportedOperationException("Unimplemented method 'keepAliveOnce'");
+    }
+
+    @Override
+    public CompletableFuture<LeaseTimeToLiveResponse> timeToLive(long leaseId, LeaseOption leaseOption) {
+        throw new UnsupportedOperationException("Unimplemented method 'timeToLive'");
+    }
+
+    @Override
+    public CloseableClient keepAlive(long leaseId, StreamObserver<LeaseKeepAliveResponse> observer) {
+        throw new UnsupportedOperationException("Unimplemented method 'keepAlive'");
+    }
+    
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdWatchClient.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdWatchClient.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.etcd.internal.mocks;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Watch;
+import io.etcd.jetcd.options.WatchOption;
+
+public class MockEtcdWatchClient implements Watch {
+
+    @Override
+    public Watcher watch(ByteSequence key, WatchOption option, Listener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'watch'");
+    }
+
+    @Override
+    public void requestProgress() {
+        throw new UnsupportedOperationException("Unimplemented method 'requestProgress'");
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
@@ -29,6 +29,8 @@ import dev.galasa.framework.api.common.SystemEnvironment;
 import dev.galasa.framework.auth.spi.AuthServiceFactory;
 import dev.galasa.framework.auth.spi.IAuthService;
 import dev.galasa.framework.auth.spi.IAuthServiceFactory;
+import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.utils.ITimeService;
 import dev.galasa.framework.spi.utils.SystemTimeService;
@@ -44,6 +46,7 @@ public class AuthenticationServlet extends BaseServlet {
     @Reference
     protected IFramework framework;
 
+    private static final String AUTH_DSS_NAMESPACE = "auth";
     private static final long serialVersionUID = 1L;
 
     private Log logger = LogFactory.getLog(getClass());
@@ -68,10 +71,17 @@ public class AuthenticationServlet extends BaseServlet {
             factory = new AuthServiceFactory(framework, env);
         }
 
+        IDynamicStatusStoreService dssService = null;
+        try {
+            dssService = framework.getDynamicStatusStoreService(AUTH_DSS_NAMESPACE);
+        } catch (DynamicStatusStoreException e) {
+            throw new ServletException("Failed to initialise authentication servlet");
+        }
+
         IAuthService authService = factory.getAuthService();
-        addRoute(new AuthRoute(getResponseBuilder(), oidcProvider, authService, env));
+        addRoute(new AuthRoute(getResponseBuilder(), oidcProvider, authService, env, dssService));
         addRoute(new AuthClientsRoute(getResponseBuilder(), authService));
-        addRoute(new AuthCallbackRoute(getResponseBuilder(), externalApiServerUrl));
+        addRoute(new AuthCallbackRoute(getResponseBuilder(), externalApiServerUrl, dssService));
         addRoute(new AuthTokensRoute(getResponseBuilder(), oidcProvider, authService, timeService, env));
         addRoute(new AuthTokensDetailsRoute(getResponseBuilder(), authService));
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/IOidcProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/IOidcProvider.java
@@ -5,8 +5,6 @@ import java.net.http.HttpResponse;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 
-import javax.servlet.http.HttpSession;
-
 import com.google.gson.JsonObject;
 
 /**
@@ -25,13 +23,13 @@ public interface IOidcProvider {
      * Gets the URL of the upstream connector to authenticate with (e.g. a
      * github.com URL to authenticate with an OAuth application in GitHub).
      */
-    public String getConnectorRedirectUrl(String clientId, String callbackUrl, HttpSession session) throws IOException, InterruptedException;
+    public String getConnectorRedirectUrl(String clientId, String callbackUrl, String stateId) throws IOException, InterruptedException;
 
     /**
      * Sends a GET request to an OpenID Connect authorization endpoint, returning
      * the received response.
      */
-    public HttpResponse<String> sendAuthorizationGet(String clientId, String callbackUrl, HttpSession session) throws IOException, InterruptedException;
+    public HttpResponse<String> sendAuthorizationGet(String clientId, String callbackUrl, String stateId) throws IOException, InterruptedException;
 
     /**
      * Sends a POST request with a given request body to an OpenID Connect /token endpoint, returning the received response.

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
@@ -30,9 +30,7 @@ import java.util.Optional;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -136,10 +134,10 @@ public class OidcProvider implements IOidcProvider {
      * Gets the URL of the upstream connector to authenticate with (e.g. a
      * github.com URL to authenticate with an OAuth application in GitHub).
      */
-    public String getConnectorRedirectUrl(String clientId, String callbackUrl, HttpSession session) throws IOException, InterruptedException {
+    public String getConnectorRedirectUrl(String clientId, String callbackUrl, String stateId) throws IOException, InterruptedException {
         logger.info("Sending GET request to " + authorizationEndpoint);
 
-        HttpResponse<String> authResponse = sendAuthorizationGet(clientId, callbackUrl, session);
+        HttpResponse<String> authResponse = sendAuthorizationGet(clientId, callbackUrl, stateId);
         String redirectUrl = getLocationHeaderFromResponse(authResponse);
 
         // In case the "Location" header contains a relative URI, get an absolute URI from the response
@@ -155,17 +153,12 @@ public class OidcProvider implements IOidcProvider {
      * Sends a GET request to an OpenID Connect authorization endpoint, returning
      * the received response.
      */
-    public HttpResponse<String> sendAuthorizationGet(String clientId, String callbackUrl, HttpSession session) throws IOException, InterruptedException {
-        String state = RandomStringUtils.insecure().nextAlphanumeric(32);
+    public HttpResponse<String> sendAuthorizationGet(String clientId, String callbackUrl, String stateId) throws IOException, InterruptedException {
         String queryParams = "?response_type=code"
             + "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
             + "&redirect_uri=" + URLEncoder.encode(callbackUrl, StandardCharsets.UTF_8)
             + "&scope=" + URLEncoder.encode(BEARER_TOKEN_SCOPE, StandardCharsets.UTF_8)
-            + "&state=" + state;
-
-        // Save the state in a session for validation later
-        logger.info("Storing state parameter in session");
-        session.setAttribute("state", state);
+            + "&state=" + stateId;
 
         String authUrl = authorizationEndpoint + queryParams;
         return sendGetRequest(URI.create(authUrl));

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
@@ -158,7 +158,7 @@ public class OidcProvider implements IOidcProvider {
             + "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
             + "&redirect_uri=" + URLEncoder.encode(callbackUrl, StandardCharsets.UTF_8)
             + "&scope=" + URLEncoder.encode(BEARER_TOKEN_SCOPE, StandardCharsets.UTF_8)
-            + "&state=" + stateId;
+            + "&state=" + URLEncoder.encode(stateId, StandardCharsets.UTF_8);
 
         String authUrl = authorizationEndpoint + queryParams;
         return sendGetRequest(URI.create(authUrl));

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AbstractAuthRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AbstractAuthRoute.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.authentication.internal.routes;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import dev.galasa.framework.api.common.BaseRoute;
+import dev.galasa.framework.api.common.ResponseBuilder;
+
+/**
+ * An abstract route class containing common methods used by auth routes.
+ */
+public abstract class AbstractAuthRoute extends BaseRoute {
+
+    // Suffix for the DSS auth property 'dss.auth.STATEID.callback.url'
+    public static final String DSS_CALLBACK_URL_PROPERTY_SUFFIX = ".callback.url";
+
+    public AbstractAuthRoute(ResponseBuilder responseBuilder, String path) {
+        super(responseBuilder, path);
+    }
+
+    /**
+     * Checks if a given URL is a valid URL.
+     */
+    protected boolean isUrlValid(String url) {
+        boolean isValid = false;
+        try {
+            new URL(url).toURI();
+            isValid = true;
+            logger.info("Valid URL provided: '" + url + "'");
+        } catch (URISyntaxException | MalformedURLException e) {
+            logger.error("Invalid URL provided: '" + url + "'");
+        }
+        return isValid;
+    }
+
+    protected String sanitizeString(String paramValue) {
+        String cleanValue = null;
+        if (paramValue != null) {
+            cleanValue = paramValue.trim()
+                .replaceAll("\n", "")
+                .replaceAll("\r", "");
+        }
+        return cleanValue;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRoute.java
@@ -11,7 +11,6 @@ import java.net.URI;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
 import dev.galasa.framework.api.common.BaseRoute;
 import dev.galasa.framework.api.common.InternalServletException;
@@ -19,18 +18,25 @@ import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
 
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 public class AuthCallbackRoute extends BaseRoute {
 
     private static String externalApiServerUrl;
+    private IDynamicStatusStoreService dssService;
 
     // Regex to match /auth/callback only
     private static final String PATH_PATTERN = "\\/callback";
 
-    public AuthCallbackRoute(ResponseBuilder responseBuilder, String externalApiServerUrl) {
+    public AuthCallbackRoute(
+        ResponseBuilder responseBuilder,
+        String externalApiServerUrl,
+        IDynamicStatusStoreService dssService
+    ) {
         super(responseBuilder, PATH_PATTERN);
+        this.dssService = dssService;
         AuthCallbackRoute.externalApiServerUrl = externalApiServerUrl;
     }
 
@@ -55,45 +61,36 @@ public class AuthCallbackRoute extends BaseRoute {
         String authCode = queryParams.getSingleString("code", null);
         String state = queryParams.getSingleString("state", null);
 
-        if (state != null && authCode != null) {
-
-            // Make sure the state parameter is the same as the state that was previously stored in the session
-            HttpSession session = request.getSession();
-            if (isStateParameterValid(session, state)) {
-                logger.info("State query parameter matches previously-generated state");
-
-                String clientCallbackUrl = (String) session.getAttribute("callbackUrl");
-                if (clientCallbackUrl != null) {
-
-                    // If the callback URL already has query parameters, append to them
-                    String authCodeQuery = "code=" + authCode;
-                    clientCallbackUrl = appendQueryParameterToUrl(clientCallbackUrl, authCodeQuery);
-
-                    // We don't need the session anymore, so invalidate it
-                    session.invalidate();
-
-                    // Redirect the user back to the callback URL provided in the original /auth request
-                    response.addHeader("Location", clientCallbackUrl);
-                    return getResponseBuilder().buildResponse(request, response, null, null,
-                            HttpServletResponse.SC_FOUND);
-                } else {
-                    logger.error("Unable to redirect back to the client application (failed to retrieve callback URL from session)");
-                }
-            } else {
-                logger.error("The provided 'state' query parameter does not match the state parameter stored in the session");
-            }
+        if (state == null || authCode == null) {
+            ServletError error = new ServletError(GAL5400_BAD_REQUEST, request.getServletPath());
+            throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
         }
-        ServletError error = new ServletError(GAL5400_BAD_REQUEST, request.getServletPath());
-        throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
-    }
 
-    /**
-     * Checks whether the provided state parameter matches the state parameter that was stored
-     * when initiating an authentication flow.
-     */
-    private boolean isStateParameterValid(HttpSession session, String state) {
-        String storedState = (String) session.getAttribute("state");
-        return (storedState != null && state.equals(storedState));
+        // Make sure the state parameter is the same as the state that was previously stored in the DSS
+        String callbackUrlDssKey = state + ".callback.url";
+        String clientCallbackUrl = dssService.get(callbackUrlDssKey);
+
+        if (clientCallbackUrl == null) {
+            logger.error("The provided 'state' query parameter does not match the stored state parameter");
+            ServletError error = new ServletError(GAL5103_UNEXPECTED_STATE_PARAMETER_PROVIDED);
+            throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
+        }
+
+        logger.info("State query parameter matches previously-generated state");
+
+        // If the callback URL already has query parameters, append to them
+        String authCodeQuery = "code=" + authCode;
+        clientCallbackUrl = appendQueryParameterToUrl(clientCallbackUrl, authCodeQuery);
+
+        // We don't need the stored state anymore, so remove it from the DSS
+        dssService.delete(callbackUrlDssKey);
+
+        // Redirect the user back to the callback URL provided in the original /auth request
+        response.addHeader("Location", clientCallbackUrl);
+
+        logger.info("handleGetRequest() exiting");
+        return getResponseBuilder().buildResponse(request, response, null, null,
+                HttpServletResponse.SC_FOUND);
     }
 
     /**

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRoute.java
@@ -67,7 +67,8 @@ public class AuthCallbackRoute extends BaseRoute {
         }
 
         // Make sure the state parameter is the same as the state that was previously stored in the DSS
-        String callbackUrlDssKey = state + ".callback.url";
+        // using the 'dss.auth.STATEID.callback.url' property
+        String callbackUrlDssKey = state + AuthRoute.DSS_CALLBACK_URL_PROPERTY_SUFFIX;
         String clientCallbackUrl = dssService.get(callbackUrlDssKey);
 
         if (clientCallbackUrl == null) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -6,9 +6,6 @@
 package dev.galasa.framework.api.authentication.internal.routes;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.net.http.HttpResponse;
 import java.util.UUID;
 
@@ -24,7 +21,6 @@ import dev.galasa.framework.api.authentication.IOidcProvider;
 import dev.galasa.framework.api.common.JwtWrapper;
 import dev.galasa.framework.api.authentication.internal.TokenPayloadValidator;
 import dev.galasa.framework.api.beans.TokenPayload;
-import dev.galasa.framework.api.common.BaseRoute;
 import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.IBeanValidator;
 import dev.galasa.framework.api.common.InternalServletException;
@@ -42,10 +38,7 @@ import dev.galasa.framework.spi.auth.IInternalUser;
 
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
-public class AuthRoute extends BaseRoute {
-
-    // Suffix for the DSS auth property 'dss.auth.STATEID.callback.url'
-    public static final String DSS_CALLBACK_URL_PROPERTY_SUFFIX = ".callback.url";
+public class AuthRoute extends AbstractAuthRoute {
 
     private IAuthStoreService authStoreService;
     private IOidcProvider oidcProvider;
@@ -89,8 +82,8 @@ public class AuthRoute extends BaseRoute {
 
         logger.info("AuthRoute: handleGetRequest() entered.");
         try {
-            String clientId = queryParams.getSingleString("client_id", null);
-            String clientCallbackUrl = queryParams.getSingleString("callback_url", null);
+            String clientId = sanitizeString(queryParams.getSingleString("client_id", null));
+            String clientCallbackUrl = sanitizeString(queryParams.getSingleString("callback_url", null));
 
             // Make sure the required query parameters exist
             if (clientId == null || clientCallbackUrl == null || !isUrlValid(clientCallbackUrl)) {
@@ -207,21 +200,6 @@ public class AuthRoute extends BaseRoute {
             }
         }
         return response;
-    }
-
-    /**
-     * Checks if a given URL is a valid URL.
-     */
-    private boolean isUrlValid(String url) {
-        boolean isValid = false;
-        try {
-            new URL(url).toURI();
-            isValid = true;
-            logger.info("Valid URL provided: '" + url + "'");
-        } catch (URISyntaxException | MalformedURLException e) {
-            logger.error("Invalid URL provided: '" + url + "'");
-        }
-        return isValid;
     }
 
     /**

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -91,8 +91,7 @@ public class AuthRoute extends AbstractAuthRoute {
                 throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
             }
 
-            // Create a random ID to identify this auth request
-            String stateId = UUID.randomUUID().toString();
+            String stateId = generateStateId(request.getRemoteAddr());
 
             // Get the redirect URL to the upstream connector and add it to the response's "Location" header
             String authUrl = oidcProvider.getConnectorRedirectUrl(clientId, AuthCallbackRoute.getExternalAuthCallbackUrl(), stateId);
@@ -222,5 +221,14 @@ public class AuthRoute extends AbstractAuthRoute {
             throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
         }
         logger.info("Stored token record in the auth store OK");
+    }
+
+    // Creates a random ID to identify an auth request
+    private String generateStateId(String clientIp) {
+        String stateId = UUID.randomUUID().toString();
+        if (clientIp != null && !clientIp.isBlank()) {
+            stateId += "-" + clientIp;
+        }
+        return stateId;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -44,6 +44,9 @@ import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 public class AuthRoute extends BaseRoute {
 
+    // Suffix for the DSS auth property 'dss.auth.STATEID.callback.url'
+    public static final String DSS_CALLBACK_URL_PROPERTY_SUFFIX = ".callback.url";
+
     private IAuthStoreService authStoreService;
     private IOidcProvider oidcProvider;
     private IDexGrpcClient dexGrpcClient;
@@ -105,7 +108,7 @@ public class AuthRoute extends BaseRoute {
                 response.addHeader(HttpHeaders.LOCATION, authUrl);
 
                 // Store the callback URL in the DSS to redirect to at the end of the authentication process
-                dssService.put(stateId + ".callback.url", clientCallbackUrl, AUTH_DSS_STATE_EXPIRY_SECONDS);
+                dssService.put(stateId + DSS_CALLBACK_URL_PROPERTY_SUFFIX, clientCallbackUrl, AUTH_DSS_STATE_EXPIRY_SECONDS);
 
             } else {
                 ServletError error = new ServletError(GAL5054_FAILED_TO_GET_CONNECTOR_URL);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/OidcProviderTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/OidcProviderTest.java
@@ -38,7 +38,6 @@ import dev.galasa.framework.api.authentication.internal.OidcProvider;
 import dev.galasa.framework.api.authentication.internal.beans.JsonWebKey;
 import dev.galasa.framework.api.common.mocks.MockHttpClient;
 import dev.galasa.framework.api.common.mocks.MockHttpResponse;
-import dev.galasa.framework.api.common.mocks.MockHttpSession;
 import dev.galasa.framework.mocks.MockTimeService;
 import dev.galasa.framework.spi.utils.GalasaGson;
 
@@ -594,19 +593,14 @@ public class OidcProviderTest {
 
         mockHttpClient.setMockResponse(mockResponse);
 
-        MockHttpSession mockSession = new MockHttpSession();
+        String mockState = "this-is-a-random-id";
 
         // When...
-        HttpResponse<String> response = oidcProvider.sendAuthorizationGet("my-client-id", "http://my.server/callback", mockSession);
+        HttpResponse<String> response = oidcProvider.sendAuthorizationGet("my-client-id", "http://my.server/callback", mockState);
 
         // Then...
         assertThat(response).isNotNull();
         assertThat(response).isEqualTo(mockResponse);
-
-        // Ensure the "state" parameter has been set as a session attribute
-        String stateAttribute = (String) mockSession.getAttribute("state");
-        assertThat(stateAttribute).isNotNull();
-        assertThat(stateAttribute).hasSize(32);
     }
 
     @Test
@@ -622,10 +616,10 @@ public class OidcProviderTest {
 
         mockHttpClient.setMockResponse(mockResponse);
 
-        MockHttpSession mockSession = new MockHttpSession();
+        String mockState = "this-is-a-random-id";
 
         // When...
-        String redirectUrl = oidcProvider.getConnectorRedirectUrl("my-client-id", "http://my.server/callback", mockSession);
+        String redirectUrl = oidcProvider.getConnectorRedirectUrl("my-client-id", "http://my.server/callback", mockState);
 
         // Then...
         assertThat(redirectUrl).isNull();
@@ -645,10 +639,10 @@ public class OidcProviderTest {
 
         mockHttpClient.setMockResponse(mockResponse);
 
-        MockHttpSession mockSession = new MockHttpSession();
+        String mockState = "this-is-a-random-id";
 
         // When...
-        String redirectUrl = oidcProvider.getConnectorRedirectUrl("my-client-id", "http://my.server/callback", mockSession);
+        String redirectUrl = oidcProvider.getConnectorRedirectUrl("my-client-id", "http://my.server/callback", mockState);
 
         // Then...
         assertThat(redirectUrl).isNotNull();
@@ -669,10 +663,10 @@ public class OidcProviderTest {
 
         mockHttpClient.setMockResponse(mockResponse);
 
-        MockHttpSession mockSession = new MockHttpSession();
+        String mockState = "this-is-a-random-id";
 
         // When...
-        String redirectUrl = oidcProvider.getConnectorRedirectUrl("my-client-id", "http://my.server/callback", mockSession);
+        String redirectUrl = oidcProvider.getConnectorRedirectUrl("my-client-id", "http://my.server/callback", mockState);
 
         // Then...
         assertThat(redirectUrl).isNotNull();

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRouteTest.java
@@ -16,9 +16,10 @@ import org.junit.Test;
 
 import dev.galasa.framework.api.authentication.mocks.MockAuthenticationServlet;
 import dev.galasa.framework.api.common.BaseServletTest;
+import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
-import dev.galasa.framework.api.common.mocks.MockHttpSession;
+import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
 
 public class AuthCallbackRouteTest extends BaseServletTest {
 
@@ -103,7 +104,9 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestWithBadCallbackUrlReturnsError() throws Exception {
         // Given...
-        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockFramework mockFramework = new MockFramework(mockDss);
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockFramework);
 
         String expectedCode = "my-auth-code";
         String expectedState = "my-state";
@@ -113,11 +116,9 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         queryParams.put("code", new String[] { expectedCode });
         queryParams.put("state", new String[] { expectedState });
 
-        MockHttpSession mockSession = new MockHttpSession();
-        mockSession.setAttribute("state", expectedState);
-        mockSession.setAttribute("callbackUrl", expectedCallbackUrl);
+        mockDss.put(expectedState + ".callback.url", expectedCallbackUrl);
 
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback", mockSession);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback");
 
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
         ServletOutputStream outStream = servletResponse.getOutputStream();
@@ -127,21 +128,16 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         servlet.doGet(mockRequest, servletResponse);
 
         // Then...
-        // Expecting this json:
-        // {
-        // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occurred when trying to execute request
-        // '/auth/callback'. Please check your request parameters or report the problem to your
-        // Galasa Ecosystem owner."
-        // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5103, "GAL5103E", "Unexpected 'state' query parameter value provided");
     }
 
     @Test
     public void testAuthCallbackGetRequestWithValidStateAndCodeReturnsCode() throws Exception {
         // Given...
-        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockFramework mockFramework = new MockFramework(mockDss);
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockFramework);
 
         String expectedCode = "my-auth-code";
         String expectedState = "my-state";
@@ -151,11 +147,9 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         queryParams.put("code", new String[] { expectedCode });
         queryParams.put("state", new String[] { expectedState });
 
-        MockHttpSession mockSession = new MockHttpSession();
-        mockSession.setAttribute("state", expectedState);
-        mockSession.setAttribute("callbackUrl", expectedCallbackUrl);
+        mockDss.put(expectedState + ".callback.url", expectedCallbackUrl);
 
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback", mockSession);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback");
 
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
 
@@ -172,7 +166,9 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestCallbackUrlWithQueryAppendsCodeToQueryParams() throws Exception {
         // Given...
-        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockFramework mockFramework = new MockFramework(mockDss);
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockFramework);
 
         String expectedCode = "my-auth-code";
         String expectedState = "my-state";
@@ -182,11 +178,9 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         queryParams.put("code", new String[] { expectedCode });
         queryParams.put("state", new String[] { expectedState });
 
-        MockHttpSession mockSession = new MockHttpSession();
-        mockSession.setAttribute("state", expectedState);
-        mockSession.setAttribute("callbackUrl", expectedCallbackUrl);
+        mockDss.put(expectedState + ".callback.url", expectedCallbackUrl);
 
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback", mockSession);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback");
 
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
 
@@ -203,7 +197,9 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestWithInvalidStateReturnsBadRequest() throws Exception {
         // Given...
-        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockFramework mockFramework = new MockFramework(mockDss);
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockFramework);
 
         String expectedCode = "my-auth-code";
         String expectedState = "my-state";
@@ -212,10 +208,9 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         queryParams.put("code", new String[] { expectedCode });
         queryParams.put("state", new String[] { expectedState });
 
-        MockHttpSession mockSession = new MockHttpSession();
-        mockSession.setAttribute("state", "a different state");
+        mockDss.put("a-different-state.callback.url", "a-different-callback-url");
 
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback", mockSession);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback");
 
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
         ServletOutputStream outStream = servletResponse.getOutputStream();
@@ -225,21 +220,16 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         servlet.doGet(mockRequest, servletResponse);
 
         // Then...
-        // Expecting this json:
-        // {
-        // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occurred when trying to execute request
-        // '/auth/callback'. Please check your request parameters or report the problem to your
-        // Galasa Ecosystem owner."
-        // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5103, "GAL5103E", "Unexpected 'state' query parameter value provided");
     }
 
     @Test
     public void testAuthCallbackGetRequestWithNoMatchingStateSessionReturnsBadRequest() throws Exception {
         // Given...
-        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockFramework mockFramework = new MockFramework(mockDss);
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockFramework);
 
         String expectedCode = "my-auth-code";
         String expectedState = "my-state";
@@ -248,10 +238,9 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         queryParams.put("code", new String[] { expectedCode });
         queryParams.put("state", new String[] { expectedState });
 
-        MockHttpSession mockSession = new MockHttpSession();
-        mockSession.setAttribute("not state", "something else");
+        mockDss.put("not.an.auth.property", "something else");
 
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback", mockSession);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback");
 
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
         ServletOutputStream outStream = servletResponse.getOutputStream();
@@ -261,15 +250,8 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         servlet.doGet(mockRequest, servletResponse);
 
         // Then...
-        // Expecting this json:
-        // {
-        // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occurred when trying to execute request
-        // '/auth/callback'. Please check your request parameters or report the problem to your
-        // Galasa Ecosystem owner."
-        // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5103, "GAL5103E", "Unexpected 'state' query parameter value provided");
     }
 
     @Test
@@ -293,14 +275,7 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         servlet.doGet(mockRequest, servletResponse);
 
         // Then...
-        // Expecting this json:
-        // {
-        // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occurred when trying to execute request
-        // '/auth/callback'. Please check your request parameters or report the problem to your
-        // Galasa Ecosystem owner."
-        // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5103, "GAL5103E", "Unexpected 'state' query parameter value provided");
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRouteTest.java
@@ -278,4 +278,35 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         assertThat(servletResponse.getStatus()).isEqualTo(400);
         checkErrorStructure(outStream.toString(), 5103, "GAL5103E", "Unexpected 'state' query parameter value provided");
     }
+
+    @Test
+    public void testGetAuthCallbackWithInvalidStoredCallbackUrlThrowsError() throws Exception {
+        // Given...
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockFramework mockFramework = new MockFramework(mockDss);
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockFramework);
+
+        String expectedCode = "my-auth-code";
+        String expectedState = "my-state";
+        String badCallbackUrl = "not a valid \n callback URL!";
+
+        Map<String, String[]> queryParams = new HashMap<>();
+        queryParams.put("code", new String[] { expectedCode });
+        queryParams.put("state", new String[] { expectedState });
+
+        mockDss.put(expectedState + ".callback.url", badCallbackUrl);
+
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, "/callback");
+
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doGet(mockRequest, servletResponse);
+
+        // Then...
+        assertThat(servletResponse.getStatus()).isEqualTo(400);
+        checkErrorStructure(outStream.toString(), 5104, "GAL5104E", "Invalid callback URL provided");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthRouteTest.java
@@ -414,6 +414,7 @@ public class AuthRouteTest extends BaseServletTest {
     public void testAuthGetRequestWithClientIdAndCallbackUrlRedirectsToConnector() throws Exception {
         // Given...
         String redirectLocation = "http://my.connector/auth";
+        String clientIp = "123.456.789.010";
         String clientId = "my-client";
         String clientCallbackUrl = "http://my.app";
 
@@ -430,6 +431,8 @@ public class AuthRouteTest extends BaseServletTest {
         );
 
         MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, null);
+        mockRequest.setRemoteAddr(clientIp);
+
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
 
         // When...
@@ -445,6 +448,8 @@ public class AuthRouteTest extends BaseServletTest {
     @Test
     public void testAuthGetRequestWithEmptyReturnedLocationHeaderReturnsError() throws Exception {
         // Given...
+        String clientIp = "123.456.789.010";
+
         // No "Location" returned from the issuer, will not be able to redirect anywhere to authenticate
         Map<String, List<String>> headers = new HashMap<>();
         BiPredicate<String, String> defaultFilter = (a, b) -> true;
@@ -459,6 +464,8 @@ public class AuthRouteTest extends BaseServletTest {
         );
 
         MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, null);
+        mockRequest.setRemoteAddr(clientIp);
+
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
         ServletOutputStream outStream = servletResponse.getOutputStream();
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockAuthenticationServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockAuthenticationServlet.java
@@ -17,6 +17,7 @@ import dev.galasa.framework.auth.spi.IDexGrpcClient;
 import dev.galasa.framework.auth.spi.internal.AuthService;
 import dev.galasa.framework.auth.spi.mocks.MockAuthServiceFactory;
 import dev.galasa.framework.auth.spi.mocks.MockDexGrpcClient;
+import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
 import dev.galasa.framework.spi.IFramework;
 
 public class MockAuthenticationServlet extends AuthenticationServlet {
@@ -26,7 +27,7 @@ public class MockAuthenticationServlet extends AuthenticationServlet {
     }
 
     public MockAuthenticationServlet(IDexGrpcClient dexGrpcClient) {
-        this(new MockOidcProvider(), dexGrpcClient, new MockFramework());
+        this(new MockOidcProvider(), dexGrpcClient, new MockFramework(new MockIDynamicStatusStoreService()));
     }
 
     public MockAuthenticationServlet(IOidcProvider oidcProvider) {
@@ -38,7 +39,7 @@ public class MockAuthenticationServlet extends AuthenticationServlet {
     }
 
     public MockAuthenticationServlet(IOidcProvider oidcProvider, IDexGrpcClient dexGrpcClient) {
-        this(oidcProvider, dexGrpcClient, new MockFramework());
+        this(oidcProvider, dexGrpcClient, new MockFramework(new MockIDynamicStatusStoreService()));
     }
 
     public MockAuthenticationServlet(IOidcProvider oidcProvider, IDexGrpcClient dexGrpcClient, IFramework framework) {
@@ -53,6 +54,10 @@ public class MockAuthenticationServlet extends AuthenticationServlet {
         IAuthService authService = new AuthService(framework.getAuthStoreService(), dexGrpcClient);
         setAuthServiceFactory(new MockAuthServiceFactory(authService));
         setResponseBuilder(new ResponseBuilder(env));
+    }
+
+    public void setFramework(IFramework framework) {
+        this.framework = framework;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockOidcProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockOidcProvider.java
@@ -10,8 +10,6 @@ import java.net.http.HttpResponse;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 
-import javax.servlet.http.HttpSession;
-
 import com.google.gson.JsonObject;
 
 import dev.galasa.framework.api.authentication.IOidcProvider;
@@ -59,7 +57,7 @@ public class MockOidcProvider implements IOidcProvider {
     }
 
     @Override
-    public String getConnectorRedirectUrl(String clientId, String callbackUrl, HttpSession session)
+    public String getConnectorRedirectUrl(String clientId, String callbackUrl, String stateId)
             throws IOException, InterruptedException {
         if (throwException) {
             throwIOException();
@@ -86,7 +84,7 @@ public class MockOidcProvider implements IOidcProvider {
     }
 
     @Override
-    public HttpResponse<String> sendAuthorizationGet(String clientId, String callbackUrl, HttpSession session)
+    public HttpResponse<String> sendAuthorizationGet(String clientId, String callbackUrl, String stateId)
             throws IOException, InterruptedException {
         if (throwException) {
             throwIOException();

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -144,7 +144,7 @@ public enum ServletErrorMessage {
     GAL5102_INVALID_SECRET_DESCRIPTION_PROVIDED       (5102, "E: Invalid secret description provided. The description should not only contain spaces or tabs. When provided, it must contain characters in the Latin-1 character set. Report the problem to your Galasa Ecosystem owner."),
     
     // Auth callback API...
-    GAL5103_UNEXPECTED_STATE_PARAMETER_PROVIDED       (5103, "E: Unexpected ''state'' query parameter value provided. The provided ''state'' parameter value does not match the stored state identifier. Check that the ''state'' query parameter is correct and try again."),
+    GAL5103_UNEXPECTED_STATE_PARAMETER_PROVIDED       (5103, "E: Unexpected ''state'' query parameter value provided. The provided ''state'' parameter value does not match the stored state identifier or the auth request has timed out. Try to log in again."),
 
     // RBAC APIs...
     GAL5120_INVALID_ACTION_NAME_PROVIDED              (5120, "E: Invalid action name provided."),

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -145,6 +145,9 @@ public enum ServletErrorMessage {
     
     // Auth callback API...
     GAL5103_UNEXPECTED_STATE_PARAMETER_PROVIDED       (5103, "E: Unexpected ''state'' query parameter value provided. The provided ''state'' parameter value does not match the stored state identifier or the auth request has timed out. Try to log in again."),
+    GAL5104_INVALID_CALLBACK_URL_PROVIDED             (5104, "E: Invalid callback URL provided. The callback URL must be a valid URL. Check your request parameters and try again."),
+    GAL5105_INTERNAL_DSS_ERROR                        (5105, "E: Error occurred when trying to access the Dynamic Status Store. Report the problem to your Galasa Ecosystem owner."),
+
 
     // RBAC APIs...
     GAL5120_INVALID_ACTION_NAME_PROVIDED              (5120, "E: Invalid action name provided."),

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -143,6 +143,8 @@ public enum ServletErrorMessage {
     GAL5101_ERROR_UNEXPECTED_SECRET_TYPE_DETECTED     (5101, "E: Unknown secret type detected. A secret retrieved from the credentials store is in an unknown or unsupported format. Report the problem to your Galasa Ecosystem owner."),
     GAL5102_INVALID_SECRET_DESCRIPTION_PROVIDED       (5102, "E: Invalid secret description provided. The description should not only contain spaces or tabs. When provided, it must contain characters in the Latin-1 character set. Report the problem to your Galasa Ecosystem owner."),
     
+    // Auth callback API...
+    GAL5103_UNEXPECTED_STATE_PARAMETER_PROVIDED       (5103, "E: Unexpected ''state'' query parameter value provided. The provided ''state'' parameter value does not match the stored state identifier. Check that the ''state'' query parameter is correct and try again."),
 
     // RBAC APIs...
     GAL5120_INVALID_ACTION_NAME_PROVIDED              (5120, "E: Invalid action name provided."),

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockFramework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockFramework.java
@@ -34,12 +34,13 @@ import java.util.Random;
 import javax.validation.constraints.NotNull;
 
 public class MockFramework implements IFramework {
-    IResultArchiveStore archiveStore;
-    IFrameworkRuns frameworkRuns;
-    MockIConfigurationPropertyStoreService cpsService = new MockIConfigurationPropertyStoreService("framework");
-    MockCredentialsService creds = new MockCredentialsService(new HashMap<>());
-    IAuthStoreService authStoreService;
+    private IResultArchiveStore archiveStore;
+    private IFrameworkRuns frameworkRuns;
+    private MockIConfigurationPropertyStoreService cpsService = new MockIConfigurationPropertyStoreService("framework");
+    private MockCredentialsService creds = new MockCredentialsService(new HashMap<>());
+    private IAuthStoreService authStoreService;
     private RBACService rbacService;
+    private IDynamicStatusStoreService dssService;
     
     public MockFramework() {
         // Do nothing...
@@ -63,6 +64,10 @@ public class MockFramework implements IFramework {
 
     public MockFramework(RBACService rbacService){ 
         this.rbacService = rbacService;
+    }
+
+    public MockFramework(IDynamicStatusStoreService dssService) {
+        this.dssService = dssService;
     }
 
     public MockFramework(IResultArchiveStore archiveStore, IFrameworkRuns frameworkRuns) {
@@ -109,6 +114,12 @@ public class MockFramework implements IFramework {
     }
 
     @Override
+    public @NotNull IDynamicStatusStoreService getDynamicStatusStoreService(@NotNull String namespace)
+            throws DynamicStatusStoreException {
+        return this.dssService;
+    }
+
+    @Override
     public void setFrameworkProperties(Properties overrideProperties) {
         throw new UnsupportedOperationException("Unimplemented method 'setFrameworkProperties'");
     }
@@ -116,12 +127,6 @@ public class MockFramework implements IFramework {
     @Override
     public boolean isInitialised() {
         throw new UnsupportedOperationException("Unimplemented method 'isInitialised'");
-    }
-
-    @Override
-    public @NotNull IDynamicStatusStoreService getDynamicStatusStoreService(@NotNull String namespace)
-            throws DynamicStatusStoreException {
-        throw new UnsupportedOperationException("Unimplemented method 'getDynamicStatusStoreService'");
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockHttpServletRequest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockHttpServletRequest.java
@@ -41,6 +41,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
     private String method = "GET"; 
     private String contextPath = "/api";
     private String contentType = "application/json";
+    private String clientIp;
 
     private MockHttpSession session;
 
@@ -199,6 +200,15 @@ public class MockHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
+    public String getRemoteAddr() {
+        return this.clientIp;
+    }
+
+    public void setRemoteAddr(String clientIp) {
+        this.clientIp = clientIp;
+    }
+
+    @Override
     public Object getAttribute(String name) {
         throw new UnsupportedOperationException("Unimplemented method 'getAttribute'");
     }
@@ -246,11 +256,6 @@ public class MockHttpServletRequest implements HttpServletRequest {
     @Override
     public int getServerPort() {
         throw new UnsupportedOperationException("Unimplemented method 'getServerPort'");
-    }
-
-    @Override
-    public String getRemoteAddr() {
-        throw new UnsupportedOperationException("Unimplemented method 'getRemoteAddr'");
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/dss/FpfDynamicStatusStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/dss/FpfDynamicStatusStore.java
@@ -79,6 +79,12 @@ public class FpfDynamicStatusStore implements IDynamicStatusStore {
 
     }
 
+    @Override
+    public void put(@NotNull String key, @NotNull String value, @NotNull long timeToLiveSecs)
+            throws DynamicStatusStoreException {
+        throw new UnsupportedOperationException("Creating entries that expire for a file-based DSS is not supported");
+    }
+
     /**
      * <p>
      * This method swaps an old value with a new value for a given key in the DSS.

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/dss/FrameworkDynamicStoreKeyAccess.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/dss/FrameworkDynamicStoreKeyAccess.java
@@ -85,6 +85,12 @@ public class FrameworkDynamicStoreKeyAccess implements IDynamicStatusStoreKeyAcc
         this.dssStore.put(newKeyValues);
     }
 
+    @Override
+    public void put(@NotNull String key, @NotNull String value, @NotNull long timeToLiveSecs)
+            throws DynamicStatusStoreException {
+        this.dssStore.put(prefixKey(key), value, timeToLiveSecs);
+    }
+
     /*
      * (non-Javadoc)
      * 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/FrameworkResourcePoolingService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/FrameworkResourcePoolingService.java
@@ -506,6 +506,15 @@ public class FrameworkResourcePoolingService implements IResourcePoolingService 
          * Commenting as unused, but required from IDynamicStatusStore implementation.
          */
         @Override
+        public void put(@NotNull String key, @NotNull String value, @NotNull long timeToLiveSecs)
+                throws DynamicStatusStoreException {
+            // EMPTY METHOD
+        }
+
+        /**
+         * Commenting as unused, but required from IDynamicStatusStore implementation.
+         */
+        @Override
         public UUID watch(IDynamicStatusStoreWatcher watcher, String key) throws DynamicStatusStoreException {
             return null;
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IDynamicStatusStoreKeyAccess.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IDynamicStatusStoreKeyAccess.java
@@ -54,6 +54,16 @@ public interface IDynamicStatusStoreKeyAccess {
     void put(@NotNull Map<String, String> keyValues) throws DynamicStatusStoreException;
 
     /**
+     * Store a new key-value pair with a given expiry time in the server
+     * 
+     * @param key            - the key to store
+     * @param value          - the value to associate with the given key
+     * @param timeToLiveSecs - the amount of time in seconds for the key-value pair to remain available
+     * @throws DynamicStatusStoreException if there was an issue accessing the DSS
+     */
+    void put(@NotNull String key, @NotNull String value, @NotNull long timeToLiveSecs) throws DynamicStatusStoreException;
+
+    /**
      * Put a key/value pair in the server if the key is set to the oldValue.
      * 
      * @param key      - the key to use

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockDSSStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockDSSStore.java
@@ -141,5 +141,11 @@ public class MockDSSStore implements IDynamicStatusStore, IDynamicStatusStoreSer
     public IDynamicRun getDynamicRun() throws DynamicStatusStoreException {
         throw new UnsupportedOperationException("Unimplemented method 'getDynamicRun'");
     }
+
+    @Override
+    public void put(@NotNull String key, @NotNull String value, @NotNull long timeToLiveSecs)
+            throws DynamicStatusStoreException {
+        throw new UnsupportedOperationException("Unimplemented method 'put'");
+    }
     
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIDynamicStatusStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIDynamicStatusStoreService.java
@@ -70,12 +70,18 @@ public class MockIDynamicStatusStoreService implements IDynamicStatusStoreServic
         return data.get(key);
     }
 
-    // ------------------- un-implemented methods follow --------------------
-
     @Override
     public void put(@NotNull String key, @NotNull String value) throws DynamicStatusStoreException {
-               throw new UnsupportedOperationException("Unimplemented method 'put'");
+        data.put(key, value);
     }
+
+    @Override
+    public void put(@NotNull String key, @NotNull String value, @NotNull long timeToLiveSecs)
+            throws DynamicStatusStoreException {
+        put(key, value);
+    }
+
+    // ------------------- un-implemented methods follow --------------------
 
     @Override
     public void put(@NotNull Map<String, String> keyValues) throws DynamicStatusStoreException {

--- a/modules/framework/galasa-parent/galasa-testharness/src/main/java/dev/galasa/testharness/InMemoryDss.java
+++ b/modules/framework/galasa-parent/galasa-testharness/src/main/java/dev/galasa/testharness/InMemoryDss.java
@@ -51,6 +51,12 @@ public class InMemoryDss implements IDynamicStatusStore {
     }
 
     @Override
+    public void put(@NotNull String key, @NotNull String value, @NotNull long timeToLiveSecs)
+            throws DynamicStatusStoreException {
+        throw new UnsupportedOperationException("Creating entries that expire for an in-memory DSS is not supported");
+    }
+
+    @Override
     public synchronized boolean putSwap(@NotNull String key, String oldValue, @NotNull String newValue)
             throws DynamicStatusStoreException {
         


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2096

## Changes
- Stored auth state (callback URL and state ID) in a `dss.auth.STATEID.callback.url` DSS property (used to redirect the user back to a client after logging in from Dex/the API server)
  - This property is automatically deleted after 10mins if the auth process has not been completed
- Added DSS method to set a property with a given time-to-live in seconds (currently only implemented in etcd extension, not for local DSS)
- Added more validation around query parameters and callback URLs