### PR TITLE
stop user updating their own role

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ProtectedRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ProtectedRoute.java
@@ -28,6 +28,7 @@ public abstract class ProtectedRoute extends BaseRoute {
     }
 
     protected void validateActionPermitted(BuiltInAction action, String loginId) throws InternalServletException {
+        logger.info("Checking to make sure user "+loginId+" has action "+action.getAction().getId());
         rbacValidator.validateActionPermitted(action, loginId);
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -161,6 +161,7 @@ public enum ServletErrorMessage {
     GAL5124_ROLE_ID_NOT_FOUND_FOR_USER                (5124, "E: A user has a role which cannot be found in the system. Inconsistent data. Report this issue to your Galasa systems administrator."),
     GAL5125_ACTION_NOT_PERMITTED                      (5125, "E: Insufficient privileges to perform the requested operation. Check with your Galasa systems administrator that you have been assigned the correct role with the ''{0}'' action before trying again."),
     GAL5126_INTERNAL_RBAC_ERROR                       (5126, "E: Error occurred when trying to access the Role Based Access Control service. Report the problem to your Galasa systems administrator."),
+    GAL5413_USER_CANNOT_UPDATE_OWN_USER_ROLE          (5413, "E: A user is not allowed to update their own role. Ask a Galasa service administrator to change your role instead."),
 
     ;
 
@@ -170,7 +171,7 @@ public enum ServletErrorMessage {
     // >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
     // >>>       If you do use this number for a new error template, please incriment this value.
     // >>>
-    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5413 ;
+    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5414 ;
 
 
     private String template ;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/bnd.bnd
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/bnd.bnd
@@ -3,4 +3,5 @@ Bundle-Name: Galasa API Users microservices
 Export-Package: !dev.galasa.framework.api.users.internal*;dev.galasa.framework.api.users*;
 Import-Package: dev.galasa.framework.api.common,\
 dev.galasa.framework.api.rbac,\
+org.apache.http,\
                 *

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation project(':dev.galasa.framework.api.rbac')
     implementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
     implementation 'org.apache.commons:commons-lang3'
+    implementation 'org.apache.httpcomponents:httpcore-osgi'
 
     compileOnly 'org.apache.tomcat:annotations-api'
     

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/internal/routes/UserRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/internal/routes/UserRoute.java
@@ -11,6 +11,12 @@ import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.apache.http.HttpStatus;
+
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 import dev.galasa.framework.spi.auth.IInternalAuthToken;
@@ -45,6 +51,8 @@ public class UserRoute extends AbstractUsersRoute {
     protected static final String path = "\\/([a-zA-Z0-9\\-\\_]+)\\/?" ;
 
     protected Pattern pathPattern;
+
+    private Log logger = LogFactory.getLog(getClass());
 
     private BeanTransformer beanTransformer ;
 
@@ -83,7 +91,8 @@ public class UserRoute extends AbstractUsersRoute {
         HttpServletResponse response
     ) throws FrameworkException, IOException {
 
-        validateActionPermitted(BuiltInAction.USER_EDIT_OTHER, requestContext.getUsername());
+        String requestingUserLoginId = requestContext.getUsername();
+        validateActionPermitted(BuiltInAction.USER_EDIT_OTHER, requestingUserLoginId);
         logger.info("handlePutRequest() entered");
 
         HttpServletRequest request = requestContext.getRequest();
@@ -97,7 +106,7 @@ public class UserRoute extends AbstractUsersRoute {
 
         updateRequestValidator.validateUpdateRequest(updatePayload);
 
-        IUser updatedUser = updateUser(originalUser, updatePayload);
+        IUser updatedUser = updateUser(originalUser, updatePayload, requestingUserLoginId);
 
         UserData updatedUserBean = beanTransformer.convertUserToUserBean(updatedUser);
 
@@ -135,7 +144,11 @@ public class UserRoute extends AbstractUsersRoute {
     }
 
 
-    private IUser updateUser(IUser user , UserUpdateData updatePayload) throws AuthStoreException, InternalServletException, RBACException{
+    private IUser updateUser(
+        IUser user, 
+        UserUpdateData updatePayload, 
+        String requestingUserLoginId
+    ) throws AuthStoreException, InternalServletException, RBACException{
 
         boolean isStoreUpdateRequired = false ;
 
@@ -143,6 +156,9 @@ public class UserRoute extends AbstractUsersRoute {
         String desiredRoleId = updatePayload.getrole();
         if (desiredRoleId != null ) {
             if (! desiredRoleId.equals(user.getRoleId() )) {
+
+                validateUserIsNotUpdatingTheirOwnRole(requestingUserLoginId, user);
+
                 user.setRoleId(desiredRoleId);
                 isStoreUpdateRequired = true;
             }
@@ -154,6 +170,17 @@ public class UserRoute extends AbstractUsersRoute {
         }
 
         return user;
+    }
+
+    void validateUserIsNotUpdatingTheirOwnRole(
+        String requestingUserLoginId, 
+        IUser userRecordBeingUpdated
+    ) throws InternalServletException {
+        String loginIdBeingUpdated = userRecordBeingUpdated.getLoginId();
+        if (requestingUserLoginId.equals(loginIdBeingUpdated)) {
+            ServletError msg = new ServletError(GAL5413_USER_CANNOT_UPDATE_OWN_USER_ROLE);
+            throw new InternalServletException(msg, HttpStatus.SC_FORBIDDEN);
+        }
     }
 
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/BuiltInAction.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/BuiltInAction.java
@@ -14,7 +14,7 @@ import dev.galasa.framework.internal.rbac.ActionImpl;
 
 public enum BuiltInAction {
     GENERAL_API_ACCESS            (new ActionImpl("GENERAL_API_ACCESS", "General API access", "Able to access the REST API" )),
-    USER_EDIT_OTHER              (new ActionImpl("USER_EDIT_OTHER", "Edit or delete a user other than you", "Edit or delete a user other than you, including role and access tokens")),
+    USER_EDIT_OTHER               (new ActionImpl("USER_EDIT_OTHER", "Edit or delete a user other than you", "Edit or delete a user other than you, including role and access tokens")),
     SECRETS_GET_UNREDACTED_VALUES (new ActionImpl("SECRETS_GET_UNREDACTED_VALUES", "Get secret values", "Able to get unredacted secret values")),
     SECRETS_SET                   (new ActionImpl("SECRETS_SET", "Secrets set", "Able to set secrets")),
     SECRETS_DELETE                (new ActionImpl("SECRETS_DELETE", "Secrets delete", "Able to delete secrets")),


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Doing more testing of the RBAC functionality it became clear that no user should be able to change their own role.

This means that the last admin user can't set themselves to a non-admin, making it less likely that we will see admin lock-out... a system where there are no admins.

- [x] Code the check.
- [x] Add a unit test.