### PR TITLE
Remove assertj-parent-pom from platform

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     api platform('org.apache.httpcomponents:httpcomponents-client:4.5.14')
     api platform('org.apache.httpcomponents:httpcomponents-core:4.4.16')
     api platform('org.apache.httpcomponents:httpcomponents-parent:11')
-    api platform('org.assertj:assertj-parent-pom:2.2.1')
     api platform('org.slf4j:slf4j-parent:1.7.25')
 
     // TODO: Isolated/MVP contain multiple versions of these to be consolidated.


### PR DESCRIPTION
## Why?

Since removing the assertj-parent-pom dependency from the Isolated pom2.xml (see [PR](https://github.com/galasa-dev/isolated/pull/94/files)) this has caused the Compilation* tests to fail with an error like the below:

```
   > Could not resolve dev.galasa:dev.galasa.framework:0.+.
     Required by:
         project :dev.galasa.simbank.manager
      > Could not resolve dev.galasa:dev.galasa.framework:0.39.0.
         > Could not parse POM /home/galasa88/galasaconfig/isolatedrepo/maven/dev/galasa/dev.galasa.framework/0.39.0/dev.galasa.framework-0.39.0.pom
            > Could not resolve dev.galasa:dev.galasa.platform:0.39.0.
               > Could not resolve dev.galasa:dev.galasa.platform:0.39.0.
                  > Could not parse POM /home/galasa88/galasaconfig/isolatedrepo/maven/dev/galasa/dev.galasa.platform/0.39.0/dev.galasa.platform-0.39.0.pom
                     > Could not find org.assertj:assertj-parent-pom:2.2.1.
```

This removes the assertj-parent-pom from the Platform as its version is no longer required anywhere in the source code, which will hopefully get rid of this error.