### PR TITLE
Blank property values are allowed

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -785,7 +785,7 @@
         "hashed_secret": "a5c1ad5f1dc7d24152e39cb14dfa99775fa1884d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 147,
+        "line_number": 151,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -843,7 +843,7 @@
         "hashed_secret": "8cbd3af3de67a89adedc45b1e3d99b7b135a8ca4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 320,
+        "line_number": 319,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -851,7 +851,7 @@
         "hashed_secret": "3d19b59783a48f4e22f03cb4e69fb165b6a4b40f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 378,
+        "line_number": 377,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletError.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletError.java
@@ -7,6 +7,9 @@ package dev.galasa.framework.api.common;
 
 import java.text.MessageFormat;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import com.google.gson.JsonObject;
 
 public class ServletError {
@@ -15,6 +18,8 @@ public class ServletError {
     ServletErrorMessage template ;
     String message ;
 
+    private static final Log logger = LogFactory.getLog(ServletError.class);
+
     public ServletError( ServletErrorMessage template , String... params ) {
 
         String templateString = template.toString();        
@@ -22,6 +27,8 @@ public class ServletError {
 
         this.template = template;
         this.params = params;
+
+        logger.info("ServletError(...) "+message);
     }
 
     public String toJsonString() {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -68,6 +68,10 @@ public enum ServletErrorMessage {
     //Galasa Property...
     GAL5023_UNABLE_TO_CAST_TO_GALASAPROPERTY          (5023, "E: Error occurred trying to interpret resource ''{0}''. This could indicate a mis-match between client and server levels. Check the level with your Ecosystem administrator. You may have to upgrade/downgrade your client program."),
     GAL5024_INVALID_GALASAPROPERTY                    (5024, "E: Error occurred because the Galasa Property is invalid. ''{0}''"),
+    GAL5415_INVALID_GALASAPROPERTY_EMPTY_METADATA     (5415, "E: Error occurred because the Galasa Property is invalid. The 'metadata' field cannot be empty. The fields 'name' and 'namespace' are mandatory for the type GalasaProperty."),
+    GAL5416_INVALID_GALASAPROPERTY_NULL_VALUE         (5416, "E: Error occurred because the Galasa Property is invalid. The 'value' field cannot be null. The field 'value' is mandatory for the type GalasaProperty."),
+    GAL5417_INVALID_GALASAPROPERTY_DATA_FIELD_MISSING (5417, "E: Error occurred because the Galasa Property is invalid. The 'data' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty."),
+
     GAL5031_EMPTY_NAMESPACE                           (5031, "E: Invalid namespace. Namespace is empty."),
     GAL5032_INVALID_FIRST_CHARACTER_NAMESPACE         (5032, "E: Invalid namespace name. ''{0}'' must not start with the ''{1}'' character. Allowable first characters are 'a'-'z' or 'A'-'Z'."),
     GAL5033_INVALID_NAMESPACE_INVALID_MIDDLE_CHAR     (5033, "E: Invalid namespace name. ''{0}'' must not contain the ''{1}'' character. Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9'."),
@@ -173,7 +177,7 @@ public enum ServletErrorMessage {
     // >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
     // >>>       If you do use this number for a new error template, please incriment this value.
     // >>>
-    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5415 ;
+    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5418 ;
 
 
     private String template ;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/CPSProperty.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/CPSProperty.java
@@ -141,7 +141,7 @@ public class CPSProperty {
     }
 
     private boolean isPropertyValueValid() {
-        return this.value != null && !this.value.isBlank();
+        return this.value != null ;
     }
 
     public boolean isPropertyValid() throws InternalServletException {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/resources/TestCPSProperty.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/resources/TestCPSProperty.java
@@ -243,7 +243,7 @@ public class TestCPSProperty extends BaseServletTest {
     }
 
     @Test
-    public void testCPSPropertyBlankValueIsInvalid() throws InternalServletException{
+    public void testCPSPropertyBlankValueIsValid() throws InternalServletException{
         //Given...
         String namespace = "framework";
         String propertyName = "property";

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/resources/TestCPSProperty.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/resources/TestCPSProperty.java
@@ -243,7 +243,7 @@ public class TestCPSProperty extends BaseServletTest {
     }
 
     @Test
-    public void testCPSPropertyNoValueIsInvalid() throws InternalServletException{
+    public void testCPSPropertyBlankValueIsInvalid() throws InternalServletException{
         //Given...
         String namespace = "framework";
         String propertyName = "property";
@@ -257,12 +257,9 @@ public class TestCPSProperty extends BaseServletTest {
         assertThat(property.getNamespace()).isEqualTo(namespace);
         assertThat(property.getName()).isEqualTo(propertyName);
         assertThat(property.getValue()).isEqualTo(propertyValue);
-        Throwable thrown = catchThrowable( () -> {
-            property.isPropertyValid();
-        });
+        boolean isValid = property.isPropertyValid();
 
-        assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5024","value");
+        assertThat(isValid).isTrue();
     }
 
     @Test

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/validators/GalasaPropertyValidator.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/validators/GalasaPropertyValidator.java
@@ -74,8 +74,8 @@ public class GalasaPropertyValidator extends GalasaResourceValidator<JsonObject>
         JsonObject data = propertyJson.get("data").getAsJsonObject();
         if (data.size() > 0 && data.has("value")) {
             String value = data.get("value").getAsString();
-            if (value == null || value.isBlank()) {
-                String message = "The 'value' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.";
+            if (value == null ) {
+                String message = "The 'value' field cannot be null. The field 'value' is mandatory for the type GalasaProperty.";
                 ServletError error = new ServletError(GAL5024_INVALID_GALASAPROPERTY, message);
                 validationErrors.add(new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST).getMessage());
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/validators/GalasaPropertyValidator.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/validators/GalasaPropertyValidator.java
@@ -5,7 +5,7 @@
  */
 package dev.galasa.framework.api.resources.validators;
 
-import static dev.galasa.framework.api.common.ServletErrorMessage.GAL5024_INVALID_GALASAPROPERTY;
+import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 import static dev.galasa.framework.api.common.resources.ResourceAction.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -63,8 +63,7 @@ public class GalasaPropertyValidator extends GalasaResourceValidator<JsonObject>
                 validationErrors.add(e.getMessage());   
             }
         } else {
-            String message = "The 'metadata' field cannot be empty. The fields 'name' and 'namespace' are mandatory for the type GalasaProperty.";
-            ServletError error = new ServletError(GAL5024_INVALID_GALASAPROPERTY, message);
+            ServletError error = new ServletError(GAL5415_INVALID_GALASAPROPERTY_EMPTY_METADATA);
             validationErrors.add(new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST).getMessage());
         }
     }
@@ -75,13 +74,11 @@ public class GalasaPropertyValidator extends GalasaResourceValidator<JsonObject>
         if (data.size() > 0 && data.has("value")) {
             String value = data.get("value").getAsString();
             if (value == null ) {
-                String message = "The 'value' field cannot be null. The field 'value' is mandatory for the type GalasaProperty.";
-                ServletError error = new ServletError(GAL5024_INVALID_GALASAPROPERTY, message);
+                ServletError error = new ServletError(GAL5416_INVALID_GALASAPROPERTY_NULL_VALUE);
                 validationErrors.add(new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST).getMessage());
             }
         } else {
-            String message = "The 'data' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.";
-            ServletError error = new ServletError(GAL5024_INVALID_GALASAPROPERTY, message);
+            ServletError error = new ServletError(GAL5417_INVALID_GALASAPROPERTY_DATA_FIELD_MISSING);
             validationErrors.add(new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST).getMessage());
         }
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/processors/GalasaPropertyProcessorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/processors/GalasaPropertyProcessorTest.java
@@ -373,10 +373,8 @@ public class GalasaPropertyProcessorTest extends ResourcesServletTest {
         //Then...
         assertThat(errors).isNotNull();
         assertThat(errors.size()).isEqualTo(2);
-        assertThat(errors.get(0)).contains("GAL5024E: Error occurred because the Galasa Property is invalid.",
-            "The 'metadata' field cannot be empty. The fields 'name' and 'namespace' are mandatory for the type GalasaProperty.");
-        assertThat(errors.get(1)).contains("GAL5024E: Error occurred because the Galasa Property is invalid.",
-            "The 'data' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.");
+        assertThat(errors.get(0)).contains("GAL5415E");
+        assertThat(errors.get(1)).contains("GAL5417E");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/processors/GalasaPropertyProcessorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/processors/GalasaPropertyProcessorTest.java
@@ -303,7 +303,7 @@ public class GalasaPropertyProcessorTest extends ResourcesServletTest {
     }
 
     @Test
-    public void testProcessGalasaPropertyMissingPropertyValueReturnsError() throws Exception {
+    public void testProcessGalasaPropertyMissingPropertyValueIsTreatedAsBlankReturnsOK() throws Exception {
         //Given...
         String username = "myuser";
         String namespace = "framework";
@@ -322,10 +322,7 @@ public class GalasaPropertyProcessorTest extends ResourcesServletTest {
 
         //Then...
         assertThat(errors).isNotNull();
-        assertThat(errors.size()).isEqualTo(1);
-        assertThat(errors.get(0)).contains("GAL5024E: Error occurred because the Galasa Property is invalid.",
-            "The 'value' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.");
-        checkPropertyNotInNamespace(namespace,propertyname,value);
+        assertThat(errors.size()).isEqualTo(0);
     }
 
     @Test
@@ -348,10 +345,9 @@ public class GalasaPropertyProcessorTest extends ResourcesServletTest {
 
         //Then...
         assertThat(errors).isNotNull();
-        assertThat(errors.size()).isEqualTo(3);
+        assertThat(errors.size()).isEqualTo(2);
         assertThat(errors.get(0)).contains("GAL5040E: Invalid property name. Property name is missing or empty.");
         assertThat(errors.get(1)).contains("GAL5031E: Invalid namespace. Namespace is empty.");
-        assertThat(errors.get(2)).contains("GAL5024E: Error occurred because the Galasa Property is invalid. 'The 'value' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.'");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
See issue [Galasa Resources Apply fails if properties are given an empty value, even though ETCD accepts properties that are empty #2115](https://github.com/galasa-dev/projectmanagement/issues/2115)

# Tasks
- relax some validation checks to allow blanks.
- adjust unit tests to test that blank values are allowed.
- expand some error messages so that they are unique, and capture all the message text in the  correct place so messages could later be translated.