### PR TITLE
Revert 'initial attempt at better error cleanup in the java test runner (#207)' This reverts commit 072dcdfb41665b8f74c22fb7b6267026896a9148.

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -83,7 +83,6 @@ public class BaseTestRunner {
     }
 
     protected void shutdownFramework(IShuttableFramework framework) {
-        logger.debug("Cleaning up framework...");
         try {
             framework.shutdown();
         } catch(Exception e) {
@@ -203,7 +202,6 @@ public class BaseTestRunner {
 
     protected void writeTestStructure() {
         try {
-            logger.debug("Writing test structure to RAS. status: "+testStructure.getStatus()+" result:"+testStructure.getResult());
             this.ras.updateTestStructure(testStructure);
         } catch (ResultArchiveStoreException e) {
             logger.warn("Unable to write the test structure to the RAS", e);
@@ -313,7 +311,6 @@ public class BaseTestRunner {
     }
 
     protected void updateStatus(TestRunLifecycleStatus status, String dssTimePropSuffix) throws TestRunException {
-        
         Instant time = Instant.now();
 
         this.testStructure.setStatus(status.toString());

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -105,7 +105,7 @@ public class GherkinTestRunner extends BaseTestRunner {
             try {
                 managers = dataProvider.createTestRunManagers(new GalasaTest(gherkinTest));
             } catch (TestRunException e) {
-                String msg = "Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
+                String msg = "Exception Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
                 logger.error(msg);
                 throw new TestRunException("Problem initialising the Managers for a test run", e);
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -78,12 +78,6 @@ public class TestClassWrapper {
         this.testClass = testClass;
         this.testStructure = testStructure;
 
-        // Fill-in as much of the test structure as we can at this point.
-        // If any failures occur after this, they will at least have the correct test name/bundle...etc attached.
-        this.testStructure.setBundle(testBundle);
-        this.testStructure.setTestName(testClass.getName());
-        this.testStructure.setTestShortName(testClass.getSimpleName());
-
         this.continueOnTestFailure = this.testRunner.getContinueOnTestFailureFromCPS();
     }
 
@@ -94,8 +88,6 @@ public class TestClassWrapper {
      * @throws TestRunException
      */
     public void parseTestClass() throws TestRunException {
-
-        logger.debug("Parsing test class...");
 
         ArrayList<GenericMethodWrapper> temporaryBeforeMethods = new ArrayList<>();
         ArrayList<GenericMethodWrapper> temporaryAfterMethods = new ArrayList<>();
@@ -125,9 +117,11 @@ public class TestClassWrapper {
             .add(new TestMethodWrapper(method, this.testClass, temporaryBeforeMethods, temporaryAfterMethods));
         }
 
+        // *** Create the reporting Test Structure
 
-        // Populate more fields in the test structure, so reporting is better.
-
+        this.testStructure.setBundle(testBundle);
+        this.testStructure.setTestName(testClass.getName());
+        this.testStructure.setTestShortName(testClass.getSimpleName());
         ArrayList<TestMethod> structureMethods = new ArrayList<>();
         this.testStructure.setMethods(structureMethods);
 
@@ -153,8 +147,6 @@ public class TestClassWrapper {
      * @throws TestRunException
      */
     public void instantiateTestClass() throws TestRunException {
-
-        logger.debug("Instantiating test class...");
         try {
             testClassObject = testClass.getDeclaredConstructor().newInstance();
         } catch (InstantiationException | IllegalAccessException | NullPointerException | 
@@ -363,13 +355,6 @@ public class TestClassWrapper {
     }
 
     protected void setResult(Result result) {
-        String from ;
-        if( this.result == null) {
-            from = "null";
-        } else {
-            from = this.result.getName();
-        }
-        logger.info("Result in test structure changed from "+from+" to "+result);
         this.result = result;
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
@@ -68,6 +68,7 @@ public class TestRunManagers implements ITestRunManagers {
 
         logger.debug("The following Managers are sorted in provisioning order:-");
         reportManagers(false);
+
     }
 
     /**
@@ -159,7 +160,7 @@ public class TestRunManagers implements ITestRunManagers {
         for (IManager manager : allManagers) {
             try {
                 manager.initialise(framework, allManagers, activeManagers, galasaTest);
-            } catch (Exception e) {
+            } catch (ManagerException e) {
                 throw new FrameworkException("Unable to initialise Manager " + manager.getClass().getName(), e);
             }
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -27,6 +27,7 @@ import dev.galasa.framework.internal.runner.RunTypeDetails;
 import dev.galasa.framework.internal.runner.TestRunnerDataProvider;
 import dev.galasa.framework.maven.repository.spi.IMavenRepository;
 import dev.galasa.framework.spi.AbstractManager;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.FrameworkResourceUnavailableException;
@@ -34,7 +35,6 @@ import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IManager;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.language.GalasaTest;
-import dev.galasa.framework.spi.teststructure.TestStructure;
 
 /**
  * Run the supplied test class
@@ -93,286 +93,197 @@ public class TestRunner extends BaseTestRunner {
                 new FelixRepoAdminOBRAdder(this.repositoryAdmin, this.cps)
                     .addOBRsToRepoAdmin(streamName, run.getOBR());
 
+
                 // This is java-test-runner-specific
                 loadTestBundle(repositoryAdmin, bundleContext, testBundleName);
                 testClass = getTestClass(bundleContext, testBundleName, testClassName);
+
 
             } catch (Exception ex) {
                 updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
                 throw new TestRunException(ex.getMessage(),ex);
             }
 
+
             RunTypeDetails runTypeDetails = new RunTypeDetails(dataProvider.getAnnotationExtractor(), testClass, testBundleName, testClassName , framework);
             this.runType = runTypeDetails.getDetectedRunType();
 
             logger.debug("Test runType is "+this.runType.toString());
-            switch(this.runType) {
-            case TEST:
+            if (this.runType == RunType.TEST) {
+
                 heartbeat = createBeatingHeart(framework);
+
                 incrimentMetric(dss,run);
-                break;
-            case SHARED_ENVIRONMENT_BUILD:
+
+
+            } else if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
                 int expireHours = runTypeDetails.getSharedEnvironmentExpireAfterHours();
-                saveSharedEnvExpiryTime(this.run.getName(), expireHours);
-                break;
-            case SHARED_ENVIRONMENT_DISCARD:
-                // No construction of anything to be done.
-                break;
-            default:
-                // Logic error. 
-                logger.error("Logic error. A RunType has been added for which the cleanup logic has not been implemented!");
+                Instant expire = Instant.now().plus(expireHours, ChronoUnit.HOURS);
+                try {
+                    this.dss.put("run." + this.run.getName() + ".shared.environment.expire", expire.toString());
+                } catch (DynamicStatusStoreException e) {
+                    String msg = "DynamicStatusStoreException Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
+                    logger.error(msg);
+                    deleteRunProperties(this.framework);
+                    throw new TestRunException("Unable to set the shared environment expire time",e);
+                }
             }
 
             logger.debug("state changing to started.");
             updateStatus(TestRunLifecycleStatus.STARTED, "started");
 
+            // *** Try to load the Core Manager bundle, even if the test doesn't use it, and if not already active
+            if (!bundleManager.isBundleActive(bundleContext, "dev.galasa.core.manager")) {
+                try {
+                    bundleManager.loadBundle(repositoryAdmin, bundleContext, "dev.galasa.core.manager");
+                } catch (FrameworkException e) {
+                    logger.warn("Tried to load the Core Manager bundle, but failed, test can continue without it",e);
+                }
+            }
+
+            logger.debug("Bundle is loaded ok.");
+
+            // *** Initialise the Managers ready for the test run
             ITestRunManagers managers = null;
             try {
-                // Create the test wrapper as soon as we can, as it populates some data into the 
-                // test structure about the test being executed.
-                // Failures from this point have the name of the test class, bundle name...etc.
-                TestClassWrapper testClassWrapper = createTestClassWrapper(testBundleName, testClass, testStructure);
+                GalasaTest galasaTest = new GalasaTest(testClass);
+                managers = dataProvider.createTestRunManagers(galasaTest);
+            } catch (TestRunException e) {
+                String msg = "Exception Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
+                logger.error(msg);
+                throw new TestRunException("Problem initialising the Managers for a test run", e);
+            }
 
-                loadCoreManagerBundle();
+            logger.debug("Test managers ok.");
 
-                managers = initialiseManagers(testClass,dataProvider);
-
-                if( isAnyReasonToIgnoreTests(managers) ) {
-                    logger.debug("Test class should be ignored.");
-                    return ; 
+            try {
+                if (managers.anyReasonTestClassShouldBeIgnored()) {
+                    logger.debug("managers.anyReasonTestClassShouldBeIgnored() is true. Shutting down.");
+                    stopHeartbeat();
+                    updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+                    return; // TODO handle ignored classes
                 }
+            } catch (FrameworkException e) {
+                String msg = "Problem asking Managers for an ignore reason";
+                logger.error(msg+" "+e.getMessage());
+                throw new TestRunException(msg, e);
+            }
+            logger.debug("Test class should not be ignored.");
+
+            
+            TestClassWrapper testClassWrapper;
+            try { 
                 
-                testClassWrapper.parseTestClass();
-                testClassWrapper.instantiateTestClass();
+                testClassWrapper = new TestClassWrapper(this, testBundleName, testClass, testStructure);
+            } catch(ConfigurationPropertyStoreException e) {
+                String msg = "Problem with the CPS when adding a wrapper";
+                logger.error(msg+" "+e.getMessage());
+                throw new TestRunException(msg,e);
+            }
 
-                if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
-                    isRunOK = doActiveManagersSupportSharedEnvBuild(managers, testClassWrapper);
+            logger.debug("Parsing test class...");
+            testClassWrapper.parseTestClass();
+
+            logger.debug("Instantiating test class...");
+            testClassWrapper.instantiateTestClass();
+
+            if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
+                logger.debug("Checking active managers to see if they support shared env build...");
+                //*** Check all the active Managers to see if they support a shared environment build
+                boolean invalidManager = false;
+                for(IManager manager : managers.getActiveManagers()) {
+                    if (!manager.doYouSupportSharedEnvironments()) {
+                        logger.error("Manager " + manager.getClass().getName() + " does not support Shared Environments");
+                        invalidManager = true;
+                    }
                 }
 
-                logger.debug("isRunOK: "+Boolean.toString(isRunOK));
-                isRunOK = generateEnvironment(testClassWrapper, managers, this.dss, this.run.getName() , isRunOK);
-
-                switch(this.runType) {
-                    case TEST:
-                    case SHARED_ENVIRONMENT_DISCARD:
-                        cleanupTestState(managers);
-                    break;
-                    case SHARED_ENVIRONMENT_BUILD:
-                        if( isRunOK) {
-                            saveSharedBuildEnvironmentState();
-                        } else {
-                            cleanupTestState(managers);
-                        }
-                    break;
-                    default:
-                        // Logic error. 
-                        logger.error("Logic error. A RunType has been added for which the cleanup logic has not been implemented!");
-                        cleanupTestState(managers);
+                if (invalidManager) {
+                    logger.error("There are Managers that do not support Shared Environment builds");
+                    testClassWrapper.setResult(Result.failed("Invalid Shared Environment build"));
+                    testStructure.setResult(testClassWrapper.getResult().getName());
+                    isRunOK = false;
                 }
+            }
+            logger.debug("isRunOK: "+Boolean.toString(isRunOK));
 
-                logger.debug("isRunOK: "+Boolean.toString(isRunOK)+" runType: "+runType.toString());
+            logger.debug("Generating environment...");
+            try {
+                generateEnvironment(testClassWrapper, managers, this.dss, this.run.getName() , isRunOK);
+            } catch(Exception e) {
+                logger.fatal("Error within test runner",e);
+                this.isRunOK = false;
+            }
 
-            } catch(Exception ex) {
-                logger.error("Failed to run the test."+ex.getMessage());
-                if (ex instanceof TestRunException) {
-                    throw ex ;
+            logger.debug("isRunOK: "+Boolean.toString(isRunOK)+" runType: "+runType.toString());
+
+            if (!isRunOK || this.runType == RunType.TEST || this.runType == RunType.SHARED_ENVIRONMENT_DISCARD) {
+                logger.debug("Test did not run OK... or runtype is not "+RunType.SHARED_ENVIRONMENT_BUILD.toString());
+                updateStatus(TestRunLifecycleStatus.ENDING, null);
+                managers.endOfTestRun();
+
+                boolean markedWaiting = false;
+
+                if (!isResourcesAvailable && !run.isLocal()) {
+                    markWaiting(this.framework);
+                    logger.info("Placing queue on the waiting list");
+                    markedWaiting = true;
                 } else {
-                    throw new TestRunException(ex);
-                }
-
-            } finally {
-
-                // Make sure the test is marked as finished, as there was a failure.
-                if ( ! TestRunLifecycleStatus.FINISHED.toString().equals(testStructure.getStatus())) {
+                    if (this.runType == RunType.SHARED_ENVIRONMENT_DISCARD) {
+                        this.testStructure.setResult("Discarded");
+                        try {
+                            this.dss.deletePrefix("run." + this.run.getName() + ".shared.environment");
+                        } catch (DynamicStatusStoreException e) {
+                            logger.error("Problem cleaning shared environment properties", e);
+                        }
+                    }
                     updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
                 }
 
-                cleanUpManagers(managers);
+                logger.debug("Stopping heartbeat...");
+                stopHeartbeat();
+
+                // Record all the CPS properties that were accessed
+                saveUsedCPSPropertiesToArtifact(this.framework.getRecordProperties(), this.fileSystem, this.ras);
+                // And all the overrides the test was passed.
+                saveAllOverridesPassedToArtifact(overrideProperties, this.fileSystem , this.ras);
+
+                // *** If this was a local run, then we will want to remove the run properties
+                // from the DSS immediately
+                // *** for automation, we will let the core manager clean up after a while
+                // *** Local runs will have access to the run details via a view,
+                // *** But automation runs will only exist in the RAS if we delete them, so need
+                // to give
+                // *** time for things like jenkins and other run requesters to obtain the
+                // result and RAS id before
+                // *** deleting, default is to keep the automation run properties for 5 minutes
+                if (!markedWaiting) {
+                    deleteRunProperties(this.framework);
+                }
+            } else if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
+
+                // Record all the CPS properties that were accessed
+                saveUsedCPSPropertiesToArtifact(this.framework.getRecordProperties(), this.fileSystem, this.ras);
+                // And all the overrides the test was passed.
+                saveAllOverridesPassedToArtifact(overrideProperties, this.fileSystem , this.ras);
+                
+                updateStatus(TestRunLifecycleStatus.UP, "built");
+            } else {
+                logger.error("Unrecognised end condition");
             }
 
+            logger.debug("Cleaning up managers...");
+            managers.shutdown();
+
         } finally {
+            logger.debug("Cleaning up framework...");
             shutdownFramework(framework);
         }
     }
 
-    private void cleanUpManagers(ITestRunManagers managers) {
-        if (managers!=null) {
-            logger.debug("Cleaning up managers...");
-            try {
-                managers.shutdown();
-            } catch (Exception ex) {
-                logger.error("Managers failed to clean up. "+ex.getMessage());
-            }
-        }
-    }
 
-    private void loadCoreManagerBundle() {
-        // *** Try to load the Core Manager bundle, even if the test doesn't use it, and if not already active
-        if (!bundleManager.isBundleActive(bundleContext, "dev.galasa.core.manager")) {
-            try {
-                bundleManager.loadBundle(repositoryAdmin, bundleContext, "dev.galasa.core.manager");
-            } catch (FrameworkException e) {
-                logger.warn("Tried to load the Core Manager bundle, but failed, test can continue without it",e);
-            }
-        }
-        logger.debug("Core Manager Bundle is loaded ok.");
-    }
 
-    private void saveSharedEnvExpiryTime(String runName, int expireHours) throws TestRunException {
-        Instant expire = Instant.now().plus(expireHours, ChronoUnit.HOURS);
-        try {
-            this.dss.put("run." + this.run.getName() + ".shared.environment.expire", expire.toString());
-        } catch (DynamicStatusStoreException e) {
-            String msg = "DynamicStatusStoreException Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
-            logger.error(msg);
-            deleteRunProperties(this.framework);
-            throw new TestRunException("Unable to set the shared environment expire time",e);
-        }
-    }
-
-    private TestClassWrapper createTestClassWrapper(String testBundleName, Class<?> testClass, TestStructure testStructure) throws TestRunException {
-        TestClassWrapper testClassWrapper ;
-        try { 
-            testClassWrapper = new TestClassWrapper(this, testBundleName, testClass, testStructure);
-        } catch(Exception e) {
-            String msg = "Problem with the CPS when adding a wrapper";
-            logger.error(msg+" "+e.getMessage());
-            reportEnvFailFinishedResult(e);
-            throw new TestRunException(msg,e);
-        }
-        return testClassWrapper;
-    }
-
-    private boolean isAnyReasonToIgnoreTests(ITestRunManagers managers) throws TestRunException {
-        boolean isIgnore = false ;
-        try {
-            if (managers.anyReasonTestClassShouldBeIgnored()) {
-                logger.debug("managers.anyReasonTestClassShouldBeIgnored() is true. Shutting down.");
-                stopHeartbeat();
-                updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-                isIgnore = true; // TODO handle ignored classes
-            }
-        } catch (Exception e) {
-            String msg = "Problem asking Managers for an ignore reason";
-            logger.error(msg);
-            reportEnvFailFinishedResult(e);
-            throw new TestRunException(msg, e);
-        }
-        return isIgnore;
-    }
-
-    private ITestRunManagers initialiseManagers(Class<?> testClass , ITestRunnerDataProvider dataProvider) throws TestRunException {
-        // *** Initialise the Managers ready for the test run
-        ITestRunManagers managers ;
-        try {
-            GalasaTest galasaTest = new GalasaTest(testClass);
-            managers = dataProvider.createTestRunManagers(galasaTest);
-        } catch (Exception e) {
-            // Managers are custom code, may be prone to failure if they are immature...
-            // so catch any exception and turn it into a TestRunException.
-            String msg = "Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
-            logger.error(msg);
-            reportEnvFailFinishedResult(e);
-            throw new TestRunException("Problem initialising the Managers for a test run", e);
-        }
-
-        logger.debug("Test managers initialised ok.");
-        return managers;
-    }
-
-    private boolean doActiveManagersSupportSharedEnvBuild(ITestRunManagers managers, TestClassWrapper testClassWrapper) {
-        boolean isRunOK = true ;
-        logger.debug("Checking active managers to see if they support shared env build...");
-        //*** Check all the active Managers to see if they support a shared environment build
-        boolean invalidManager = false;
-        for(IManager manager : managers.getActiveManagers()) {
-            if (!manager.doYouSupportSharedEnvironments()) {
-                logger.error("Manager " + manager.getClass().getName() + " does not support Shared Environments");
-                invalidManager = true;
-            }
-        }
-
-        if (invalidManager) {
-            logger.error("There are Managers that do not support Shared Environment builds");
-            testClassWrapper.setResult(Result.failed("Invalid Shared Environment build"));
-            testStructure.setResult(testClassWrapper.getResult().getName());
-            isRunOK = false;
-        }
-        return isRunOK;
-    }
-
-    /**
-     * Clean up any state we can, as the test has finished (good or bad) or the shared
-     * environment is no longer needed.
-     * @param managers Managers to clean up.
-     * @throws TestRunException Something failed within cleanup.
-     */
-    private void cleanupTestState(ITestRunManagers managers) throws TestRunException {
-        updateStatus(TestRunLifecycleStatus.ENDING, null);
-        managers.endOfTestRun();
-
-        boolean markedWaiting = false;
-
-        if (!isResourcesAvailable && !run.isLocal()) {
-            markWaiting(this.framework);
-            logger.info("Placing queue on the waiting list");
-            markedWaiting = true;
-        } else {
-            if (this.runType == RunType.SHARED_ENVIRONMENT_DISCARD) {
-                this.testStructure.setResult("Discarded");
-                try {
-                    this.dss.deletePrefix("run." + this.run.getName() + ".shared.environment");
-                } catch (DynamicStatusStoreException e) {
-                    logger.error("Problem cleaning shared environment properties", e);
-                }
-            }
-            updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-        }
-
-        logger.debug("Stopping heartbeat...");
-        stopHeartbeat();
-
-        // Record all the CPS properties that were accessed
-        saveUsedCPSPropertiesToArtifact(this.framework.getRecordProperties(), this.fileSystem, this.ras);
-        // And all the overrides the test was passed.
-        saveAllOverridesPassedToArtifact(overrideProperties, this.fileSystem , this.ras);
-
-        // *** If this was a local run, then we will want to remove the run properties
-        // from the DSS immediately
-        // *** for automation, we will let the core manager clean up after a while
-        // *** Local runs will have access to the run details via a view,
-        // *** But automation runs will only exist in the RAS if we delete them, so need
-        // to give
-        // *** time for things like jenkins and other run requesters to obtain the
-        // result and RAS id before
-        // *** deleting, default is to keep the automation run properties for 5 minutes
-        if (!markedWaiting) {
-            deleteRunProperties(this.framework);
-        }
-
-    }
-
-    private void saveSharedBuildEnvironmentState() throws TestRunException {
-        // Record all the CPS properties that were accessed
-        saveUsedCPSPropertiesToArtifact(this.framework.getRecordProperties(), this.fileSystem, this.ras);
-        // And all the overrides the test was passed.
-        saveAllOverridesPassedToArtifact(overrideProperties, this.fileSystem , this.ras);
-        
-        updateStatus(TestRunLifecycleStatus.UP, "built");
-    }
-
-    private void reportEnvFailFinishedResult(Exception ex) {
-        try {
-            this.testStructure.setResult(Result.envfail(ex).getName());
-            updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-        } catch (Exception failureProcessingException) {
-            String msg2 = "Exception caught while dealing with manager failure. "+failureProcessingException.getMessage();
-            logger.error(msg2);
-        }
-    }
-
-    private boolean generateEnvironment(TestClassWrapper testClassWrapper, ITestRunManagers managers, IDynamicStatusStoreService dss, String runName , boolean isRunOK) throws TestRunException {
-        logger.debug("Generating environment...");
+    private void generateEnvironment(TestClassWrapper testClassWrapper, ITestRunManagers managers, IDynamicStatusStoreService dss, String runName , boolean isRunOK) throws TestRunException {
         if(isRunOK){
             try {
                 updateStatus(TestRunLifecycleStatus.GENERATING, null);
@@ -392,7 +303,6 @@ public class TestRunner extends BaseTestRunner {
                 isRunOK = false;
             }
         }
-        return isRunOK;
     }
 
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
@@ -99,8 +99,8 @@ public class TestRunnerDataProvider implements ITestRunnerDataProvider {
         ITestRunManagers managers ;
         try {
             managers = new TestRunManagers(this.framework, galasaTest);
-        } catch (Exception e) {
-            String msg = "Exception caught. "+e.getMessage();
+        } catch (FrameworkException e) {
+            String msg = "FrameworkException Exception caught. "+e.getMessage();
             throw new TestRunException(msg,e);
         }
         return managers;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestRunner.java
@@ -22,7 +22,6 @@ import dev.galasa.framework.maven.repository.spi.IMavenRepository;
 import dev.galasa.framework.mocks.*;
 import dev.galasa.framework.mocks.MockTestRunnerEventsProducer.ProducedEvent;
 import dev.galasa.framework.spi.*;
-import dev.galasa.framework.spi.language.GalasaTest;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class TestTestRunner {
@@ -49,7 +48,17 @@ public class TestTestRunner {
         Properties overrideProps = new Properties();
         MockIResultArchiveStore ras = new MockIResultArchiveStore("myRunId", mockFileSystem ); 
 
-        MockIDynamicStatusStoreService dss = new MockDSSWhichDoesNothing();
+        MockIDynamicStatusStoreService dss = new MockIDynamicStatusStoreService() {
+            @Override
+            public Map<String, String> getPrefix(@NotNull String keyPrefix) throws DynamicStatusStoreException {
+                return new HashMap<String,String>();
+            }
+
+            @Override
+            public void put(@NotNull String key, @NotNull String value) throws DynamicStatusStoreException {
+                // Do nothing.
+            }
+        };
 
         IRun run = new MockRun(
             TEST_BUNDLE_NAME, 
@@ -264,172 +273,5 @@ public class TestTestRunner {
             .contains(TEST_RUN_NAME,"TestRunLifecycleStatusChangedEvent",TestRunLifecycleStatus.FINISHED);
         assertThat(events.get(8)).extracting("testRunName","eventType","testRunLifecycleStatus")
             .contains(TEST_RUN_NAME,"TestHeartbeatStoppedEvent",null);
-    }
-
-    class MockDSSWhichDoesNothing extends MockIDynamicStatusStoreService {
-        @Override
-        public Map<String, String> getPrefix(@NotNull String keyPrefix) throws DynamicStatusStoreException {
-            return new HashMap<String,String>();
-        }
-
-        @Override
-        public void put(@NotNull String key, @NotNull String value) throws DynamicStatusStoreException {
-            // Do nothing.
-        }
-    };
-
-    @Test
-    public void testCanCleanupOkIfManagerLoadFails() throws Exception {
-
-        String TEST_STREAM_REPO_URL = "http://myhost/myRepositoryForMyRun";
-        String TEST_BUNDLE_NAME = "myTestBundle";
-        String TEST_CLASS_NAME = MyActualTestClass.class.getName();
-        String TEST_RUN_NAME = "myTestRun";
-        String TEST_STREAM = "myStreamForMyRun";
-        String TEST_STREAM_OBR = "http://myhost/myObrForMyRun";
-        String TEST_REQUESTOR_NAME = "daffyduck";
-        boolean TEST_IS_LOCAL_RUN_TRUE = true;
-        boolean IGNORE_TEST_CLASS_FALSE = false;
-
-        MockFileSystem mockFileSystem = new MockFileSystem();
-        Properties overrideProps = new Properties();
-        MockIResultArchiveStore ras = new MockIResultArchiveStore("myRunId", mockFileSystem ); 
-
-        MockIDynamicStatusStoreService dss = new MockDSSWhichDoesNothing();
-
-        IRun run = new MockRun(
-            TEST_BUNDLE_NAME, 
-            TEST_CLASS_NAME , 
-            TEST_RUN_NAME, 
-            TEST_STREAM, 
-            TEST_STREAM_OBR , 
-            TEST_STREAM_REPO_URL,
-            TEST_REQUESTOR_NAME,
-            TEST_IS_LOCAL_RUN_TRUE
-        );
-
-
-        MockIFrameworkRuns frameworkRuns = new MockIFrameworkRuns( "myRunsGroup", List.of(run));
-
-        MockShutableFramework framework = new MockShutableFramework(ras,dss,TEST_RUN_NAME, run, frameworkRuns );
-        IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
-
-
-
-        IMavenRepository mockMavenRepo = new MockMavenRepository();
-
-        Repository repo1 = new MockRepository(TEST_STREAM_REPO_URL);
-        List<Repository> repositories = List.of(repo1);
-
-        boolean IS_RESOLVER_GOING_TO_RESOLVE_TEST_BUNDLE = true;
-        Resolver resolver = new MockResolver( IS_RESOLVER_GOING_TO_RESOLVE_TEST_BUNDLE );
-        Resource mockResource = new MockResource(TEST_STREAM_OBR);
-
-        MockRepositoryAdmin mockRepoAdmin = new MockRepositoryAdmin(repositories, resolver) {
-            @Override
-            public Resource[] discoverResources(String filterExpr) throws InvalidSyntaxException {
-                Resource[] results = new Resource[1];
-                results[0] = mockResource ;
-                return results;
-            }
-        };
-
-        MockBundleManager mockBundleManager = new MockBundleManager();
-
-        Map<String,MockServiceReference<?>> servicesMap = new HashMap<>();
-
-        Map<String,Class<?>> loadedClasses = Map.of( TEST_CLASS_NAME , MyActualTestClass.class );
-        MockBundle myBundle1 = new MockBundle( loadedClasses , TEST_BUNDLE_NAME );
-        List<Bundle> bundles = List.of(myBundle1);
-        MockBundleContext mockBundleContext = new MockBundleContext(servicesMap, bundles);
-
-
-        class MockAnnotationExtractor implements IAnnotationExtractor {
-
-            Map<String, Annotation> annotationToReturnMap = new HashMap<>();
-
-            public <A, B extends Annotation> void addAnnotation( Class<A> testClass, Class<B> annotationClass , B toReturn) {
-                String key = testClass.getName()+"-"+annotationClass.getName();
-                annotationToReturnMap.put( key, toReturn );
-            }
-
-            @SuppressWarnings("unchecked")
-            @Override
-            public <A, B extends Annotation> B getAnnotation(Class<A> testClass, Class<B> annotationClass) {
-                String key = testClass.getName()+"-"+annotationClass.getName();
-                // The following type-cast is unsafe, or would be were we not in full control of all the 
-                // inputs and outputs in a unit test setting...
-                return  (B) annotationToReturnMap.get(key);
-            }
-        }
-
-        MockAnnotationExtractor mockAnnotationExtractor = new MockAnnotationExtractor();
-        dev.galasa.Test annotationToReturn = MyActualTestClass.class.getAnnotation(dev.galasa.Test.class);
-        assertThat(annotationToReturn).isNotNull();
-
-        mockAnnotationExtractor.addAnnotation(
-            MyActualTestClass.class, 
-            dev.galasa.Test.class,
-            annotationToReturn
-        );
-
-        TestRunner runner = new TestRunner() ;
-
-        runner.mavenRepository = mockMavenRepo;
-        runner.repositoryAdmin = mockRepoAdmin;
-
-        // Inject the bundle context before we run the test.
-        runner.activate(mockBundleContext);
-
-        Result testResult = Result.passed();
-        
-        MockTestRunManagers mockTestRunManagers = new MockTestRunManagers(IGNORE_TEST_CLASS_FALSE, testResult );
-
-        MockTestRunnerEventsProducer mockEventsPublisher = new MockTestRunnerEventsProducer();
-        
-        MockTestRunnerDataProvider testRunData = new MockTestRunnerDataProvider(
-            cps,
-            dss,
-            ras,
-            run,
-            framework,
-            overrideProps,
-            mockAnnotationExtractor,
-            mockBundleManager,
-            mockTestRunManagers,
-            mockFileSystem,
-            mockEventsPublisher
-        ) {
-
-            // *********** this is the 'spicey bit' for this test, where we simulate a failure.
-            @Override
-            public ITestRunManagers createTestRunManagers(GalasaTest galasaTest) throws TestRunException {
-                throw new NullPointerException("Simulating a bad failure in a custom manager");
-            }
-        };
-
-        // When...
-        TestRunException ex = catchThrowableOfType( ()->runner.runTest(testRunData), TestRunException.class);
-
-        /// Then...
-        assertThat(ex).isNotNull();      
-
-        // Check the RAS history
-        // We expect started->generating->building->provstart->running->rundone->ending->finished
-        List<TestStructure> rasHistory = ras.getTestStructureHistory();
-        assertThat(rasHistory).hasSize(3);
-
-        // initial setup.
-        assertThat(rasHistory.get(0)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
-            .containsExactly("myTestRun",null,null, null, "daffyduck", null,null);
-
-        // status = started
-        assertThat(rasHistory.get(1)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
-            .containsExactly("myTestRun",null,null, null, "daffyduck", "started",null);
-
-        // status = finished
-        assertThat(rasHistory.get(2)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
-            .containsExactly("myTestRun","myTestBundle","dev.galasa.framework.MyActualTestClass", "MyActualTestClass", "daffyduck", "finished","EnvFail");
-
     }
 }


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Concerned that these changes 'may' have stopped pods being cleaned up.

Reverting to make sure they didn't.

