### PR TITLE
Be able to run private images in GHCR in workflows

### DIFF
--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -56,6 +56,17 @@ jobs:
         with:
           gradle-version: 8.9
           cache-disabled: true
+
+      # This is required so the openapi2beans image can be run in the next step.
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        env:
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
       
       - name: Build servlet beans with openapi2beans
         env:

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -79,7 +79,7 @@ jobs:
         run: |
           gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
 
-      # This is required so the openapi2beans image can be run in the next step.
+      # This is required so the galasabld-amd64 image can be run in the next step.
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
         env:
@@ -171,7 +171,7 @@ jobs:
           path: modules/obr/galasa-bom-build.log
           retention-days: 7
 
-      # This is required so the openapi2beans image can be run in the next step.
+      # This is required so the galasabld-amd64 image can be run in the next step.
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
         env:
@@ -388,7 +388,7 @@ jobs:
         run: |
           gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
 
-      # This is required so the openapi2beans image can be run in the next step.
+      # This is required so the galasabld-amd64 image can be run in the next step.
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
         env:
@@ -610,7 +610,7 @@ jobs:
         run: |
           gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
 
-      # This is required so the openapi2beans image can be run in the next step.
+      # This is required so the galasabld-amd64 image can be run in the next step.
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
         env:

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -78,6 +78,17 @@ jobs:
       - name: Import GPG
         run: |
           gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+
+      # This is required so the openapi2beans image can be run in the next step.
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        env:
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
       
       - name:  Generate Galasa BOM
         run: |
@@ -159,6 +170,17 @@ jobs:
           name: galasa-bom-build-log
           path: modules/obr/galasa-bom-build.log
           retention-days: 7
+
+      # This is required so the openapi2beans image can be run in the next step.
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        env:
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
       
       - name:  Generate Galasa OBR
         run: |
@@ -365,6 +387,17 @@ jobs:
       - name: Import GPG
         run: |
           gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+
+      # This is required so the openapi2beans image can be run in the next step.
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        env:
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
           
       - name: Build Galasa Javadoc
         run: |
@@ -576,6 +609,17 @@ jobs:
       - name: Import GPG
         run: |
           gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+
+      # This is required so the openapi2beans image can be run in the next step.
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        env:
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
       
       - name:  Generate Galasa OBR generic pom.xml
         run: |


### PR DESCRIPTION
## Why?
When contributors first fork this repo and run an initial Main Build, the openapi2beans and galasabld-amd64 images are built and published to their GH packages, but they are private visibility as default. This means that later in the workflow when these images are used with `docker run`, the workflow must authenticate to GHCR to be able to run them.