### PR TITLE
Iss2054 - Upgrade assertj-core version

### DIFF
--- a/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
+++ b/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    implementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    implementation platform('dev.galasa:dev.galasa.platform:'+version)
     implementation 'dev.galasa:dev.galasa.framework'
     implementation 'dev.galasa:dev.galasa'
 
@@ -17,7 +17,7 @@ dependencies {
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.awaitility:awaitility'
-    testImplementation 'org.assertj:assertj-core:3.16.1'
+    testImplementation 'org.assertj:assertj-core'
 }
 
 test {

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testFixturesImplementation 'org.apache.httpcomponents:httpcore-osgi'
     testFixturesImplementation 'dev.galasa:dev.galasa.framework'
     testFixturesImplementation 'javax.validation:validation-api'
-    testFixturesImplementation 'org.assertj:assertj-core:3.16.1'
+    testFixturesImplementation 'org.assertj:assertj-core'
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.api.server.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.api.server.gradle
@@ -17,5 +17,5 @@ dependencies {
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.awaitility:awaitility'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core'
 }

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.api.server.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.api.server.gradle
@@ -17,5 +17,5 @@ dependencies {
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.awaitility:awaitility'
-    testImplementation 'org.assertj:assertj-core:3.16.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle
@@ -14,5 +14,5 @@ dependencies {
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.awaitility:awaitility'
-    testImplementation 'org.assertj:assertj-core:3.16.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.framework.gradle
@@ -14,5 +14,5 @@ dependencies {
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.awaitility:awaitility'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core'
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testFixturesImplementation platform('dev.galasa:dev.galasa.platform:'+version)
     testFixturesImplementation 'javax.servlet:javax.servlet-api'
-    testFixturesImplementation 'org.assertj:assertj-core:3.16.1'
+    testFixturesImplementation 'org.assertj:assertj-core:3.25.3'
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.gson'
     testFixturesImplementation(project(':dev.galasa.framework'))
     testFixturesImplementation(project(':dev.galasa.framework.api.beans'))

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testFixturesImplementation platform('dev.galasa:dev.galasa.platform:'+version)
     testFixturesImplementation 'javax.servlet:javax.servlet-api'
-    testFixturesImplementation 'org.assertj:assertj-core:3.25.3'
+    testFixturesImplementation 'org.assertj:assertj-core'
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.gson'
     testFixturesImplementation(project(':dev.galasa.framework'))
     testFixturesImplementation(project(':dev.galasa.framework.api.beans'))

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':dev.galasa.framework.api.common')
 
     testImplementation(testFixtures(project(':dev.galasa.framework.api.common')))
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
     // to use 3.23.1 caused unit test failures. Fixes for this to be completed in a future story.
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':dev.galasa.framework.api.common')
 
     testImplementation(testFixtures(project(':dev.galasa.framework.api.common')))
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core'
     // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
     // to use 3.23.1 caused unit test failures. Fixes for this to be completed in a future story.
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testFixturesImplementation platform('dev.galasa:dev.galasa.platform:'+version)
     testFixturesImplementation 'javax.servlet:javax.servlet-api'
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
-    testFixturesImplementation 'org.assertj:assertj-core:3.16.1'
+    testFixturesImplementation 'org.assertj:assertj-core:3.25.3'
     testFixturesImplementation(project(':dev.galasa.framework'))
     testFixturesImplementation(testFixtures(project(':dev.galasa.framework')))
     testFixturesImplementation(project(':dev.galasa.framework.api.beans'))

--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testFixturesImplementation platform('dev.galasa:dev.galasa.platform:'+version)
     testFixturesImplementation 'javax.servlet:javax.servlet-api'
     testFixturesImplementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
-    testFixturesImplementation 'org.assertj:assertj-core:3.25.3'
+    testFixturesImplementation 'org.assertj:assertj-core'
     testFixturesImplementation(project(':dev.galasa.framework'))
     testFixturesImplementation(testFixtures(project(':dev.galasa.framework')))
     testFixturesImplementation(project(':dev.galasa.framework.api.beans'))

--- a/modules/framework/galasa-parent/dev.galasa.framework/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testFixturesImplementation project (':dev.galasa')
     testFixturesImplementation platform('dev.galasa:dev.galasa.platform:'+version)
     testFixturesImplementation 'javax.validation:validation-api'
-    testFixturesImplementation 'org.assertj:assertj-core:3.16.1'
+    testFixturesImplementation 'org.assertj:assertj-core:3.25.3'
     testFixturesImplementation 'junit:junit'
     testFixturesImplementation 'commons-io:commons-io'
     testFixturesImplementation 'org.apache.felix:org.apache.felix.bundlerepository'

--- a/modules/framework/galasa-parent/dev.galasa.framework/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testFixturesImplementation project (':dev.galasa')
     testFixturesImplementation platform('dev.galasa:dev.galasa.platform:'+version)
     testFixturesImplementation 'javax.validation:validation-api'
-    testFixturesImplementation 'org.assertj:assertj-core:3.25.3'
+    testFixturesImplementation 'org.assertj:assertj-core'
     testFixturesImplementation 'junit:junit'
     testFixturesImplementation 'commons-io:commons-io'
     testFixturesImplementation 'org.apache.felix:org.apache.felix.bundlerepository'

--- a/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation 'junit:junit'
     // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
     // to higher versions caused unit test failures. Fixes for this to be completed in a future story.
-	testImplementation 'org.assertj:assertj-core:3.25.3'
+	testImplementation 'org.assertj:assertj-core'
     implementation project(':dev.galasa.plugin.common')
     testImplementation project(':dev.galasa.plugin.common.test')
 }

--- a/modules/gradle/dev.galasa.plugin.common.test/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.test/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	implementation 'commons-io:commons-io'
     // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
     // to higher versions caused unit test failures. Fixes for this to be completed in a future story.
-	implementation 'org.assertj:assertj-core:3.25.3'
+	implementation 'org.assertj:assertj-core'
     implementation 'org.apache.httpcomponents:httpcore'
     implementation 'org.apache.httpcomponents:httpclient'
     implementation project(':dev.galasa.plugin.common')

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    api platform('dev.galasa:dev.galasa.platform:0.39.0')
+    api platform('dev.galasa:dev.galasa.platform:'+version)
     api 'dev.galasa:dev.galasa'
     
     implementation 'dev.galasa:dev.galasa.framework'
@@ -14,11 +14,11 @@ dependencies {
     implementation 'org.osgi:org.osgi.service.component.annotations'
     compileOnly 'javax.validation:validation-api'
 
-    testImplementation platform('dev.galasa:dev.galasa.platform:0.39.0')
+    testImplementation platform('dev.galasa:dev.galasa.platform:'+version)
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core:4.6.1' // Platform has 3.1.0
     testImplementation 'org.awaitility:awaitility'
-    testImplementation 'org.assertj:assertj-core:3.16.1'
+    testImplementation 'org.assertj:assertj-core'
     testImplementation 'dev.galasa:galasa-testharness'
     testCompileOnly 'javax.validation:validation-api'
 }

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.ivt.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.ivt.gradle
@@ -10,5 +10,5 @@ dependencies {
     
     implementation 'commons-logging:commons-logging'
     
-    implementation 'org.assertj:assertj-core:3.11.1'
+    implementation 'org.assertj:assertj-core'
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerBatchIVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerBatchIVT.java
@@ -166,7 +166,7 @@ public class ZosManagerBatchIVT {
     	IZosBatchJob job = batch.submitJob(jclInput, null);
     	job.waitForJob();
     	List<IZosBatchJob> jobs = batch.getJobs(job.getJobname().getName(), job.getOwner());
-    	assertThat(jobs).asList().size().isEqualTo(1);
+    	assertThat(jobs).hasSize(1);
     }
     
     //@Test

--- a/modules/obr/obr-generic/pom.template
+++ b/modules/obr/obr-generic/pom.template
@@ -42,7 +42,6 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.11.1</version>
 		</dependency>
 	</dependencies>
 

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -265,6 +265,10 @@ external:
     mvp: true
     isolated: true
 
+  - group: net.bytebuddy
+    artifact: byte-buddy
+    obr: true
+
   - group: org.apache.bcel
     artifact: bcel
     obr: true
@@ -380,7 +384,7 @@ external:
 
   - group: org.assertj
     artifact: assertj-core
-    version: 3.11.1
+    version: 3.25.3
     obr: true
     bom: true
     mvp: true

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -250,10 +250,7 @@ dependencies {
 
         api 'org.apache.velocity:velocity-engine-core:2.4.1'
 
-        // Removing from the platform! Breaks the tests.
-        // api 'org.assertj:assertj-core:3.16.1'
-        // 3.23.1 found in dev.galasa.framework.api.cps but breaks Extensions unit tests when used in other bundles.
-        // So using 3.16.1 as the default and 3.23.1 as override in dev.galasa.framework.api.cps.
+        api 'org.assertj:assertj-core:3.25.3'
 
         api 'org.awaitility:awaitility:3.0.0'
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2054 (Story was originally to upgrade assertj-core to 3.23.1, but version 3.25.3 was being used in the Gradle plugins and the Bean generator of galasabld, so upgraded to 3.25.3 for consistency across all modules).

- Upgraded version of org.assertj:assertj-core to 3.25.3 in the Platform 
- Remove all explicit versions of the dependency throughout all modules so that they use the Platform version (other than in the OBR release.yaml as this is used to create the galasa-bom, so we leave the version in for these to ensure the galasa-bom is stable)
- Remove the depracated `asList()` method from the ZosManagerBatchIVT (deprecated in 3.25.0 of assertj-core)
- Add net.bytebuddy:byte-buddy to the OBR release.yaml as its required to resolve assertj-core 3.25.3