### PR TITLE
Iss2132 - Move CoreManagerIVT to new 'ivts' module

### DIFF
--- a/.github/workflows/ivts.yaml
+++ b/.github/workflows/ivts.yaml
@@ -50,6 +50,48 @@ jobs:
           gradle-version: 8.9
           cache-disabled: true
 
+      - name: Download platform from this workflow
+        id: download-platform
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts
+
+      - name: Download managers artifacts from this workflow
+        id: download-managers
+        uses: actions/download-artifact@v4
+        with:
+          name: managers
+          path: modules/artifacts
+
       - name: Build IVTs
         working-directory: modules/ivts/dev.galasa.ivts
         env:
@@ -61,7 +103,7 @@ jobs:
           set -o pipefail
           gradle build check publish --info \
           --no-daemon --console plain \
-          -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
           -PtargetMaven=${{ github.workspace }}/modules/ivts/repo \
           -PisMainOrRelease=${{ inputs.sign_artifacts }} 2>&1 | tee build.log

--- a/.github/workflows/ivts.yaml
+++ b/.github/workflows/ivts.yaml
@@ -92,6 +92,13 @@ jobs:
           name: managers
           path: modules/artifacts
 
+      - name: Download obr artifacts from this workflow
+        id: download-obr
+        uses: actions/download-artifact@v4
+        with:
+          name: obr
+          path: modules/artifacts
+
       - name: Build IVTs
         working-directory: modules/ivts/dev.galasa.ivts
         env:

--- a/.github/workflows/ivts.yaml
+++ b/.github/workflows/ivts.yaml
@@ -20,6 +20,8 @@ on:
         type: string
 
 env:
+  REGISTRY: ghcr.io
+  NAMESPACE: ${{ github.repository_owner }}
   BRANCH: ${{ github.ref_name }}
 
 jobs:
@@ -71,22 +73,52 @@ jobs:
           name: ivts-gradle-build-log
           path: modules/ivts/build.log
 
-      - name: Upload Platform artifacts
+      - name: Upload IVT artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ivts
           path: modules/ivts/repo
 
-#   report-failure:
-#     # Skip this job for forks
-#     if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
-#     name: Report failure in workflow
-#     runs-on: ubuntu-latest
-#     needs: [log-github-ref, build-ivts]
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        env:
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
+    
+      - name: Extract metadata for IVTs
+        id: metadata
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/ivts-maven-artefacts
+    
+      - name: Build IVTs image for development Maven registry
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/ivts
+          file: modules/ivts/dockerfiles/dockerfile.ivts
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            baseVersion=latest
+            dockerRepository=${{ env.REGISTRY }}
+            branch=${{ env.BRANCH }}
 
-#     steps:
-#       - name: Report failure in workflow to Slack
-#         env: 
-#           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-#         run : |
-#           docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "ivts" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+  report-failure:
+    # Skip this job for forks
+    if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [log-github-ref, build-ivts]
+
+    steps:
+      - name: Report failure in workflow to Slack
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run : |
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "ivts" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/ivts.yaml
+++ b/.github/workflows/ivts.yaml
@@ -1,0 +1,92 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: IVTs Main Build
+
+on:
+  workflow_call:
+    inputs:
+      jacoco_enabled:
+        description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
+        required: false
+        default: 'true'
+        type: string
+      sign_artifacts:
+        description: 'True if the artifacts built should be signed (set to "false" for development branch builds)'
+        required: false
+        default: 'true'
+        type: string
+
+env:
+  BRANCH: ${{ github.ref_name }}
+
+jobs:
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+
+  build-ivts:
+    name: Build IVTs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            modules/ivts
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+          cache-disabled: true
+
+      - name: Build IVTs
+        working-directory: modules/ivts/dev.galasa.ivts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKeyId:  ${{ secrets.GPG_KEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -o pipefail
+          gradle build check publish --info \
+          --no-daemon --console plain \
+          -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/modules/ivts/repo \
+          -PisMainOrRelease=${{ inputs.sign_artifacts }} 2>&1 | tee build.log
+
+      - name: Upload Gradle build log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ivts-gradle-build-log
+          path: modules/ivts/build.log
+
+      - name: Upload Platform artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ivts
+          path: modules/ivts/repo
+
+#   report-failure:
+#     # Skip this job for forks
+#     if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
+#     name: Report failure in workflow
+#     runs-on: ubuntu-latest
+#     needs: [log-github-ref, build-ivts]
+
+#     steps:
+#       - name: Report failure in workflow to Slack
+#         env: 
+#           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+#         run : |
+#           docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "ivts" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/pr-ivts.yaml
+++ b/.github/workflows/pr-ivts.yaml
@@ -183,7 +183,7 @@ jobs:
         run: |
           gradle build check publish --info \
           --no-daemon --console plain \
-          -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
           -PtargetMaven=${{ github.workspace }}/modules/ivts/repo
 

--- a/.github/workflows/pr-ivts.yaml
+++ b/.github/workflows/pr-ivts.yaml
@@ -96,14 +96,6 @@ jobs:
           name: framework
           path: modules/artifacts
 
-      - name: Download extensions artifacts from this workflow
-        id: download-extensions
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: extensions
-          path: modules/artifacts
-
       - name: Download managers artifacts from this workflow
         id: download-managers
         continue-on-error: true
@@ -159,15 +151,6 @@ jobs:
             path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.artifact-id }}
-
-      - name: Download extensions artifacts from last successful workflow
-        if: ${{ steps.download-extensions.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: extensions
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.artifact-id }}
 
       - name: Download managers artifacts from last successful workflow
         if: ${{ steps.download-managers.outcome == 'failure' }}

