### PR TITLE
Remove hard coded value in Docker Manager for busybox image name

### DIFF
--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.docker/src/main/java/dev/galasa/ivts/docker/DockerManagerIVT.java
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.docker/src/main/java/dev/galasa/ivts/docker/DockerManagerIVT.java
@@ -66,13 +66,13 @@ public class DockerManagerIVT {
     @Logger
     public Log logger;
 
-    @DockerContainer(image = "library/httpd:latest", dockerContainerTag = "a", start = false)
+    @DockerContainer(image = "galasa-dev/httpd:2.4.59", dockerContainerTag = "a", start = false)
     public IDockerContainer container;
 
-    @DockerContainer(image = "library/httpd:latest", dockerContainerTag = "b", start = false)
+    @DockerContainer(image = "galasa-dev/httpd:2.4.59", dockerContainerTag = "b", start = false)
     public IDockerContainer containerSecondry;
-    
-    @DockerContainer(image = "library/httpd:latest", dockerContainerTag = "AUTOSTART", start = true)
+
+    @DockerContainer(image = "galasa-dev/httpd:2.4.59", dockerContainerTag = "AUTOSTART", start = true)
     public IDockerContainer containerAutoStart;
 
     @DockerContainerConfig

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerEngineImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerEngineImpl.java
@@ -31,6 +31,8 @@ import dev.galasa.docker.internal.properties.DockerDSEEngine;
 import dev.galasa.docker.internal.properties.DockerEngine;
 import dev.galasa.docker.internal.properties.DockerEnginePort;
 import dev.galasa.docker.internal.properties.DockerEngines;
+import dev.galasa.docker.internal.properties.DockerRegistry;
+import dev.galasa.docker.internal.properties.DockerRegistryBusyboxImage;
 import dev.galasa.docker.internal.properties.DockerSlots;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
@@ -381,7 +383,9 @@ public class DockerEngineImpl implements IDockerEngine {
 	}
 	
 	public String getBusybox() throws DockerManagerException {
-		DockerImageImpl image = new DockerImageImpl(framework, dockerManager, this, "library/busybox:latest");
+		String[] dockerRegistries = DockerRegistry.get();
+		String busyboxImageName = DockerRegistryBusyboxImage.get(dockerRegistries);
+		DockerImageImpl image = new DockerImageImpl(framework, dockerManager, this, busyboxImageName);
 		image.locateImage();
 		return image.getFullName();
 	}

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryBusyboxImage.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryBusyboxImage.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.docker.internal.properties;
+
+import dev.galasa.docker.DockerManagerException;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.cps.CpsProperties;
+
+/**
+ * Docker Registry Busybox Image CPS property
+ * 
+ * @galasa.cps.property
+ * 
+ * @galasa.name docker.registry.[registryId].busybox.image
+ * 
+ * @galasa.description Provides fully qualified image name including repository and tag of a 'busybox' Docker image on a given registry.
+ * 
+ * @galasa.required No - if not provided it will default to 'library/busybox:latest' which is compatible with the default Docker registry, Dockerhub.
+ * 
+ * @galasa.default library/busybox:latest
+ * 
+ * @galasa.valid_values library/busybox:latest, myorg/busybox:1.1.1
+ * 
+ * @galasa.examples 
+ * <code>docker.registry.[registryId].busybox.image=registryorg/busybox:latest</code>
+ * 
+ * @galasa.extra
+ * This CPS property is required when you want to allow the Docker Manager to search for a 'busybox' image in the Docker Registries<br>
+ * provided in the docker.default.registries CPS property, instead of in Dockerhub. If you do not specify this CPS property for any of<br>
+ * the provided Docker Registries, it will default to 'library/busybox:latest' so either your Docker Registries or Dockerhub will be<br>
+ * searched for the an image in 'library/busybox:latest'. This CPS property allows you to point the Docker Manager at a 'busybox' image that<br>
+ * may not be in the 'library' namespace and may not be tagged with 'latest'.<br> 
+ * */
+public class DockerRegistryBusyboxImage extends CpsProperties {
+
+    public static String get(String[] dockerRegistries) throws DockerManagerException {
+		String busyboxImage = "";
+		if (dockerRegistries.length > 0) {
+			for (String dockerRegistry : dockerRegistries) {
+				try {
+					busyboxImage = getStringNulled(DockerPropertiesSingleton.cps(), "registry", "busybox.image", dockerRegistry);
+				} catch (ConfigurationPropertyStoreException e) {
+					throw new DockerManagerException("Problem asking the CPS for the Busybox image name on registry ID: "  + dockerRegistry, e);
+				}
+				if (busyboxImage != null && !busyboxImage.equals("")) {
+					break;
+				}
+			}
+		}
+		if (busyboxImage == null || busyboxImage.equals("")) {
+			busyboxImage = "library/busybox:latest";
+		}
+		return busyboxImage;
+	}
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryBusyboxImage.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryBusyboxImage.java
@@ -7,6 +7,7 @@ package dev.galasa.docker.internal.properties;
 
 import dev.galasa.docker.DockerManagerException;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.cps.CpsProperties;
 
 /**
@@ -38,10 +39,11 @@ public class DockerRegistryBusyboxImage extends CpsProperties {
 
     public static String get(String[] dockerRegistries) throws DockerManagerException {
 		String busyboxImage = "";
+        IConfigurationPropertyStoreService cps = DockerPropertiesSingleton.cps();
 		if (dockerRegistries.length > 0) {
 			for (String dockerRegistry : dockerRegistries) {
 				try {
-					busyboxImage = getStringNulled(DockerPropertiesSingleton.cps(), "registry", "busybox.image", dockerRegistry);
+					busyboxImage = getStringNulled(cps, "registry", "busybox.image", dockerRegistry);
 				} catch (ConfigurationPropertyStoreException e) {
 					throw new DockerManagerException("Problem asking the CPS for the Busybox image name on registry ID: "  + dockerRegistry, e);
 				}
@@ -50,7 +52,7 @@ public class DockerRegistryBusyboxImage extends CpsProperties {
 				}
 			}
 		}
-		if (busyboxImage == null || busyboxImage.equals("")) {
+		if (busyboxImage == null || busyboxImage.isBlank()) {
 			busyboxImage = "library/busybox:latest";
 		}
 		return busyboxImage;


### PR DESCRIPTION
## Why?

The Docker Manager has a hard coded string for the fully qualified name of a busybox Docker image at `library/busybox:latest`. This should not be hard coded and should be configurable as it only fits the naming convention for Dockerhub and might do other Docker registries. However, if a user of the Docker Manager has a 'busybox' image in their Docker registry in any other org or with another tag, the image won't be found and the test using the Docker Manager will fail.

This is the behaviour we have seen in our DockerLocalJava11Ubuntu test.