### PR TITLE
Fix image used for DockerManagerIVT

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/src/main/java/dev/galasa/docker/manager/ivt/DockerManagerIVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/src/main/java/dev/galasa/docker/manager/ivt/DockerManagerIVT.java
@@ -64,13 +64,13 @@ public class DockerManagerIVT {
     @Logger
     public Log logger;
 
-    @DockerContainer(image = "galasa-dev/httpd:latest", dockerContainerTag = "a", start = false)
+    @DockerContainer(image = "galasa-dev/httpd:2.4.59", dockerContainerTag = "a", start = false)
     public IDockerContainer container;
 
-    @DockerContainer(image = "galasa-dev/httpd:latest", dockerContainerTag = "b", start = false)
+    @DockerContainer(image = "galasa-dev/httpd:2.4.59", dockerContainerTag = "b", start = false)
     public IDockerContainer containerSecondry;
     
-    @DockerContainer(image = "galasa-dev/httpd:latest", dockerContainerTag = "AUTOSTART", start = true)
+    @DockerContainer(image = "galasa-dev/httpd:2.4.59", dockerContainerTag = "AUTOSTART", start = true)
     public IDockerContainer containerAutoStart;
 
     @DockerContainerConfig


### PR DESCRIPTION
## Why?

Continued from PR #196 - I thought the `latest` tag would pick the latest of the https://github.com/orgs/galasa-dev/packages/container/package/httpd image but apparently not.

This should fix the 404 response for the image check at /v2/galasa-dev/httpd/manifests/latest