### PR TITLE
0.40.0 version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `set-version.sh` script allows you to set the version of the Galasa througho
 
 Use the `--help` flag to see what options are supported.
 
-Basic usage: `set-version.sh --version 0.39.0`
+Basic usage: `set-version.sh --version 0.40.0`
 
 ## Using vscode
 When using vscode to develop this code, we recommend the following settings are added to your `settings.json` file:

--- a/build.properties
+++ b/build.properties
@@ -1,3 +1,3 @@
 # This file is used to source the version of artifacts created by the github build workflows.
 # It gets maintained by the set-version.sh script, so don't change it manually without using that script.
-GALASA_VERSION=0.39.0
+GALASA_VERSION=0.40.0

--- a/modules/buildutils/pkg/cmd/root.go
+++ b/modules/buildutils/pkg/cmd/root.go
@@ -17,7 +17,7 @@ var rootCmd = &cobra.Command{
 	Use:     "galasabld",
 	Short:   "Build utilities for Galasa",
 	Long:    "",
-	Version: "0.39.0",
+	Version: "0.40.0",
 }
 
 func Execute() {

--- a/modules/extensions/galasa-extensions-parent/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'biz.aQute.bnd.builder' version '5.3.0' apply false
-    id 'dev.galasa.githash' version '0.39.0' apply false
+    id 'dev.galasa.githash' version '0.40.0' apply false
     id 'maven-publish'
     id 'signing'
 }
 
 allprojects {
     group = 'dev.galasa'
-    version = '0.39.0'
+    version = '0.40.0'
 }
 
 //---------------------------------------------------------------
