### PR TITLE
Update docker image for DockerManagerIVT

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/src/main/java/dev/galasa/docker/manager/ivt/DockerManagerIVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/src/main/java/dev/galasa/docker/manager/ivt/DockerManagerIVT.java
@@ -64,13 +64,13 @@ public class DockerManagerIVT {
     @Logger
     public Log logger;
 
-    @DockerContainer(image = "httpd", dockerContainerTag = "a", start = false)
+    @DockerContainer(image = "galasa-dev/httpd:latest", dockerContainerTag = "a", start = false)
     public IDockerContainer container;
 
-    @DockerContainer(image = "httpd", dockerContainerTag = "b", start = false)
+    @DockerContainer(image = "galasa-dev/httpd:latest", dockerContainerTag = "b", start = false)
     public IDockerContainer containerSecondry;
     
-    @DockerContainer(image = "httpd", dockerContainerTag = "AUTOSTART", start = true)
+    @DockerContainer(image = "galasa-dev/httpd:latest", dockerContainerTag = "AUTOSTART", start = true)
     public IDockerContainer containerAutoStart;
 
     @DockerContainerConfig

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/src/main/java/dev/galasa/docker/manager/ivt/DockerManagerIVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/src/main/java/dev/galasa/docker/manager/ivt/DockerManagerIVT.java
@@ -64,13 +64,13 @@ public class DockerManagerIVT {
     @Logger
     public Log logger;
 
-    @DockerContainer(image = "library/httpd:latest", dockerContainerTag = "a", start = false)
+    @DockerContainer(image = "httpd", dockerContainerTag = "a", start = false)
     public IDockerContainer container;
 
-    @DockerContainer(image = "library/httpd:latest", dockerContainerTag = "b", start = false)
+    @DockerContainer(image = "httpd", dockerContainerTag = "b", start = false)
     public IDockerContainer containerSecondry;
     
-    @DockerContainer(image = "library/httpd:latest", dockerContainerTag = "AUTOSTART", start = true)
+    @DockerContainer(image = "httpd", dockerContainerTag = "AUTOSTART", start = true)
     public IDockerContainer containerAutoStart;
 
     @DockerContainerConfig


### PR DESCRIPTION
## Why?

Since completing story https://github.com/galasa-dev/projectmanagement/issues/1888 the images have been cleared out of the docker_proxy_cache namespace in Harbor, so this test has been failing to find the httpd image it requires.

Alongside the change made in https://github.com/galasa-dev/integratedtests/pull/221, this change updates the docker image name so that the DockerManager should look for the image at ghcr.io/galasa-dev/httpd:latest, from <registry>/library/httpd:latest.