### PR TITLE
Build an arm64 version of the galasa-boot-embedded Docker image, fix main build GPG errors in forks

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -111,8 +111,8 @@ jobs:
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/maven/repo \
           -Dgalasa.jacocoEnabled=${{ inputs.jacoco_enabled }} \
           -Dgalasa.isRelease=${{ inputs.sign_artifacts }} \
-          -Dgpg.key.id=${{ env.GPG_KEYID }} \
-          -Dgpg.passphrase=${{ env.GPG_PASSPHRASE }} \
+          -Dgpg.key.id="${{ env.GPG_KEYID }}" \
+          -Dgpg.passphrase="${{ env.GPG_PASSPHRASE }}" \
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
       

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -158,8 +158,8 @@ jobs:
           -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/repo \
-          -Dgpg.key.id=${{ env.GPG_KEYID }} \
-          -Dgpg.passphrase=${{ env.GPG_PASSPHRASE }} \
+          -Dgpg.key.id="${{ env.GPG_KEYID }}" \
+          -Dgpg.passphrase="${{ env.GPG_PASSPHRASE }}" \
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-bom-build.log
         
@@ -201,8 +201,8 @@ jobs:
           -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/repo \
-          -Dgpg.key.id=${{ env.GPG_KEYID }} \
-          -Dgpg.passphrase=${{ env.GPG_PASSPHRASE }} \
+          -Dgpg.key.id="${{ env.GPG_KEYID }}" \
+          -Dgpg.passphrase="${{ env.GPG_PASSPHRASE }}" \
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-obr-build.log
     
@@ -468,8 +468,8 @@ jobs:
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/javadocs/docker/repo \
           -Dmaven.javadoc.failOnError=false \
-          -Dgpg.key.id=${{ env.GPG_KEYID }} \
-          -Dgpg.passphrase=${{ env.GPG_PASSPHRASE }} \
+          -Dgpg.key.id="${{ env.GPG_KEYID }}" \
+          -Dgpg.passphrase="${{ env.GPG_PASSPHRASE }}" \
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
       
@@ -697,8 +697,8 @@ jobs:
           mvn -f pom.xml process-sources -X \
           -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
-          -Dgpg.key.id=${{ env.GPG_KEYID }} \
-          -Dgpg.passphrase=${{ env.GPG_PASSPHRASE }} \
+          -Dgpg.key.id="${{ env.GPG_KEYID }}" \
+          -Dgpg.passphrase="${{ env.GPG_PASSPHRASE }}" \
           dev.galasa:galasa-maven-plugin:${{inputs.galasa-version}}:obrembedded \
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -581,6 +581,12 @@ jobs:
           distribution: 'semeru'
           # cache: 'maven'
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Make secrets directory
         run : |
           mkdir /home/runner/work/secrets
@@ -737,18 +743,11 @@ jobs:
           tags: ${{ steps.metadata-obr-generic.outputs.tags }}
           labels: ${{ steps.metadata-obr-generic.outputs.labels }}
 
-      - name: Copy files from kubectl image for Galasa boot embedded images
-        run: |
-          mkdir -p /opt/k8s/bin
-          curl -L https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl -o /opt/k8s/bin/kubectl
-          chmod +x /opt/k8s/bin/kubectl
-          cp -vr /opt/k8s/bin/kubectl ${{ github.workspace }}/modules/obr/dockerfiles/trace-log4j.properties ${{ github.workspace }}/modules/obr/obr-generic/
-
       - name: Extract metadata for Galasa boot embedded image
         id: metadata-boot-embedded
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasa-boot-embedded-x86_64
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasa-boot-embedded
   
       - name: Build and push Galasa boot embedded image
         id: build-boot-embedded
@@ -756,6 +755,7 @@ jobs:
         with:
           context: modules/obr
           file: modules/obr/dockerfiles/dockerfile.bootembedded
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metadata-boot-embedded.outputs.tags }}
           labels: ${{ steps.metadata-boot-embedded.outputs.labels }}
@@ -768,7 +768,7 @@ jobs:
         id: metadata-ibm-boot-embedded
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasa-ibm-boot-embedded-x86_64
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasa-ibm-boot-embedded
   
       - name: Build and push Galasa IBM boot embedded image
         id: build-ibm-boot-embedded
