### PR TITLE
Support customizable VTAM logon strings (#2109)

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/internal/CicstsDefaultLogonProvider.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/internal/CicstsDefaultLogonProvider.java
@@ -10,6 +10,7 @@ import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.ICredentialsUsernamePassword;
 import dev.galasa.cicsts.CicstsManagerException;
+import dev.galasa.cicsts.ICicsRegion;
 import dev.galasa.cicsts.ICicsTerminal;
 import dev.galasa.cicsts.internal.properties.DefaultLogonGmText;
 import dev.galasa.cicsts.internal.properties.DefaultLogonInitialText;
@@ -18,6 +19,7 @@ import dev.galasa.framework.spi.IConfidentialTextService;
 import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.creds.CredentialsException;
 import dev.galasa.framework.spi.creds.ICredentialsService;
+import dev.galasa.zos.IZosImage;
 import dev.galasa.zos3270.Zos3270Exception;
 
 public class CicstsDefaultLogonProvider implements ICicsRegionLogonProvider {
@@ -63,11 +65,12 @@ public class CicstsDefaultLogonProvider implements ICicsRegionLogonProvider {
                 checkForInitialText(cicsTerminal);
             }
 
-            cicsTerminal.type("LOGON APPLID(" + cicsTerminal.getCicsRegion().getApplid() + ")").enter().wfk();
+            ICicsRegion region = cicsTerminal.getCicsRegion();
+            cicsTerminal.type(region.getZosImage().getVtamLogonString(region.getApplid())).enter().wfk();
 
             waitForGmText(cicsTerminal);
 
-            logger.debug("Logged onto " + cicsTerminal.getCicsRegion());
+            logger.debug("Logged onto " + region);
 
             // If loginCredentialsTag is provided, attempt to sign-in
             // via CESL

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zos/IZosImage.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zos/IZosImage.java
@@ -39,6 +39,14 @@ public interface IZosImage {
     String getSysname();
     
     /**
+     * Get the name of the VTAM logon string for the zOS Image. Defaults to LOGON APPLID(applid)
+     * 
+     * @return The VTAM logon string, never null
+     */
+    @NotNull
+    String getVtamLogonString(String applid);
+    
+    /**
      * Get the name of the Sysplex this Image belongs to
      * 
      * @return the sysplex id, if the sysplexid has not been defined, the imageid will be returned

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zos/internal/ZosBaseImageImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zos/internal/ZosBaseImageImpl.java
@@ -6,6 +6,7 @@
 package dev.galasa.zos.internal;
 
 import java.nio.charset.Charset;
+import java.text.MessageFormat;
 
 import javax.validation.constraints.NotNull;
 
@@ -18,6 +19,7 @@ import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosManagerException;
 import dev.galasa.zos.internal.properties.ImageCodePage;
 import dev.galasa.zos.internal.properties.ImageSysname;
+import dev.galasa.zos.internal.properties.ImageVtamLogon;
 
 public abstract class ZosBaseImageImpl implements IZosImage {
 
@@ -26,6 +28,7 @@ public abstract class ZosBaseImageImpl implements IZosImage {
 
     private final String        imageId;
     private final String        sysname;
+    private final String        vtamLogonString;
     private final String        clusterId;
     private final String        sysplexID;
     private final String        defaultCredentialsId;
@@ -50,6 +53,7 @@ public abstract class ZosBaseImageImpl implements IZosImage {
         try {
             this.codePage = ImageCodePage.get(this.imageId);
             this.sysname = ImageSysname.get(this.imageId);
+            this.vtamLogonString = ImageVtamLogon.get(imageId);
             this.sysplexID = AbstractManager.nulled(this.cps.getProperty("image." + this.imageId, "sysplex"));
             this.defaultCredentialsId = AbstractManager.defaultString(this.cps.getProperty("image", "credentials", this.imageId), "ZOS");
         } catch(Exception e) {
@@ -84,6 +88,11 @@ public abstract class ZosBaseImageImpl implements IZosImage {
     @Override
     public @NotNull String getSysname() {
         return this.sysname;
+    }
+
+    @Override
+    public @NotNull String getVtamLogonString(String applid) {
+        return MessageFormat.format(this.vtamLogonString, applid);
     }
 
     @Override

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zos/internal/properties/ImageVtamLogon.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zos/internal/properties/ImageVtamLogon.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.zos.internal.properties;
+
+import javax.validation.constraints.NotNull;
+
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.cps.CpsProperties;
+import dev.galasa.zos.ZosManagerException;
+
+/**
+ * The VTAM logon string
+ * 
+ * @galasa.cps.property
+ * 
+ * @galasa.name zos.image.[tag].vtam.logon
+ * 
+ * @galasa.description The VTAM logon string for the specified tag
+ * 
+ * @galasa.required No
+ * 
+ * @galasa.default LOGON APPLID({0})
+ * 
+ * @galasa.valid_values 
+ * 
+ * @galasa.examples 
+ * <code>zos.image.[tag].vtam.logon=LOGON APPLID {0}</code><br>
+ *
+ */
+public class ImageVtamLogon extends CpsProperties {
+    
+    private static final String DEFAULT_VTAM_LOGON_STRING = "LOGON APPLID({0})";
+
+    public static String get(@NotNull String tag) throws ZosManagerException {
+        try {
+            String vtamLogon = getStringNulled(ZosPropertiesSingleton.cps(), "image", "vtam.logon", tag);
+            if (vtamLogon == null)  {
+                return DEFAULT_VTAM_LOGON_STRING;
+            }
+            return vtamLogon;
+        } catch (ConfigurationPropertyStoreException e) {
+            throw new ZosManagerException("Problem asking the CPS for the VTAM logon string for z/OS image with tag '"  + tag + "'", e);
+        }
+    }
+
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/test/java/dev/galasa/zos/internal/properties/TestImageVtamLogon.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/test/java/dev/galasa/zos/internal/properties/TestImageVtamLogon.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.zos.internal.properties;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.zos.ZosManagerException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestImageVtamLogon {
+    
+    @Mock
+    private static IConfigurationPropertyStoreService cps;
+    private static ZosPropertiesSingleton zps = new ZosPropertiesSingleton();
+    
+    private static final String DEFAULT_VTAM_LOGON_STRING = "LOGON APPLID({0})";
+    private static final String TAG_VTAM_LOGON_STRING = "TESTING({0})";
+    private static final String TAG = "tag";
+ 
+    @Before
+    public void setup() throws ZosManagerException, ConfigurationPropertyStoreException {
+        zps.activate();
+        ZosPropertiesSingleton.setCps(cps);
+        Mockito.when(cps.getProperty(Mockito.eq("image"), Mockito.eq("vtam.logon"),Mockito.any())).thenReturn(null);
+        Mockito.when(cps.getProperty("image", "vtam.logon",TAG)).thenReturn(TAG_VTAM_LOGON_STRING);
+        Mockito.when(cps.getProperty("image", "vtam.logon", "EXC")).thenThrow(new ConfigurationPropertyStoreException());
+}
+
+    @Test
+    public void testNull() throws Exception {        
+        Assert.assertEquals("Unexpected value returned from ImageVtamLogon.get()", DEFAULT_VTAM_LOGON_STRING, ImageVtamLogon.get(null));
+    }
+    
+    @Test
+    public void testUndefined() throws Exception {        
+        Assert.assertEquals("Unexpected value returned from ImageVtamLogon.get()", DEFAULT_VTAM_LOGON_STRING, ImageVtamLogon.get("ANY"));
+    }
+    
+    @Test
+    public void testValid() throws Exception {
+        Assert.assertEquals("Unexpected value returned from ImageVtamLogon.get()", TAG_VTAM_LOGON_STRING, ImageVtamLogon.get(TAG));
+    }
+    
+    @Test
+    public void testException() throws Exception {
+        String expectedMessage = "Problem asking the CPS for the VTAM logon string for z/OS image with tag 'EXC'";
+        ZosManagerException expectedException = Assert.assertThrows("expected exception should be thrown", ZosManagerException.class, ()->{
+        	ImageVtamLogon.get("EXC");
+        });
+    	Assert.assertEquals("Exception should contain expected message", expectedMessage, expectedException.getMessage());
+    }
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/src/main/java/dev/galasa/zos3270/manager/ivt/Zos3270IVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/src/main/java/dev/galasa/zos3270/manager/ivt/Zos3270IVT.java
@@ -177,7 +177,7 @@ public class Zos3270IVT {
 	// 	terminal.disconnect();
 	// 	terminal.connect();
 
-	// 	terminal.wfk().type("logon applid(" + cbsaApplid + ")").enter().wfk().waitForTextInField("Signon to CICS");
+	// 	terminal.wfk().type(image.getVtamLogonString(cbsaApplid)).enter().wfk().waitForTextInField("Signon to CICS");
 	// 	terminal.wfk().type(credentials.getUsername()).tab().tab().type(credentials.getPassword()).enter().wfk();
 
 	// 	// access CBSA and look up customer with ID 1


### PR DESCRIPTION
Adds the ability for users to specify a custom logon string template for a given z/OS image.
New property is zos.image.[TAG].vtam.logon, default value is "LOGON APPLID({0})" to preserve existing behaviour.

Code changes are:
- New class ImageVtamLogon to extract the new property, setting the default behaviour if not found.
- New class TestImageVtamLogon to unit test ImageVtamLogon.
- New method getVtamLogonString in ZosBaseImageImpl to return the fully formatted logon string given a supplied applid (method signature in IZosImage)
- Updates to CicstsDefaultLogonProvider to use the above.
- Zos3270IVT updated to use the above (if it ever gets uncommented).

No additional tests added since existing test classes all have their contents commented out.

Manual testing:
- Run galasa test that logs on to CICS region, new property not specified - logs on using the correct default.
- Repeat with the new property specified with the default - logs on using the default
- Repeat with the new property specified with a different pattern - attempts log on with the expected custom logon string (logon fails since my test system only accepts the default logon command - but that was expected).

Local build is clean (including run of the new jUnits).