### PR TITLE
mcobbett rbac enforce TOKENS DELETE OTHER

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
@@ -25,6 +25,7 @@ import dev.galasa.framework.api.authentication.internal.routes.AuthTokensRoute;
 import dev.galasa.framework.api.common.BaseServlet;
 import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.EnvironmentVariables;
+import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.SystemEnvironment;
 import dev.galasa.framework.auth.spi.AuthServiceFactory;
 import dev.galasa.framework.auth.spi.IAuthService;
@@ -91,7 +92,12 @@ public class AuthenticationServlet extends BaseServlet {
             throw new ServletException("Failed to initialise authentication servlet");
         }
 
-        IAuthService authService = factory.getAuthService();
+        IAuthService authService ;
+        try {
+            authService = factory.getAuthService();
+        } catch( InternalServletException ex) {
+            throw new ServletException(ex);
+        }
 
         rbacService = getRBACService(framework);
         

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -19,6 +19,9 @@ import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.auth.spi.IAuthService;
 import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.auth.IInternalAuthToken;
+import dev.galasa.framework.spi.auth.IInternalUser;
+import dev.galasa.framework.spi.rbac.BuiltInAction;
 import dev.galasa.framework.spi.rbac.RBACService;
 
 public class AuthTokensDetailsRoute extends ProtectedRoute {
@@ -43,9 +46,11 @@ public class AuthTokensDetailsRoute extends ProtectedRoute {
             throws FrameworkException {
 
         HttpServletRequest request = requestContext.getRequest();
+        String requestorUserLoginId = requestContext.getUsername();
 
         String tokenId = getTokenIdFromUrl(pathInfo);
-        authService.revokeToken(tokenId);
+
+        authService.revokeToken(tokenId,requestorUserLoginId);
 
         String responseBody = "Successfully revoked token with ID '" + tokenId + "'";
         return getResponseBuilder().buildResponse(request, response, "text/plain", responseBody, HttpServletResponse.SC_OK);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -19,9 +19,6 @@ import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.auth.spi.IAuthService;
 import dev.galasa.framework.spi.FrameworkException;
-import dev.galasa.framework.spi.auth.IInternalAuthToken;
-import dev.galasa.framework.spi.auth.IInternalUser;
-import dev.galasa.framework.spi.rbac.BuiltInAction;
 import dev.galasa.framework.spi.rbac.RBACService;
 
 public class AuthTokensDetailsRoute extends ProtectedRoute {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
@@ -384,7 +384,7 @@ public class AuthTokensRoute extends PublicRoute {
     private void validateLoginId(String loginId, String servletPath) throws InternalServletException {
 
         if (loginId == null || loginId.trim().length() == 0) {
-            ServletError error = new ServletError(GAL5067_ERROR_INVALID_LOGINID, servletPath);
+            ServletError error = new ServletError(GAL5127_ERROR_INVALID_LOGINID, servletPath);
             throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
         }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRouteTest.java
@@ -150,7 +150,7 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
         MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
 
         // Throw an exception to simulate an auth store failure
-        authStoreService.setThrowException(true);
+        authStoreService.setThrowExceptionOnDeleteToken(true);
 
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(null, mockDexGrpcClient, new MockFramework(authStoreService));
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRouteTest.java
@@ -26,8 +26,10 @@ import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
 import dev.galasa.framework.auth.spi.internal.AuthService;
 import dev.galasa.framework.auth.spi.mocks.MockDexGrpcClient;
+import dev.galasa.framework.mocks.FilledMockRBACService;
 import dev.galasa.framework.mocks.MockAuthStoreService;
 import dev.galasa.framework.mocks.MockInternalAuthToken;
+import dev.galasa.framework.mocks.MockRBACService;
 import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.auth.IInternalUser;
 
@@ -38,7 +40,9 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
     @Test
     public void testAuthTokensDetailsRouteRegexMatchesExpectedPaths() throws Exception {
         //Given...
-        String tokensDetailsRoutePath = new AuthTokensDetailsRoute(null, new AuthService(null, null), null).getPathRegex().toString();
+        MockRBACService rbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+        AuthService authService = new AuthService(null, null, rbacService);
+        String tokensDetailsRoutePath = new AuthTokensDetailsRoute(null, authService, rbacService).getPathRegex().toString();
 
         //When...
         Pattern routePattern = Pattern.compile(tokensDetailsRoutePath);
@@ -71,7 +75,7 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
         String description = "test token";
         String clientId = "my-client";
         Instant creationTime = Instant.now();
-        IInternalUser owner = new InternalUser("username", "dexId");
+        IInternalUser owner = new InternalUser(JWT_USERNAME, "dexId");
 
         List<IInternalAuthToken> tokens = new ArrayList<>();
         tokens.add(new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId));
@@ -103,7 +107,7 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
         String description = "test token";
         String clientId = "my-client";
         Instant creationTime = Instant.now();
-        IInternalUser owner = new InternalUser("username", "dexId");
+        IInternalUser owner = new InternalUser(JWT_USERNAME, "dexId");
 
         List<IInternalAuthToken> tokens = new ArrayList<>();
         tokens.add(new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId));
@@ -138,7 +142,7 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
         String description = "test token";
         String clientId = "my-client";
         Instant creationTime = Instant.now();
-        IInternalUser owner = new InternalUser("username", "dexId");
+        IInternalUser owner = new InternalUser(JWT_USERNAME, "dexId");
 
         List<IInternalAuthToken> tokens = new ArrayList<>();
         tokens.add(new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId));
@@ -206,7 +210,7 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
         String description = "test token";
         String clientId = "my-client";
         Instant creationTime = Instant.now();
-        IInternalUser owner = new InternalUser("username", "dexId");
+        IInternalUser owner = new InternalUser(JWT_USERNAME, "dexId");
 
         List<IInternalAuthToken> tokens = new ArrayList<>();
         tokens.add(new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId));
@@ -237,7 +241,7 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
         String description = "test token";
         String clientId = "my-client";
         Instant creationTime = Instant.now();
-        IInternalUser owner = new InternalUser("username", "dexId");
+        IInternalUser owner = new InternalUser(JWT_USERNAME, "dexId");
 
         List<IInternalAuthToken> tokens = new ArrayList<>();
         tokens.add(new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId));
@@ -268,7 +272,7 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
         String description = "test token";
         String clientId = "my-client";
         Instant creationTime = Instant.now();
-        IInternalUser owner = new InternalUser("username", null);
+        IInternalUser owner = new InternalUser(JWT_USERNAME, null);
 
         List<IInternalAuthToken> tokens = new ArrayList<>();
         tokens.add(new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId));

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRouteTest.java
@@ -123,7 +123,10 @@ public class AuthTokensRouteTest extends BaseServletTest {
         //Given...
         ResponseBuilder responseBuilder = null;
         IOidcProvider oidcProvider = null;
-        IAuthService authService = new AuthService(null, null);    
+        
+        MockRBACService rbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+
+        IAuthService authService = new AuthService(null, null, rbacService);    
         ITimeService timeService = null ;
         MockRBACService mockRBACService = createTestRBACKService();
         Environment env = null;
@@ -280,7 +283,7 @@ public class AuthTokensRouteTest extends BaseServletTest {
         servlet.doGet(mockRequest, servletResponse);
 
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5057, "GAL5057E");
+        checkErrorStructure(outStream.toString(), 5127, "GAL5127E");
     }
 
     @Test
@@ -306,7 +309,7 @@ public class AuthTokensRouteTest extends BaseServletTest {
         servlet.doGet(mockRequest, servletResponse);
 
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5057, "GAL5057E");
+        checkErrorStructure(outStream.toString(), 5127, "GAL5127E");
     }
 
     @Test