@@ -170,7 +170,7 @@ publishing {
                 name = "Manifest for extensions bundle versions"
                 artifactId = "dev.galasa.extensions.manifest"
                 groupId = 'dev.galasa'
-				version = '0.39.0'
+				version = '0.40.0'
                 description = "Conveys bundle version information to OBR builds."
                 licenses {
                     license {

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa RAS - CouchDB'
 
-version = '0.39.0'
+version = '0.40.0'
 
 configurations {
     implementation.transitive = false

--- a/modules/extensions/release.yaml
+++ b/modules/extensions/release.yaml
@@ -23,7 +23,7 @@ framework:
 
 
   - artifact: dev.galasa.auth.couchdb
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -32,7 +32,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.cps.etcd
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -41,7 +41,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.cps.rest
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -50,7 +50,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.events.kafka
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -59,7 +59,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.extensions.common
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -68,7 +68,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.extensions.common.couchdb
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -77,7 +77,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.ras.couchdb
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false

--- a/modules/extensions/set-version.sh
+++ b/modules/extensions/set-version.sh
@@ -142,11 +142,6 @@ cat $BASEDIR/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions
 cp $temp_dir/galasa.extensions.gradle $BASEDIR/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
 
 
-# The platform in the extensions gradle plugin src needs setting.
-cat $BASEDIR/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle | sed "s/'dev[.]galasa[:]dev[.]galasa[.]platform[:].*'/'dev.galasa:dev.galasa.platform:$component_version'/1" > $temp_dir/galasa.extensions.gradle
-cp $temp_dir/galasa.extensions.gradle $BASEDIR/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
-
-
 # The top-level build.gradle has this: id 'dev.galasa.githash' version '$version' apply false
 cat $BASEDIR/galasa-extensions-parent/build.gradle | sed  "s/id 'dev[.]galasa[.]githash' version '.*'/id 'dev.galasa.githash' version '$component_version'/1" > $temp_dir/top-build.gradle
 cp $temp_dir/top-build.gradle $BASEDIR/galasa-extensions-parent/build.gradle

--- a/modules/framework/galasa-parent/build.gradle
+++ b/modules/framework/galasa-parent/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'biz.aQute.bnd.builder' version '5.3.0' apply false
-    id 'dev.galasa.githash' version '0.39.0' apply false
+    id 'dev.galasa.githash' version '0.40.0' apply false
     id 'jacoco'
     id 'maven-publish'
     id 'signing'
@@ -9,11 +9,11 @@ plugins {
 
 // Note: The following line is changed by the set-version.sh script.
 // It is also read by other build scrips as required.
-version = "0.39.0"
+version = "0.40.0"
 
 allprojects {
     group = 'dev.galasa'
-    version = "0.39.0"
+    version = "0.40.0"
 }
 
 signing {
@@ -310,7 +310,7 @@ publishing {
                 name = "Manifest for framework bundle versions"
                 artifactId = "dev.galasa.framework.manifest"
                 groupId = 'dev.galasa'
-                version = "0.39.0"
+                version = "0.40.0"
                 description = "Conveys bundle version information to OBR builds."
                 licenses {
                     license {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@
 openapi: 3.0.3
 info:
   title: Galasa Ecosystem API
-  version : "0.39.0"
+  version : "0.40.0"
   description: The Galasa Ecosystem REST API allows you to interact with a Galasa Ecosystem.
   contact:
     url: https://galasa.dev/support

--- a/modules/framework/release.yaml
+++ b/modules/framework/release.yaml
@@ -23,7 +23,7 @@ framework:
   bundles:
 
   - artifact: dev.galasa
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -32,7 +32,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -41,7 +41,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework.auth.spi
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -50,7 +50,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework.docker.controller
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -59,7 +59,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework.k8s.controller
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -68,7 +68,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework.log4j2.bridge
-    version: 0.39.0
+    version: 0.40.0
     obr:          false
     mvp:          false
     bom:          false
@@ -77,7 +77,7 @@ framework:
     codecoverage: false
 
   - artifact: dev.galasa.framework.maven.repository
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -86,7 +86,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework.maven.repository.spi
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -95,7 +95,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework.metrics
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -104,7 +104,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework.resource.management
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -113,7 +113,7 @@ framework:
     codecoverage: true
 
   - artifact: galasa-boot
-    version: 0.39.0
+    version: 0.40.0
     obr:          false
     mvp:          true
     bom:          false
@@ -122,7 +122,7 @@ framework:
     codecoverage: true
 
   - artifact: galasa-testharness
-    version: 0.39.0
+    version: 0.40.0
     obr:          false
     mvp:          false
     bom:          false
@@ -135,7 +135,7 @@ api:
   bundles:
 
   - artifact: dev.galasa.framework.api
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -144,7 +144,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.authentication
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -153,7 +153,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.beans
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -162,7 +162,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.bootstrap
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -171,7 +171,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.common
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -180,7 +180,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.cps
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -189,7 +189,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.health
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -198,7 +198,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.launcher
-    version: 0.39.0
+    version: 0.40.0
     obr:          false
     mvp:          false
     bom:          false
@@ -207,7 +207,7 @@ api:
     codecoverage: false
 
   - artifact: dev.galasa.framework.api.openapi
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -216,7 +216,7 @@ api:
     codecoverage: false
 
   - artifact: dev.galasa.framework.api.openapi.servlet
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -225,7 +225,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.ras
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -234,7 +234,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.rbac
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -243,7 +243,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.resources
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -252,7 +252,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.runs
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -261,7 +261,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.secrets
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -270,7 +270,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.testcatalog
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -279,7 +279,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.users
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false

--- a/modules/gradle/README.md
+++ b/modules/gradle/README.md
@@ -13,7 +13,7 @@ To use the Gradle OBR plugin in a Gradle test project:
         ...
         id 'java' 
         id 'maven-publish'
-        id 'dev.galasa.tests' version '0.39.0'
+        id 'dev.galasa.tests' version '0.40.0'
         ...
     }
     ```
@@ -26,8 +26,8 @@ To use the Gradle OBR plugin in a Gradle test project:
     ```groovy
     plugins {
         ...
-        id 'dev.galasa.obr' version '0.39.0'
-        id 'dev.galasa.testcatalog' version '0.39.0'
+        id 'dev.galasa.obr' version '0.40.0'
+        id 'dev.galasa.testcatalog' version '0.40.0'
         ...
     }
 

--- a/modules/gradle/build.gradle
+++ b/modules/gradle/build.gradle
@@ -9,11 +9,11 @@ group   = "dev.galasa"
 
 // Note: The following line is changed by the set-version.sh script.
 // It is also read by other build scrips as required.
-version = "0.39.0"
+version = "0.40.0"
 
 allprojects {
     group = 'dev.galasa'
-    version = "0.39.0"
+    version = "0.40.0"
 }
 
 signing {

--- a/modules/managers/galasa-managers-parent/build.gradle
+++ b/modules/managers/galasa-managers-parent/build.gradle
@@ -9,11 +9,11 @@ plugins {
 // It is used as the version number of the managers bundle, which contains a yaml
 // file which is in a release.yaml, but published to maven, so that the OBR build 
 // can pick it up later.
-version = "0.39.0"
+version = "0.40.0"
 
 allprojects {
     group = 'dev.galasa'
-    version = "0.39.0"
+    version = "0.40.0"
 }
 
 // A configuration to publish the merge exec into
@@ -229,7 +229,7 @@ publishing {
                 name = "Manifest for managers bundle versions"
                 artifactId = "dev.galasa.managers.manifest"
                 groupId = 'dev.galasa'
-				version = "0.39.0"
+				version = "0.40.0"
                 description = "Conveys bundle version information to OBR builds."
                 licenses {
                     license {

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager.ivt/README.md
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager.ivt/README.md
@@ -18,5 +18,5 @@ To run the IVT locally:
 
 4. Run the IVT:
    ```
-   galasactl runs submit local --obr mvn:dev.galasa/dev.galasa.uber.obr/0.39.0/obr --class dev.galasa.kubernetes.manager.ivt/dev.galasa.kubernetes.manager.ivt.KubernetesManagerIVT --log -
+   galasactl runs submit local --obr mvn:dev.galasa/dev.galasa.uber.obr/0.40.0/obr --class dev.galasa.kubernetes.manager.ivt/dev.galasa.kubernetes.manager.ivt.KubernetesManagerIVT --log -
    ```

--- a/modules/managers/release.yaml
+++ b/modules/managers/release.yaml
@@ -25,7 +25,7 @@ managers:
 
 
   - artifact: dev.galasa.cicsts.ceci.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -34,7 +34,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.cicsts.ceci.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -43,7 +43,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.cicsts.ceda.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -52,7 +52,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.cicsts.ceda.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -61,7 +61,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.cicsts.cemt.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -70,7 +70,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.cicsts.cemt.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -79,7 +79,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.cicsts.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -88,7 +88,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.cicsts.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -97,7 +97,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.cicsts.resource.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -106,7 +106,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.cloud.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -115,7 +115,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.docker.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -124,7 +124,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.docker.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -133,7 +133,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.kubernetes.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -142,7 +142,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.kubernetes.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -151,7 +151,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.liberty.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          false
     mvp:          false
     bom:          false
@@ -160,7 +160,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.openstack.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -169,7 +169,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.common
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -178,7 +178,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.http.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -187,7 +187,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.http.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -196,7 +196,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.ipnetwork.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -205,7 +205,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.mq.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -214,7 +214,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.mq.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -223,7 +223,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.artifact.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -232,7 +232,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.artifact.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -241,7 +241,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.core.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -250,7 +250,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.core.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -259,7 +259,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.textscan.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -268,7 +268,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.db2.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -277,7 +277,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.db2.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -286,7 +286,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.eclipseruntime.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          false
     mvp:          false
     bom:          false
@@ -295,7 +295,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.eclipseruntime.ubuntu.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          false
     mvp:          false
     bom:          false
@@ -304,7 +304,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.java.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -313,7 +313,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.java.ubuntu.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -322,7 +322,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.java.windows.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -331,7 +331,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.elasticlog.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -340,7 +340,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.elasticlog.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -349,7 +349,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.phoenix2.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -358,7 +358,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.galasaecosystem.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -367,7 +367,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.galasaecosystem.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -376,7 +376,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.jmeter.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -385,7 +385,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.jmeter.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -394,7 +394,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.sdv.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -403,7 +403,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.sdv.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -412,7 +412,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.selenium.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -421,7 +421,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.selenium.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -430,7 +430,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.vtp.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -439,7 +439,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.vtp.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          false
     mvp:          false
     bom:          false
@@ -448,7 +448,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.linux.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -457,7 +457,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.linux.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          false
@@ -466,7 +466,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.windows.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -475,7 +475,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.githubissue.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -484,7 +484,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.zos.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -493,7 +493,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zos.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -502,7 +502,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.zos3270.common
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -511,7 +511,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.zos3270.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -520,7 +520,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zos3270.manager.ivt
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          false
@@ -529,7 +529,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.zosbatch.rseapi.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -538,7 +538,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosbatch.zosmf.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -547,7 +547,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosconsole.oeconsol.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -556,7 +556,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosconsole.zosmf.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -565,7 +565,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosfile.rseapi.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -574,7 +574,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosfile.zosmf.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -583,7 +583,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosliberty.angel.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          false
     bom:          true
@@ -592,7 +592,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosliberty.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -601,7 +601,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosmf.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -610,7 +610,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosprogram.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -619,7 +619,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosrseapi.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -628,7 +628,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zostsocommand.ssh.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true
@@ -637,7 +637,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.zosunixcommand.ssh.manager
-    version: 0.39.0
+    version: 0.40.0
     obr:          true
     mvp:          true
     bom:          true

--- a/modules/managers/set-version.sh
+++ b/modules/managers/set-version.sh
@@ -146,16 +146,6 @@ function upgrade_build_gradle {
     success "Upgraded build.gradle file OK."
 }
 
-function upgrade_manager_gradle_plugin() {
-    h2 "Upgrading the gradle manager plugin in the managers module"
-
-    cat $BASEDIR/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle \
-    | sed "s/'dev[.]galasa[:]dev[.]galasa[.]platform:.*'/'dev.galasa:dev.galasa.platform:$component_version'/g" \
-    > $temp_dir/manager-gradle-plugin
-    cp $temp_dir/manager-gradle-plugin $BASEDIR/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
-    success "OK"
-}
-
 function upgrade_kube_manager_ivt_readme() {
     cat $BASEDIR/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager.ivt/README.md \
     | sed "s/mvn[:]dev[.]galasa\/dev[.]galasa[.]uber[.]obr\/.*\/obr/mvn:dev.galasa\/dev.galasa.uber.obr\/$component_version\/obr/g" \
@@ -166,5 +156,4 @@ function upgrade_kube_manager_ivt_readme() {
 
 upgrade_build_gradle
 upgrade_dependencies_on_framework
-upgrade_manager_gradle_plugin
 upgrade_kube_manager_ivt_readme

--- a/modules/maven/galasa-maven-plugin/pom.xml
+++ b/modules/maven/galasa-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>0.39.0</version>
+	<version>0.40.0</version>
 
 	<name>Galasa Maven Plugin</name>
 	<description>Maven plugin for build Galasa artifacts such as the OBR, Test Catalog</description>
@@ -62,7 +62,7 @@
 			<dependency>
 				<groupId>dev.galasa</groupId>
 				<artifactId>dev.galasa.platform</artifactId>
-				<version>0.39.0</version>
+				<version>0.40.0</version>
 				<type>pom</type>
           		<scope>import</scope>
 			</dependency>

--- a/modules/obr/dependency-download/build.gradle
+++ b/modules/obr/dependency-download/build.gradle
@@ -7,7 +7,7 @@ plugins {
 // It is used as the version number of the managers bundle, which contains a yaml
 // file which is in a release.yaml, but published to maven, so that the OBR build 
 // can pick it up later.
-version = "0.39.0"
+version = "0.40.0"
 
 repositories {
     mavenLocal()

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -12,7 +12,7 @@ metadata:
 
 
 release:
-  version: 0.39.0
+  version: 0.40.0
 
 # Dependencies with bom: true need their versions stated explicitly
 # As the galasa-bom is a component consumed by users, its too risky
@@ -102,14 +102,14 @@ external:
 
   - group: dev.galasa
     artifact: dev.galasa.wrapping.gson
-    version: 0.39.0
+    version: 0.40.0
     obr: true
     bom: true
     mvp: true
     isolated: true
 
   - artifact: dev.galasa.wrapping.httpclient-osgi
-    version: 0.39.0
+    version: 0.40.0
     obr: true
     bom: true
     mvp: true

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'signing'
 }
 
-version = "0.39.0"
+version = "0.40.0"
 
 javaPlatform {
     allowDependencies()
@@ -328,7 +328,7 @@ publishing {
                 name = 'Gradle Java Platform for Galasa bundles'
                 groupId = 'dev.galasa'
                 artifactId = 'dev.galasa.platform'
-                version = "0.39.0"
+                version = "0.40.0"
                 description = 'Provides versions to dependencies'
                 licenses {
                     license {

--- a/modules/wrapping/dev.galasa.wrapping.com.auth0.jwt/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.com.auth0.jwt/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>dev.galasa.wrapping.parent</artifactId>
-		<version>0.39.0</version>
+		<version>0.40.0</version>
 	</parent>
 
 	<artifactId>dev.galasa.wrapping.com.auth0.jwt</artifactId>
-	<version>0.39.0</version>
+	<version>0.40.0</version>
 	<packaging>bundle</packaging>
 
 	<name>Galasa wrapped version of auth0 JWT</name>

--- a/modules/wrapping/dev.galasa.wrapping.com.jcraft.jsch/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.com.jcraft.jsch/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>dev.galasa.wrapping.parent</artifactId>
-		<version>0.39.0</version>
+		<version>0.40.0</version>
 	</parent>
 
 	<artifactId>dev.galasa.wrapping.com.jcraft.jsch</artifactId>
-	<version>0.39.0</version>
+	<version>0.40.0</version>
 	<packaging>bundle</packaging>
 
 	<name>galasa wrapped version of JSCH</name>

--- a/modules/wrapping/dev.galasa.wrapping.gson/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.gson/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>dev.galasa</groupId>
         <artifactId>dev.galasa.wrapping.parent</artifactId>
-        <version>0.39.0</version>
+        <version>0.40.0</version>
     </parent>
 
     <artifactId>dev.galasa.wrapping.gson</artifactId>
-    <version>0.39.0</version>
+    <version>0.40.0</version>
     <packaging>bundle</packaging>
 
     <name>Galasa wrapped version of GSON</name>

--- a/modules/wrapping/dev.galasa.wrapping.httpclient-osgi/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.httpclient-osgi/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>dev.galasa</groupId>
         <artifactId>dev.galasa.wrapping.parent</artifactId>
-        <version>0.39.0</version>
+        <version>0.40.0</version>
     </parent>
 
     <artifactId>dev.galasa.wrapping.httpclient-osgi</artifactId>
-    <version>0.39.0</version>
+    <version>0.40.0</version>
     <packaging>bundle</packaging>
 
     <name>Galasa wrapped version of org.apache.httpcomponents:httpclient-osgi</name>

--- a/modules/wrapping/dev.galasa.wrapping.io.grpc.java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.io.grpc.java/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>dev.galasa.wrapping.parent</artifactId>
-		<version>0.39.0</version>
+		<version>0.40.0</version>
 	</parent>
 
 	<artifactId>dev.galasa.wrapping.io.grpc.java</artifactId>
-	<version>0.39.0</version>
+	<version>0.40.0</version>
 	<packaging>bundle</packaging>
 
 	<name>Galasa wrapped version of the io.grpc packages required for grpc-java</name>

--- a/modules/wrapping/dev.galasa.wrapping.io.kubernetes.client-java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.io.kubernetes.client-java/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>dev.galasa</groupId>
         <artifactId>dev.galasa.wrapping.parent</artifactId>
-        <version>0.39.0</version>
+        <version>0.40.0</version>
     </parent>
 
     <artifactId>dev.galasa.wrapping.io.kubernetes.client-java</artifactId>
-    <version>0.39.0</version>
+    <version>0.40.0</version>
     <packaging>bundle</packaging>
 
     <name>Galasa wrapped version of io.kubernetes client-java</name>

--- a/modules/wrapping/dev.galasa.wrapping.jta/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.jta/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>dev.galasa.wrapping.parent</artifactId>
-		<version>0.39.0</version>
+		<version>0.40.0</version>
 	</parent>
 
 	<artifactId>dev.galasa.wrapping.jta</artifactId>
-	<version>0.39.0</version>
+	<version>0.40.0</version>
 	<packaging>bundle</packaging>
 
 	<name>galasa wrapped version of JTA</name>

--- a/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>dev.galasa.wrapping.parent</artifactId>
-		<version>0.39.0</version>
+		<version>0.40.0</version>
 	</parent>
 
 	<artifactId>dev.galasa.wrapping.kafka.clients</artifactId>
-	<version>0.39.0</version>
+	<version>0.40.0</version>
 	<packaging>bundle</packaging>
 
 	<name>Galasa wrapped version of the kafka-client package</name>

--- a/modules/wrapping/dev.galasa.wrapping.protobuf-java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.protobuf-java/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>dev.galasa</groupId>
         <artifactId>dev.galasa.wrapping.parent</artifactId>
-        <version>0.39.0</version>
+        <version>0.40.0</version>
     </parent>
 
     <artifactId>dev.galasa.wrapping.protobuf-java</artifactId>
-    <version>0.39.0</version>
+    <version>0.40.0</version>
     <packaging>bundle</packaging>
 
     <name>Galasa wrapped version of protobuf-java</name>

--- a/modules/wrapping/dev.galasa.wrapping.velocity-engine-core/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.velocity-engine-core/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>dev.galasa</groupId>
         <artifactId>dev.galasa.wrapping.parent</artifactId>
-        <version>0.39.0</version>
+        <version>0.40.0</version>
     </parent>
 
     <artifactId>dev.galasa.wrapping.velocity-engine-core</artifactId>
-    <version>0.39.0</version>
+    <version>0.40.0</version>
     <packaging>bundle</packaging>
 
     <name>Galasa wrapped version of velocity-engine-core</name>

--- a/modules/wrapping/pom.xml
+++ b/modules/wrapping/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>dev.galasa.wrapping.parent</artifactId>
-	<version>0.39.0</version>
+	<version>0.40.0</version>
 	<packaging>pom</packaging>
 
 	<name>Galasa OSGi Wrapping</name>
@@ -63,7 +63,7 @@
 			<dependency>
 				<groupId>dev.galasa</groupId>
 				<artifactId>dev.galasa.platform</artifactId>
-				<version>0.39.0</version>
+				<version>0.40.0</version>
 				<type>pom</type>
           		<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2079

- set-version for extensions and managers updated: removed unneeded section as the versions are passed in as a variable in these locations.