### PR TITLE
mcobbett default admin role in dev setup

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStore.java
@@ -35,7 +35,6 @@ import dev.galasa.framework.spi.auth.AuthStoreException;
 import dev.galasa.framework.spi.auth.IFrontEndClient;
 import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.auth.IUser;
-import dev.galasa.framework.spi.utils.GalasaGson;
 
 public class TestCouchdbAuthStore {
 

--- a/modules/framework/run-locally.sh
+++ b/modules/framework/run-locally.sh
@@ -183,6 +183,9 @@ function setup_galasa_dev() {
     # The GALASA_DEX_GRPC_HOSTNAME environment variable must match the "addr" value
     # within the "grpc" section in your local Dex server's configuration 
     export GALASA_DEX_GRPC_HOSTNAME="127.0.0.1:5557"
+
+    # In the test environment, when we log in for the first time, we want our userid to be given admin rights.
+    export GALASA_DEFAULT_USER_ROLE="admin"
 }
 
 


### PR DESCRIPTION

# Why ?
See RBAC story [Minimal Admin/Non-admin RBAC #2071](https://github.com/galasa-dev/projectmanagement/issues/2071)

- When launching the api server in a development test rig, new users should be admins
- I've tested things when this is not set, and the user correctly gets no permissions, and ends in the `deactivated` role... which isn't much good for trying something out live on your local machine.