@@ -776,13 +776,13 @@ jobs:
         with:
           context: modules/obr
           file: modules/obr/dockerfiles/dockerfile.ibmbootembedded
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metadata-ibm-boot-embedded.outputs.tags }}
           labels: ${{ steps.metadata-ibm-boot-embedded.outputs.labels }}
           build-args: |
             tag=${{ env.BRANCH }}
             dockerRepository=${{ env.REGISTRY }}
-            platform=x86_64
 
   trigger-next-workflows:
     # Skip this job for forks

--- a/.github/workflows/wrapping.yaml
+++ b/.github/workflows/wrapping.yaml
@@ -105,8 +105,8 @@ jobs:
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/wrapping/repo \
           -Dgalasa.jacocoEnabled=${{ inputs.jacoco_enabled }} \
           -Dgalasa.isRelease=${{ inputs.sign_artifacts }} \
-          -Dgpg.key.id=${{ env.GPG_KEYID }} \
-          -Dgpg.passphrase=${{ env.GPG_PASSPHRASE }} \
+          -Dgpg.key.id="${{ env.GPG_KEYID }}" \
+          -Dgpg.passphrase="${{ env.GPG_PASSPHRASE }}" \
           --batch-mode --errors --fail-at-end \
           --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
 

--- a/modules/obr/dockerfiles/dockerfile.bootembedded
+++ b/modules/obr/dockerfiles/dockerfile.bootembedded
@@ -2,10 +2,9 @@ ARG dockerRepository
 ARG tag
 ARG jdkImage
 
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ${jdkImage}
+FROM ${jdkImage}
 
 # Pre-defined arguments that Docker makes available for multi-platform builds
-ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/modules/obr/dockerfiles/dockerfile.bootembedded
+++ b/modules/obr/dockerfiles/dockerfile.bootembedded
@@ -2,7 +2,12 @@ ARG dockerRepository
 ARG tag
 ARG jdkImage
 
-FROM ${jdkImage}
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ${jdkImage}
+
+# Pre-defined arguments that Docker makes available for multi-platform builds
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
 RUN touch /var/run/docker.sock && \
     chmod 666 /var/run/docker.sock
@@ -11,7 +16,8 @@ RUN mkdir /galasa
 RUN useradd --home-dir /galasa galasa       && \
     chown -R galasa:galasa /galasa
 
-COPY obr-generic/kubectl /usr/bin/kubectl
+RUN curl -L https://dl.k8s.io/release/v1.22.0/bin/${TARGETOS}/${TARGETARCH}/kubectl -o /usr/bin/kubectl && \
+    chmod +x /usr/bin/kubectl
 
 WORKDIR /galasa
 
@@ -30,7 +36,7 @@ RUN mkdir /galasa/.galasa                          && \
     mkdir /galasa/load
 
 
-COPY obr-generic/trace-log4j.properties /galasa/
+COPY dockerfiles/trace-log4j.properties /galasa/
 
 VOLUME /galasa/.galasa
 VOLUME /galasa/load

--- a/modules/obr/dockerfiles/dockerfile.ibmbootembedded
+++ b/modules/obr/dockerfiles/dockerfile.ibmbootembedded
@@ -1,8 +1,7 @@
 ARG dockerRepository
 ARG tag
-ARG platform
 
-FROM ${dockerRepository}/galasa-dev/galasa-boot-embedded-${platform}:${tag}
+FROM ${dockerRepository}/galasa-dev/galasa-boot-embedded:${tag}
 
 USER root
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2117

## Changes
- Modified the OBR main build to build both linux/amd64 and linux/arm64 versions of the galasa-boot-embedded images (including the ibm-boot-embedded image)
  - Renamed the boot-embedded image from `galasa-boot-embedded-x86_64` to `galasa-boot-embedded` now that it is a multi-platform image
  - Moved the step to copy files into the boot-embedded image from the GH Actions workflow to the boot-embedded dockerfile
- Fixed an issue with running maven and passing in GPG passphrases that contain special characters (like `&`), which was causing script errors (added quotes around GPG_PASSPHRASE)