### PR TITLE
Update build-locally.sh for OBR module for obr-generic Maven build

### DIFF
--- a/modules/obr/build-locally.sh
+++ b/modules/obr/build-locally.sh
@@ -426,10 +426,11 @@ function build_generated_obr_generic_pom {
     h2 "Building the generated OBR generic pom.xml..."
     cd ${BASEDIR}/obr-generic
 
-    mvn \
+    mvn install \
     -Dgpg.passphrase=${GPG_PASSPHRASE} \
     -Dgalasa.source.repo=${SOURCE_MAVEN} \
-    -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ install \
+    -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+    dev.galasa:galasa-maven-plugin:$component_version:obrembedded \
     2>&1 >> ${log_file}
 
     rc=$?; if [[ "${rc}" != "0" ]]; then


### PR DESCRIPTION
## Why?

When using this script yesterday it successfully built me a local-galasa-boot-embedded image which I was able to use for my local Minikube ecosystem. However, on API startup, it complained that the file `galasa.obr` did not exist.

I inspected the contents of the image and found it only contained the boot.jar and log4j properties. I compared this with the actual galasa-boot-embedded image thats build by GH Actions which contains all jars needed at runtime and this `galasa.obr` file.

I compared the local build script and the GH build and saw the call to the `obrembedded` Maven plugin was missing. After adding this, the image contains all jars and files needed and I was able to bring my Minikube ecosystem up with is. 