### PR TITLE
Fix PR script - should be getting PRs on the base repo not head repo

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -57,7 +57,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ./.github/scripts/get-changed-modules-pull-request.sh --github-repo ${{ github.event.pull_request.head.repo.full_name }} --pr-number ${{ github.event.number }}
+          ./.github/scripts/get-changed-modules-pull-request.sh --github-repo ${{ github.event.pull_request.base.repo.full_name }} --pr-number ${{ github.event.number }}
 
   find-artifacts:
     name: Get Workflow Run ID to download artifacts from


### PR DESCRIPTION
## Why?

The script is designed to get which modules have changed in the PR and only rebuild those to make PR builds quicker. The script was incorrectly getting PRs on the head repo instead of the base repo though. This fixes that.