### PR TITLE
initial attempt at better error cleanup in the java test runner

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -83,6 +83,7 @@ public class BaseTestRunner {
     }
 
     protected void shutdownFramework(IShuttableFramework framework) {
+        logger.debug("Cleaning up framework...");
         try {
             framework.shutdown();
         } catch(Exception e) {
@@ -202,6 +203,7 @@ public class BaseTestRunner {
 
     protected void writeTestStructure() {
         try {
+            logger.debug("Writing test structure to RAS. status: "+testStructure.getStatus()+" result:"+testStructure.getResult());
             this.ras.updateTestStructure(testStructure);
         } catch (ResultArchiveStoreException e) {
             logger.warn("Unable to write the test structure to the RAS", e);
@@ -311,6 +313,7 @@ public class BaseTestRunner {
     }
 
     protected void updateStatus(TestRunLifecycleStatus status, String dssTimePropSuffix) throws TestRunException {
+        
         Instant time = Instant.now();
 
         this.testStructure.setStatus(status.toString());

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -105,7 +105,7 @@ public class GherkinTestRunner extends BaseTestRunner {
             try {
                 managers = dataProvider.createTestRunManagers(new GalasaTest(gherkinTest));
             } catch (TestRunException e) {
-                String msg = "Exception Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
+                String msg = "Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
                 logger.error(msg);
                 throw new TestRunException("Problem initialising the Managers for a test run", e);
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -89,6 +89,8 @@ public class TestClassWrapper {
      */
     public void parseTestClass() throws TestRunException {
 
+        logger.debug("Parsing test class...");
+
         ArrayList<GenericMethodWrapper> temporaryBeforeMethods = new ArrayList<>();
         ArrayList<GenericMethodWrapper> temporaryAfterMethods = new ArrayList<>();
         ArrayList<Method> temporaryTestMethods = new ArrayList<>();
@@ -147,6 +149,8 @@ public class TestClassWrapper {
      * @throws TestRunException
      */
     public void instantiateTestClass() throws TestRunException {
+
+        logger.debug("Instantiating test class...");
         try {
             testClassObject = testClass.getDeclaredConstructor().newInstance();
         } catch (InstantiationException | IllegalAccessException | NullPointerException | 
@@ -355,6 +359,13 @@ public class TestClassWrapper {
     }
 
     protected void setResult(Result result) {
+        String from ;
+        if( this.result == null) {
+            from = "null";
+        } else {
+            from = this.result.getName();
+        }
+        logger.info("Result in test structure changed from "+from+" to "+result);
         this.result = result;
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -78,6 +78,12 @@ public class TestClassWrapper {
         this.testClass = testClass;
         this.testStructure = testStructure;
 
+        // Fill-in as much of the test structure as we can at this point.
+        // If any failures occur after this, they will at least have the correct test name/bundle...etc attached.
+        this.testStructure.setBundle(testBundle);
+        this.testStructure.setTestName(testClass.getName());
+        this.testStructure.setTestShortName(testClass.getSimpleName());
+
         this.continueOnTestFailure = this.testRunner.getContinueOnTestFailureFromCPS();
     }
 
@@ -119,11 +125,9 @@ public class TestClassWrapper {
             .add(new TestMethodWrapper(method, this.testClass, temporaryBeforeMethods, temporaryAfterMethods));
         }
 
-        // *** Create the reporting Test Structure
 
-        this.testStructure.setBundle(testBundle);
-        this.testStructure.setTestName(testClass.getName());
-        this.testStructure.setTestShortName(testClass.getSimpleName());
+        // Populate more fields in the test structure, so reporting is better.
+
         ArrayList<TestMethod> structureMethods = new ArrayList<>();
         this.testStructure.setMethods(structureMethods);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
@@ -68,7 +68,6 @@ public class TestRunManagers implements ITestRunManagers {
 
         logger.debug("The following Managers are sorted in provisioning order:-");
         reportManagers(false);
-
     }
 
     /**
@@ -160,7 +159,7 @@ public class TestRunManagers implements ITestRunManagers {
         for (IManager manager : allManagers) {
             try {
                 manager.initialise(framework, allManagers, activeManagers, galasaTest);
-            } catch (ManagerException e) {
+            } catch (Exception e) {
                 throw new FrameworkException("Unable to initialise Manager " + manager.getClass().getName(), e);
             }
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -166,7 +166,7 @@ public class TestRunner extends BaseTestRunner {
                     break;
                     default:
                         // Logic error. 
-                        logger.error("Logic error. A RunType has been added for which the cleanup logic has not been impplemented!");
+                        logger.error("Logic error. A RunType has been added for which the cleanup logic has not been implemented!");
                         cleanupTestState(managers);
                 }
 
@@ -270,7 +270,7 @@ public class TestRunner extends BaseTestRunner {
         } catch (Exception e) {
             // Managers are custom code, may be prone to failure if they are immature...
             // so catch any exception and turn it into a TestRunException.
-            String msg = "Exception Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
+            String msg = "Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
             logger.error(msg);
             reportEnvFailFinishedResult(e);
             throw new TestRunException("Problem initialising the Managers for a test run", e);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -128,6 +128,10 @@ public class TestRunner extends BaseTestRunner {
 
             ITestRunManagers managers = null;
             try {
+                // Create the test wrapper as soon as we can, as it populates some data into the 
+                // test structure about the test being executed.
+                // Failures from this point have the name of the test class, bundle name...etc.
+                TestClassWrapper testClassWrapper = createTestClassWrapper(testBundleName, testClass, testStructure);
 
                 loadCoreManagerBundle();
 
@@ -138,7 +142,6 @@ public class TestRunner extends BaseTestRunner {
                     return ; 
                 }
                 
-                TestClassWrapper testClassWrapper = createTestClassWrapper(testBundleName, testClass, testStructure);
                 testClassWrapper.parseTestClass();
                 testClassWrapper.instantiateTestClass();
 
@@ -258,8 +261,7 @@ public class TestRunner extends BaseTestRunner {
         return isIgnore;
     }
 
-    /** Protected so we can unit test the calling code easier. */
-    protected ITestRunManagers initialiseManagers(Class<?> testClass , ITestRunnerDataProvider dataProvider) throws TestRunException {
+    private ITestRunManagers initialiseManagers(Class<?> testClass , ITestRunnerDataProvider dataProvider) throws TestRunException {
         // *** Initialise the Managers ready for the test run
         ITestRunManagers managers ;
         try {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -34,6 +34,7 @@ import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IManager;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.language.GalasaTest;
+import dev.galasa.framework.spi.teststructure.TestStructure;
 
 /**
  * Run the supplied test class
@@ -92,196 +93,270 @@ public class TestRunner extends BaseTestRunner {
                 new FelixRepoAdminOBRAdder(this.repositoryAdmin, this.cps)
                     .addOBRsToRepoAdmin(streamName, run.getOBR());
 
-
                 // This is java-test-runner-specific
                 loadTestBundle(repositoryAdmin, bundleContext, testBundleName);
                 testClass = getTestClass(bundleContext, testBundleName, testClassName);
-
 
             } catch (Exception ex) {
                 updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
                 throw new TestRunException(ex.getMessage(),ex);
             }
 
-
             RunTypeDetails runTypeDetails = new RunTypeDetails(dataProvider.getAnnotationExtractor(), testClass, testBundleName, testClassName , framework);
             this.runType = runTypeDetails.getDetectedRunType();
 
             logger.debug("Test runType is "+this.runType.toString());
-            if (this.runType == RunType.TEST) {
-
+            switch(this.runType) {
+            case TEST:
                 heartbeat = createBeatingHeart(framework);
-
                 incrimentMetric(dss,run);
-
-
-            } else if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
+                break;
+            case SHARED_ENVIRONMENT_BUILD:
                 int expireHours = runTypeDetails.getSharedEnvironmentExpireAfterHours();
-                Instant expire = Instant.now().plus(expireHours, ChronoUnit.HOURS);
-                try {
-                    this.dss.put("run." + this.run.getName() + ".shared.environment.expire", expire.toString());
-                } catch (DynamicStatusStoreException e) {
-                    String msg = "DynamicStatusStoreException Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
-                    logger.error(msg);
-                    deleteRunProperties(this.framework);
-                    throw new TestRunException("Unable to set the shared environment expire time",e);
-                }
+                saveSharedEnvExpiryTime(this.run.getName(), expireHours);
+                break;
+            case SHARED_ENVIRONMENT_DISCARD:
+                // No construction of anything to be done.
+                break;
+            default:
+                // Logic error. 
+                logger.error("Logic error. A RunType has been added for which the cleanup logic has not been implemented!");
             }
 
             logger.debug("state changing to started.");
             updateStatus(TestRunLifecycleStatus.STARTED, "started");
 
-            // *** Try to load the Core Manager bundle, even if the test doesn't use it, and if not already active
-            if (!bundleManager.isBundleActive(bundleContext, "dev.galasa.core.manager")) {
-                try {
-                    bundleManager.loadBundle(repositoryAdmin, bundleContext, "dev.galasa.core.manager");
-                } catch (FrameworkException e) {
-                    logger.warn("Tried to load the Core Manager bundle, but failed, test can continue without it",e);
-                }
-            }
-
-            logger.debug("Bundle is loaded ok.");
-
-            // *** Initialise the Managers ready for the test run
             ITestRunManagers managers = null;
             try {
-                GalasaTest galasaTest = new GalasaTest(testClass);
-                managers = dataProvider.createTestRunManagers(galasaTest);
-            } catch (Exception e) {
-                // Managers are custom code, may be prone to failure if they are immature...
-                // so catch any exception and turn it into a TestRunException.
-                String msg = "Exception Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
-                logger.error(msg);
-                reportEnvFailFinishedResult(e);
-                throw new TestRunException("Problem initialising the Managers for a test run", e);
-            }
 
-            logger.debug("Test managers ok.");
+                loadCoreManagerBundle();
 
-            try {
-                if (managers.anyReasonTestClassShouldBeIgnored()) {
-                    logger.debug("managers.anyReasonTestClassShouldBeIgnored() is true. Shutting down.");
-                    stopHeartbeat();
-                    updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-                    return; // TODO handle ignored classes
+                managers = initialiseManagers(testClass,dataProvider);
+
+                if( isAnyReasonToIgnoreTests(managers) ) {
+                    logger.debug("Test class should be ignored.");
+                    return ; 
                 }
-            } catch (Exception e) {
-                String msg = "Problem asking Managers for an ignore reason";
-                logger.error(msg);
-                reportEnvFailFinishedResult(e);
-                throw new TestRunException(msg, e);
-            }
-            logger.debug("Test class should not be ignored.");
-
-            
-            TestClassWrapper testClassWrapper;
-            try { 
-                testClassWrapper = new TestClassWrapper(this, testBundleName, testClass, testStructure);
-            } catch(Exception e) {
-                String msg = "Problem with the CPS when adding a wrapper";
-                logger.error(msg+" "+e.getMessage());
-                reportEnvFailFinishedResult(e);
-                throw new TestRunException(msg,e);
-            }
-
-            logger.debug("Parsing test class...");
-            testClassWrapper.parseTestClass();
-
-            logger.debug("Instantiating test class...");
-            testClassWrapper.instantiateTestClass();
-
-            if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
-                logger.debug("Checking active managers to see if they support shared env build...");
-                //*** Check all the active Managers to see if they support a shared environment build
-                boolean invalidManager = false;
-                for(IManager manager : managers.getActiveManagers()) {
-                    if (!manager.doYouSupportSharedEnvironments()) {
-                        logger.error("Manager " + manager.getClass().getName() + " does not support Shared Environments");
-                        invalidManager = true;
-                    }
-                }
-
-                if (invalidManager) {
-                    logger.error("There are Managers that do not support Shared Environment builds");
-                    testClassWrapper.setResult(Result.failed("Invalid Shared Environment build"));
-                    testStructure.setResult(testClassWrapper.getResult().getName());
-                    isRunOK = false;
-                }
-            }
-            logger.debug("isRunOK: "+Boolean.toString(isRunOK));
-
-            logger.debug("Generating environment...");
-            try {
-                generateEnvironment(testClassWrapper, managers, this.dss, this.run.getName() , isRunOK);
-            } catch(Exception e) {
-                logger.fatal("Error within test runner",e);
-                this.isRunOK = false;
-            }
-
-            logger.debug("isRunOK: "+Boolean.toString(isRunOK)+" runType: "+runType.toString());
-
-            if (!isRunOK || this.runType == RunType.TEST || this.runType == RunType.SHARED_ENVIRONMENT_DISCARD) {
-                logger.debug("Test did not run OK... or runtype is not "+RunType.SHARED_ENVIRONMENT_BUILD.toString());
-                updateStatus(TestRunLifecycleStatus.ENDING, null);
-                managers.endOfTestRun();
-
-                boolean markedWaiting = false;
-
-                if (!isResourcesAvailable && !run.isLocal()) {
-                    markWaiting(this.framework);
-                    logger.info("Placing queue on the waiting list");
-                    markedWaiting = true;
-                } else {
-                    if (this.runType == RunType.SHARED_ENVIRONMENT_DISCARD) {
-                        this.testStructure.setResult("Discarded");
-                        try {
-                            this.dss.deletePrefix("run." + this.run.getName() + ".shared.environment");
-                        } catch (DynamicStatusStoreException e) {
-                            logger.error("Problem cleaning shared environment properties", e);
-                        }
-                    }
-                    updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-                }
-
-                logger.debug("Stopping heartbeat...");
-                stopHeartbeat();
-
-                // Record all the CPS properties that were accessed
-                saveUsedCPSPropertiesToArtifact(this.framework.getRecordProperties(), this.fileSystem, this.ras);
-                // And all the overrides the test was passed.
-                saveAllOverridesPassedToArtifact(overrideProperties, this.fileSystem , this.ras);
-
-                // *** If this was a local run, then we will want to remove the run properties
-                // from the DSS immediately
-                // *** for automation, we will let the core manager clean up after a while
-                // *** Local runs will have access to the run details via a view,
-                // *** But automation runs will only exist in the RAS if we delete them, so need
-                // to give
-                // *** time for things like jenkins and other run requesters to obtain the
-                // result and RAS id before
-                // *** deleting, default is to keep the automation run properties for 5 minutes
-                if (!markedWaiting) {
-                    deleteRunProperties(this.framework);
-                }
-            } else if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
-
-                // Record all the CPS properties that were accessed
-                saveUsedCPSPropertiesToArtifact(this.framework.getRecordProperties(), this.fileSystem, this.ras);
-                // And all the overrides the test was passed.
-                saveAllOverridesPassedToArtifact(overrideProperties, this.fileSystem , this.ras);
                 
-                updateStatus(TestRunLifecycleStatus.UP, "built");
-            } else {
-                logger.error("Unrecognised end condition");
-            }
+                TestClassWrapper testClassWrapper = createTestClassWrapper(testBundleName, testClass, testStructure);
+                testClassWrapper.parseTestClass();
+                testClassWrapper.instantiateTestClass();
 
-            logger.debug("Cleaning up managers...");
-            managers.shutdown();
+                if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
+                    isRunOK = doActiveManagersSupportSharedEnvBuild(managers, testClassWrapper);
+                }
+
+                logger.debug("isRunOK: "+Boolean.toString(isRunOK));
+                isRunOK = generateEnvironment(testClassWrapper, managers, this.dss, this.run.getName() , isRunOK);
+
+                switch(this.runType) {
+                    case TEST:
+                    case SHARED_ENVIRONMENT_DISCARD:
+                        cleanupTestState(managers);
+                    break;
+                    case SHARED_ENVIRONMENT_BUILD:
+                        if( isRunOK) {
+                            saveSharedBuildEnvironmentState();
+                        } else {
+                            cleanupTestState(managers);
+                        }
+                    break;
+                    default:
+                        // Logic error. 
+                        logger.error("Logic error. A RunType has been added for which the cleanup logic has not been impplemented!");
+                        cleanupTestState(managers);
+                }
+
+                logger.debug("isRunOK: "+Boolean.toString(isRunOK)+" runType: "+runType.toString());
+
+            } catch(Exception ex) {
+                logger.error("Failed to run the test."+ex.getMessage());
+                if (ex instanceof TestRunException) {
+                    throw ex ;
+                } else {
+                    throw new TestRunException(ex);
+                }
+
+            } finally {
+
+                // Make sure the test is marked as finished, as there was a failure.
+                if ( ! TestRunLifecycleStatus.FINISHED.toString().equals(testStructure.getStatus())) {
+                    updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+                }
+
+                cleanUpManagers(managers);
+            }
 
         } finally {
-            logger.debug("Cleaning up framework...");
             shutdownFramework(framework);
         }
+    }
+
+    private void cleanUpManagers(ITestRunManagers managers) {
+        if (managers!=null) {
+            logger.debug("Cleaning up managers...");
+            try {
+                managers.shutdown();
+            } catch (Exception ex) {
+                logger.error("Managers failed to clean up. "+ex.getMessage());
+            }
+        }
+    }
+
+    private void loadCoreManagerBundle() {
+        // *** Try to load the Core Manager bundle, even if the test doesn't use it, and if not already active
+        if (!bundleManager.isBundleActive(bundleContext, "dev.galasa.core.manager")) {
+            try {
+                bundleManager.loadBundle(repositoryAdmin, bundleContext, "dev.galasa.core.manager");
+            } catch (FrameworkException e) {
+                logger.warn("Tried to load the Core Manager bundle, but failed, test can continue without it",e);
+            }
+        }
+        logger.debug("Core Manager Bundle is loaded ok.");
+    }
+
+    private void saveSharedEnvExpiryTime(String runName, int expireHours) throws TestRunException {
+        Instant expire = Instant.now().plus(expireHours, ChronoUnit.HOURS);
+        try {
+            this.dss.put("run." + this.run.getName() + ".shared.environment.expire", expire.toString());
+        } catch (DynamicStatusStoreException e) {
+            String msg = "DynamicStatusStoreException Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
+            logger.error(msg);
+            deleteRunProperties(this.framework);
+            throw new TestRunException("Unable to set the shared environment expire time",e);
+        }
+    }
+
+    private TestClassWrapper createTestClassWrapper(String testBundleName, Class<?> testClass, TestStructure testStructure) throws TestRunException {
+        TestClassWrapper testClassWrapper ;
+        try { 
+            testClassWrapper = new TestClassWrapper(this, testBundleName, testClass, testStructure);
+        } catch(Exception e) {
+            String msg = "Problem with the CPS when adding a wrapper";
+            logger.error(msg+" "+e.getMessage());
+            reportEnvFailFinishedResult(e);
+            throw new TestRunException(msg,e);
+        }
+        return testClassWrapper;
+    }
+
+    private boolean isAnyReasonToIgnoreTests(ITestRunManagers managers) throws TestRunException {
+        boolean isIgnore = false ;
+        try {
+            if (managers.anyReasonTestClassShouldBeIgnored()) {
+                logger.debug("managers.anyReasonTestClassShouldBeIgnored() is true. Shutting down.");
+                stopHeartbeat();
+                updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+                isIgnore = true; // TODO handle ignored classes
+            }
+        } catch (Exception e) {
+            String msg = "Problem asking Managers for an ignore reason";
+            logger.error(msg);
+            reportEnvFailFinishedResult(e);
+            throw new TestRunException(msg, e);
+        }
+        return isIgnore;
+    }
+
+    /** Protected so we can unit test the calling code easier. */
+    protected ITestRunManagers initialiseManagers(Class<?> testClass , ITestRunnerDataProvider dataProvider) throws TestRunException {
+        // *** Initialise the Managers ready for the test run
+        ITestRunManagers managers ;
+        try {
+            GalasaTest galasaTest = new GalasaTest(testClass);
+            managers = dataProvider.createTestRunManagers(galasaTest);
+        } catch (Exception e) {
+            // Managers are custom code, may be prone to failure if they are immature...
+            // so catch any exception and turn it into a TestRunException.
+            String msg = "Exception Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
+            logger.error(msg);
+            reportEnvFailFinishedResult(e);
+            throw new TestRunException("Problem initialising the Managers for a test run", e);
+        }
+
+        logger.debug("Test managers initialised ok.");
+        return managers;
+    }
+
+    private boolean doActiveManagersSupportSharedEnvBuild(ITestRunManagers managers, TestClassWrapper testClassWrapper) {
+        boolean isRunOK = true ;
+        logger.debug("Checking active managers to see if they support shared env build...");
+        //*** Check all the active Managers to see if they support a shared environment build
+        boolean invalidManager = false;
+        for(IManager manager : managers.getActiveManagers()) {
+            if (!manager.doYouSupportSharedEnvironments()) {
+                logger.error("Manager " + manager.getClass().getName() + " does not support Shared Environments");
+                invalidManager = true;
+            }
+        }
+
+        if (invalidManager) {
+            logger.error("There are Managers that do not support Shared Environment builds");
+            testClassWrapper.setResult(Result.failed("Invalid Shared Environment build"));
+            testStructure.setResult(testClassWrapper.getResult().getName());
+            isRunOK = false;
+        }
+        return isRunOK;
+    }
+
+    /**
+     * Clean up any state we can, as the test has finished (good or bad) or the shared
+     * environment is no longer needed.
+     * @param managers Managers to clean up.
+     * @throws TestRunException Something failed within cleanup.
+     */
+    private void cleanupTestState(ITestRunManagers managers) throws TestRunException {
+        updateStatus(TestRunLifecycleStatus.ENDING, null);
+        managers.endOfTestRun();
+
+        boolean markedWaiting = false;
+
+        if (!isResourcesAvailable && !run.isLocal()) {
+            markWaiting(this.framework);
+            logger.info("Placing queue on the waiting list");
+            markedWaiting = true;
+        } else {
+            if (this.runType == RunType.SHARED_ENVIRONMENT_DISCARD) {
+                this.testStructure.setResult("Discarded");
+                try {
+                    this.dss.deletePrefix("run." + this.run.getName() + ".shared.environment");
+                } catch (DynamicStatusStoreException e) {
+                    logger.error("Problem cleaning shared environment properties", e);
+                }
+            }
+            updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+        }
+
+        logger.debug("Stopping heartbeat...");
+        stopHeartbeat();
+
+        // Record all the CPS properties that were accessed
+        saveUsedCPSPropertiesToArtifact(this.framework.getRecordProperties(), this.fileSystem, this.ras);
+        // And all the overrides the test was passed.
+        saveAllOverridesPassedToArtifact(overrideProperties, this.fileSystem , this.ras);
+
+        // *** If this was a local run, then we will want to remove the run properties
+        // from the DSS immediately
+        // *** for automation, we will let the core manager clean up after a while
+        // *** Local runs will have access to the run details via a view,
+        // *** But automation runs will only exist in the RAS if we delete them, so need
+        // to give
+        // *** time for things like jenkins and other run requesters to obtain the
+        // result and RAS id before
+        // *** deleting, default is to keep the automation run properties for 5 minutes
+        if (!markedWaiting) {
+            deleteRunProperties(this.framework);
+        }
+
+    }
+
+    private void saveSharedBuildEnvironmentState() throws TestRunException {
+        // Record all the CPS properties that were accessed
+        saveUsedCPSPropertiesToArtifact(this.framework.getRecordProperties(), this.fileSystem, this.ras);
+        // And all the overrides the test was passed.
+        saveAllOverridesPassedToArtifact(overrideProperties, this.fileSystem , this.ras);
+        
+        updateStatus(TestRunLifecycleStatus.UP, "built");
     }
 
     private void reportEnvFailFinishedResult(Exception ex) {
@@ -294,7 +369,8 @@ public class TestRunner extends BaseTestRunner {
         }
     }
 
-    private void generateEnvironment(TestClassWrapper testClassWrapper, ITestRunManagers managers, IDynamicStatusStoreService dss, String runName , boolean isRunOK) throws TestRunException {
+    private boolean generateEnvironment(TestClassWrapper testClassWrapper, ITestRunManagers managers, IDynamicStatusStoreService dss, String runName , boolean isRunOK) throws TestRunException {
+        logger.debug("Generating environment...");
         if(isRunOK){
             try {
                 updateStatus(TestRunLifecycleStatus.GENERATING, null);
@@ -314,6 +390,7 @@ public class TestRunner extends BaseTestRunner {
                 isRunOK = false;
             }
         }
+        return isRunOK;
     }
 
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
@@ -99,8 +99,8 @@ public class TestRunnerDataProvider implements ITestRunnerDataProvider {
         ITestRunManagers managers ;
         try {
             managers = new TestRunManagers(this.framework, galasaTest);
-        } catch (FrameworkException e) {
-            String msg = "FrameworkException Exception caught. "+e.getMessage();
+        } catch (Exception e) {
+            String msg = "Exception Exception caught. "+e.getMessage();
             throw new TestRunException(msg,e);
         }
         return managers;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
@@ -100,7 +100,7 @@ public class TestRunnerDataProvider implements ITestRunnerDataProvider {
         try {
             managers = new TestRunManagers(this.framework, galasaTest);
         } catch (Exception e) {
-            String msg = "Exception Exception caught. "+e.getMessage();
+            String msg = "Exception caught. "+e.getMessage();
             throw new TestRunException(msg,e);
         }
         return managers;


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
See issue https://github.com/galasa-dev/projectmanagement/issues/2152

The test runner was only catching TestManager exceptions coming out of managers, not unchecked exceptions.

When such exceptions did occur eg: NullPtr , the test result and status was not being set.

Now set them to envFail and Finished.

- Catch Exceptions instead of just FrameworkExceptions or TestRunExceptions
- Created quite a few small methods which do things with exception handling, to make the calling code easier to parse manually.
- Added finally code which sets the run status to "finished" even if there was an error or not.
- Unit test added to check that the exception gets handled OK.
- Populate the test structure as early as possible , so failures report which class failed.