--- a/.github/workflows/pr-ivts.yaml
+++ b/.github/workflows/pr-ivts.yaml
@@ -104,6 +104,14 @@ jobs:
           name: managers
           path: modules/artifacts
 
+      - name: Download obr artifacts from this workflow
+        id: download-obr
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: obr
+          path: modules/artifacts
+
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
 
@@ -157,6 +165,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: managers
+            path: modules/artifacts
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.artifact-id }}
+
+      - name: Download obr artifacts from last successful workflow
+        if: ${{ steps.download-obr.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: obr
             path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.artifact-id }}

--- a/.github/workflows/pr-ivts.yaml
+++ b/.github/workflows/pr-ivts.yaml
@@ -12,6 +12,10 @@ on:
         description: 'True if this module has been changed and should be rebuilt'
         required: true
         type: string
+      artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts to download'
+        required: true
+        type: string
 
 jobs:
 
@@ -48,6 +52,131 @@ jobs:
         with:
           gradle-version: 8.9
           cache-disabled: true
+
+      # For any modules that were changed in this PR,
+      # download their artifacts from this workflow run.
+
+      - name: Download platform from this workflow
+        id: download-platform
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts
+
+      - name: Download extensions artifacts from this workflow
+        id: download-extensions
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts
+
+      - name: Download managers artifacts from this workflow
+        id: download-managers
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: managers
+          path: modules/artifacts
+
+      # For any modules that weren't changed in this PR,
+      # download artifacts from the last successful workflow.
+
+      - name: Download platform from last successful workflow
+        if: ${{ steps.download-platform.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.artifact-id }}
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: wrapping
+            path: modules/artifacts
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.artifact-id }}
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: gradle
+            path: modules/artifacts
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: maven
+            path: modules/artifacts
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.artifact-id }}
+
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: framework
+            path: modules/artifacts
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.artifact-id }}
+
+      - name: Download extensions artifacts from last successful workflow
+        if: ${{ steps.download-extensions.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.artifact-id }}
+
+      - name: Download managers artifacts from last successful workflow
+        if: ${{ steps.download-managers.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: managers
+            path: modules/artifacts
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.artifact-id }}
 
       - name: Build IVTs
         working-directory: modules/ivts/dev.galasa.ivts

--- a/.github/workflows/pr-ivts.yaml
+++ b/.github/workflows/pr-ivts.yaml
@@ -1,0 +1,65 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: IVTs PR Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+
+jobs:
+
+  log-unchanged:
+    name: IVTs are unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The IVTs module is unchanged"
+
+  build-ivts:
+    name: Build IVTs
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            modules/ivts
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+          cache-disabled: true
+
+      - name: Build IVTs
+        working-directory: modules/ivts/dev.galasa.ivts
+        run: |
+          gradle build check publish --info \
+          --no-daemon --console plain \
+          -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/modules/ivts/repo
+
+      - name: Upload IVT artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ivts
+          path: modules/ivts/repo

--- a/.github/workflows/pr-ivts.yaml
+++ b/.github/workflows/pr-ivts.yaml
@@ -204,3 +204,15 @@ jobs:
         with:
           name: ivts-obr
           path: modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build/galasa.obr
+
+      - name: Build IVTs image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/ivts
+          file: modules/ivts/dockerfiles/dockerfile.ivts
+          load: true
+          tags: ivts-maven-artefacts:test
+          build-args: |
+            baseVersion=latest
+            dockerRepository=ghcr.io
+            branch=main

--- a/.github/workflows/pr-ivts.yaml
+++ b/.github/workflows/pr-ivts.yaml
@@ -193,18 +193,6 @@ jobs:
           name: ivts
           path: modules/ivts/repo
 
-      - name: Upload IVT Test Catalog
-        uses: actions/upload-artifact@v4
-        with:
-          name: ivts-testcatalog
-          path: modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build/testcatalog.json
-
-      - name: Upload IVT OBR
-        uses: actions/upload-artifact@v4
-        with:
-          name: ivts-obr
-          path: modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build/galasa.obr
-
       - name: Build IVTs image for testing
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/pr-ivts.yaml
+++ b/.github/workflows/pr-ivts.yaml
@@ -63,3 +63,15 @@ jobs:
         with:
           name: ivts
           path: modules/ivts/repo
+
+      - name: Upload IVT Test Catalog
+        uses: actions/upload-artifact@v4
+        with:
+          name: ivts-testcatalog
+          path: modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build/testcatalog.json
+
+      - name: Upload IVT OBR
+        uses: actions/upload-artifact@v4
+        with:
+          name: ivts-obr
+          path: modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build/galasa.obr

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -151,17 +151,6 @@ jobs:
       changed: ${{ needs.get-changed-modules.outputs.managers_changed }}
       artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
 
-  # The IVTs can be built directly after Managers as they just require
-  # the Manager code (and anything required to build that).
-  pr-build-ivts:
-    name: Build the 'ivts' module
-    needs: [get-changed-modules, find-artifacts, pr-build-managers]
-    uses: ./.github/workflows/pr-ivts.yaml
-    secrets: inherit
-    with:
-      changed: ${{ needs.get-changed-modules.outputs.ivts_changed }}
-      artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
-
   pr-build-obr:
     name: Build the 'obr' module
     needs: [get-changed-modules, find-artifacts, pr-build-extensions, pr-build-managers]
@@ -169,6 +158,16 @@ jobs:
     secrets: inherit
     with:
       changed: ${{ needs.get-changed-modules.outputs.obr_changed }}
