### PR TITLE
making the delay between pod launches configurable with a cps property

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/README.md
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/README.md
@@ -1,0 +1,35 @@
+# Kubernetes controller
+
+The Kubernetes controller is responsible for looping (forever) looking for tests which are in the queued state.
+
+When it finds one, it launches a Kubernetes pod to run the test.
+
+## CPS propertites
+
+### `framework.kube.launch.interval.milliseconds` 
+The number of milliseconds which the test pod scheduler should delay between successive launches of test pods.
+
+The default is `CPSFacade.KUBE_LAUNCH_INTERVAL_MILLISECOND_DEFAULT_VALUE`
+
+Why do this ? 
+
+If we don't do this, then all the tests get scheduled on the same node, and the 
+node may run out of memory.
+
+We assume that's because the usage statistics on a pod are not synchronized totally at
+real-time, but have a lag in which they catch up. Hopefully this delay is greater
+than the lag and when we actually schedule the next pod it gets evenly distributed over
+the nodes which are available.
+
+This may or may not be necessary if the scheduling policies in the cluster are changed.
+
+This CPS property is dynamic, in that you don't need to re-start the test launcher pod for it to take effect.
+It gets read every time the value is needed, and is not cached.
+
+Any failure in the CPS will be logged and ignored, resulting in the default value being returned.
+
+
+
+
+
+

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/CPSFacade.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/CPSFacade.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.k8s.controller;
+
+import java.text.MessageFormat;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+
+public class CPSFacade {
+
+    public static final long KUBE_LAUNCH_INTERVAL_MILLISECOND_DEFAULT_VALUE = 1000L;
+
+    public static final String KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_PREFIX = "framework";
+    public static final String KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_INFIX = "kube.launch.interval.milliseconds" ;
+
+    private IConfigurationPropertyStoreService cps;
+    private final Log logger = LogFactory.getLog(getClass());
+
+    public CPSFacade(IConfigurationPropertyStoreService cps) {
+        this.cps = cps ;
+    }
+
+
+    /**
+     * The CPS property `framework.kube.launch.interval.milliseconds controls` the number of milliseconds which the test pod 
+     * scheduler should delay between successive launches of test pods.
+     * 
+     * The default is KUBE_LAUNCH_INTERVAL_MILLISECOND_DEFAULT_VALUE
+     * 
+     * Any failure in the CPS will be logged and ignored, resulting in the default value being returned.
+     * 
+     * This CPS property is dynamic, in that you don't need to re-start the test launcher pod for it to take effect.
+     * It gets read every time the value is needed, and is not cached.
+     * 
+     * @return The number of milliseconds which the test pod scheduler should delay between successive launches of test pods.
+     */
+    public long getKubeLaunchIntervalMilliseconds() {
+        long intervalMs = KUBE_LAUNCH_INTERVAL_MILLISECOND_DEFAULT_VALUE;
+
+        if (cps==null) {
+            logger.error("getKubeLaunchIntervalMilliseconds: Null CPS. Internal server logic error.");
+        } else {
+
+            try {
+                String cpsRawValue = cps.getProperty(KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_PREFIX, null, KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_INFIX);
+                if (cpsRawValue == null) {
+                    String msg = MessageFormat.format(
+                        "Info: Could not get launch interval value from the CPS (Property {0}.{1}). Using default value of {2}. CPS property is empty.",
+                        KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_PREFIX,
+                        KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_INFIX,
+                        Long.toString(intervalMs)
+                    );
+                    logger.info(msg);
+                } else {
+                    String trimmedValue = cpsRawValue.trim();
+                    try {
+                        intervalMs = Long.parseLong(trimmedValue);
+                    } catch(NumberFormatException ex) {
+                        String msg = MessageFormat.format(
+                            "Info: Could not get launch interval value from the CPS (Property {0}.{1}). Using default value of {2}. CPS Value '{3}' is not a number.",
+                            KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_PREFIX,
+                            KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_INFIX,
+                            Long.toString(intervalMs),
+                            trimmedValue
+                        );
+                        logger.info(msg);
+                    }
+                }
+
+            } catch( ConfigurationPropertyStoreException ex) {
+                String msg = MessageFormat.format(
+                    "Error: Could not get launch interval value from the CPS (Property {0}.{1}). Using default value of {2}. CPS Failure {3}",
+                    KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_PREFIX,
+                    KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_INFIX,
+                    Long.toString(intervalMs),
+                    ex
+                    );
+                logger.error(msg);
+            }
+        }
+
+        return intervalMs ;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
@@ -143,7 +143,7 @@ public class K8sController {
             // *** Start the run polling
             runDeleted = new RunDeleted(settings, api, pc, framework.getFrameworkRuns());
             scheduleDelete();
-            podScheduler = new TestPodScheduler(dss, settings, api, framework.getFrameworkRuns());
+            podScheduler = new TestPodScheduler(dss, cps, settings, api, framework.getFrameworkRuns());
             schedulePoll();
 
             

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/CPSFacadeTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/CPSFacadeTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.k8s.controller;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.MockIConfigurationPropertyStoreService;
+
+public class CPSFacadeTest {
+
+    @Test 
+    public void testCPSFacadeCanCreateACPSFacadeObject() {
+        new CPSFacade(null);
+    }
+    
+
+    @Test 
+    public void testCPSFacadeCanCopeWithANullCPS() {
+        CPSFacade cpsFacade = new CPSFacade(null);
+        long intervalMs = cpsFacade.getKubeLaunchIntervalMilliseconds();
+        assertThat(intervalMs).isEqualTo(CPSFacade.KUBE_LAUNCH_INTERVAL_MILLISECOND_DEFAULT_VALUE);
+    }
+
+    @Test 
+    public void testCPSFacadeCanCopeWithNoCPSPropertyFountForKubeLaunchIntervalMilliseconds() {
+        MockIConfigurationPropertyStoreService mockCPS = new MockIConfigurationPropertyStoreService();
+        CPSFacade cpsFacade = new CPSFacade(mockCPS);
+        long intervalMs = cpsFacade.getKubeLaunchIntervalMilliseconds();
+        assertThat(intervalMs).isEqualTo(CPSFacade.KUBE_LAUNCH_INTERVAL_MILLISECOND_DEFAULT_VALUE);
+    }
+
+    @Test 
+    public void testCPSFacadeCanOverrideDefaultKubeLaunchIntervalMilliseconds() {
+        MockIConfigurationPropertyStoreService mockCPS = new MockIConfigurationPropertyStoreService() {
+            public @Null String getProperty(@NotNull String prefix, @NotNull String suffix, String... infixes) {
+                assertThat(prefix).isEqualTo( CPSFacade.KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_PREFIX);
+                assertThat(infixes[0]).isEqualTo( CPSFacade.KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_INFIX);
+                return "2000";
+            }
+        };
+
+        CPSFacade cpsFacade = new CPSFacade(mockCPS);
+        long intervalMs = cpsFacade.getKubeLaunchIntervalMilliseconds();
+        assertThat(intervalMs).isEqualTo(2000);
+    }
+
+
+
+    @Test 
+    public void testCPSFacadeCPSPropNotANumberReturnsDefaultKubeLaunchIntervalMilliseconds() {
+        MockIConfigurationPropertyStoreService mockCPS = new MockIConfigurationPropertyStoreService() {
+            public @Null String getProperty(@NotNull String prefix, @NotNull String suffix, String... infixes) {
+                assertThat(prefix).isEqualTo( CPSFacade.KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_PREFIX);
+                assertThat(infixes[0]).isEqualTo( CPSFacade.KUBE_LAUNCH_INTERVAL_CPS_PROPERTY_INFIX);
+                return "NotANumber";
+            }
+        };
+
+        CPSFacade cpsFacade = new CPSFacade(mockCPS);
+        long intervalMs = cpsFacade.getKubeLaunchIntervalMilliseconds();
+        assertThat(intervalMs).isEqualTo(CPSFacade.KUBE_LAUNCH_INTERVAL_MILLISECOND_DEFAULT_VALUE);
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/CPSFacadeTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/CPSFacadeTest.java
@@ -30,7 +30,7 @@ public class CPSFacadeTest {
     }
 
     @Test 
-    public void testCPSFacadeCanCopeWithNoCPSPropertyFountForKubeLaunchIntervalMilliseconds() {
+    public void testCPSFacadeCanCopeWithNoCPSPropertyFoundForKubeLaunchIntervalMilliseconds() {
         MockIConfigurationPropertyStoreService mockCPS = new MockIConfigurationPropertyStoreService();
         CPSFacade cpsFacade = new CPSFacade(mockCPS);
         long intervalMs = cpsFacade.getKubeLaunchIntervalMilliseconds();

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -89,7 +89,6 @@ public class TestPodSchedulerTest {
         checkPodSpec(pod, settings);
     }
 
-    // @SuppressWarnings("null")
     private void checkPodMetadata(V1Pod pod, String expectedRunName, String expectedPodName, Settings settings) {
         V1ObjectMeta expectedMetadata = new V1ObjectMeta()
             .labels(Map.of("galasa-run", expectedRunName, "galasa-engine-controller", settings.getEngineLabel()))
@@ -124,7 +123,6 @@ public class TestPodSchedulerTest {
         return preferred;
     }
 
-    // @SuppressWarnings("null")
     private void checkPodSpec(V1Pod pod, Settings settings) {
 
         // Check the pod's spec is as expected
@@ -155,7 +153,6 @@ public class TestPodSchedulerTest {
         }
     }
 
-    // @SuppressWarnings("null")
     private void checkPodContainer(V1Pod pod, String expectedEncryptionKeysMountPath, Settings settings) {
         // Check that test container has been added
         V1PodSpec actualPodSpec = pod.getSpec();
@@ -176,7 +173,6 @@ public class TestPodSchedulerTest {
         assertThat(encryptionKeysVolumeMount.getReadOnly()).isTrue();
     }
 
-    // @SuppressWarnings("null")
     private void checkPodVolumes(V1Pod pod, Settings settings) {
         // Check that the encryption keys volume has been added
         V1PodSpec actualPodSpec = pod.getSpec();

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import dev.galasa.framework.mocks.MockCPSStore;
 import dev.galasa.framework.mocks.MockEnvironment;
 import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
 import dev.galasa.framework.mocks.MockIFrameworkRuns;
@@ -88,7 +89,7 @@ public class TestPodSchedulerTest {
         checkPodSpec(pod, settings);
     }
 
-    @SuppressWarnings("null")
+    // @SuppressWarnings("null")
     private void checkPodMetadata(V1Pod pod, String expectedRunName, String expectedPodName, Settings settings) {
         V1ObjectMeta expectedMetadata = new V1ObjectMeta()
             .labels(Map.of("galasa-run", expectedRunName, "galasa-engine-controller", settings.getEngineLabel()))
@@ -123,7 +124,7 @@ public class TestPodSchedulerTest {
         return preferred;
     }
 
-    @SuppressWarnings("null")
+    // @SuppressWarnings("null")
     private void checkPodSpec(V1Pod pod, Settings settings) {
 
         // Check the pod's spec is as expected
@@ -154,7 +155,7 @@ public class TestPodSchedulerTest {
         }
     }
 
-    @SuppressWarnings("null")
+    // @SuppressWarnings("null")
     private void checkPodContainer(V1Pod pod, String expectedEncryptionKeysMountPath, Settings settings) {
         // Check that test container has been added
         V1PodSpec actualPodSpec = pod.getSpec();
@@ -175,7 +176,7 @@ public class TestPodSchedulerTest {
         assertThat(encryptionKeysVolumeMount.getReadOnly()).isTrue();
     }
 
-    @SuppressWarnings("null")
+    // @SuppressWarnings("null")
     private void checkPodVolumes(V1Pod pod, Settings settings) {
         // Check that the encryption keys volume has been added
         V1PodSpec actualPodSpec = pod.getSpec();
@@ -202,8 +203,9 @@ public class TestPodSchedulerTest {
         V1ConfigMap mockConfigMap = createMockConfigMap();
         MockSettings settings = new MockSettings(mockConfigMap, controller, null);
         settings.init();
+        MockCPSStore mockCPS = new MockCPSStore(null);
 
-        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, settings, null, mockFrameworkRuns);
+        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, null, mockFrameworkRuns);
 
         String runName = "run1";
         String podName = settings.getEngineLabel() + "-" + runName;


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?

See issue [Galasa Ecosystem test runs are causing k8s nodes to run out of memory with a high enough throttle value #2045](https://github.com/galasa-dev/projectmanagement/issues/2045)

- added a new CPS property

### `framework.kube.launch.interval.milliseconds` 
The number of milliseconds which the test pod scheduler should delay between successive launches of test pods.

The default is `CPSFacade.KUBE_LAUNCH_INTERVAL_MILLISECOND_DEFAULT_VALUE`

Why do this ? 

If we don't do this, then all the tests get scheduled on the same node, and the 
node may run out of memory.

We assume that's because the usage statistics on a pod are not synchronized totally at
real-time, but have a lag in which they catch up. Hopefully this delay is greater
than the lag and when we actually schedule the next pod it gets evenly distributed over
the nodes which are available.

This may or may not be necessary if the scheduling policies in the cluster are changed.

This CPS property is dynamic, in that you don't need to re-start the test launcher pod for it to take effect.
It gets read every time the value is needed, and is not cached.

Any failure in the CPS will be logged and ignored, resulting in the default value being returned.