### PR TITLE
Remove the map used to cache RBAC users-to-actions

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestCacheRBACImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestCacheRBACImpl.java
@@ -27,15 +27,19 @@ public class TestCacheRBACImpl {
         // Given...
         MockTimeService timeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
-        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACService();
-        CacheRBAC cache = new CacheRBACImpl(mockAuthStoreService, mockRbacService);
+
         String loginId = "bob";
+        MockUser mockUser = new MockUser();
+        mockUser.setLoginId(loginId);
+        mockUser.setRoleId("2");
+
+        mockAuthStoreService.addUser(mockUser);
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(loginId);
+
+        CacheRBAC cache = new CacheRBACImpl(mockAuthStoreService, mockRbacService);
 
         String apiAccessActionId = "GENERAL_API_ACCESS";
         String secretsGetActionId = "SECRETS_GET";
-        List<String> actions = List.of(apiAccessActionId, secretsGetActionId);
-
-        cache.addUser(loginId, actions);
 
         // When...
         boolean isApiAccessPermitted = cache.isActionPermitted(loginId, apiAccessActionId);
@@ -46,6 +50,8 @@ public class TestCacheRBACImpl {
         assertThat(isSecretsAccessPermitted).isTrue();
     }
 
+    // Ignore for now as the auth store is used directly to pull users instead of a cache
+    @Ignore
     @Test
     public void testIsActionPermittedUpdatesCacheWhenUserIsNotCached() throws Exception {
         // Given...
@@ -81,9 +87,16 @@ public class TestCacheRBACImpl {
         // Given...
         MockTimeService timeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
-        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACService();
-        CacheRBAC cache = new CacheRBACImpl(mockAuthStoreService, mockRbacService);
+
         String loginId = "bob";
+        MockUser mockUser = new MockUser();
+        mockUser.setLoginId(loginId);
+        mockUser.setRoleId("2");
+
+        mockAuthStoreService.addUser(mockUser);
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(loginId);
+
+        CacheRBAC cache = new CacheRBACImpl(mockAuthStoreService, mockRbacService);
 
         String apiAccessActionId = "GENERAL_API_ACCESS";
         String secretsGetActionId = "SECRETS_GET";
@@ -115,6 +128,8 @@ public class TestCacheRBACImpl {
         assertThat(thrown.getMessage()).contains("No user with the given login ID exists");
     }
 
+    // Ignore for now as users are fetched from the auth store
+    @Ignore
     @Test
     public void testInvalidateRemovesUserFromCache() throws Exception {
         // Given...

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestCacheRBACImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestCacheRBACImpl.java
@@ -50,7 +50,7 @@ public class TestCacheRBACImpl {
         assertThat(isSecretsAccessPermitted).isTrue();
     }
 
-    // Ignore for now as the auth store is used directly to pull users instead of a cache
+    // TODO: Ignore for now as the auth store is used directly to pull users instead of a cache
     @Ignore
     @Test
     public void testIsActionPermittedUpdatesCacheWhenUserIsNotCached() throws Exception {
@@ -128,7 +128,7 @@ public class TestCacheRBACImpl {
         assertThat(thrown.getMessage()).contains("No user with the given login ID exists");
     }
 
-    // Ignore for now as users are fetched from the auth store
+    // TODO: Ignore for now as users are fetched from the auth store
     @Ignore
     @Test
     public void testInvalidateRemovesUserFromCache() throws Exception {


### PR DESCRIPTION
## Why?
See story https://github.com/galasa-dev/projectmanagement/issues/2071