+      artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
+
+  # The IVTs are built after the OBR as they require the galasa-bom to get dependencies.
+  pr-build-ivts:
+    name: Build the 'ivts' module
+    needs: [get-changed-modules, find-artifacts, pr-build-obr]
+    uses: ./.github/workflows/pr-ivts.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.ivts_changed }}
       artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
 
   # This is required as all previous jobs are optional based on if a module has changed.

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -151,7 +151,7 @@ jobs:
       changed: ${{ needs.get-changed-modules.outputs.managers_changed }}
       artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
 
-  # For PRs, the IVTs can be built directly after Managers as they just require
+  # The IVTs can be built directly after Managers as they just require
   # the Manager code (and anything required to build that).
   pr-build-ivts:
     name: Build the 'ivts' module

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -43,6 +43,7 @@ jobs:
       framework_changed: ${{ steps.get-changed-modules.outputs.FRAMEWORK_CHANGED }}
       extensions_changed: ${{ steps.get-changed-modules.outputs.EXTENSIONS_CHANGED }}
       managers_changed: ${{ steps.get-changed-modules.outputs.MANAGERS_CHANGED }}
+      ivts_changed: 'true'
       obr_changed: ${{ steps.get-changed-modules.outputs.OBR_CHANGED }}
 
     steps:
@@ -149,6 +150,15 @@ jobs:
     with:
       changed: ${{ needs.get-changed-modules.outputs.managers_changed }}
       artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
+
+  pr-build-ivts:
+    name: Build the 'ivts' module
+    needs: [get-changed-modules, find-artifacts, pr-build-managers]
+    uses: ./.github/workflows/pr-ivts.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.ivts_changed }}
+      # artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
 
   pr-build-obr:
     name: Build the 'obr' module

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -175,7 +175,7 @@ jobs:
   # This job is set in the branch protection rules as required to merge a Pull Request.
   end-pull-request-build:
     name: Pull Request build was successful
-    needs: [pr-build-obr, detect-secrets]
+    needs: [pr-build-obr, pr-build-ivts, detect-secrets]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -151,6 +151,8 @@ jobs:
       changed: ${{ needs.get-changed-modules.outputs.managers_changed }}
       artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
 
+  # For PRs, the IVTs can be built directly after Managers as they just require
+  # the Manager code (and anything required to build that).
   pr-build-ivts:
     name: Build the 'ivts' module
     needs: [get-changed-modules, find-artifacts, pr-build-managers]
@@ -158,7 +160,7 @@ jobs:
     secrets: inherit
     with:
       changed: ${{ needs.get-changed-modules.outputs.ivts_changed }}
-      # artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
+      artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
 
   pr-build-obr:
     name: Build the 'obr' module

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -94,6 +94,12 @@ jobs:
     uses: ./.github/workflows/managers.yaml
     secrets: inherit
 
+  build-ivts:
+    name: Build the 'ivts' module
+    needs: [build-managers]
+    uses: ./.github/workflows/ivts.yaml
+    secrets: inherit
+
   build-obr:
     name: Build the 'obr' module
     needs: [build-extensions, build-managers, set-build-properties]
@@ -102,10 +108,3 @@ jobs:
     with:
       galasa-version: "${{ needs.set-build-properties.outputs.galasa-version }}"
 
-  # For the Main build, the IVTs are built last so they can just point at
-  # the development maven repo to get the artifacts it needs.
-  build-ivts:
-    name: Build the 'ivts' module
-    needs: [build-obr]
-    uses: ./.github/workflows/ivts.yaml
-    secrets: inherit

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -94,12 +94,6 @@ jobs:
     uses: ./.github/workflows/managers.yaml
     secrets: inherit
 
-  build-ivts:
-    name: Build the 'ivts' module
-    needs: [build-managers]
-    uses: ./.github/workflows/ivts.yaml
-    secrets: inherit
-
   build-obr:
     name: Build the 'obr' module
     needs: [build-extensions, build-managers, set-build-properties]
@@ -107,4 +101,11 @@ jobs:
     secrets: inherit
     with:
       galasa-version: "${{ needs.set-build-properties.outputs.galasa-version }}"
+
+  # The IVTs are built after the OBR as they require the galasa-bom to get dependencies.
+  build-ivts:
+    name: Build the 'ivts' module
+    needs: [build-obr]
+    uses: ./.github/workflows/ivts.yaml
+    secrets: inherit
 

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -94,12 +94,6 @@ jobs:
     uses: ./.github/workflows/managers.yaml
     secrets: inherit
 
-  build-ivts:
-    name: Build the 'ivts' module
-    needs: [build-managers]
-    uses: ./.github/workflows/ivts.yaml
-    secrets: inherit
-
   build-obr:
     name: Build the 'obr' module
     needs: [build-extensions, build-managers, set-build-properties]
@@ -107,3 +101,11 @@ jobs:
     secrets: inherit
     with:
       galasa-version: "${{ needs.set-build-properties.outputs.galasa-version }}"
+
+  # For the Main build, the IVTs are built last so they can just point at
+  # the development maven repo to get the artifacts it needs.
+  build-ivts:
+    name: Build the 'ivts' module
+    needs: [build-obr]
+    uses: ./.github/workflows/ivts.yaml
+    secrets: inherit

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -94,6 +94,12 @@ jobs:
     uses: ./.github/workflows/managers.yaml
     secrets: inherit
 
+  build-ivts:
+    name: Build the 'ivts' module
+    needs: [build-managers]
+    uses: ./.github/workflows/ivts.yaml
+    secrets: inherit
+
   build-obr:
     name: Build the 'obr' module
     needs: [build-extensions, build-managers, set-build-properties]

