### PR TITLE
Fix OSGi issue with logging bundle not being resolved in cps.etcd

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/bnd.bnd
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/bnd.bnd
@@ -9,7 +9,8 @@ Import-Package: \
     dev.galasa.framework.spi,\
     dev.galasa.framework.spi.creds,\
     javax.net.ssl,\
-    javax.security.cert
+    javax.security.cert,\
+    org.apache.commons.logging
 Embed-Transitive: true
 Embed-Dependency: *;scope=compile|runtime
 -includeresource: \


### PR DESCRIPTION
## Why?

Since PR #211 a logger was added to a class in the CPS extension, however this is causing a NoClassDefFoundError at runtime as the logging bundle had not been added to the bnd.bnd for dev.galasa.cps.etcd.

```
28/02/2025 15:04:03.877 ERROR dev.galasa.boot.Launcher.launch - Unable to run test class
dev.galasa.boot.LauncherException: java.lang.NoClassDefFoundError: org/apache/commons/logging/LogFactory
	at dev.galasa.boot.felix.FelixFramework.runTest(FelixFramework.java:250)
	at dev.galasa.boot.Launcher.launch(Launcher.java:171)
	at dev.galasa.boot.Launcher.main(Launcher.java:121)
Caused by: java.lang.NoClassDefFoundError: org/apache/commons/logging/LogFactory
	at dev.galasa.cps.etcd.internal.Etcd3DynamicStatusStore.<init>(Etcd3DynamicStatusStore.java:74)
	at dev.galasa.cps.etcd.internal.Etcd3DynamicStatusStore.<init>(Etcd3DynamicStatusStore.java:88)
	at dev.galasa.cps.etcd.internal.Etcd3DynamicStatusStoreRegistration.initialise(Etcd3DynamicStatusStoreRegistration.java:47)
```