### PR TITLE
Iss2104- Fix non executable galasabld in obr-with-galasabld image

### DIFF
--- a/modules/obr/dockerfiles/dockerfile.obrgalasabld
+++ b/modules/obr/dockerfiles/dockerfile.obrgalasabld
@@ -12,5 +12,6 @@ FROM ${dockerRepository}/galasa-dev/obr-maven-artefacts:${tag}
 # 2. The `galasabld` exectuable is installed here.
 ARG platform
 COPY galasabld-${platform} /bin/galasabld
+RUN chmod +x /bin/galasabld
 
 ENTRYPOINT ["/bin/galasabld"]


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2104

The galasabld executable currently being placed into the obr-with-galasabld-executable image as part of the OBR workflow is not executable (verified by checking `ls -l /bin/galasabld` when running the image). I believe this is due to the fact that when the galasabld binary is downloaded from the uploaded artifacts, it is not executable at that point. Adding `chmod +x` into the Dockerfile will make it executable hopefully resolving this error.

Group and user settings should be added to the Dockerfile in future so we aren't running as root, but I'll raise a separate story for that.