--- a/modules/extensions/build-locally.sh
+++ b/modules/extensions/build-locally.sh
@@ -173,7 +173,7 @@ info "Log will be placed at ${log_file}"
 function clean_maven_repo {
     h2 "Removing .m2 artifacts"
     rm -fr ~/.m2/repository/dev/galasa/dev.galasa.cps.etcd
-    rm -fr ~/.m2/repository/dev/galasa/dev.galasa.raw.couchdb
+    rm -fr ~/.m2/repository/dev/galasa/dev.galasa.ras.couchdb
     rm -fr ~/.m2/repository/dev/galasa/dev.galasa.cps.rest
     rm -fr ~/.m2/repository/dev/galasa/dev.galasa.events.kafka
     success "OK"

--- a/modules/ivts/README.md
+++ b/modules/ivts/README.md
@@ -1,0 +1,40 @@
+# IVTs
+
+This module contains the Galasa Installation Verification Tests (IVTs) that are written to test the installation and functionality of different Galasa Managers. For example, the `CoreManagerIVT` tests the Galasa Core Manager. Each IVT is itself a Galasa test that uses a Manager to do certain things, then tests that the expected action was completed successfully.
+
+## IVTs in this module
+
+The IVTs are currently in the process of being migrated from within the Managers module to this module. IVTs were previously stored in their own bundles within the Managers module in the same subdirectory as the Manager bundle they tested. However, they are now being moved to this module and added as a submodule of the 'dev.galasa.ivts' bundle to simplify the project's testing.
+
+IVTs that have been moved over and are within this module are:
+* CoreManagerIVT: Tests the Core Manager
+
+## How this module is used
+
+The IVTs contained in this module are built as part of the GitHub Actions build process which builds the test cases, OBR and a test catalog, which altogether represent a test stream called 'ivts'. See the build process in the [.github directory](../../.github/workflows/ivts.yaml).
+
+This test stream is referenced in the CPS properties of a Galasa service which can then run tests from the stream remotely in the Galasa service with `galasactl runs submit`. These tests are run on a daily basis to test the functionality of the Managers and check for any regressions.
+
+## Building locally
+
+To build this module locally, use the `./build-locally` script. This will build the IVT test cases, OBR and test catalog and publish them to your local Maven repository.
+
+## Running locally
+
+Any IVT in this module can also be run locally with `galasactl runs submit local` after building the module locally. You will need to set up certain CPS properties in your local Galasa environment to do this, as the IVTs initialise and use Galasa Managers as part of the test case, which require CPS properties to be set up. 
+
+To find out how to initialise your local environment, see [Initialising your local environment](https://galasa.dev/docs/cli-command-reference/initialising-home-folder) on our website. To learn what CPS properties each Manager needs, see the individual Manager documentation on our [website](https://galasa.dev/docs/managers).
+
+As an example, to run the `CoreManagerIVT` locally, run the following command:
+```
+galasactl runs submit local \
+--obr mvn:dev.galasa.ivts/dev.galasa.ivts.obr/0.40.0/obr \
+--class dev.galasa.ivts.core/dev.galasa.ivts.core.CoreManagerIVT \
+--log -
+```
+
+## Further documentation
+
+For more information on Test streams, see the [Test streams page](https://galasa.dev/docs/manage-ecosystem/test-streams) on our website.
+
+For more information on running tests locally or remotely with `galasactl`, see our [command-line interface documentation](https://github.com/galasa-dev/cli/blob/main/README.md) on GitHub.

--- a/modules/ivts/build-locally.sh
+++ b/modules/ivts/build-locally.sh
@@ -1,0 +1,141 @@
+#! /usr/bin/env bash
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+#-----------------------------------------------------------------------------------------
+#
+# Objectives: Build this repository code locally.
+#
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+# echo "Running from directory ${BASEDIR}"
+export ORIGINAL_DIR=$(pwd)
+
+cd "${BASEDIR}/../.."
+REPO_ROOT=$(pwd)
+
+cd "${BASEDIR}"
+
+#-----------------------------------------------------------------------------------------
+#
+# Set Colors
+#
+#-----------------------------------------------------------------------------------------
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------
+#
+# Headers and Logging
+#
+#-----------------------------------------------------------------------------------------
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ;}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ;}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ;}
+debug() { printf "${white}%s${reset}\n" "$@" ;}
+info() { printf "${white}➜ %s${reset}\n" "$@" ;}
+success() { printf "${green}✔ %s${reset}\n" "$@" ;}
+error() { printf "${red}✖ %s${reset}\n" "$@" ;}
+warn() { printf "${tan}➜ %s${reset}\n" "$@" ;}
+bold() { printf "${bold}%s${reset}\n" "$@" ;}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
+
+#-------------------------------------------------------------
+function check_exit_code () {
+    # This function takes 2 parameters in the form:
+    # $1 an integer value of the returned exit code
+    # $2 an error message to display if $1 is not equal to 0
+    if [[ "$1" != "0" ]]; then 
+        error "$2" 
+        exit 1  
+    fi
+}
+
+function usage {
+    info "Syntax: build-locally.sh [OPTIONS]"
+    cat << EOF
+Options are:
+-s | --detectsecrets true|false : Do we want to detect secrets in the entire repo codebase ? Default is 'true'. Valid values are 'true' or 'false'
+
+Environment variables used:
+SOURCE_MAVEN - Optional. Where gradle can look for pre-built development levels of things.
+    Defaults to https://development.galasa.dev/main/maven-repo/obr/
+EOF
+}
+
+#-----------------------------------------------------------------------------------------                   
+# Process parameters
+#-----------------------------------------------------------------------------------------                   
+
+detectsecrets="true"
+while [ "$1" != "" ]; do
+    case $1 in
+        -s | --detectsecrets )  detectsecrets="$2"
+                                shift
+                                ;;
+
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     error "Unexpected argument $1"
+                                usage
+                                exit 1
+    esac
+    shift
+done
+
+if [[ "${detectsecrets}" != "true" ]] && [[ "${detectsecrets}" != "false" ]]; then
+    error "--detectsecrets flag must be 'true' or 'false'. Was $detectesecrets"
+    exit 1
+fi
+
+#-----------------------------------------------------------------------------------------                   
+# Main logic.
+#-----------------------------------------------------------------------------------------                   
+h1 "Building the ivts module"
+
+# Override SOURCE_MAVEN if you want to build from a different maven repo...
+if [[ -z ${SOURCE_MAVEN} ]]; then
+    export SOURCE_MAVEN=https://development.galasa.dev/main/maven-repo/obr/
+    info "SOURCE_MAVEN repo defaulting to ${SOURCE_MAVEN}."
+    info "Set this environment variable if you want to override this value."
+else
+    info "SOURCE_MAVEN set to ${SOURCE_MAVEN} by caller."
+fi
+
+function clean_ivts() {
+    TARGET_MAVEN_FOLDER=~/.m2/repository
+    h2 "Cleaning the existing built ivts in the ${TARGET_MAVEN_FOLDER} repository"
+    rm -fr ${TARGET_MAVEN_FOLDER}/dev/galasa/ivts/dev.galasa.ivts*
+    success "Cleaned up ${TARGET_MAVEN_FOLDER} repository"
+}
+
+function build_ivts() {
+    h2 "Building the ivts source using gradle."
+    cd $BASEDIR/dev.galasa.ivts
+    rc=$?
+    check_exit_code $rc "Failed to cd to the ivts source folder"
+    gradle build check publish -PtargetMaven=${TARGET_MAVEN_FOLDER} -PsourceMaven=${SOURCE_MAVEN}
+    rc=$?
+    check_exit_code $rc "Failed to build the ivts module source"
+    success "OK"
+}
+
+clean_ivts
+build_ivts
+
+if [[ "$detectsecrets" == "true" ]]; then
+    $REPO_ROOT/tools/detect-secrets.sh 
+    check_exit_code $? "Failed to detect secrets"
+fi

