### PR TITLE
If a user has a valid JWT but their user record is deleted, say no permissions instead of internal server error

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/CacheRBAC.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/CacheRBAC.java
@@ -3,9 +3,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.framework.spi.rbac;
+package dev.galasa.framework.internal.rbac;
 
 import java.util.Set;
+
+import dev.galasa.framework.spi.rbac.RBACException;
 
 public interface CacheRBAC {
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/RBACServiceImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/rbac/RBACServiceImpl.java
@@ -21,7 +21,6 @@ import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.auth.IAuthStoreService;
 import dev.galasa.framework.spi.rbac.Action;
 import dev.galasa.framework.spi.rbac.BuiltInAction;
-import dev.galasa.framework.spi.rbac.CacheRBAC;
 import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.rbac.Role;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/RBACException.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/RBACException.java
@@ -5,6 +5,7 @@
  */
 package dev.galasa.framework.spi.rbac;
 
+import dev.galasa.framework.spi.FrameworkErrorDetails;
 import dev.galasa.framework.spi.FrameworkException;
 
 public class RBACException extends FrameworkException {
@@ -28,6 +29,12 @@ public class RBACException extends FrameworkException {
     public RBACException(String message, Throwable cause, boolean enableSuppression,
             boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public RBACException(FrameworkErrorDetails errorDetails, Throwable cause, boolean enableSuppression,
+        boolean writableStackTrace
+    ) {
+        super(errorDetails,cause,enableSuppression, writableStackTrace);
     }
     
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockCacheRBAC.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockCacheRBAC.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import dev.galasa.framework.spi.rbac.CacheRBAC;
+import dev.galasa.framework.internal.rbac.CacheRBAC;
 import dev.galasa.framework.spi.rbac.RBACException;
 
 public class MockCacheRBAC implements CacheRBAC {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRBACService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRBACService.java
@@ -12,8 +12,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import dev.galasa.framework.internal.rbac.CacheRBAC;
 import dev.galasa.framework.spi.rbac.Action;
-import dev.galasa.framework.spi.rbac.CacheRBAC;
 import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.rbac.Role;

--- a/modules/framework/run-locally.sh
+++ b/modules/framework/run-locally.sh
@@ -172,7 +172,7 @@ function setup_galasa_dev() {
     info "Setting environment variables"
     export GALASA_OBR_VERSION=$GALASA_VERSION
     export GALASA_BOOT_JAR_VERSION=$GALASA_VERSION
-    export GALASA_OWNER_LOGIN_IDS="tester"
+    export GALASA_OWNER_LOGIN_IDS="owner"
     export GALASA_EXTERNAL_API_URL="http://localhost:8080"
     export GALASA_USERNAME_CLAIMS="preferred_username,name,sub"
     export GALASA_ALLOWED_ORIGINS="*"
@@ -188,7 +188,6 @@ function setup_galasa_dev() {
     # In the test environment, when we log in for the first time, we want our userid to be given admin rights.
     export GALASA_DEFAULT_USER_ROLE="admin"
 }
-
 
 
 
@@ -409,6 +408,10 @@ staticPasswords:
 - email: "deactivated@example.com"
   hash: "${DEX_ADMIN_PASSWORD}"
   username: "deactivated"
+  userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+- email: "owner@example.com"
+  hash: "${DEX_ADMIN_PASSWORD}"
+  username: "owner"
   userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 
 EOF


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
See [http 500 instead of FORBIDDEN when trying to access using an invalid token. #2119](https://github.com/galasa-dev/projectmanagement/issues/2119)

- When the code checks to see if this loginId has permissions to do something
- (So the caller must already have a valid JWT)
- There is no cache hit for that user's permissions in the dss.
- So the code goes to the auth/users store to look up that user.
- If the user has been deleted/not found, then it's not a 500 error, but a 403 Forbidden one.

- Unit test changed to make sure this is the case.
- [ ] Tested locally by deleting the user then trying to use the users' JWT.