### PR TITLE
k8s engine should not schedule pods if we've hit our limit, inactive pods still count

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -116,7 +116,10 @@ public class TestPodScheduler implements Runnable {
             while (true) {
                 // *** Check we are not at max engines
                 List<V1Pod> pods = getPods(this.api, this.settings);
-                filterActiveRuns(pods);
+                
+                // Do not filter out active runs. Completed runs still consume memory. 
+                // We should limit active+inactive runs to the max threashold.
+
                 logger.info("Active runs=" + pods.size() + ",max=" + settings.getMaxEngines());
 
                 int currentActive = pods.size();

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/DssEvent.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/DssEvent.java
@@ -28,13 +28,13 @@ public class DssEvent {
         this.newValue = newValue;
         this.oldValue = oldValue ;
 
-        logger.debug(this.toString());
+        logger.debug("Created: "+this.toString());
     }
 
 
     @Override
     public String toString() {
-        return "Dss event created: type:"+eventType+" runName:"+runName+" oldValue:"+oldValue+" newValue:"+newValue;
+        return "Dss event: type:"+eventType+" runName:"+runName+" oldValue:"+oldValue+" newValue:"+newValue;
     }
 
     public String getRunName() {


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
In tests, when 30 tests were launched all at once, and the Galasa service configuration had a max-pods set to 10, we saw 10 pods running at once, but 20+ pods overall, because some of the pods were `completed` and not cleaned up yet.

If there are tons of completed pods around, these should still count towards the total number of pods that the k8s controller can launch.

Removing the filtering which discounts completed pods, so the engine will effectively wait for pod cleanup before launching new ones.