--- a/modules/ivts/dev.galasa.ivts/.gitignore
+++ b/modules/ivts/dev.galasa.ivts/.gitignore
@@ -1,0 +1,14 @@
+
+# Ignore Mac metadata files.
+**/.DS_Store
+# Ignore anything built by gradle
+**/build/
+**/.gradle/
+**/target/
+
+# Ignore any built java artifacts
+**/*.class
+**/*.jar
+
+# Ignore any temporary folder locally
+temp/

--- a/modules/ivts/dev.galasa.ivts/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/build.gradle
@@ -1,0 +1,4 @@
+allprojects {
+    group = 'dev.galasa'
+    version = '0.40.0'
+}

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/bnd.bnd
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/bnd.bnd
@@ -1,5 +1,4 @@
 -snapshot: ${tstamp}
-Bundle-Version: 0.0.1-SNAPSHOT
 Bundle-Name: dev.galasa.ivts.core
 Export-Package: dev.galasa.core.manager.ivt
 Import-Package: !javax.validation.constraints, \

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/bnd.bnd
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/bnd.bnd
@@ -1,0 +1,6 @@
+-snapshot: ${tstamp}
+Bundle-Version: 0.0.1-SNAPSHOT
+Bundle-Name: dev.galasa.ivts.core
+Export-Package: dev.galasa.core.manager.ivt
+Import-Package: !javax.validation.constraints, \
+                *

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
@@ -13,21 +13,19 @@ repositories {
     mavenCentral()
     // To use the bleeding edge version of galasa's obr plugin, use the development obr
     maven {
-       url 'https://development.galasa.dev/main/maven-repo/obr'
+       url = "$sourceMaven"
     }
 
 }
 
 // Set the variables which will control what the built OSGi bundle will be called
 // and the name it will be published under in the maven repository.
-group = 'dev.galasa.ivts'
-version = '0.40.0'
 description = 'Galasa Core Manager IVTs'
 
 // What are the dependencies of the test code ? 
 // When more managers and dependencies are added, this list will need to grow.
 dependencies {
-    implementation platform('dev.galasa:galasa-bom:0.40.0')
+    implementation platform('dev.galasa:galasa-bom:'+version)
 
     implementation 'dev.galasa:dev.galasa'
     implementation 'dev.galasa:dev.galasa.framework'

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
@@ -12,9 +12,9 @@ repositories {
     mavenLocal()
     mavenCentral()
     // To use the bleeding edge version of galasa's obr plugin, use the development obr
-    // maven {
-    //    url 'https://development.galasa.dev/main/maven-repo/obr'
-    // }
+    maven {
+       url 'https://development.galasa.dev/main/maven-repo/obr'
+    }
 
 }
 

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
@@ -45,4 +45,16 @@ publishing {
             from components.java
         }
     }
