### PR TITLE
more flexible way of initialising the framework and customizing what gets set and what doesnt based on use it will be put to.

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiServerInitialisation.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiServerInitialisation.java
@@ -20,6 +20,7 @@ import org.osgi.framework.ServiceReference;
 
 import dev.galasa.framework.FileSystem;
 import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.GalasaFactory;
 import dev.galasa.framework.IFileSystem;
 import dev.galasa.framework.spi.Environment;
 import dev.galasa.framework.spi.FrameworkException;
@@ -55,7 +56,7 @@ public class ApiServerInitialisation extends FrameworkInitialisation implements 
         IFileSystem fileSystem, 
         Environment env
     ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
-        super(bootstrapProperties, overrideProperties, false, initLogger, bundleContext, fileSystem, env);
+        super(bootstrapProperties, overrideProperties, initLogger, bundleContext, fileSystem, env, GalasaFactory.getInstance().newDefaultInitStrategy());
 
         if (initLogger == null) {
             logger = LogFactory.getLog(this.getClass());

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
 import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.GalasaFactory;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
@@ -81,7 +82,7 @@ public class ResourceManagement implements IResourceManagement {
             // *** Initialise the framework services
             FrameworkInitialisation frameworkInitialisation = null;
             try {
-                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+                frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties, GalasaFactory.getInstance().newResourceManagerInitStrategy());
             } catch (Exception e) {
                 throw new FrameworkException("Unable to initialise the Framework Services", e);
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -13,10 +13,8 @@ import javax.validation.constraints.NotNull;
 import org.apache.commons.logging.*;
 import org.osgi.framework.*;
 
-import dev.galasa.framework.beans.Property;
 import dev.galasa.framework.spi.*;
 import dev.galasa.framework.spi.creds.*;
-import dev.galasa.framework.spi.utils.GalasaGson;
 
 public class FrameworkInitialisation implements IFrameworkInitialisation {
 
@@ -36,50 +34,79 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
     private IFileSystem fileSystem ;
 
     private String galasaHome;
-
-    private static final GalasaGson gson = new GalasaGson();
     
     public FrameworkInitialisation(
         Properties bootstrapProperties, 
         Properties overrideProperties
     ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
-        this(bootstrapProperties, overrideProperties, false, null, 
-        getBundleContext() , new FileSystem() , new SystemEnvironment());
+        this(bootstrapProperties, overrideProperties, null, 
+        getBundleContext() , new FileSystem() , new SystemEnvironment(),
+        GalasaFactory.getInstance().newDefaultInitStrategy());
     }
 
+
+    // public FrameworkInitialisation(
+    //     Properties bootstrapProperties, 
+    //     Properties overrideProperties, 
+    //     boolean isTestRun
+    // ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
+    //     this(bootstrapProperties, overrideProperties, null, 
+    //         getBundleContext() , new FileSystem(), new SystemEnvironment(),
+    //         isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
+    //     );
+    // }
 
     public FrameworkInitialisation(
         Properties bootstrapProperties, 
         Properties overrideProperties, 
-        boolean testrun
+        IFrameworkInitialisationStrategy initStrategy
     ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
-        this(bootstrapProperties, overrideProperties, testrun, null, 
-        getBundleContext() , new FileSystem(), new SystemEnvironment());
+        this(bootstrapProperties, overrideProperties, null, 
+            getBundleContext() , new FileSystem(), new SystemEnvironment(),
+            initStrategy
+        );
     }
 
 
-    public FrameworkInitialisation(
-        Properties bootstrapProperties, 
-        Properties overrideProperties,
-        boolean testrun,
-        Log initLogger
-    ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
-        this(bootstrapProperties, overrideProperties, testrun, initLogger, 
-        getBundleContext(), new FileSystem(), new SystemEnvironment());
-    }
+    // public FrameworkInitialisation(
+    //     Properties bootstrapProperties, 
+    //     Properties overrideProperties,
+    //     boolean isTestRun,
+    //     Log initLogger
+    // ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
+    //     this(bootstrapProperties, overrideProperties, initLogger, 
+    //         getBundleContext(), new FileSystem(), new SystemEnvironment(),
+    //         isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
+    //     );
+    // }
 
+    // public FrameworkInitialisation(
+    //     Properties bootstrapProperties, 
+    //     Properties overrideProperties, 
+    //     boolean isTestRun,
+    //     Log initLogger,
+    //     BundleContext bundleContext , 
+    //     IFileSystem fileSystem,
+    //     Environment env
+    // ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
+    //     this(bootstrapProperties, overrideProperties, initLogger, bundleContext, fileSystem, env, 
+    //         isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
+    //     );
+    // }
+    
     public FrameworkInitialisation(
         Properties bootstrapProperties, 
         Properties overrideProperties, 
-        boolean testrun,
         Log initLogger,
         BundleContext bundleContext , 
         IFileSystem fileSystem,
-        Environment env
+        Environment env,
+        IFrameworkInitialisationStrategy initStrategy
     ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
 
         this.fileSystem = fileSystem;
 
+        // Allows unit tests to inject the logger.
         if (initLogger == null) {
             logger = LogFactory.getLog(this.getClass());
         } else {
@@ -104,10 +131,8 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
 
         this.framework.setFrameworkProperties(overrideProperties);
 
-        // *** If this is a test run, then we need to install the log4j capture routine
-        if (testrun) {
-            this.framework.installLogCapture();
-        }
+        // The initialisation strategy may wish to install Log capture at this point ?
+        initStrategy.startLoggingCapture(framework);
 
         this.uriConfigurationPropertyStore = locateConfigurationPropertyStore(
             this.logger, overrideProperties, this.fileSystem);
@@ -117,14 +142,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
             this.logger, overrideProperties, this.cpsFramework, this.fileSystem);
         this.dssFramework = initialiseDynamicStatusStore(logger,bundleContext);
 
-        if (testrun) {
-            // *** Is this a test run,
-            // *** Then we need to make sure we have a runname for the RAS. If there isnt
-            // one, we need to allocate one
-            // *** Need the DSS for this as the latest run number number is stored in there
-            String runName = locateRunName(this.cpsFramework);
-            this.framework.setTestRunName(runName);
-        }
+        initStrategy.setTestRunName(framework, this.cpsFramework);
 
         this.uriResultArchiveStores = createUriResultArchiveStores(overrideProperties, this.cpsFramework);
         logger.debug("Result Archive Stores are " + this.uriResultArchiveStores.toString());
@@ -144,31 +162,9 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
             logger.info("The Framework does not think it is initialised, but we didn't get any errors");
         }
 
-        // *** If this is a test run, add the overrides from the run dss properties to
-        // these overrides
-        if (testrun) {
-            loadOverridePropertiesFromDss(overrideProperties);
-        }
+        overrideProperties = initStrategy.applyOverrides(framework, this.dssFramework, overrideProperties);
+        
     }
-
-    private void loadOverridePropertiesFromDss(Properties overrideProperties) throws DynamicStatusStoreException {
-        // The overrides DSS property contains a JSON array of overrides in the form:
-        // dss.framework.run.X.overrides=[{ "key1": "value1" }, { "key2", "value2" }]
-        String runOverridesProp = "run." + framework.getTestRunName() + ".overrides";
-        String runOverrides = this.dssFramework.get(runOverridesProp);
-        if (runOverrides != null && !runOverrides.isBlank()) {
-            Property[] properties = gson.fromJson(runOverrides, Property[].class);
-            for (Property override : properties) {
-                String key = override.getKey();
-                String value = override.getValue();
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Setting run override " + key + "=" + value);
-                }
-                overrideProperties.put(key, value);
-            }
-        }
-    }
-
 
     private static BundleContext getBundleContext() {
         return FrameworkUtil.getBundle(FrameworkInitialisation.class).getBundleContext();
@@ -226,7 +222,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
      * @param input
      * @return The stripped (or unaltered) string.
      */
-    String stripLeadingAndTrailingQuotes(String input ) {
+    private String stripLeadingAndTrailingQuotes(String input ) {
         String output = input ;
         if (output.startsWith("\"")) {
             output = output.replaceFirst("\"", "");
@@ -235,39 +231,6 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
             output = output.substring(0,output.length()-1);
         }
         return output;
-    }
-
-    
-
-    /**
-     * Submit the run and return the run name.
-     * 
-     * @param runBundleClass
-     * @param language
-     * @return The name of the run created.
-     * @throws FrameworkException
-     */
-    protected String submitRun(String runBundleClass, String language) throws FrameworkException {
-        IRun run = null;
-        IFrameworkRuns frameworkRuns = this.framework.getFrameworkRuns();
-
-        switch(language) {
-            case "java": 
-                String split[] = runBundleClass.split("/");
-                String bundle = split[0];
-                String test = split[1];
-                run = frameworkRuns.submitRun("local", null, bundle, test, null, null, null, null, true, false, null, null, null, language);
-                break;
-            case "gherkin":
-                run = frameworkRuns.submitRun("local", null, null, runBundleClass, null, null, null, null, true, false, null, null, null, language);
-                break;
-            default:
-                throw new FrameworkException("Unknown language to create run");
-        }
-
-        logger.info("Allocated Run Name " + run.getName() + " to this run");
-
-        return run.getName();
     }
 
     /**
@@ -508,25 +471,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         }
     }
 
-    // Find the run name of the test run, if it's not a set property 
-    // ("framework.run.name")
-    // then create a run name by submitting the run, based on language, properties.
-    private String locateRunName(IConfigurationPropertyStoreService cpsFramework) throws FrameworkException {
-        //*** Ensure the shared environment = true is set for Shenv runs
-        String runName = AbstractManager.nulled(cpsFramework.getProperty("run", "name"));
-        if (runName == null) {
-            String testName = AbstractManager.nulled(cpsFramework.getProperty("run", "testbundleclass"));
-            String testLanguage  = "java";
-            if (testName == null) {
-                testName = AbstractManager.nulled(cpsFramework.getProperty("run", "gherkintest"));
-                testLanguage = "gherkin";
-            }
-            logger.info("Submitting test "+testName);
-            runName = submitRun(testName, testLanguage);
-        }
-        logger.info("Run name is "+runName);
-        return runName;
-    }
+
 
     private void processRASlocationProperty(String rasProperty , List<URI> uriResultArchiveStores) throws URISyntaxException {
         if((rasProperty != null) && !rasProperty.isEmpty()){

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -45,16 +45,20 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
     }
 
 
-    // public FrameworkInitialisation(
-    //     Properties bootstrapProperties, 
-    //     Properties overrideProperties, 
-    //     boolean isTestRun
-    // ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
-    //     this(bootstrapProperties, overrideProperties, null, 
-    //         getBundleContext() , new FileSystem(), new SystemEnvironment(),
-    //         isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
-    //     );
-    // }
+    /**
+     * @deprecated Use one of the other constructors.
+     */
+    @Deprecated(since = "0.40.0", forRemoval = true)
+    public FrameworkInitialisation(
+        Properties bootstrapProperties, 
+        Properties overrideProperties, 
+        boolean isTestRun
+    ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
+        this(bootstrapProperties, overrideProperties, null, 
+            getBundleContext() , new FileSystem(), new SystemEnvironment(),
+            isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
+        );
+    }
 
     public FrameworkInitialisation(
         Properties bootstrapProperties, 
@@ -68,32 +72,54 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
     }
 
 
-    // public FrameworkInitialisation(
-    //     Properties bootstrapProperties, 
-    //     Properties overrideProperties,
-    //     boolean isTestRun,
-    //     Log initLogger
-    // ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
-    //     this(bootstrapProperties, overrideProperties, initLogger, 
-    //         getBundleContext(), new FileSystem(), new SystemEnvironment(),
-    //         isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
-    //     );
-    // }
+    /**
+     * @deprecated Use one of the other constructors.
+     */
+    @Deprecated(since = "0.40.0", forRemoval = true)
+    public FrameworkInitialisation(
+        Properties bootstrapProperties, 
+        Properties overrideProperties,
+        boolean isTestRun,
+        Log initLogger
+    ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
+        this(bootstrapProperties, overrideProperties, initLogger, 
+            getBundleContext(), new FileSystem(), new SystemEnvironment(),
+            isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
+        );
+    }
 
-    // public FrameworkInitialisation(
-    //     Properties bootstrapProperties, 
-    //     Properties overrideProperties, 
-    //     boolean isTestRun,
-    //     Log initLogger,
-    //     BundleContext bundleContext , 
-    //     IFileSystem fileSystem,
-    //     Environment env
-    // ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
-    //     this(bootstrapProperties, overrideProperties, initLogger, bundleContext, fileSystem, env, 
-    //         isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
-    //     );
-    // }
+    /**
+     * @deprecated Use one of the other constructors.
+     */
+    @Deprecated(since = "0.40.0", forRemoval = true)
+    public FrameworkInitialisation(
+        Properties bootstrapProperties, 
+        Properties overrideProperties, 
+        boolean isTestRun,
+        Log initLogger,
+        BundleContext bundleContext , 
+        IFileSystem fileSystem,
+        Environment env
+    ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
+        this(bootstrapProperties, overrideProperties, initLogger, bundleContext, fileSystem, env, 
+            isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
+        );
+    }
     
+    /**
+     * 
+     * @param bootstrapProperties
+     * @param overrideProperties
+     * @param initLogger
+     * @param bundleContext
+     * @param fileSystem
+     * @param env
+     * @param initStrategy One of the initialisation strategies, depending on what you want to use the Framework for.
+     * See `GalasaFactory.getInstance().newDefaultInitStrategy()` or one of the other `newXXXStrategy` methods.
+     * @throws URISyntaxException
+     * @throws InvalidSyntaxException
+     * @throws FrameworkException
+     */
     public FrameworkInitialisation(
         Properties bootstrapProperties, 
         Properties overrideProperties, 
@@ -643,7 +669,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
     }  
 
 
-    void initialiseResultsArchiveStore(Log logger, BundleContext bundleContext) throws FrameworkException, InvalidSyntaxException {
+    private void initialiseResultsArchiveStore(Log logger, BundleContext bundleContext) throws FrameworkException, InvalidSyntaxException {
         this.logger.trace("Searching for RAS providers");
         final ServiceReference<?>[] rasServiceReference = bundleContext
                 .getAllServiceReferences(IResultArchiveStoreRegistration.class.getName(), null);
@@ -673,7 +699,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
     }
 
 
-    void initialiseCredentialsStore(
+    private void initialiseCredentialsStore(
         Log logger, 
         BundleContext bundleContext 
     ) throws FrameworkException, InvalidSyntaxException {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GalasaFactory.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GalasaFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+
+import dev.galasa.framework.internal.init.DefaultInitStrategy;
+import dev.galasa.framework.internal.init.ResourceManagerInitStrategy;
+import dev.galasa.framework.internal.init.TestRunInitStrategy;
+import dev.galasa.framework.spi.Environment;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IFrameworkInitialisation;
+
+
+public class GalasaFactory implements IGalasaFactory {
+
+    private static IGalasaFactory instance ;
+    private static final String lock = "aConcurrencyLock";
+
+    public static IGalasaFactory getInstance() {
+        IGalasaFactory instanceToReturn = instance;
+        if (instanceToReturn==null) {
+            synchronized(lock) {   
+                if (instance== null) {
+                    instance = new GalasaFactory();
+                }
+                instanceToReturn = instance;
+            }
+        }
+        return instanceToReturn ;
+    }
+
+    protected static void setInstance(IGalasaFactory newInstance) {
+        instance = newInstance ;
+    }
+    
+    public IFrameworkInitialisationStrategy newTestRunInitStrategy() {
+        return new TestRunInitStrategy();
+    }
+
+    public IFrameworkInitialisationStrategy newResourceManagerInitStrategy() {
+        return new ResourceManagerInitStrategy();
+    }
+
+    public IFrameworkInitialisationStrategy newDefaultInitStrategy() {
+        return new DefaultInitStrategy();
+    }
+
+    public IFrameworkInitialisation newFrameworkInitialisation(
+        Properties bootstrapProperties, 
+        Properties overrideProperties, 
+        Log initLogger,
+        BundleContext bundleContext , 
+        IFileSystem fileSystem,
+        Environment env,
+        IFrameworkInitialisationStrategy initStrategy
+    ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
+        IFrameworkInitialisation framworkInit = new FrameworkInitialisation(
+            bootstrapProperties, 
+            overrideProperties, 
+            initLogger,
+            bundleContext , 
+            fileSystem,
+            env,
+            initStrategy
+        );
+        return framworkInit;
+    }
+
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IFrameworkInitialisationStrategy.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IFrameworkInitialisationStrategy.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.IFramework;
+
+import java.util.Properties;
+
+/**
+ * Controls how a Framework is initialised, based on the type of server we want to stand up.
+ */
+public interface IFrameworkInitialisationStrategy {
+
+    void setTestRunName(Framework framework, IConfigurationPropertyStoreService cps) throws FrameworkException;
+    
+    void startLoggingCapture(Framework framework) throws FrameworkException;
+        
+    Properties applyOverrides(IFramework framework, IDynamicStatusStoreService dss, Properties overrideProperties) throws DynamicStatusStoreException ;
+
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IGalasaFactory.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IGalasaFactory.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+
+/**
+ * Implementations allow the caller to instantiate internal instances of interfaces without having access to the internals.
+ */
+public interface IGalasaFactory {
+    
+    public IFrameworkInitialisationStrategy newTestRunInitStrategy();
+
+    public IFrameworkInitialisationStrategy newResourceManagerInitStrategy();
+
+    public IFrameworkInitialisationStrategy newDefaultInitStrategy();
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/DefaultInitStrategy.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/DefaultInitStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.init;
+
+import java.util.Properties;
+
+import dev.galasa.framework.Framework;
+import dev.galasa.framework.IFrameworkInitialisationStrategy;
+import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.IFramework;
+
+public class DefaultInitStrategy implements IFrameworkInitialisationStrategy {
+
+    @Override
+    public void setTestRunName(Framework framework, IConfigurationPropertyStoreService cps) throws FrameworkException {
+        // Do nothing by default.
+    }
+
+    @Override
+    public void startLoggingCapture(Framework framework) throws FrameworkException {
+        // Do nothing by default.
+
+    }
+
+    @Override
+    public Properties applyOverrides(IFramework framework, IDynamicStatusStoreService dss,
+            Properties overrideProperties) throws DynamicStatusStoreException {
+        // Do nothing by default.
+        return overrideProperties;
+    }
+
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/ResourceManagerInitStrategy.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/ResourceManagerInitStrategy.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.init;
+
+import dev.galasa.framework.Framework;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+
+public class ResourceManagerInitStrategy extends DefaultInitStrategy {
+
+    @Override
+    public void setTestRunName(Framework framework, IConfigurationPropertyStoreService cps) throws FrameworkException {
+        framework.setTestRunName("resourceManagement");
+    }
+
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/TestRunInitStrategy.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/TestRunInitStrategy.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.init;
+
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import dev.galasa.framework.Framework;
+import dev.galasa.framework.IFrameworkInitialisationStrategy;
+import dev.galasa.framework.beans.Property;
+import dev.galasa.framework.spi.AbstractManager;
+import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.IFramework;
+import dev.galasa.framework.spi.IFrameworkRuns;
+import dev.galasa.framework.spi.IRun;
+import dev.galasa.framework.spi.utils.GalasaGson;
+
+public class TestRunInitStrategy implements IFrameworkInitialisationStrategy {
+
+    private final static Log logger = LogFactory.getLog(Framework.class);
+    private static final GalasaGson gson = new GalasaGson();
+
+    @Override
+    public void startLoggingCapture(Framework framework) {
+        // Each test run needs to install the log4j capture routine
+        framework.installLogCapture();
+    }
+
+    @Override
+    public void setTestRunName(Framework framework, IConfigurationPropertyStoreService cps) throws FrameworkException {
+        // We need to make sure we have a runname for the RAS. If there isn't one, we need to allocate one
+        // Need the DSS for this as the latest run number number is stored in there
+        String runName = locateRunName(framework,cps);
+        framework.setTestRunName(runName);
+    }
+
+    // Find the run name of the test run, if it's not a set property 
+    // ("framework.run.name")
+    // then create a run name by submitting the run, based on language, properties.
+    private String locateRunName(IFramework framework ,IConfigurationPropertyStoreService cps) throws FrameworkException {
+        //*** Ensure the shared environment = true is set for Shenv runs
+        String runName = AbstractManager.nulled(cps.getProperty("run", "name"));
+        if (runName == null) {
+            String testName = AbstractManager.nulled(cps.getProperty("run", "testbundleclass"));
+            String testLanguage  = "java";
+            if (testName == null) {
+                testName = AbstractManager.nulled(cps.getProperty("run", "gherkintest"));
+                testLanguage = "gherkin";
+            }
+            logger.info("Submitting test "+testName);
+            runName = submitRun(framework, testName, testLanguage);
+        }
+        logger.info("Run name is "+runName);
+        return runName;
+    }
+
+        /**
+     * Submit the run and return the run name.
+     * 
+     * @param runBundleClass
+     * @param language
+     * @return The name of the run created.
+     * @throws FrameworkException
+     */
+    protected String submitRun(IFramework framework, String runBundleClass, String language) throws FrameworkException {
+        IRun run = null;
+        IFrameworkRuns frameworkRuns = framework.getFrameworkRuns();
+
+        switch(language) {
+            case "java": 
+                String split[] = runBundleClass.split("/");
+                String bundle = split[0];
+                String test = split[1];
+                run = frameworkRuns.submitRun("local", null, bundle, test, null, null, null, null, true, false, null, null, null, language);
+                break;
+            case "gherkin":
+                run = frameworkRuns.submitRun("local", null, null, runBundleClass, null, null, null, null, true, false, null, null, null, language);
+                break;
+            default:
+                throw new FrameworkException("Unknown language to create run");
+        }
+
+        logger.info("Allocated Run Name " + run.getName() + " to this run");
+
+        return run.getName();
+    }
+
+    @Override
+    public Properties applyOverrides(IFramework framework, IDynamicStatusStoreService dss, Properties overrideProperties) throws DynamicStatusStoreException {
+        // If this is a test run, add the overrides from the run dss properties to these overrides
+        overrideProperties = loadOverridePropertiesFromDss(framework, dss, overrideProperties);
+        return overrideProperties ;
+    }
+    
+    private Properties loadOverridePropertiesFromDss(IFramework framework, IDynamicStatusStoreService dss, Properties overrideProperties) throws DynamicStatusStoreException {
+        // The overrides DSS property contains a JSON array of overrides in the form:
+        // dss.framework.run.X.overrides=[{ "key1": "value1" }, { "key2", "value2" }]
+        String runOverridesProp = "run." + framework.getTestRunName() + ".overrides";
+        String runOverrides = dss.get(runOverridesProp);
+        if (runOverrides != null && !runOverrides.isBlank()) {
+            Property[] properties = gson.fromJson(runOverrides, Property[].class);
+            for (Property override : properties) {
+                String key = override.getKey();
+                String value = override.getValue();
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Setting run override " + key + "=" + value);
+                }
+                overrideProperties.put(key, value);
+            }
+        }
+        return overrideProperties;
+    }
+
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
@@ -9,6 +9,7 @@ import java.util.Properties;
 
 import dev.galasa.framework.FileSystem;
 import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.GalasaFactory;
 import dev.galasa.framework.IAnnotationExtractor;
 import dev.galasa.framework.IBundleManager;
 import dev.galasa.framework.IFileSystem;
@@ -34,8 +35,9 @@ public class TestRunnerDataProvider implements ITestRunnerDataProvider {
         
         FrameworkInitialisation frameworkInitialisation = null;
         try {
-            boolean isThisATestRun = true ;
-            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties, isThisATestRun);
+            frameworkInitialisation = new FrameworkInitialisation( 
+                bootstrapProperties, overrideProperties, GalasaFactory.getInstance().newTestRunInitStrategy() 
+            );
             framework = frameworkInitialisation.getShutableFramework();
             cps = framework.getConfigurationPropertyService("framework");
             dss = framework.getDynamicStatusStoreService("framework");

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/init/TestDefaultInitStrategy.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/init/TestDefaultInitStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.init;
+
+import org.junit.Test;
+
+import dev.galasa.framework.GalasaFactory;
+import dev.galasa.framework.IFrameworkInitialisationStrategy;
+
+
+public class TestDefaultInitStrategy {
+
+    @Test
+    public void testCanCreateStrategy() {
+        GalasaFactory.getInstance().newDefaultInitStrategy();
+    }
+
+    @Test
+    public void testCanSetTestRunNameWithNulls() throws Exception {
+        IFrameworkInitialisationStrategy strategy = GalasaFactory.getInstance().newDefaultInitStrategy();
+        strategy.setTestRunName(null, null);
+    }
+    
+    @Test
+    public void testCanStartLoggingCaptureWithNulls() throws Exception {
+        IFrameworkInitialisationStrategy strategy = GalasaFactory.getInstance().newDefaultInitStrategy();
+        strategy.startLoggingCapture(null);
+    }
+    @Test
+    public void testCanApplyOverridesWithNulls() throws Exception {
+        IFrameworkInitialisationStrategy strategy = GalasaFactory.getInstance().newDefaultInitStrategy();
+        strategy.applyOverrides(null, null, null);
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/init/TestResourceManagerInitStrategy.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/init/TestResourceManagerInitStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.init;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+    
+import dev.galasa.framework.GalasaFactory;
+import dev.galasa.framework.IFrameworkInitialisationStrategy;
+import dev.galasa.framework.mocks.MockFramework;
+
+
+public class TestResourceManagerInitStrategy {
+
+    @Test
+    public void testCanCreateStrategy() {
+        GalasaFactory.getInstance().newResourceManagerInitStrategy();
+    }
+
+    @Test
+    public void testCanSetTestRunAsresourceManagement() throws Exception {
+        // Given...
+        IFrameworkInitialisationStrategy strategy = GalasaFactory.getInstance().newResourceManagerInitStrategy();
+        MockFramework framework = new MockFramework();
+
+        // When...
+        strategy.setTestRunName(framework, null);
+
+        // Then...
+        String nameGotBack = framework.getTestRunName();
+        assertThat(nameGotBack).isEqualTo("resourceManagement");
+    }
+    
+    @Test
+    public void testCanStartLoggingCaptureWithNulls() throws Exception {
+        IFrameworkInitialisationStrategy strategy = GalasaFactory.getInstance().newResourceManagerInitStrategy();
+        strategy.startLoggingCapture(null);
+    }
+    @Test
+    public void testCanApplyOverridesWithNulls() throws Exception {
+        IFrameworkInitialisationStrategy strategy = GalasaFactory.getInstance().newResourceManagerInitStrategy();
+        strategy.applyOverrides(null, null, null);
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/init/TestTestRunInitStrategy.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/init/TestTestRunInitStrategy.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.init;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Test;
+    
+import dev.galasa.framework.GalasaFactory;
+import dev.galasa.framework.IFrameworkInitialisationStrategy;
+import dev.galasa.framework.mocks.MockCPSStore;
+import dev.galasa.framework.mocks.MockDSSStore;
+import dev.galasa.framework.mocks.MockFramework;
+
+
+public class TestTestRunInitStrategy {
+
+    @Test
+    public void testCanCreateStrategy() {
+        GalasaFactory.getInstance().newTestRunInitStrategy();
+    }
+
+    @Test
+    public void testCanSetTestRunAsresourceManagementRunNameGotFromCPS() throws Exception {
+        // Given...
+        IFrameworkInitialisationStrategy strategy = GalasaFactory.getInstance().newTestRunInitStrategy();
+        MockFramework framework = new MockFramework();
+
+        Map<String,String> properties = new HashMap<String,String>();
+        properties.put("run.name","myRunName");
+        MockCPSStore mockCPS = new MockCPSStore(properties);
+
+        // When...
+        strategy.setTestRunName(framework, mockCPS);
+
+        // Then...
+        String nameGotBack = framework.getTestRunName();
+        assertThat(nameGotBack).isEqualTo("myRunName");
+    }
+    
+    @Test
+    public void testCanStartLoggingCaptureWithNulls() throws Exception {
+        MockFramework framework = new MockFramework();
+
+        IFrameworkInitialisationStrategy strategy = GalasaFactory.getInstance().newTestRunInitStrategy();
+        strategy.startLoggingCapture(framework);
+        assertThat(framework.isLogCaptured).isTrue();
+    }
+    @Test
+    public void testCanApplyOverrides() throws Exception {
+        IFrameworkInitialisationStrategy strategy = GalasaFactory.getInstance().newTestRunInitStrategy();
+
+
+        MockFramework framework = new MockFramework();
+
+        // Set up the test run name.
+        Map<String,String> cpsProperties = new HashMap<String,String>();
+        cpsProperties.put("run.name","myRunName");
+        MockCPSStore mockCPS = new MockCPSStore(cpsProperties);
+        framework.setMockCps(mockCPS);
+        framework.setTestRunName("myRunName");
+
+        // Set up the dss with a few override values.
+        Map<String,String> dssProperties = new HashMap<String,String>();
+        String overridesJson = "[ { \"key\" :\"prop1\" , \"value\" : \"overrideProp1Value\" } , { \"key\" : \"prop2\", \"value\": \"overrideProp2Value\" }]";
+        dssProperties.put("run.myRunName.overrides",overridesJson);
+        MockDSSStore dss = new MockDSSStore(dssProperties);
+        
+        // Set up some properties which can be over-ridden... or not.
+        Properties propsIn = new Properties();
+        propsIn.setProperty("prop1", "originalProp1Value");
+        propsIn.setProperty("prop3", "originalProp3Value");
+
+        // When...
+        Properties propsOut = strategy.applyOverrides(framework, dss, propsIn);
+
+        // Then...
+        assertThat(propsOut.getProperty("prop1")).as("Expected the original property to be overridden").isEqualTo("overrideProp1Value");
+        assertThat(propsOut.getProperty("prop2")).as("Expected the override to be visible as there was no original value").isEqualTo("overrideProp2Value");
+        assertThat(propsOut.getProperty("prop3")).as("Expected the original property to show through as it wasn't overridden").isEqualTo("originalProp3Value");
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/TestFrameworkInitialisation.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/TestFrameworkInitialisation.java
@@ -95,7 +95,7 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
         // Given...
         Properties bootstrapProperties = bootstrapProps;
         Properties overrideProperties = new Properties();
-        boolean isTestrun = true ;
+        boolean isTestRun = true ;
         Log logger = new MockLog();
 
         // A fake OSGi service registry...
@@ -131,11 +131,12 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
         FrameworkInitialisation frameworkInitUnderTest = new FrameworkInitialisation( 
             bootstrapProperties,  
             overrideProperties, 
-            isTestrun,
             logger,
             bundleContext,
             mockFileSystem,
-            mockEnv);
+            mockEnv,
+            isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
+        );
 
         // Then...
         assertThat(mockFramework.getConfidentialTextService()).isEqualTo(mockConfidentialTextStore);
@@ -160,7 +161,7 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
         // Given...
         Properties bootstrapProperties = new Properties();
         Properties overrideProperties = new Properties();
-        boolean isTestrun = true ;
+        boolean isTestRun = true ;
         Log logger = new MockLog();
         MockEnvironment mockEnv = new MockEnvironment();
 
@@ -177,11 +178,12 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
             new FrameworkInitialisation( 
                 bootstrapProperties,  
                 overrideProperties, 
-                isTestrun,
                 logger, 
                 bundleContext,
                 mockFileSystem,
-                mockEnv);
+                mockEnv,
+                isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
+            );
             fail("There is no CPS service configured on purpose, there should have been an error thrown!");
         } catch( Exception ex ) {
             assertThat(ex)
@@ -199,7 +201,7 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
         // Given...
         Properties bootstrapProperties = new Properties();
         Properties overrideProperties = new Properties();
-        boolean isTestrun = true ;
+        boolean isTestRun = true ;
         Log logger = new MockLog();
         MockEnvironment mockEnv = new MockEnvironment();
         mockEnv.setProperty("user.home","/home");
@@ -224,11 +226,12 @@ public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase
             frameworkInitUnderTest = new FrameworkInitialisation( 
                 bootstrapProperties,  
                 overrideProperties, 
-                isTestrun,
                 logger, 
                 bundleContext,
                 mockFileSystem,
-                mockEnv);
+                mockEnv,
+                isTestRun? GalasaFactory.getInstance().newTestRunInitStrategy(): GalasaFactory.getInstance().newDefaultInitStrategy()
+            );
             fail("There is no CPS service configured on purpose, there should have been an error thrown!");
         } catch( Exception ex ) {
             assertThat(ex)

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFramework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFramework.java
@@ -10,6 +10,7 @@ import dev.galasa.framework.internal.cps.FpfConfigurationPropertyStore;
 import dev.galasa.framework.internal.cps.FrameworkConfigurationPropertyService;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
 
@@ -25,6 +26,10 @@ public class MockFramework extends Framework {
 
     private MockDSSStore mockDss;
     private MockCPSStore mockCps;
+
+    private String runName ;
+
+    public boolean isLogCaptured = false ;
 
     public MockFramework() {
         super();
@@ -72,5 +77,20 @@ public class MockFramework extends Framework {
 
     public void setMockDss(MockDSSStore mockDss) {
         this.mockDss = mockDss;
+    }
+
+    @Override
+    public void setTestRunName(String runName) throws FrameworkException {
+        this.runName = runName;
+    }
+
+    @Override
+    public String getTestRunName() {
+        return this.runName ;
+    }
+    
+    @Override
+    public void installLogCapture() {
+        this.isLogCaptured = true;
     }
 }

--- a/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -82,7 +82,6 @@ public class Launcher {
     private String                  testClassName;
     private String                  runName;
     private String                  gherkinName;
-    private String                  filePath;
 
     private String                  galasaHome;
 
@@ -91,13 +90,13 @@ public class Launcher {
     private Properties              bootstrapProperties;
     private Properties              overridesProperties;
 
-    private boolean                 testRun;
-    private boolean                 resourceManagement;
-    private boolean                 k8sController;
-    private boolean                 dockerController;
-    private boolean                 metricsServer;
-    private boolean                 api;
-    private boolean                 dryRun;
+    private boolean                 isTestRun;
+    private boolean                 isResourceManagement;
+    private boolean                 isK8sController;
+    private boolean                 isDockerController;
+    private boolean                 isMetricsServer;
+    private boolean                 isApiServer;
+    private boolean                 isDryRun;
     private boolean                 setupEco;
     private boolean                 validateEco;
 
@@ -155,7 +154,7 @@ public class Launcher {
             // Build the Framework
             buildFramework();
 
-            if (testRun) {
+            if (isTestRun) {
                 if (testBundleName != null && testClassName != null) {
                     // Run test class
                     logger.debug("Test Bundle: " + testBundleName);
@@ -170,19 +169,19 @@ public class Launcher {
                 }
 
                 felixFramework.runTest(bootstrapProperties, overridesProperties);
-            } else if (resourceManagement) {
+            } else if (isResourceManagement) {
                 logger.debug("Resource Management");
                 felixFramework.runResourceManagement(bootstrapProperties, overridesProperties, bundles, metrics, health);
-            } else if (k8sController) {
+            } else if (isK8sController) {
                 logger.debug("Kubernetes Controller");
                 felixFramework.runK8sController(bootstrapProperties, overridesProperties, bundles, metrics, health);
-            } else if (dockerController) {
+            } else if (isDockerController) {
                 logger.debug("Docker Controller");
                 felixFramework.runDockerController(bootstrapProperties, overridesProperties, bundles, metrics, health);
-            } else if (metricsServer) {
+            } else if (isMetricsServer) {
                 logger.debug("Metrics Server");
                 felixFramework.runMetricsServer(bootstrapProperties, overridesProperties, bundles, metrics, health);
-            } else if (api) {
+            } else if (isApiServer) {
                 logger.debug("Web API Server");
                 felixFramework.runWebApiServer(bootstrapProperties, overridesProperties, bundles, metrics, health);
             } else if (setupEco) {
@@ -298,17 +297,17 @@ public class Launcher {
         checkForLocalMaven(commandLine);
         checkForRemoteMaven(commandLine);
 
-        testRun = commandLine.hasOption(TEST_OPTION) || commandLine.hasOption(RUN_OPTION) || commandLine.hasOption(GHERKIN_OPTION);
-        resourceManagement = commandLine.hasOption(RESOURCEMANAGEMENT_OPTION);
-        k8sController = commandLine.hasOption(K8SCONTROLLER_OPTION);
-        dockerController = commandLine.hasOption(DOCKERCONTROLLER_OPTION);
-        metricsServer = commandLine.hasOption(METRICSERVER_OPTION);
-        api = commandLine.hasOption(API_OPTION);
-        dryRun = commandLine.hasOption(DRY_RUN_OPTION);
+        isTestRun = commandLine.hasOption(TEST_OPTION) || commandLine.hasOption(RUN_OPTION) || commandLine.hasOption(GHERKIN_OPTION);
+        isResourceManagement = commandLine.hasOption(RESOURCEMANAGEMENT_OPTION);
+        isK8sController = commandLine.hasOption(K8SCONTROLLER_OPTION);
+        isDockerController = commandLine.hasOption(DOCKERCONTROLLER_OPTION);
+        isMetricsServer = commandLine.hasOption(METRICSERVER_OPTION);
+        isApiServer = commandLine.hasOption(API_OPTION);
+        isDryRun = commandLine.hasOption(DRY_RUN_OPTION);
         setupEco = commandLine.hasOption(SETUPECO_OPTION);
         validateEco = commandLine.hasOption(VALIDATEECO_OPTION);
 
-        if (testRun) {
+        if (isTestRun) {
             runName = commandLine.getOptionValue(RUN_OPTION);
             testName = commandLine.getOptionValue(TEST_OPTION);
             gherkinName = commandLine.getOptionValue(GHERKIN_OPTION);
@@ -334,23 +333,23 @@ public class Launcher {
             return;
         }
 
-        if (resourceManagement) {
+        if (isResourceManagement) {
             return;
         }
 
-        if (k8sController) {
+        if (isK8sController) {
             return;
         }
 
-        if (dockerController) {
+        if (isDockerController) {
             return;
         }
 
-        if (metricsServer) {
+        if (isMetricsServer) {
             return;
         }
         
-        if (api) {
+        if (isApiServer) {
             return;
         }
         


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?

Part of the changes related to this story: [Ability to access managers during Resource Management #2124](https://github.com/galasa-dev/projectmanagement/issues/2124)

- Needed a more flexible way of initialising the framework without letting the framework 
know what type of framework it is.

- Added Init strategy interface and 3 implementations of it, called from different places depending on which server is being created.
- Added a Factory class so you can get at the implementations of the strategies without having direct access to them
- Intention is to move as much as we can to internal and provide access via interfaces and this GalasaFactory class

Intended as an alternative to https://github.com/galasa-dev/galasa/pull/180
