### PR TITLE
Link to the new contributors guide from the other READMEs

### DIFF
--- a/modules/buildutils/README.md
+++ b/modules/buildutils/README.md
@@ -38,3 +38,7 @@ $galasabld versioning suffix remove --sourcefolderpath {my-source-folder}
 ```
 This will recursively look for module versions, stripping off any existing suffix.
 So for example, `0.0.1-SNAPSHOT` will be changed to `0.0.1`
+
+### How to contribute to this module
+
+Take a look at the [Contributor's Guide](https://github.com/galasa-dev/galasa/blob/main/CONTRIBUTING.md).

--- a/modules/extensions/README.md
+++ b/modules/extensions/README.md
@@ -15,7 +15,7 @@ Other repositories are available via [GitHub](https://github.com/galasa-dev).
 
 If you are interested in the development of Galasa, take a look at the documentation and feel free to post a question on [Galasa Slack channel](https://galasa.slack.com) or raise new ideas /features / bugs etc. as issues on [GitHub](https://github.com/galasa-dev/projectmanagement).
 
-Take a look at the [contribution guidelines](https://github.com/galasa-dev/projectmanagement/blob/main/contributing.md).
+Take a look at the [contribution guidelines](https://github.com/galasa-dev/projectmanagement/blob/main/contributing.md) and the [Contributor's Guide](https://github.com/galasa-dev/galasa/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/modules/framework/README.md
+++ b/modules/framework/README.md
@@ -17,7 +17,7 @@ Other repositories are available via [GitHub](https://github.com/galasa-dev).
 
 If you are interested in the development of Galasa, take a look at the documentation and feel free to post a question on [Galasa Slack channel](https://galasa.slack.com) or raise new ideas / features / bugs etc. as issues on [GitHub](https://github.com/galasa-dev/projectmanagement).
 
-Take a look at the [contribution guidelines](https://github.com/galasa-dev/projectmanagement/blob/main/contributing.md)
+Take a look at the [contribution guidelines](https://github.com/galasa-dev/projectmanagement/blob/main/contributing.md) and the [Contributor's Guide](https://github.com/galasa-dev/galasa/blob/main/CONTRIBUTING.md).
 
 ## Build locally
 Use the `build-locally.sh` script. 

--- a/modules/gradle/README.md
+++ b/modules/gradle/README.md
@@ -149,3 +149,7 @@ To publish the test catalog to a live Galasa ecosystem, you will need the follow
 Use the `.build-locally.sh` script to invoke a build.
 
 See the notes at the top of the script for a list of environment variables which can be over-ridden to control build behaviour.
+
+## How to contribute to this module
+
+Take a look at the [Contributor's Guide](https://github.com/galasa-dev/galasa/blob/main/CONTRIBUTING.md).

--- a/modules/ivts/README.md
+++ b/modules/ivts/README.md
@@ -57,3 +57,8 @@ galasactl runs submit local \
 For more information on Test streams, see the [Test streams page](https://galasa.dev/docs/manage-ecosystem/test-streams) on our website.
 
 For more information on running tests locally or remotely with `galasactl`, see our [command-line interface documentation](https://github.com/galasa-dev/cli/blob/main/README.md) on GitHub.
+
+
+## How to contribute to this module
+
+Take a look at the [Contributor's Guide](https://github.com/galasa-dev/galasa/blob/main/CONTRIBUTING.md).

--- a/modules/managers/README.md
+++ b/modules/managers/README.md
@@ -9,7 +9,7 @@ We're adding new Manager every month. Look at the [summary table of Managers](ht
 ## Contributing
 If you are interested in the development of Galasa, take a look at the documentation and feel free to post a question on the <a href="https://join.slack.com/t/galasa/shared_invite/zt-ele2ic8x-VepEO1o13t4Jtb3ZuM4RUA" target="_blank"> Galasa Slack channel</a>, or start sharing usage and development experiences with other Galasa users and the IBM team. You can also raise new ideas / features / bugs etc. as issues on [GitHub](https://github.com/galasa-dev/projectmanagement).  
 
-Take a look at the [contribution guidelines](https://github.com/galasa-dev/projectmanagement/blob/main/contributing.md).
+Take a look at the [contribution guidelines](https://github.com/galasa-dev/projectmanagement/blob/main/contributing.md) and the [Contributor's Guide](https://github.com/galasa-dev/galasa/blob/main/CONTRIBUTING.md).
  
 
 ## Documentation

--- a/modules/maven/README.md
+++ b/modules/maven/README.md
@@ -16,7 +16,7 @@ Other repositories are available via [GitHub](https://github.com/galasa-dev).
 
 If you are interested in the development of Galasa, take a look at the documentation and feel free to post a question on [Galasa Slack channel](https://galasa.slack.com) or raise new ideas / features / bugs etc. as issues on [GitHub](https://github.com/galasa-dev/projectmanagement).
 
-Take a look at the [contribution guidelines](https://github.com/galasa-dev/projectmanagement/blob/main/contributing.md).
+Take a look at the [contribution guidelines](https://github.com/galasa-dev/projectmanagement/blob/main/contributing.md) and the [Contributor's Guide](https://github.com/galasa-dev/galasa/blob/main/CONTRIBUTING.md).
 
 ## How to build locally
 Use the `build-locally.sh` script to build this code locally.

--- a/modules/obr/README.md
+++ b/modules/obr/README.md
@@ -1,4 +1,9 @@
 # OBR
+
 This module houses code which can create OSGi Bundle Repositories. 
-These are the OSGi way of packaging OSGi bundles together so that they can be loaded on demand
-within the OSGi framework
+
+These are the OSGi way of packaging OSGi bundles together so that they can be loaded on demand within the OSGi framework.
+
+## Contributing
+
+To contribute to this module, take a look at the [Contributor's Guide](https://github.com/galasa-dev/galasa/blob/main/CONTRIBUTING.md).

--- a/modules/platform/README.md
+++ b/modules/platform/README.md
@@ -1,0 +1,7 @@
+# Platform
+
+This module houses the Galasa Platform (dev.galasa.platform). This uses Gradle's Java Platform plugin to declare a platform, which is used to share a set of dependency versions throughout Galasa.
+
+## Contributing
+
+To contribute to this module, take a look at the [Contributor's Guide](https://github.com/galasa-dev/galasa/blob/main/CONTRIBUTING.md).

--- a/modules/wrapping/README.md
+++ b/modules/wrapping/README.md
@@ -15,7 +15,7 @@ Other repositories are available via [GitHub](https://github.com/galasa-dev).
 
 If you are interested in the development of Galasa, take a look at the documentation and feel free to post a question on [Galasa Slack channel](https://galasa.slack.com) or raise new ideas / features / bugs etc. as issues on [GitHub](https://github.com/galasa-dev/projectmanagement).
 
-Take a look at the [contribution guidelines](https://github.com/galasa-dev/projectmanagement/blob/main/contributing.md).
+Take a look at the [contribution guidelines](https://github.com/galasa-dev/projectmanagement/blob/main/contributing.md) and the [Contributor's Guide](https://github.com/galasa-dev/galasa/blob/main/CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Why?

For issue https://github.com/galasa-dev/projectmanagement/issues/2101

Link to the contributor's guide from the contributing section in the individual module READMEs, so contributors can easily find their way there if reading about a module and wanting to contribute.