### PR TITLE
trying to delete completed pods quicker

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -212,10 +212,6 @@ public class BaseTestRunner {
 
         IRun run = framework.getTestRun();
 
-        if (!run.isLocal()) { // *** Not interested in non-local runs
-            return;
-        }
-
         try {
             framework.getFrameworkRuns().delete(run.getName());
         } catch (FrameworkException e) {


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
In the test runner, the dss properties for the test run are now deleted at the end of the test.

That should kick off the etcd watcher which will cause managers to cleanup, and the k8s engine controller to delete the pod.


