### PR TITLE
Introduce FrameworkType and set Run name of Resource Management

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.launcher/src/main/java/dev/galasa/framework/api/launcher/Launcher.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.launcher/src/main/java/dev/galasa/framework/api/launcher/Launcher.java
@@ -17,6 +17,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.FrameworkType;
 import dev.galasa.framework.spi.FrameworkException;
 
 @Component(configurationPid = { "dev.galasa" }, configurationPolicy = ConfigurationPolicy.REQUIRE)
@@ -54,6 +55,6 @@ public class Launcher {
 
     public FrameworkInitialisation init(Properties bootstrap, Properties overrides)
             throws FrameworkException, InvalidSyntaxException, URISyntaxException {
-        return new FrameworkInitialisation(bootstrap, overrides);
+        return new FrameworkInitialisation(bootstrap, overrides, FrameworkType.launcher);
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiServerInitialisation.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiServerInitialisation.java
@@ -20,6 +20,7 @@ import org.osgi.framework.ServiceReference;
 
 import dev.galasa.framework.FileSystem;
 import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.FrameworkType;
 import dev.galasa.framework.IFileSystem;
 import dev.galasa.framework.spi.Environment;
 import dev.galasa.framework.spi.FrameworkException;
@@ -42,7 +43,8 @@ public class ApiServerInitialisation extends FrameworkInitialisation implements 
 
     public ApiServerInitialisation(
         Properties bootstrapProperties,
-        Properties overrideProperties
+        Properties overrideProperties,
+        FrameworkType type
     ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
         this(bootstrapProperties, overrideProperties, null, getBundleContext(), new FileSystem(), new SystemEnvironment());
     }
@@ -55,7 +57,7 @@ public class ApiServerInitialisation extends FrameworkInitialisation implements 
         IFileSystem fileSystem, 
         Environment env
     ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
-        super(bootstrapProperties, overrideProperties, false, initLogger, bundleContext, fileSystem, env);
+        super(bootstrapProperties, overrideProperties, FrameworkType.server, initLogger, bundleContext, fileSystem, env);
 
         if (initLogger == null) {
             logger = LogFactory.getLog(this.getClass());

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiStartup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiStartup.java
@@ -28,6 +28,7 @@ import org.apache.felix.bundlerepository.RepositoryAdmin;
 import org.apache.felix.bundlerepository.Resource;
 
 import dev.galasa.framework.BundleManagement;
+import dev.galasa.framework.FrameworkType;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IFrameworkInitialisation;
 
@@ -97,7 +98,7 @@ public class ApiStartup {
         // *** Initialise the framework
         IFrameworkInitialisation frameworkInitialisation = null;
         try {
-            frameworkInitialisation = new ApiServerInitialisation(bootstrapProperties, overrideProperties);
+            frameworkInitialisation = new ApiServerInitialisation(bootstrapProperties, overrideProperties, FrameworkType.server);
         } catch (Exception e) {
             throw new FrameworkException("Unable to initialise the Framework Services", e);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/src/main/java/dev/galasa/framework/docker/controller/DockerController.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/src/main/java/dev/galasa/framework/docker/controller/DockerController.java
@@ -28,6 +28,7 @@ import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
 
 import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.FrameworkType;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
@@ -58,7 +59,7 @@ public class DockerController {
             // *** Initialise the framework services
             FrameworkInitialisation frameworkInitialisation = null;
             try {
-                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties, FrameworkType.controller);
             } catch (Exception e) {
                 throw new FrameworkException("Unable to initialise the Framework Services", e);
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
@@ -17,6 +17,7 @@ import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.annotations.Component;
 
 import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.FrameworkType;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
@@ -64,7 +65,7 @@ public class K8sController {
             // *** Initialise the framework services
             FrameworkInitialisation frameworkInitialisation = null;
             try {
-                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties, FrameworkType.controller);
             } catch (Exception e) {
                 throw new FrameworkException("Unable to initialise the Framework Services", e);
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework.metrics/src/main/java/dev/galasa/framework/metrics/MetricsServer.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.metrics/src/main/java/dev/galasa/framework/metrics/MetricsServer.java
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
 import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.FrameworkType;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
@@ -75,7 +76,7 @@ public class MetricsServer implements IMetricsServer {
             // *** Initialise the framework services
             FrameworkInitialisation frameworkInitialisation = null;
             try {
-                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties, FrameworkType.server);
             } catch (Exception e) {
                 throw new FrameworkException("Unable to initialise the Framework Services", e);
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
 import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.FrameworkType;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
@@ -81,7 +82,7 @@ public class ResourceManagement implements IResourceManagement {
             // *** Initialise the framework services
             FrameworkInitialisation frameworkInitialisation = null;
             try {
-                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties, FrameworkType.resourceManagement);
             } catch (Exception e) {
                 throw new FrameworkException("Unable to initialise the Framework Services", e);
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkType.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+public enum FrameworkType {
+    test, resourceManagement, ecosystem, launcher, controller, server
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/SetupEcosystem.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/SetupEcosystem.java
@@ -46,7 +46,7 @@ public class SetupEcosystem {
 
         FrameworkInitialisation frameworkInitialisation = null;
         try {
-            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties, FrameworkType.ecosystem);
         } catch (Exception e) {
             throw new FrameworkException("Unable to initialise the Framework Service", e);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ValidateEcosystem.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ValidateEcosystem.java
@@ -37,7 +37,7 @@ public class ValidateEcosystem {
         
         FrameworkInitialisation frameworkInitialisation = null;
         try {
-            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties, FrameworkType.ecosystem);
         } catch (Exception e) {
             throw new FrameworkException("Unable to initialise the Framework Service", e);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
@@ -9,6 +9,7 @@ import java.util.Properties;
 
 import dev.galasa.framework.FileSystem;
 import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.FrameworkType;
 import dev.galasa.framework.IAnnotationExtractor;
 import dev.galasa.framework.IBundleManager;
 import dev.galasa.framework.IFileSystem;
@@ -34,8 +35,7 @@ public class TestRunnerDataProvider implements ITestRunnerDataProvider {
         
         FrameworkInitialisation frameworkInitialisation = null;
         try {
-            boolean isThisATestRun = true ;
-            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties, isThisATestRun);
+            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties, FrameworkType.test);
             framework = frameworkInitialisation.getShutableFramework();
             cps = framework.getConfigurationPropertyService("framework");
             dss = framework.getDynamicStatusStoreService("framework");

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/TestFrameworkInitialisation.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/TestFrameworkInitialisation.java
@@ -95,7 +95,6 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
         // Given...
         Properties bootstrapProperties = bootstrapProps;
         Properties overrideProperties = new Properties();
-        boolean isTestrun = true ;
         Log logger = new MockLog();
 
         // A fake OSGi service registry...
@@ -131,7 +130,7 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
         FrameworkInitialisation frameworkInitUnderTest = new FrameworkInitialisation( 
             bootstrapProperties,  
             overrideProperties, 
-            isTestrun,
+            FrameworkType.test,
             logger,
             bundleContext,
             mockFileSystem,
@@ -160,7 +159,6 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
         // Given...
         Properties bootstrapProperties = new Properties();
         Properties overrideProperties = new Properties();
-        boolean isTestrun = true ;
         Log logger = new MockLog();
         MockEnvironment mockEnv = new MockEnvironment();
 
@@ -177,7 +175,7 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
             new FrameworkInitialisation( 
                 bootstrapProperties,  
                 overrideProperties, 
-                isTestrun,
+                FrameworkType.test,
                 logger, 
                 bundleContext,
                 mockFileSystem,
@@ -199,7 +197,6 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
         // Given...
         Properties bootstrapProperties = new Properties();
         Properties overrideProperties = new Properties();
-        boolean isTestrun = true ;
         Log logger = new MockLog();
         MockEnvironment mockEnv = new MockEnvironment();
         mockEnv.setProperty("user.home","/home");
@@ -224,7 +221,7 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
             frameworkInitUnderTest = new FrameworkInitialisation( 
                 bootstrapProperties,  
                 overrideProperties, 
-                isTestrun,
+                FrameworkType.test,
                 logger, 
                 bundleContext,
                 mockFileSystem,


### PR DESCRIPTION
fixes galasa-dev/projectmanagement#2124

This is the first part of the Resource Management changes.  To allow RAS directory pieces to start to work correctly this introduces the new internal FrameworkType enum at the moment that are the following enums:

- test
- resourceManagement
- ecosystem
- launcher
- controller
- server

Some of these could be expanded but at the moment the only two that actually mean anything are test and resourceManager.  When the framework is initialised it uses these to decide what to do with the testRunName which is either set to the next run number if a test or "resourceManagement" if its the resourceManagement, otherwise no RunName is set.