### PR TITLE
Add byte-buddy into Isolated/MVP zips

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -268,6 +268,8 @@ external:
   - group: net.bytebuddy
     artifact: byte-buddy
     obr: true
+    mvp: true
+    isolated: true
 
   - group: org.apache.bcel
     artifact: bcel


### PR DESCRIPTION
## Why?

Upgrading assertj-core to version 3.25.3 for story [2054](https://github.com/galasa-dev/projectmanagement/issues/2054) required adding byte-buddy 1.15.10 into the OBR, as it's required for resolving assertj-core at 3.25.3 (see [PR](https://github.com/galasa-dev/galasa/pull/151/files) with these changes).

This change also adds byte-buddy into the MVP and Isolated zips so that the offline tests can get the artifact from the maven repo within their zips, instead of reaching out to Maven Central, which causes a Connection timeout like below as it seems to take > 5 mins to download the jar.

```
13/01/2025 12:43:56.400 DEBUG main dev.galasa.framework.maven.repository.internal.GalasaMavenUrlHandlerService.getArtifact - Checking https://repo.maven.apache.org/maven2
13/01/2025 12:43:56.401 DEBUG main dev.galasa.framework.maven.repository.internal.GalasaMavenUrlHandlerService.getArtifact - Attempting to download https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.15.10/byte-buddy-1.15.10.jar with connection timeout of 300000ms and read timeout of 300000ms 
13/01/2025 12:46:06.478 TRACE main dev.galasa.framework.maven.repository.internal.GalasaMavenUrlHandlerService.getArtifact - Release artifact https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.15.10/byte-buddy-1.15.10.jar failed to download.
java.net.ConnectException: Connection timed out (Connection timed out)
```

I have checked the Maven repository website and byte-buddy 1.15.10 has no reported vulnerabilities on that site.