### PR TITLE
Add a basic Galasa test to 'ivts' stream that we can test  with

### DIFF
--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/TestSleep.java
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/TestSleep.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.ivts.core;
+
+import org.apache.commons.logging.Log;
+
+import dev.galasa.Summary;
+import dev.galasa.Test;
+import dev.galasa.core.manager.CoreManager;
+import dev.galasa.core.manager.ICoreManager;
+import dev.galasa.core.manager.Logger;
+import dev.galasa.core.manager.RunName;
+
+@Test
+@Summary("A basic test with a sleep so there is sufficient time to test the `galasactl runs reset` command")
+public class TestSleep {
+
+    @Logger
+    public Log logger;
+
+    @Test
+    public void sleep() throws Exception {
+        logger.info("Sleeping for 1-minute.");
+        Thread.sleep(60000);
+    }
+
+}


### PR DESCRIPTION
## Why?

[PR 344 in CLI](https://github.com/galasa-dev/cli/pull/344) updated the bash script that tests CLI commands from running CoreLocalJava11Ubuntu on prod1 to CoreManagerIVT ecosystem1. Since this change it was challenging to test the `galasactl runs reset` command as the CoreManagerIVT finishes in a few seconds, leaving not enough time to reset it between it starting and finishing.

This basic test class has a minute long sleep which will allow us to test the `galasactl runs reset` command against it.