### PR TITLE
maven build should include a META-INF/maven/plugin.xml file

### DIFF
--- a/modules/maven/galasa-maven-plugin/pom.xml
+++ b/modules/maven/galasa-maven-plugin/pom.xml
@@ -217,6 +217,8 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- This plugin generates and adds the META-INF/maven/plugin.xml file to the built jar. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
@@ -229,6 +231,7 @@
 					</execution>
 				</executions>
 			</plugin>
+			
 			<plugin>
 				<groupId>com.google.code.maven-replacer-plugin</groupId>
 				<artifactId>maven-replacer-plugin</artifactId>

--- a/modules/maven/galasa-maven-plugin/pom.xml
+++ b/modules/maven/galasa-maven-plugin/pom.xml
@@ -177,6 +177,11 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.13.0</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-site-plugin</artifactId>
+					<version>3.21.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -213,6 +218,18 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>galasa-maven-plugin</id>
+						<goals>
+							<goal>descriptor</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>com.google.code.maven-replacer-plugin</groupId>
 				<artifactId>maven-replacer-plugin</artifactId>
 				<executions>
@@ -234,6 +251,7 @@
 					</replacements>
 				</configuration>
 			</plugin>
+
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
I have a local build fail because the galasa manven plugin didn't contain a `META-INF/maven/plugin.xml` file.

Change the maven build process to generate this file and include it in the jar.

All v3.0 plugins needs such a file it seems, and ours was missing.

They can be hand-crafted and added-in, or just generated. I chose the easier generated option less likely to become out of date.

# To solve...
I changed the pom.xml to generate this file.

It comes out like this:
[plugin.xml.zip](https://github.com/user-attachments/files/18674383/plugin.xml.zip)
