### PR TITLE
Cache user-to-actions entries in the DSS

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/Framework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/Framework.java
@@ -555,7 +555,12 @@ public class Framework implements IFramework, IShuttableFramework {
     @Override
     public RBACService getRBACService() throws RBACException {
         if (this.rbacService == null) {
-            this.rbacService = new RBACServiceImpl(getAuthStoreService());
+            try {
+                IDynamicStatusStoreService dssService = getDynamicStatusStoreService("rbac");
+                this.rbacService = new RBACServiceImpl(dssService, getAuthStoreService());
+            } catch (DynamicStatusStoreException e) {
+                throw new RBACException("Failed to initialise Role-Based Access Control service", e);
+            }
         }
         return this.rbacService;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/CacheRBACImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/CacheRBACImpl.java
@@ -110,7 +110,7 @@ public class CacheRBACImpl implements CacheRBAC {
 
     private String getUserActionsPropertyKey(String loginId) {
         // The users-to-actions DSS property is in the form:
-        // dss.rbac.user-<loginId>.actions = <comma-separated action IDs>
+        // dss.rbac.user.<loginId>.actions = <comma-separated action IDs>
         return USER_PROPERTY_PREFIX + loginId + ACTIONS_PROPERTY_SUFFIX;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/CacheRBACImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/CacheRBACImpl.java
@@ -5,8 +5,12 @@
  */
 package dev.galasa.framework.internal.rbac;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.auth.AuthStoreException;
 import dev.galasa.framework.spi.auth.IAuthStoreService;
 import dev.galasa.framework.spi.auth.IUser;
@@ -17,37 +21,76 @@ import dev.galasa.framework.spi.rbac.Role;
 
 public class CacheRBACImpl implements CacheRBAC {
 
+    // Only keep users-to-actions entries in the cache for 24 hours
+    private static final long CACHED_ACTIONS_TIME_TO_LIVE_SECS = 24 * 60 * 60;
+
+    private static final String ACTIONS_PROPERTY_SUFFIX = ".actions";
+
+    private IDynamicStatusStoreService dssService;
     private IAuthStoreService authStoreService;
     private RBACService rbacService;
     
-    public CacheRBACImpl(IAuthStoreService authStoreService, RBACService rbacService) {
+    public CacheRBACImpl(
+        IDynamicStatusStoreService dssService,
+        IAuthStoreService authStoreService,
+        RBACService rbacService
+    ) {
+        this.dssService = dssService;
         this.authStoreService = authStoreService;
         this.rbacService = rbacService;
     }
 
     @Override
     public synchronized void addUser(String loginId, List<String> actionIds) throws RBACException {
-        // Do nothing for now...
+        try {
+            // Create a property in the DSS of the form:
+            // dss.rbac.<loginId>.actions = <comma-separated action IDs>
+            String commaSeparatedActionIds = String.join(",", actionIds);
+            String actionsKey = loginId + ACTIONS_PROPERTY_SUFFIX;
+            dssService.put(actionsKey, commaSeparatedActionIds, CACHED_ACTIONS_TIME_TO_LIVE_SECS);
+        } catch (DynamicStatusStoreException e) {
+            throw new RBACException("Failed to cache user actions", e);
+        }
     }
 
     @Override
     public synchronized boolean isActionPermitted(String loginId, String actionId) throws RBACException {
-        IUser user = getUserFromAuthStore(loginId);
-        String userRoleId = user.getRoleId();
-        if (userRoleId == null) {
-            userRoleId = rbacService.getDefaultRoleId();
-            user.setRoleId(userRoleId);
+        boolean isActionPermitted = false;
+        try {
+            String userActionsKey = loginId + ACTIONS_PROPERTY_SUFFIX;
+            String commaSeparatedUserActions = dssService.get(userActionsKey);
+    
+            List<String> userActions = new ArrayList<>();
+            if (commaSeparatedUserActions == null) {
+                // Cache miss, so get the user's actions from the auth store
+                IUser user = getUserFromAuthStore(loginId);
+                String userRoleId = user.getRoleId();
+                Role userRole = rbacService.getRoleById(userRoleId);
+    
+                userActions = userRole.getActionIds();
+    
+                // Add this user to the cache
+                addUser(loginId, userActions);
+            } else {
+                userActions = Arrays.asList(commaSeparatedUserActions.split(","));
+            }
+    
+            // Check if the user is allowed to perform the given action
+            isActionPermitted = userActions.contains(actionId);
+        } catch (DynamicStatusStoreException e) {
+            throw new RBACException("Error occurred when accessing the DSS", e);
         }
-        Role userRole = rbacService.getRoleById(userRoleId);
-
-        // Check if the user is allowed to perform the given action
-        boolean isActionPermitted = userRole.getActionIds().contains(actionId);
         return isActionPermitted;
     }
 
     @Override
     public synchronized void invalidateUser(String loginId) throws RBACException {
-        // Do nothing for now...
+        try {
+            String userActionsKey = loginId + ACTIONS_PROPERTY_SUFFIX;
+            dssService.delete(userActionsKey);
+        } catch (DynamicStatusStoreException e) {
+            throw new RBACException("Failed to delete cached user actions", e);
+        }
     }
 
     private synchronized IUser getUserFromAuthStore(String loginId) throws RBACException {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/RBACServiceImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/RBACServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.auth.IAuthStoreService;
 import dev.galasa.framework.spi.rbac.Action;
 import dev.galasa.framework.spi.rbac.BuiltInAction;
@@ -76,8 +77,8 @@ public class RBACServiceImpl implements RBACService {
         }
     }
 
-    public RBACServiceImpl(IAuthStoreService authStoreService) {
-        userActionsCache = new CacheRBACImpl(authStoreService, this);
+    public RBACServiceImpl(IDynamicStatusStoreService dssService, IAuthStoreService authStoreService) {
+        userActionsCache = new CacheRBACImpl(dssService, authStoreService, this);
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/CacheRBAC.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/CacheRBAC.java
@@ -5,11 +5,11 @@
  */
 package dev.galasa.framework.spi.rbac;
 
-import java.util.List;
+import java.util.Set;
 
 public interface CacheRBAC {
 
-    void addUser(String loginId, List<String> actionIds) throws RBACException;
+    void addUser(String loginId, Set<String> actionIds) throws RBACException;
 
     boolean isActionPermitted(String loginId, String actionId) throws RBACException;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestCacheRBACImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestCacheRBACImpl.java
@@ -7,18 +7,24 @@ package dev.galasa.framework.internal.rbac;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.*;
 
 import dev.galasa.framework.mocks.FilledMockRBACService;
 import dev.galasa.framework.mocks.MockAuthStoreService;
+import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
 import dev.galasa.framework.mocks.MockRBACService;
 import dev.galasa.framework.mocks.MockTimeService;
 import dev.galasa.framework.mocks.MockUser;
+import dev.galasa.framework.spi.rbac.Action;
+import dev.galasa.framework.spi.rbac.BuiltInAction;
 import dev.galasa.framework.spi.rbac.CacheRBAC;
 import dev.galasa.framework.spi.rbac.RBACException;
 
 import static org.assertj.core.api.Assertions.*;
+import static dev.galasa.framework.spi.rbac.BuiltInAction.*;
 
 public class TestCacheRBACImpl {
 
@@ -27,6 +33,7 @@ public class TestCacheRBACImpl {
         // Given...
         MockTimeService timeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
 
         String loginId = "bob";
         MockUser mockUser = new MockUser();
@@ -36,7 +43,7 @@ public class TestCacheRBACImpl {
         mockAuthStoreService.addUser(mockUser);
         MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(loginId);
 
-        CacheRBAC cache = new CacheRBACImpl(mockAuthStoreService, mockRbacService);
+        CacheRBAC cache = new CacheRBACImpl(mockDssService, mockAuthStoreService, mockRbacService);
 
         String apiAccessActionId = "GENERAL_API_ACCESS";
         String secretsGetActionId = "SECRETS_GET_UNREDACTED_VALUES";
@@ -50,36 +57,42 @@ public class TestCacheRBACImpl {
         assertThat(isSecretsAccessPermitted).isTrue();
     }
 
-    // TODO: Ignore for now as the auth store is used directly to pull users instead of a cache
-    @Ignore
     @Test
     public void testIsActionPermittedUpdatesCacheWhenUserIsNotCached() throws Exception {
         // Given...
         MockTimeService timeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
 
         String loginId = "bob";
         MockUser mockUser = new MockUser();
         mockUser.setLoginId(loginId);
+        mockUser.setRoleId("2");
 
         mockAuthStoreService.addUser(mockUser);
 
-        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACService();
-        CacheRBAC cache = new CacheRBACImpl(mockAuthStoreService, mockRbacService);
+        List<Action> permittedActions = List.of(GENERAL_API_ACCESS.getAction(), CPS_PROPERTIES_SET.getAction());
 
-        String apiAccessActionId = "GENERAL_API_ACCESS";
-        String secretsGetActionId = "SECRETS_GET_UNREDACTED_VALUES";
-        List<String> actions = List.of(apiAccessActionId, secretsGetActionId);
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(loginId, permittedActions);
+        CacheRBAC cache = new CacheRBACImpl(mockDssService, mockAuthStoreService, mockRbacService);
 
-        cache.addUser(loginId, actions);
+        Map<String, String> dssData = mockDssService.data;
+        assertThat(dssData).isEmpty();
 
         // When...
-        boolean isApiAccessPermitted = cache.isActionPermitted(loginId, apiAccessActionId);
-        boolean isSecretsAccessPermitted = cache.isActionPermitted(loginId, secretsGetActionId);
+        boolean isApiAccessPermitted = cache.isActionPermitted(loginId, GENERAL_API_ACCESS.getAction().getId());
 
         // Then...
         assertThat(isApiAccessPermitted).isTrue();
-        assertThat(isSecretsAccessPermitted).isTrue();
+        assertThat(dssData).hasSize(1);
+
+        // The DSS should have a property of the form:
+        // dss.rbac.loginId.actions = GENERAL_API_ACCESS,CPS_PROPERTIES_SET
+        String commaSeparatedActionsList = permittedActions.stream()
+            .map(Action::getId)
+            .collect(Collectors.joining(","));
+
+        assertThat(dssData.get(loginId + ".actions")).isEqualTo(commaSeparatedActionsList);
     }
 
     @Test
@@ -87,6 +100,7 @@ public class TestCacheRBACImpl {
         // Given...
         MockTimeService timeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
 
         String loginId = "bob";
         MockUser mockUser = new MockUser();
@@ -96,13 +110,12 @@ public class TestCacheRBACImpl {
         mockAuthStoreService.addUser(mockUser);
         MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(loginId);
 
-        CacheRBAC cache = new CacheRBACImpl(mockAuthStoreService, mockRbacService);
+        CacheRBAC cache = new CacheRBACImpl(mockDssService, mockAuthStoreService, mockRbacService);
 
-        String apiAccessActionId = "GENERAL_API_ACCESS";
-        String secretsGetActionId = "SECRETS_GET_UNREDACTED_VALUES";
-        List<String> actions = List.of(apiAccessActionId, secretsGetActionId);
+        List<Action> permittedActions = List.of(GENERAL_API_ACCESS.getAction(), SECRETS_GET_UNREDACTED_VALUES.getAction());
+        List<String> permittedActionsIds = permittedActions.stream().map(Action::getId).collect(Collectors.toList());
 
-        cache.addUser(loginId, actions);
+        cache.addUser(loginId, permittedActionsIds);
 
         // Then...
         assertThat(cache.isActionPermitted(loginId, "not_a_permitted_action")).isFalse();
@@ -114,7 +127,9 @@ public class TestCacheRBACImpl {
         MockTimeService timeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
         MockRBACService mockRbacService = FilledMockRBACService.createTestRBACService();
-        CacheRBAC cache = new CacheRBACImpl(mockAuthStoreService, mockRbacService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        CacheRBAC cache = new CacheRBACImpl(mockDssService, mockAuthStoreService, mockRbacService);
         String loginId = "unknown";
         String apiAccessActionId = "GENERAL_API_ACCESS";
 
@@ -128,33 +143,30 @@ public class TestCacheRBACImpl {
         assertThat(thrown.getMessage()).contains("No user with the given login ID exists");
     }
 
-    // TODO: Ignore for now as users are fetched from the auth store
-    @Ignore
     @Test
     public void testInvalidateRemovesUserFromCache() throws Exception {
         // Given...
         MockTimeService timeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
         MockRBACService mockRbacService = FilledMockRBACService.createTestRBACService();
-        CacheRBAC cache = new CacheRBACImpl(mockAuthStoreService, mockRbacService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        CacheRBAC cache = new CacheRBACImpl(mockDssService, mockAuthStoreService, mockRbacService);
         String loginId = "bob";
 
-        String apiAccessActionId = "GENERAL_API_ACCESS";
-        String secretsGetActionId = "SECRETS_GET_UNREDACTED_VALUES";
-        List<String> actions = List.of(apiAccessActionId, secretsGetActionId);
+        List<Action> permittedActions = BuiltInAction.getActions();
+        List<String> permittedActionsIds = permittedActions.stream().map(Action::getId).collect(Collectors.toList());
 
-        cache.addUser(loginId, actions);
-        assertThat(cache.isActionPermitted(loginId, apiAccessActionId)).isTrue();
+        cache.addUser(loginId, permittedActionsIds);
+
+        Map<String, String> dssData = mockDssService.data;
+        assertThat(dssData).hasSize(1);
+        assertThat(dssData).containsKey(loginId + ".actions");
 
         // When...
         cache.invalidateUser(loginId);
 
         // Then...
-        RBACException thrown = catchThrowableOfType(() -> {
-            cache.isActionPermitted(loginId, apiAccessActionId);
-        }, RBACException.class);
-
-        assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("No user with the given login ID exists");
+        assertThat(dssData).isEmpty();
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestRBACServiceImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestRBACServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.junit.*;
 
 import dev.galasa.framework.mocks.MockAuthStoreService;
+import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
 import dev.galasa.framework.mocks.MockTimeService;
 import dev.galasa.framework.spi.rbac.Action;
 import dev.galasa.framework.spi.rbac.RBACService;
@@ -25,7 +26,9 @@ public class TestRBACServiceImpl {
     public void testRolesMapByIdContainsAdminRole() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Map<String,Role> roleMap = service.getRolesMapById();
 
         Role roleGot = roleMap.get("2");
@@ -45,7 +48,9 @@ public class TestRBACServiceImpl {
     public void testRolesMapByIdContainsTesterRole() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Map<String,Role> roleMap = service.getRolesMapById();
 
         Role roleGot = roleMap.get("1");
@@ -62,7 +67,9 @@ public class TestRBACServiceImpl {
     public void testRolesMapByIdContainsDeactivateddRole() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Map<String,Role> roleMap = service.getRolesMapById();
 
         Role roleGot = roleMap.get("0");
@@ -77,7 +84,9 @@ public class TestRBACServiceImpl {
     public void testActionsMapByIdContainsActionUserRoleUpdateAny() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Map<String,Action> actionMap = service.getActionsMapById();
 
         Action action = actionMap.get("USER_ROLE_UPDATE_ANY");
@@ -89,7 +98,9 @@ public class TestRBACServiceImpl {
     public void testActionsMapByIdContainsActionSecretsGet() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Map<String,Action> actionMap = service.getActionsMapById();
 
         Action action = actionMap.get("SECRETS_GET_UNREDACTED_VALUES");
@@ -100,7 +111,9 @@ public class TestRBACServiceImpl {
     public void testActionsMapByIdContainsActionGeneralApiAccess() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Map<String,Action> actionMap = service.getActionsMapById();
 
         Action action = actionMap.get("GENERAL_API_ACCESS");
@@ -111,7 +124,9 @@ public class TestRBACServiceImpl {
     public void testActionsMapByIdContainsActionCpsPropertiesSet() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Map<String,Action> actionMap = service.getActionsMapById();
 
         Action action = actionMap.get("CPS_PROPERTIES_SET");
@@ -122,7 +137,9 @@ public class TestRBACServiceImpl {
     public void testActionsMapByNameContainsSecretsGet() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Map<String,Action> actionMapById = service.getActionsMapById();
 
         Action action = actionMapById.get("SECRETS_GET_UNREDACTED_VALUES");
@@ -134,7 +151,9 @@ public class TestRBACServiceImpl {
     public void testServiceCanLookupAdminRoleById() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Role roleGotBack = service.getRoleById("2");
         assertThat(roleGotBack.getName()).isEqualTo("admin");
     }
@@ -143,7 +162,9 @@ public class TestRBACServiceImpl {
     public void testServiceCanLookupGetSecretsActionById() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Action actionGotBack = service.getActionById("SECRETS_GET_UNREDACTED_VALUES");
         assertThat(actionGotBack.getId()).isEqualTo("SECRETS_GET_UNREDACTED_VALUES");
     }
@@ -152,7 +173,9 @@ public class TestRBACServiceImpl {
     public void testServiceCanLookupGetSecretsActionByName() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Action actionGotBack = service.getActionById("SECRETS_GET_UNREDACTED_VALUES");
         assertThat(actionGotBack.getId()).isEqualTo("SECRETS_GET_UNREDACTED_VALUES");
     }
@@ -161,7 +184,9 @@ public class TestRBACServiceImpl {
     public void testGetSecretsActionHasDescription() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Action actionGotBack = service.getActionById("SECRETS_GET_UNREDACTED_VALUES");
         assertThat(actionGotBack.getDescription()).contains("Able to get unredacted secret values");
     }
@@ -170,7 +195,9 @@ public class TestRBACServiceImpl {
     public void testSetCpsPropertiesActionHasDescription() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Map<String,Action> actionMap = service.getActionsMapById();
 
         Action action = actionMap.get("CPS_PROPERTIES_SET");
@@ -181,7 +208,9 @@ public class TestRBACServiceImpl {
     public void testActionsAreSorted() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Iterator<Action> walker = service.getActionsSortedByName().iterator();
         assertThat(walker.hasNext()).isTrue();
         // Only check the first one. Should be enough...
@@ -192,7 +221,9 @@ public class TestRBACServiceImpl {
     public void testRolesAreSorted() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         Iterator<Role> walker = service.getRolesSortedByName().iterator();
         assertThat(walker.hasNext()).isTrue();
         // Only check the first one (alphabetically). Should be enough...
@@ -203,7 +234,9 @@ public class TestRBACServiceImpl {
     public void testDefaultRoleIsAdmin() throws Exception {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
-        RBACService service = new RBACServiceImpl(mockAuthStoreService);
+        MockIDynamicStatusStoreService mockDssService = new MockIDynamicStatusStoreService();
+
+        RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService);
         String defaultRoleId = service.getDefaultRoleId();
         Role defaultRole = service.getRoleById(defaultRoleId);
         assertThat(defaultRole).isNotNull();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockCacheRBAC.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockCacheRBAC.java
@@ -5,9 +5,11 @@
  */
 package dev.galasa.framework.mocks;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import dev.galasa.framework.spi.rbac.CacheRBAC;
 import dev.galasa.framework.spi.rbac.RBACException;
@@ -25,8 +27,8 @@ public class MockCacheRBAC implements CacheRBAC {
     }
 
     @Override
-    public void addUser(String loginId, List<String> actionIds) throws RBACException {
-        usersToActionsMap.put(loginId, actionIds);
+    public void addUser(String loginId, Set<String> actionIds) throws RBACException {
+        usersToActionsMap.put(loginId, new ArrayList<>(actionIds));
     }
 
     @Override


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2071

## Changes
- Added caching of users-to-actions mappings via a `dss.rbac.<loginId>.actions` DSS property
  -  The property's value is a comma-separated list of action IDs, for example: `GENERAL_API_ACCESS,CPS_PROPERTIES_SET,SECRETS_GET_UNREDACTED_VALUES`
  - These cached properties are stored in the DSS for 24 hours before they expire