+    repositories {
+        maven {
+            url  = "$targetMaven"
+            
+            if ("$targetMaven".startsWith('http')) {
+                credentials {
+                    username System.getenv('GITHUB_ACTOR')
+                    password System.getenv('GITHUB_TOKEN')
+                }
+            }
+        }
+    }
 }

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
@@ -21,7 +21,7 @@ repositories {
 // Set the variables which will control what the built OSGi bundle will be called
 // and the name it will be published under in the maven repository.
 group = 'dev.galasa.ivts'
-version = '0.0.1-SNAPSHOT'
+version = '0.40.0'
 description = 'Galasa Core Manager IVTs'
 
 // What are the dependencies of the test code ? 

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
@@ -1,0 +1,48 @@
+
+// This section tells gradle which gradle plugins to use to build this project.
+plugins {
+    id 'java'
+    id 'maven-publish'
+    id 'dev.galasa.tests' version '0.40.0'
+    id 'biz.aQute.bnd.builder' version '6.4.0'
+}
+
+// This section tells gradle where it should look for any dependencies
+repositories {
+    mavenLocal()
+    mavenCentral()
+    // To use the bleeding edge version of galasa's obr plugin, use the development obr
+    // maven {
+    //    url 'https://development.galasa.dev/main/maven-repo/obr'
+    // }
+
+}
+
+// Set the variables which will control what the built OSGi bundle will be called
+// and the name it will be published under in the maven repository.
+group = 'dev.galasa.ivts'
+version = '0.0.1-SNAPSHOT'
+description = 'Galasa Core Manager IVTs'
+
+// What are the dependencies of the test code ? 
+// When more managers and dependencies are added, this list will need to grow.
+dependencies {
+    implementation platform('dev.galasa:galasa-bom:0.40.0')
+
+    implementation 'dev.galasa:dev.galasa'
+    implementation 'dev.galasa:dev.galasa.framework'
+    implementation 'dev.galasa:dev.galasa.core.manager'
+    implementation 'dev.galasa:dev.galasa.artifact.manager'
+    implementation 'commons-logging:commons-logging'
+    implementation 'org.assertj:assertj-core'
+}
+
+// Tell gradle to publish the built OSGi bundles as maven artifacts on the 
+// local maven repository.
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/CoreManagerIVT.java
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/CoreManagerIVT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.ivts.core;
+
+import org.apache.commons.logging.Log;
+
+import dev.galasa.Summary;
+import dev.galasa.Test;
+import dev.galasa.core.manager.CoreManager;
+import dev.galasa.core.manager.ICoreManager;
+import dev.galasa.core.manager.Logger;
+import dev.galasa.core.manager.RunName;
+
+@Test
+@Summary("Ensure the basic functions are working in the Core Manager")
+public class CoreManagerIVT {
+    
+    @Logger
+    public Log logger;
+    
+    @RunName
+    public String runName;
+    
+    @CoreManager
+    public ICoreManager coreManager;
+    
+    @Test
+    public void checkLogger() throws Exception {
+        if (logger == null) {
+            throw new Exception("Logger field is null, should have been filled by the Core Manager");
+        }
+        logger.info("The Logger field has been correctly initialised");
+    }
+
+    @Test
+    public void checkRunName() throws Exception {
+        if (runName == null || runName.trim().isEmpty()) {
+            throw new Exception("Run Name field is null, should have been filled by the Core Manager");
+        }
+        logger.info("The Run Name  field has been correctly initialised = '" + runName + "'");
+    }
+
+    @Test
+    public void checkCoreManager() throws Exception {
+        if (coreManager == null) {
+            throw new Exception("Core Manager field is null, should have been filled by the Core Manager");
+        }
+        logger.info("The Core Manager field has been correctly initialised");
+    }
+
+}

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
@@ -9,8 +9,6 @@ plugins {
 
 // Set the variables which will control what the built OSGi bundle will be called
 // and the name it will be published under in the maven repository.
-group = 'dev.galasa.ivts'
-version = '0.40.0'
 
 // What are the dependencies of the obr ? 
 dependencies {

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
@@ -1,0 +1,51 @@
+   
+// This section tells gradle which gradle plugins to use to build this project.
+plugins {
+    id 'base'
+    id 'maven-publish'
+    id 'dev.galasa.obr' version '0.40.0'
+    id 'dev.galasa.testcatalog' version '0.40.0'
+}
+
+// Set the variables which will control what the built OSGi bundle will be called
+// and the name it will be published under in the maven repository.
+group = 'dev.galasa.ivts'
+version = '0.0.1-SNAPSHOT'
+
+// What are the dependencies of the obr ? 
+dependencies {
+    bundle project(':dev.galasa.ivts.core')
+}
+
+def testcatalog = file('build/testcatalog.json')
+def obrFile = file('build/galasa.obr')
+
+
+tasks.withType(PublishToMavenLocal) { task ->
+    task.dependsOn genobr
+    task.dependsOn mergetestcat
+}
+
+// Tell gradle to publish the built OBR as a maven artifact on the 
+// local maven repository.
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact obrFile
+            artifact (testcatalog) {
+                classifier "testcatalog"
+                extension "json"
+            }
+        }
+    }
+}
+
+// If we are deploying a test catalog using the galasa plugin,
+// directly to the ecosystem, then we can get the properties
+// we need from the system properties, passed on the command line using
+// -DGALASA_STREAM=xxx -DGALASA_BOOTSTRAP=xxx -DGALASA_TOKEN=xxx
+deployTestCatalog {
+    bootstrap = System.getProperty("GALASA_BOOTSTRAP")
+    stream = System.getProperty("GALASA_STREAM")
+    token = System.getProperty("GALASA_TOKEN");
+}

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
@@ -38,6 +38,18 @@ publishing {
             }
         }
     }
