### PR TITLE
Move required secrets check to Main Build Orchestrator

### DIFF
--- a/.github/workflows/buildutils.yaml
+++ b/.github/workflows/buildutils.yaml
@@ -14,20 +14,9 @@ env:
   BRANCH: ${{ github.ref_name }}
 
 jobs:
-  check-required-secrets-configured:
-    name: Check required secrets configured
-    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
-    with:
-      check_write_github_packages_username: 'true'
-      check_write_github_packages_token: 'true'
-    secrets:
-      WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-      WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
-
   build-push-galasabld:
     name: Build and push galasabld artifacts
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout code
@@ -145,7 +134,6 @@ jobs:
   build-push-openapi2beans:
     name: Build and push openapi2beans artifacts
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
     
     steps:
       - name: Checkout code
@@ -211,7 +199,6 @@ jobs:
   build-push-buildutils-executables:
     name: Build and push buildutils repository executables
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout code

--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -31,22 +31,9 @@ jobs:
         run: |
           echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
 
-  check-required-secrets-configured:
-    name: Check required secrets configured
-    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
-    with:
-      check_gpg_key: 'true'
-      check_gpg_keyid: 'true'
-      check_gpg_passphrase: 'true'
-    secrets:
-      GPG_KEY: ${{ secrets.GPG_KEY }}
-      GPG_KEYID: ${{ secrets.GPG_KEYID }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
   build-extensions:
     name: Build Extensions source code and Docker image for development Maven registry
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -33,26 +33,9 @@ jobs:
         run: |
           echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
 
-  check-required-secrets-configured:
-    name: Check required secrets configured
-    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
-    with:
-      check_gpg_key: 'true'
-      check_gpg_keyid: 'true'
-      check_gpg_passphrase: 'true'
-      check_write_github_packages_username: 'true'
-      check_write_github_packages_token: 'true'
-    secrets:
-      GPG_KEY: ${{ secrets.GPG_KEY }}
-      GPG_KEYID: ${{ secrets.GPG_KEYID }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-      WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
-
   build-framework:
     name: Build Framework using openapi2beans and gradle
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -31,22 +31,9 @@ jobs:
         run: |
           echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
 
-  check-required-secrets-configured:
-    name: Check required secrets configured
-    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
-    with:
-      check_gpg_key: 'true'
-      check_gpg_keyid: 'true'
-      check_gpg_passphrase: 'true'
-    secrets:
-      GPG_KEY: ${{ secrets.GPG_KEY }}
-      GPG_KEYID: ${{ secrets.GPG_KEYID }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
   build-gradle:
     name: Build 'gradle' source code
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/managers.yaml
+++ b/.github/workflows/managers.yaml
@@ -31,22 +31,9 @@ jobs:
         run: |
           echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
 
-  check-required-secrets-configured:
-    name: Check required secrets configured
-    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
-    with:
-      check_gpg_key: 'true'
-      check_gpg_keyid: 'true'
-      check_gpg_passphrase: 'true'
-    secrets:
-      GPG_KEY: ${{ secrets.GPG_KEY }}
-      GPG_KEYID: ${{ secrets.GPG_KEYID }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
   build-managers:
     name: Build Managers source code and Docker image for development Maven registry
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -31,22 +31,9 @@ jobs:
         run: |
           echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
 
-  check-required-secrets-configured:
-    name: Check required secrets configured
-    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
-    with:
-      check_maven_settings_xml: 'true'
-      check_gpg_key: 'true'
-      check_gpg_passphrase: 'true'
-    secrets:
-      MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-      GPG_KEY: ${{ secrets.GPG_KEY }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
   build-maven:
     name: Build Maven source code and Docker image for development Maven registry
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -28,26 +28,9 @@ jobs:
         run: |
           echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
 
-  check-required-secrets-configured:
-    name: Check required secrets configured
-    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
-    with:
-      check_maven_settings_xml: 'true'
-      check_gpg_key: 'true'
-      check_gpg_passphrase: 'true'
-      check_write_github_packages_username: 'true'
-      check_write_github_packages_token: 'true'
-    secrets:
-      MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-      GPG_KEY: ${{ secrets.GPG_KEY }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-      WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
-
   build-obr:
     name: Build OBR using galasabld image and maven
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout Code
@@ -324,7 +307,6 @@ jobs:
   build-obr-javadocs:
     name: Build OBR javadocs using galasabld image and maven
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/platform.yaml
+++ b/.github/workflows/platform.yaml
@@ -31,22 +31,9 @@ jobs:
         run: |
           echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
 
-  check-required-secrets-configured:
-    name: Check required secrets configured
-    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
-    with:
-      check_gpg_key: 'true'
-      check_gpg_keyid: 'true'
-      check_gpg_passphrase: 'true'
-    secrets:
-      GPG_KEY: ${{ secrets.GPG_KEY }}
-      GPG_KEYID: ${{ secrets.GPG_KEYID }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
   build-platform:
     name: Build Platform
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -30,13 +30,33 @@ jobs:
         run: |
           cat build.properties | grep "=" >> $GITHUB_OUTPUT
 
+  check-required-secrets-configured:
+    name: Check required secrets configured
+    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
+    with:
+      check_write_github_packages_username: 'true'
+      check_write_github_packages_token: 'true'
+      check_maven_settings_xml: 'true'
+      check_gpg_key: 'true'
+      check_gpg_keyid: 'true'
+      check_gpg_passphrase: 'true'
+    secrets:
+      WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+      WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+      MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+      GPG_KEY: ${{ secrets.GPG_KEY }}
+      GPG_KEYID: ${{ secrets.GPG_KEYID }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
   build-platform:
     name: Build the 'platform' module
+    needs: [check-required-secrets-configured]
     uses: ./.github/workflows/platform.yaml
     secrets: inherit
 
   build-buildutils:
     name: Build the 'buildutils' module
+    needs: [check-required-secrets-configured]
     uses: ./.github/workflows/buildutils.yaml
     secrets: inherit
 

--- a/.github/workflows/wrapping.yaml
+++ b/.github/workflows/wrapping.yaml
@@ -32,22 +32,9 @@ jobs:
         run: |
           echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
 
-  check-required-secrets-configured:
-    name: Check required secrets configured
-    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
-    with:
-      check_maven_settings_xml: 'true'
-      check_gpg_key: 'true'
-      check_gpg_passphrase: 'true'
-    secrets:
-      MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
-      GPG_KEY: ${{ secrets.GPG_KEY }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
   build-wrapping:
     name: Build Wrapping source code and Docker image for development Maven registry
     runs-on: ubuntu-latest
-    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
## Why?

The Main Build Orchestrator calls the main builds for each of the Galasa modules, and each of these require different secrets from each other. Currently, there are multiple checks happening at the start of each module's build to check for the required secrets for that particular module. However it makes more sense to check only once in the Main Build Orchestrator for all secrets that are needed by the child workflows, so that contributors are informed straight away about missing secrets, can go set them up, then rerun the workflow in its entirety.

Having spoken with a couple of contributors this week and helping them get set up, it was obvious this change was needed as they were only being informed of missing secrets for the first workflows, to then find out about other missing secrets later on.