@@ -956,7 +959,8 @@ public class AuthTokensRouteTest extends BaseServletTest {
         mockEnv.setenv(EnvironmentVariables.GALASA_USERNAME_CLAIMS,"sub");
         String dummyJwt = DUMMY_JWT;
 
-        IAuthService authService = new AuthService(authStoreService, mockDexGrpcClient);
+        MockRBACService rbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+        IAuthService authService = new AuthService(authStoreService, mockDexGrpcClient, rbacService);
 
         MockRBACService mockRBACService = createTestRBACKService();
 
@@ -1029,7 +1033,8 @@ public class AuthTokensRouteTest extends BaseServletTest {
         mockEnv.setenv(EnvironmentVariables.GALASA_USERNAME_CLAIMS,"sub");
         String dummyJwt = DUMMY_JWT;
 
-        IAuthService authService = new AuthService(authStoreService, mockDexGrpcClient);
+        MockRBACService rbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+        IAuthService authService = new AuthService(authStoreService, mockDexGrpcClient, rbacService);
 
         MockRBACService mockRBACService = createTestRBACKService();
 
@@ -1080,7 +1085,8 @@ public class AuthTokensRouteTest extends BaseServletTest {
         mockEnv.setenv(EnvironmentVariables.GALASA_USERNAME_CLAIMS,"sub");
         String dummyJwt = DUMMY_JWT;
 
-        IAuthService authService = new AuthService(authStoreService, mockDexGrpcClient);
+        MockRBACService rbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+        IAuthService authService = new AuthService(authStoreService, mockDexGrpcClient, rbacService);
 
         MockRBACService mockRBACService = createTestRBACKService();
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockAuthenticationServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockAuthenticationServlet.java
@@ -54,7 +54,8 @@ public class MockAuthenticationServlet extends AuthenticationServlet {
         super.oidcProvider = oidcProvider;
         super.framework = framework;
         super.rbacService = rbacService;
-        IAuthService authService = new AuthService(framework.getAuthStoreService(), dexGrpcClient);
+        
+        IAuthService authService = new AuthService(framework.getAuthStoreService(), dexGrpcClient, rbacService);
         setAuthServiceFactory(new MockAuthServiceFactory(authService));
         setResponseBuilder(new ResponseBuilder(env));
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
@@ -107,16 +107,21 @@ public class BaseServlet extends HttpServlet {
         }
     }
 
-    private void processRoutes(HttpServletRequest req, HttpServletResponse res)
-            throws ServletException, IOException, FrameworkException, InterruptedException {
+    private String extractUrlFromPath(HttpServletRequest req) {
         String url = req.getPathInfo();
         if (url == null) {
             // There is no path information, so this must be a root path (e.g. /cps)
             url = "";
         }
+        return url;
+    }
+
+    private void processRoutes(HttpServletRequest req, HttpServletResponse res)
+            throws ServletException, IOException, FrameworkException, InterruptedException {
 
         QueryParameters queryParameters = new QueryParameters(req.getParameterMap());
 
+        String url = extractUrlFromPath(req);
         IRoute route = selectRoute(url);
 
         if (route == null) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -119,7 +119,7 @@ public enum ServletErrorMessage {
     GAL5064_FAILED_TO_REVOKE_TOKEN                    (5064, "E: Failed to revoke the token with the given ID. Ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
     GAL5065_FAILED_TO_GET_TOKEN_ID_FROM_URL           (5065, "E: Failed to retrieve a token ID from the request path. Ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
     GAL5066_ERROR_NO_SUCH_TOKEN_EXISTS                (5066, "E: No such token with the given ID exists. Ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
-    GAL5067_ERROR_INVALID_LOGINID                     (5057, "E: Invalid login ID provided. This could be because no value was given for the loginId query parameter. Check your provided loginId query parameter value and try again."),
+    GAL5127_ERROR_INVALID_LOGINID                     (5127, "E: Invalid login ID provided. This could be because no value was given for the loginId query parameter. Check your provided loginId query parameter value and try again."),
 
     // OpenAPI Servlet...
     GAL5071_FAILED_TO_PARSE_YAML_INTO_JSON            (5071, "E: Internal server error. Failed to convert OpenAPI specification from YAML into JSON. Report the problem to your Galasa Ecosystem owner"),
@@ -162,6 +162,7 @@ public enum ServletErrorMessage {
     GAL5125_ACTION_NOT_PERMITTED                      (5125, "E: Insufficient privileges to perform the requested operation. Check with your Galasa systems administrator that you have been assigned the correct role with the ''{0}'' action before trying again."),
     GAL5126_INTERNAL_RBAC_ERROR                       (5126, "E: Error occurred when trying to access the Role Based Access Control service. Report the problem to your Galasa systems administrator."),
 
+    // Next one to allocate is: 5127
     ;
 
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -166,6 +166,9 @@ public enum ServletErrorMessage {
 
     // >>>
     // >>> Note: Please keep this up to date, to save us wondering what to allocate next... 
+    // >>>       otherwise you have to find a 'gap' in the range.
+    // >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
+    // >>>       If you do use this number for a new error template, please incriment this value.
     // >>>
     public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5413 ;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -162,7 +162,6 @@ public enum ServletErrorMessage {
     GAL5125_ACTION_NOT_PERMITTED                      (5125, "E: Insufficient privileges to perform the requested operation. Check with your Galasa systems administrator that you have been assigned the correct role with the ''{0}'' action before trying again."),
     GAL5126_INTERNAL_RBAC_ERROR                       (5126, "E: Error occurred when trying to access the Role Based Access Control service. Report the problem to your Galasa systems administrator."),
 
-
     ;
 
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -162,10 +162,12 @@ public enum ServletErrorMessage {
     GAL5125_ACTION_NOT_PERMITTED                      (5125, "E: Insufficient privileges to perform the requested operation. Check with your Galasa systems administrator that you have been assigned the correct role with the ''{0}'' action before trying again."),
     GAL5126_INTERNAL_RBAC_ERROR                       (5126, "E: Error occurred when trying to access the Role Based Access Control service. Report the problem to your Galasa systems administrator."),
 
-    // Next one to allocate is: 5127
     ;
 
-
+    // >>>
+    // >>> Note: Please keep this up to date, to save us wondering what to allocate next... 
+    // >>>
+    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5413 ;
 
 
     private String template ;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestServletErrorMessage.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestServletErrorMessage {
+
+    @Test
+    public void TestCanGetAMessageOutOfTheList() throws Exception {
+        // Given...
+        ServletErrorMessage msg = ServletErrorMessage.GAL5002_INVALID_RUN_ID;
+    }
+
+    @Test
+    public void TestAllErrorMessageNumbersAreUnique() throws Exception {
+
+        Map<Integer,ServletErrorMessage> messagesLookedAtSoFar = new HashMap<>();
+
+        StringBuilder buff = new StringBuilder();
+
+        for( ServletErrorMessage msg : EnumSet.allOf(ServletErrorMessage.class)) {
+
+            int msgNumber = msg.getTemplateNumber();
+            ServletErrorMessage clashingErrorMessage = messagesLookedAtSoFar.get(msgNumber);
+            if( clashingErrorMessage != null) {
+                buff.append("Error message number clashes: Template number "+msgNumber+" is used more than once!\n");
+                buff.append("  Template1: "+msg.toString()+"\n");
+                buff.append("  Template2: "+clashingErrorMessage.toString()+"\n");
+            } else {
+                messagesLookedAtSoFar.put(msgNumber,msg);
+            }
+        }
+
+        String errorMsg = buff.toString();
+        assertThat(errorMsg).isBlank();
+    }
+
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestServletErrorMessage.java
@@ -7,6 +7,7 @@ package dev.galasa.framework.api.common;
 
 import org.junit.Test;
 
+import static dev.galasa.framework.api.common.ServletErrorMessage.GALxxx_NEXT_MESSAGE_NUMBER_TO_USE;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.EnumSet;
@@ -22,7 +23,7 @@ public class TestServletErrorMessage {
     }
 
     @Test
-    public void TestAllErrorMessageNumbersAreUnique() throws Exception {
+    public void testAllErrorMessageNumbersAreUnique() throws Exception {
 
         Map<Integer,ServletErrorMessage> messagesLookedAtSoFar = new HashMap<>();
 
@@ -44,5 +45,26 @@ public class TestServletErrorMessage {
         String errorMsg = buff.toString();
         assertThat(errorMsg).isBlank();
     }
+
+    @Test
+    public void testNextMessageNumberToAllocateIsHighestSoFar() {
+
+        int highestMsgNumber = 0 ;
+        for( ServletErrorMessage msg : EnumSet.allOf(ServletErrorMessage.class)) {
+            int msgNumber = msg.getTemplateNumber();
+            if (msgNumber>highestMsgNumber) {
+                highestMsgNumber = msgNumber;
+            }
+        }
+        assertThat(highestMsgNumber)
+            .as("Highest message number in use is higher than the GALxxx_NEXT_MESSAGE_NUMBER_TO_USE marker value."+
+                " Edit the GALxxx_NEXT_MESSAGE_NUMBER_TO_USE value to be higher than that.")
+            .isLessThan(GALxxx_NEXT_MESSAGE_NUMBER_TO_USE);
+    }
+
+
+
+
+
 
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestServletErrorMessage.java
@@ -18,8 +18,9 @@ public class TestServletErrorMessage {
 
     @Test
     public void TestCanGetAMessageOutOfTheList() throws Exception {
-        // Given...
+        // Given... we force the class to load.
         ServletErrorMessage msg = ServletErrorMessage.GAL5002_INVALID_RUN_ID;
+        assertThat(msg).isNotNull();
     }
 
     @Test

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -2161,7 +2161,7 @@ paths:
                     actions:
                       - GENERAL_API_ACCESS
                       - SECRETS_GET_UNREDACTED_VALUES
-                      - USER_ROLE_UPDATE_ANY
+                      - USER_EDIT_OTHER
                       - CPS_PROPERTIES_SET
         '404':
           $ref: '#/components/responses/NotFound'

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/UsersServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/UsersServlet.java
@@ -24,6 +24,7 @@ import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.api.common.BaseServlet;
 import dev.galasa.framework.api.common.Environment;
+import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.SystemEnvironment;
 
 @Component(service = Servlet.class, scope = ServiceScope.PROTOTYPE, property = {
@@ -58,11 +59,12 @@ public class UsersServlet extends BaseServlet {
             factory = new AuthServiceFactory(framework, env);
         }
 
-        IAuthService authService = factory.getAuthService();
+        IAuthService authService ;
         RBACService rbacService ;
         try {
+            authService = factory.getAuthService();
             rbacService = framework.getRBACService();
-        } catch ( RBACException ex) {
+        } catch ( InternalServletException | RBACException ex) {
             throw new ServletException(ex);
         }
         

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/internal/routes/UserRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/internal/routes/UserRoute.java
@@ -83,7 +83,7 @@ public class UserRoute extends AbstractUsersRoute {
         HttpServletResponse response
     ) throws FrameworkException, IOException {
 
-        validateActionPermitted(BuiltInAction.USER_ROLE_UPDATE_ANY, requestContext.getUsername());
+        validateActionPermitted(BuiltInAction.USER_EDIT_OTHER, requestContext.getUsername());
         logger.info("handlePutRequest() entered");
 
         HttpServletRequest request = requestContext.getRequest();
@@ -161,7 +161,7 @@ public class UserRoute extends AbstractUsersRoute {
         if (!loginIdToBeDeleted.equals(loginIdOfRequestor)) {
             // The user is trying to delete someone else's user record.
             // This is only allowed if you have permissions.
-            validateActionPermitted(BuiltInAction.USER_DELETE_OTHER , loginIdOfRequestor);
+            validateActionPermitted(BuiltInAction.USER_EDIT_OTHER , loginIdOfRequestor);
         } else {
             // The user is trying to delete their own record. This is never allowed.
             // Enforcing this makes it less likely that the last admin on the sysyem will delete themselves.
@@ -180,7 +180,7 @@ public class UserRoute extends AbstractUsersRoute {
             //Need to delete access tokens of a user if we delete the user
             List<IInternalAuthToken> tokens = authStoreService.getTokensByLoginId(loginId);
             for (IInternalAuthToken token : tokens) {
-                authService.revokeToken(token.getTokenId());
+                authService.revokeToken(token.getTokenId(),requestingUserLoginId);
             }
 
             authStoreService.deleteUser(user);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/test/java/dev/galasa/framework/api/users/internal/routes/UsersRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/test/java/dev/galasa/framework/api/users/internal/routes/UsersRouteTest.java
@@ -47,8 +47,8 @@ public class UsersRouteTest extends BaseServletTest {
         MockEnvironment env = new MockEnvironment();
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService authStoreService = new MockAuthStoreService(mockTimeService);
-        IAuthService authService = new AuthService(authStoreService, null);
         MockRBACService rbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+        IAuthService authService = new AuthService(authStoreService, null, rbacService);
 
         String baseUrl = "http://my.server/api";
 
@@ -119,8 +119,8 @@ public class UsersRouteTest extends BaseServletTest {
         MockEnvironment env = new MockEnvironment();
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockAuthStoreService authStoreService = new MockAuthStoreService(mockTimeService);
-        IAuthService authService = new AuthService(authStoreService, null);
         MockRBACService rbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+        IAuthService authService = new AuthService(authStoreService, null, rbacService);
 
         String baseUrl = "http://my.server/api";
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/src/main/java/dev/galasa/framework/auth/spi/IAuthService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/src/main/java/dev/galasa/framework/auth/spi/IAuthService.java
@@ -10,7 +10,7 @@ import dev.galasa.framework.spi.auth.IAuthStoreService;
 
 public interface IAuthService {
 
-    void revokeToken(String tokenId) throws InternalServletException;
+    void revokeToken(String tokenId, String requestorUserLoginId) throws InternalServletException;
 
     IDexGrpcClient getDexGrpcClient();
     IAuthStoreService getAuthStoreService();

--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/src/main/java/dev/galasa/framework/auth/spi/IAuthServiceFactory.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/src/main/java/dev/galasa/framework/auth/spi/IAuthServiceFactory.java
@@ -5,8 +5,8 @@
  */
 package dev.galasa.framework.auth.spi;
 
-import javax.servlet.ServletException;
+import dev.galasa.framework.api.common.InternalServletException;
 
 public interface IAuthServiceFactory {
-    IAuthService getAuthService() throws ServletException;
+    IAuthService getAuthService() throws InternalServletException;
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/src/main/java/dev/galasa/framework/auth/spi/internal/AuthService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/src/main/java/dev/galasa/framework/auth/spi/internal/AuthService.java
@@ -7,6 +7,7 @@ package dev.galasa.framework.auth.spi.internal;
 
 import static dev.galasa.framework.api.common.ServletErrorMessage.GAL5064_FAILED_TO_REVOKE_TOKEN;
 import static dev.galasa.framework.api.common.ServletErrorMessage.GAL5066_ERROR_NO_SUCH_TOKEN_EXISTS;
+import static dev.galasa.framework.api.common.ServletErrorMessage.GAL5125_ACTION_NOT_PERMITTED;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -21,21 +22,25 @@ import dev.galasa.framework.spi.auth.AuthStoreException;
 import dev.galasa.framework.spi.auth.IAuthStoreService;
 import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.auth.IInternalUser;
+import dev.galasa.framework.spi.rbac.BuiltInAction;
+import dev.galasa.framework.spi.rbac.RBACService;
 
 public class AuthService implements IAuthService {
 
     private IAuthStoreService authStoreService;
     private IDexGrpcClient dexGrpcClient;
+    private RBACService rbacService;
 
     private final Log logger = LogFactory.getLog(getClass());
 
-    public AuthService(IAuthStoreService authStoreService, IDexGrpcClient dexGrpcClient) {
+    public AuthService(IAuthStoreService authStoreService, IDexGrpcClient dexGrpcClient, RBACService rbacService) {
         this.authStoreService = authStoreService;
         this.dexGrpcClient = dexGrpcClient;
+        this.rbacService = rbacService;
     }
 
     @Override
-    public void revokeToken(String tokenId) throws InternalServletException {
+    public void revokeToken(String tokenId, String requestingUserLoginId) throws InternalServletException {
         try {
             logger.info("Attempting to revoke token with ID '" + tokenId + "'");
 
@@ -44,6 +49,8 @@ public class AuthService implements IAuthService {
                 ServletError error = new ServletError(GAL5066_ERROR_NO_SUCH_TOKEN_EXISTS);
                 throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
             }
+
+            validateRequestingUserIsPermittedToDeleteToken(tokenToRevoke, requestingUserLoginId);
 
             // Delete the Dex client associated with the token
             String dexClientId = tokenToRevoke.getDexClientId();
@@ -63,6 +70,25 @@ public class AuthService implements IAuthService {
         } catch (AuthStoreException ex) {
             ServletError error = new ServletError(GAL5064_FAILED_TO_REVOKE_TOKEN);
             throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex);
+        }
+    }
+
+    private void validateRequestingUserIsPermittedToDeleteToken(IInternalAuthToken tokenToRevoke, String requestingUserLoginId) throws InternalServletException { 
+        IInternalUser user = tokenToRevoke.getOwner();
+        if( user != null) {
+            String tokenOwnerLoginId = user.getLoginId();
+            if( tokenOwnerLoginId!=null) {
+                if( requestingUserLoginId != null) {
+                    if( !requestingUserLoginId.equals(tokenOwnerLoginId)) {
+                        // The user is not deleting their own token, they are deleting someone else's
+                        String actionId = BuiltInAction.TOKEN_DELETE_OTHER_USERS.getAction().getId();
+                        if (rbacService.isActionPermitted(requestingUserLoginId,actionId)) {
+                            ServletError error = new ServletError(GAL5125_ACTION_NOT_PERMITTED, actionId);
+                            throw new InternalServletException(error, HttpServletResponse.SC_FORBIDDEN);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/src/testFixtures/java/dev/galasa/framework/auth/spi/mocks/MockAuthServiceFactory.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/src/testFixtures/java/dev/galasa/framework/auth/spi/mocks/MockAuthServiceFactory.java
@@ -5,8 +5,7 @@
  */
 package dev.galasa.framework.auth.spi.mocks;
 
-import javax.servlet.ServletException;
-
+import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.auth.spi.IAuthService;
 import dev.galasa.framework.auth.spi.IAuthServiceFactory;
 
@@ -19,7 +18,7 @@ public class MockAuthServiceFactory implements IAuthServiceFactory {
     }
 
     @Override
-    public IAuthService getAuthService() throws ServletException {
+    public IAuthService getAuthService() throws InternalServletException {
         return authService;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/RBACServiceImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/RBACServiceImpl.java
@@ -65,7 +65,7 @@ public class RBACServiceImpl implements RBACService {
         roleAdmin= new RoleImpl("admin","2","Administrator access",allActionIds);
 
         roleTester = new RoleImpl("tester", "1", "Test developer and runner", 
-            List.of( USER_ROLE_UPDATE_ANY.getAction().getId() , GENERAL_API_ACCESS.getAction().getId() )   
+            List.of( USER_EDIT_OTHER.getAction().getId() , GENERAL_API_ACCESS.getAction().getId() )   
         );
 
         roleDeactivated = new RoleImpl("deactivated", "0", "User has no access", new ArrayList<String>());

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/BuiltInAction.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/BuiltInAction.java
@@ -14,14 +14,12 @@ import dev.galasa.framework.internal.rbac.ActionImpl;
 
 public enum BuiltInAction {
     GENERAL_API_ACCESS            (new ActionImpl("GENERAL_API_ACCESS", "General API access", "Able to access the REST API" )),
-    USER_ROLE_UPDATE_ANY          (new ActionImpl("USER_ROLE_UPDATE_ANY", "User role update any", "Able to update the role of any user")),
-    USER_DELETE_OTHER             (new ActionImpl("USER_DELETE_OTHER", "Delete a user (but not yourself)", "Able to delete a user who is not yourself")),
+    USER_EDIT_OTHER              (new ActionImpl("USER_EDIT_OTHER", "Edit or delete a user other than you", "Edit or delete a user other than you, including role and access tokens")),
     SECRETS_GET_UNREDACTED_VALUES (new ActionImpl("SECRETS_GET_UNREDACTED_VALUES", "Get secret values", "Able to get unredacted secret values")),
     SECRETS_SET                   (new ActionImpl("SECRETS_SET", "Secrets set", "Able to set secrets")),
     SECRETS_DELETE                (new ActionImpl("SECRETS_DELETE", "Secrets delete", "Able to delete secrets")),
     CPS_PROPERTIES_SET            (new ActionImpl("CPS_PROPERTIES_SET", "CPS properties set", "Able to set CPS properties")),
     CPS_PROPERTIES_DELETE         (new ActionImpl("CPS_PROPERTIES_DELETE", "CPS properties delete", "Able to delete CPS properties")),
-    TOKEN_DELETE_OTHER_USERS      (new ActionImpl("TOKEN_DELETE_OTHER_USERS", "Delete a personal access token owned by other users", "Able to delete a personal access token not owned by yourself.")),
     RUNS_DELETE_OTHER_USERS       (new ActionImpl("RUNS_DELETE_OTHER_USERS", "Runs delete other users", "Able to delete runs submitted by other users"));
 
     private Action action;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/BuiltInAction.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/BuiltInAction.java
@@ -21,6 +21,7 @@ public enum BuiltInAction {
     SECRETS_DELETE                (new ActionImpl("SECRETS_DELETE", "Secrets delete", "Able to delete secrets")),
     CPS_PROPERTIES_SET            (new ActionImpl("CPS_PROPERTIES_SET", "CPS properties set", "Able to set CPS properties")),
     CPS_PROPERTIES_DELETE         (new ActionImpl("CPS_PROPERTIES_DELETE", "CPS properties delete", "Able to delete CPS properties")),
+    TOKEN_DELETE_OTHER_USERS      (new ActionImpl("TOKEN_DELETE_OTHER_USERS", "Delete a personal access token owned by other users", "Able to delete a personal access token not owned by yourself.")),
     RUNS_DELETE_OTHER_USERS       (new ActionImpl("RUNS_DELETE_OTHER_USERS", "Runs delete other users", "Able to delete runs submitted by other users"));
 
     private Action action;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestRBACServiceImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestRBACServiceImpl.java
@@ -38,15 +38,14 @@ public class TestRBACServiceImpl {
         assertThat(roleGot.getDescription()).contains("Administrator access");
 
         assertThat(roleGot.getActionIds())
-            .hasSize(9)
-            .contains("USER_ROLE_UPDATE_ANY")
+            .hasSize(8)
+            .contains("USER_EDIT_OTHER")
             .contains("SECRETS_GET_UNREDACTED_VALUES")
             .contains("GENERAL_API_ACCESS")
             .contains("CPS_PROPERTIES_DELETE")
             .contains("CPS_PROPERTIES_SET")
             .contains("SECRETS_SET")
             .contains("SECRETS_DELETE")
-            .contains("USER_DELETE_OTHER")
             .contains("RUNS_DELETE_OTHER_USERS");
     }
 
@@ -65,7 +64,7 @@ public class TestRBACServiceImpl {
 
         assertThat(roleGot.getActionIds())
             .hasSize(2)
-            .contains("USER_ROLE_UPDATE_ANY")
+            .contains("USER_EDIT_OTHER")
             .contains("GENERAL_API_ACCESS");
     }
 
@@ -95,8 +94,8 @@ public class TestRBACServiceImpl {
         RBACService service = new RBACServiceImpl(mockDssService, mockAuthStoreService, new MockEnvironment());
         Map<String,Action> actionMap = service.getActionsMapById();
 
-        Action action = actionMap.get("USER_ROLE_UPDATE_ANY");
-        assertThat(action.getId()).isEqualTo("USER_ROLE_UPDATE_ANY");
+        Action action = actionMap.get("USER_EDIT_OTHER");
+        assertThat(action.getId()).isEqualTo("USER_EDIT_OTHER");
     }
 
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockAuthStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockAuthStoreService.java
@@ -30,6 +30,7 @@ public class MockAuthStoreService implements IAuthStoreService {
     private int tokenIdCounter = 0;
 
     private boolean throwException = false;
+    private boolean isThrowExceptionOnDeleteToken = false ;
 
     public MockAuthStoreService(List<IInternalAuthToken> tokens) {
         this.tokens = tokens;
@@ -38,6 +39,10 @@ public class MockAuthStoreService implements IAuthStoreService {
 
     public MockAuthStoreService(ITimeService timeService) {
         this.timeService = timeService;
+    }
+
+    public void setThrowExceptionOnDeleteToken(boolean isThrowExceptionOnDeleteToken) {
+        this.isThrowExceptionOnDeleteToken = isThrowExceptionOnDeleteToken ;
     }
 
     public void setThrowException(boolean throwException) {
@@ -67,7 +72,7 @@ public class MockAuthStoreService implements IAuthStoreService {
 
     @Override
     public void deleteToken(String tokenId) throws AuthStoreException {
-        if (throwException) {
+        if (isThrowExceptionOnDeleteToken) {
             throwAuthStoreException();
         }
 


### PR DESCRIPTION
# Why ?
See https://github.com/galasa-dev/projectmanagement/issues/2110

- Added the new USERS_EDIT_OTHER
- Changed all checks for token deletion and user delection, and role editing of others to use this single permission, as they are all about editing other users.
- rbac service injected into the auth service
- tokens routes do the required checking.
- fixed a clash/duplicate use of an error message number, and added unit test to make sure all error messages use unique numbers.