+    repositories {
+        maven {
+            url  = "$targetMaven"
+            
+            if ("$targetMaven".startsWith('http')) {
+                credentials {
+                    username System.getenv('GITHUB_ACTOR')
+                    password System.getenv('GITHUB_TOKEN')
+                }
+            }
+        }
+    }
 }
 
 // If we are deploying a test catalog using the galasa plugin,

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
@@ -10,7 +10,7 @@ plugins {
 // Set the variables which will control what the built OSGi bundle will be called
 // and the name it will be published under in the maven repository.
 group = 'dev.galasa.ivts'
-version = '0.0.1-SNAPSHOT'
+version = '0.40.0'
 
 // What are the dependencies of the obr ? 
 dependencies {

--- a/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
+++ b/modules/ivts/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
@@ -26,6 +26,11 @@ tasks.withType(PublishToMavenLocal) { task ->
     task.dependsOn mergetestcat
 }
 
+tasks.withType(PublishToMavenRepository) { task ->
+    task.dependsOn genobr
+    task.dependsOn mergetestcat
+}
+
 // Tell gradle to publish the built OBR as a maven artifact on the 
 // local maven repository.
 publishing {

--- a/modules/ivts/dev.galasa.ivts/settings.gradle
+++ b/modules/ivts/dev.galasa.ivts/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
         mavenLocal()
         // To use the bleeding edge version of galasa's obr plugin, use the development obr
         maven {
-           url 'https://development.galasa.dev/main/maven-repo/obr'
+           url = "$sourceMaven"
         }
 
         gradlePluginPortal()

--- a/modules/ivts/dev.galasa.ivts/settings.gradle
+++ b/modules/ivts/dev.galasa.ivts/settings.gradle
@@ -6,9 +6,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         // To use the bleeding edge version of galasa's obr plugin, use the development obr
-        // maven {
-        //    url 'https://development.galasa.dev/main/maven-repo/obr'
-        // }
+        maven {
+           url 'https://development.galasa.dev/main/maven-repo/obr'
+        }
 
         gradlePluginPortal()
         mavenCentral()

--- a/modules/ivts/dev.galasa.ivts/settings.gradle
+++ b/modules/ivts/dev.galasa.ivts/settings.gradle
@@ -1,0 +1,20 @@
+
+
+
+// Tell gradle where it should look to find the plugins and dependencies it needs to build.
+pluginManagement {
+    repositories {
+        mavenLocal()
+        // To use the bleeding edge version of galasa's obr plugin, use the development obr
+        // maven {
+        //    url 'https://development.galasa.dev/main/maven-repo/obr'
+        // }
+
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+// Tell gradle to build the sub-projects in child folders
+include 'dev.galasa.ivts.core'
+include 'dev.galasa.ivts.obr'

--- a/modules/ivts/dockerfiles/dockerfile.ivts
+++ b/modules/ivts/dockerfiles/dockerfile.ivts
@@ -1,0 +1,10 @@
+ARG baseVersion
+ARG dockerRepository
+FROM ${dockerRepository}/galasa-dev/base-image:${baseVersion}
+
+ARG branch
+
+RUN sed -i "s/--branchname--/${branch}/"     /usr/local/apache2/conf/httpd.conf
+RUN sed -i 's/--repositoryname--/ivts/'  /usr/local/apache2/conf/httpd.conf
+
+COPY repo/ /usr/local/apache2/htdocs/

--- a/modules/ivts/set-version.sh
+++ b/modules/ivts/set-version.sh
@@ -1,0 +1,145 @@
+#! /usr/bin/env bash 
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Objectives: Sets the version number of this component.
+#
+# Environment variable over-rides:
+# None
+# 
+#-----------------------------------------------------------------------------------------                   
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+# echo "Running from directory ${BASEDIR}"
+export ORIGINAL_DIR=$(pwd)
+# cd "${BASEDIR}"
+
+cd "${BASEDIR}/.."
+WORKSPACE_DIR=$(pwd)
+
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Set Colors
+#
+#-----------------------------------------------------------------------------------------                   
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Headers and Logging
+#
+#-----------------------------------------------------------------------------------------                   
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ;}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ;}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ;}
+debug() { printf "${white}%s${reset}\n" "$@" ;}
+info() { printf "${white}➜ %s${reset}\n" "$@" ;}
+success() { printf "${green}✔ %s${reset}\n" "$@" ;}
+error() { printf "${red}✖ %s${reset}\n" "$@" ;}
+warn() { printf "${tan}➜ %s${reset}\n" "$@" ;}
+bold() { printf "${bold}%s${reset}\n" "$@" ;}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
+
+
+#-----------------------------------------------------------------------------------------                   
+# Functions
+#-----------------------------------------------------------------------------------------                   
+function usage {
+    h1 "Syntax"
+    cat << EOF
+set-version.sh [OPTIONS]
+Options are:
+-v | --version xxx : Mandatory. Set the version number to something explicitly. 
+    For example '--version 0.29.0'
+EOF
+}
+
+#-----------------------------------------------------------------------------------------                   
+# Process parameters
+#-----------------------------------------------------------------------------------------                   
+component_version=""
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -v | --version )        shift
+                                export component_version=$1
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     error "Unexpected argument $1"
+                                usage
+                                exit 1
+    esac
+    shift
+done
+
+if [[ -z $component_version ]]; then 
+    error "Missing mandatory '--version' argument."
+    usage
+    exit 1
+fi
+
+temp_dir=$BASEDIR/temp/version_bump
+mkdir -p $temp_dir
+
+function upgrade_parent_build_gradle {
+
+        # Updates the version in 'allprojects' for the IVTs bundle which sets the version of each IVT bundle.
+
+    h2 "upgrading the dev.galasa.ivts parent build.gradle"
+
+    cat $BASEDIR/dev.galasa.ivts/build.gradle | sed "s/version[ ]*=.*/version = '$component_version'/1" > $temp_dir/ivts-build.gradle
+    cp $temp_dir/ivts-build.gradle $BASEDIR/dev.galasa.ivts/build.gradle
+
+    success "dev.galasa.ivts parent build.gradle upgraded OK."
+}
+
+function upgrade_obr_build_gradle {
+
+    # Updates the version of the dev.galasa.obr and dev.galasa.testcatalog plugins used in the IVT OBR.
+
+    h2 "upgrading the dev.galasa.ivts.obr build.gradle"
+
+    cat $BASEDIR/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle \
+    | sed "s/id 'dev[.]galasa[.]obr' version '.*'/id 'dev.galasa.obr' version '$component_version'/1" \
+    | sed "s/id 'dev[.]galasa[.]testcatalog' version '.*'/id 'dev.galasa.testcatalog' version '$component_version'/1" \
+    > $temp_dir/obr-build.gradle
+    cp $temp_dir/obr-build.gradle $BASEDIR/dev.galasa.ivts/dev.galasa.ivts.obr/build.gradle
+
+    success "dev.galasa.ivts.obr build.gradle upgraded OK."
+
+}
+
+function upgrade_plugins_in_ivt_bundles {
+
+    # Updates the version of the dev.galasa.tests plugin used in each IVT bundle.
+
+    h2 "upgrading the dev.galasa.ivts.core build.gradle"
+
+    cat $BASEDIR/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle | sed "s/id 'dev[.]galasa[.]tests' version '.*'/id 'dev.galasa.tests' version '$component_version'/1" > $temp_dir/core-build.gradle
+    cp $temp_dir/core-build.gradle $BASEDIR/dev.galasa.ivts/dev.galasa.ivts.core/build.gradle
+
+    success "dev.galasa.ivts.core build.gradle upgraded OK."
+
+    # More bundles to be added...
+}
+
+upgrade_parent_build_gradle
+upgrade_obr_build_gradle
+upgrade_plugins_in_ivt_bundles

--- a/modules/ivts/set-version.sh
+++ b/modules/ivts/set-version.sh
@@ -98,9 +98,22 @@ fi
 temp_dir=$BASEDIR/temp/version_bump
 mkdir -p $temp_dir
 
+function upgrade_read_me_example {
+
+    # Updates the version in the galasactl runs submit local example in the README.md
+
+    h2 "upgrading the ivts README.md"
+
+    cat $BASEDIR/README.md | sed "s/dev[.]galasa[.]ivts[.]obr\/.*\/obr/dev.galasa.ivts.obr\/$component_version\/obr/1" > $temp_dir/ivts-README.md
+    cp $temp_dir/ivts-README.md $BASEDIR/README.md
+
+    success "ivts README.md upgraded OK."
+    
+}
+
 function upgrade_parent_build_gradle {
 
-        # Updates the version in 'allprojects' for the IVTs bundle which sets the version of each IVT bundle.
+    # Updates the version in 'allprojects' for the IVTs bundle which sets the version of each IVT bundle.
 
     h2 "upgrading the dev.galasa.ivts parent build.gradle"
 
@@ -140,6 +153,7 @@ function upgrade_plugins_in_ivt_bundles {
     # More bundles to be added...
 }
 
-upgrade_parent_build_gradle
-upgrade_obr_build_gradle
-upgrade_plugins_in_ivt_bundles
+upgrade_read_me_example
+# upgrade_parent_build_gradle
+# upgrade_obr_build_gradle
+# upgrade_plugins_in_ivt_bundles

--- a/modules/ivts/set-version.sh
+++ b/modules/ivts/set-version.sh
@@ -108,7 +108,7 @@ function upgrade_read_me_example {
     cp $temp_dir/ivts-README.md $BASEDIR/README.md
 
     success "ivts README.md upgraded OK."
-    
+
 }
 
 function upgrade_parent_build_gradle {
@@ -154,6 +154,6 @@ function upgrade_plugins_in_ivt_bundles {
 }
 
 upgrade_read_me_example
-# upgrade_parent_build_gradle
-# upgrade_obr_build_gradle
-# upgrade_plugins_in_ivt_bundles
+upgrade_parent_build_gradle
+upgrade_obr_build_gradle
+upgrade_plugins_in_ivt_bundles

--- a/tools/build-locally.sh
+++ b/tools/build-locally.sh
@@ -90,6 +90,7 @@ module_names=(\
     "extensions" \
     "managers" \
     "obr" \
+    "ivts" \
 )
 
 function check_module_name_is_supported() {
@@ -257,7 +258,18 @@ function build_module() {
     if [[ "$module" == "obr" ]]; then
         h2 "Building $module"
         cd ${PROJECT_DIR}/modules/$module
-        info "Using SOURCE_MAVEN of $SOURCE_MAVEN"
+        ${PROJECT_DIR}/modules/$module/build-locally.sh --detectsecrets false
+        rc=$? ;  if [[ "${rc}" != "0" ]]; then error "Failed to build module $module. rc=$rc" ; exit 1 ; fi
+        success "Built module $module OK"
+        if [[ "$chain" == "true" ]]; then 
+            module="ivts"
+        fi
+    fi
+
+    # ivts
+    if [[ "$module" == "ivts" ]]; then
+        h2 "Building $module"
+        cd ${PROJECT_DIR}/modules/$module
         ${PROJECT_DIR}/modules/$module/build-locally.sh --detectsecrets false
         rc=$? ;  if [[ "${rc}" != "0" ]]; then error "Failed to build module $module. rc=$rc" ; exit 1 ; fi
         success "Built module $module OK"


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2132

- New module created called 'ivts' to house the IVTs in a new `dev.galasa.ivts` bundle.
- CoreManagerIVT added to this bundle and has successfully been built and deployed to new test stream, and ran in the prod1 service.
- build-locally.sh script written and is called from the parent build-locally.
- set-version.sh script written and is called from the parent set-version.
- README.md written.
- Github Actions build process created and added to the build orchestrators.
