### PR TITLE
Revert "Set test run IDs when submitting tests to be scheduled (#225)"

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
@@ -538,9 +538,11 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
 
     @Override
     public IRunResult getRunById(@NotNull String runId) throws ResultArchiveStoreException {
-        if (runId.startsWith("cdb-")) {
-            runId = runId.substring(4);
+        if (!runId.startsWith("cdb-")) {
+            return null;
         }
+
+        runId = runId.substring(4);
 
         try {
             return fetchRun(runId);

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryServiceTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryServiceTest.java
@@ -28,6 +28,7 @@ import dev.galasa.extensions.common.couchdb.pojos.ViewRow;
 import dev.galasa.extensions.common.impl.HttpRequestFactoryImpl;
 import dev.galasa.extensions.common.mocks.BaseHttpInteraction;
 import dev.galasa.extensions.common.mocks.HttpInteraction;
+import dev.galasa.extensions.common.mocks.MockAsyncCloseableHttpClient;
 import dev.galasa.extensions.common.mocks.MockCloseableHttpClient;
 import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.spi.IRunResult;

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/CouchdbTestFixtures.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/CouchdbTestFixtures.java
@@ -113,11 +113,8 @@ public class CouchdbTestFixtures {
         @Override
         public void validateRequest(HttpHost host, HttpRequest request) throws RuntimeException {
             super.validateRequest(host,request);
-
-            String rasUriStr = getRasUriStr();
-            String documentId = getDocumentId();
-            assertThat(request.getRequestLine().getMethod()).isEqualTo("PUT");
-            assertThat(request.getRequestLine().getUri()).isEqualTo(rasUriStr+"/galasa_run/"+documentId);
+            assertThat(request.getRequestLine().getMethod()).isEqualTo("POST");
+            assertThat(request.getRequestLine().getUri()).isEqualTo(getRasUriStr()+"/galasa_run");
         }
 
         @Override
@@ -224,7 +221,7 @@ public class CouchdbTestFixtures {
 
         MockConfigurationPropertyStoreService mockCps = new MockConfigurationPropertyStoreService(props);
 
-        IRun mockIRun = new MockIRun(runName1, documentId1);
+        IRun mockIRun = new MockIRun(runName1);
 
         return createCouchdbRasStore(mockCps, mockIRun, logFactory, new MockCloseableHttpClient(allInteractions));
     }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
@@ -13,21 +13,14 @@ import dev.galasa.framework.spi.IRun;
 public class MockIRun implements IRun {
 
     private String name ;
-    private String runId;
 
-    public MockIRun(String name, String runId) {
+    public MockIRun(String name) {
         this.name = name ;
-        this.runId = runId;
     }
 
     @Override
     public String getName() {
         return this.name;
-    }
-
-    @Override
-    public String getRasRunId() {
-        return this.runId;
     }
 
     @Override
@@ -129,4 +122,5 @@ public class MockIRun implements IRun {
     public String getGherkin() {
         throw new UnsupportedOperationException("Unimplemented method 'getGherkin'");
     }
+    
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
@@ -63,7 +63,7 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
     @Override
     public @NotNull IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String runId)
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language)
             throws FrameworkException {
             if (stream.equals("null")){
                 throw new FrameworkException(language);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
@@ -146,10 +146,5 @@ public class MockIRun implements IRun{
     public String getGherkin() {
         throw new UnsupportedOperationException("Unimplemented method 'getGherkin'");
     }
-
-    @Override
-    public String getRasRunId() {
-        throw new UnsupportedOperationException("Unimplemented method 'getRasRunId'");
-    }
     
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockArchiveStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockArchiveStore.java
@@ -61,4 +61,9 @@ public class MockArchiveStore implements IResultArchiveStore {
     public @NotNull List<IResultArchiveStoreDirectoryService> getDirectoryServices() {
         return this.directoryServices;
     }
+
+    @Override
+    public String calculateRasRunId() {
+        throw new UnsupportedOperationException("Unimplemented method 'calculateRasRunId'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
@@ -8,7 +8,6 @@ package dev.galasa.framework.api.runs.common;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.UUID;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -101,30 +100,16 @@ public class GroupRuns extends ProtectedRoute {
                 }
             }
 
-            if (jwtRequestor == null) {
+            if(jwtRequestor == null){
                 jwtRequestor = request.getRequestor(); 
             }
-
-            String runId = UUID.randomUUID().toString();
-
             try {
-                IRun newRun = framework.getFrameworkRuns().submitRun(
-                    request.getRequestorType(),
-                    jwtRequestor,
-                    classNameSplit[0],
-                    classNameSplit[1],
-                    groupName,
-                    request.getMavenRepository(),
-                    request.getObr(),
-                    request.getTestStream(),
-                    false,
-                    request.isTrace(),
-                    request.getOverrides(), 
-                    senvPhase, 
-                    request.getSharedEnvironmentRunName(),
-                    "java",
-                    runId
-                );
+                IRun newRun = framework.getFrameworkRuns().submitRun(request.getRequestorType(), jwtRequestor, classNameSplit[0], classNameSplit[1],
+                        groupName, request.getMavenRepository(), request.getObr(), request.getTestStream(), false,
+                        request.isTrace(), request.getOverrides(), 
+                        senvPhase, 
+                        request.getSharedEnvironmentRunName(),
+                        "java");
                 
                 status.getRuns().add(newRun.getSerializedRun());
             } catch (FrameworkException fe) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockFrameworkRuns.java
@@ -46,7 +46,7 @@ public class MockFrameworkRuns implements IFrameworkRuns {
     @Override
     public @NotNull IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String runId)
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language)
             throws FrameworkException {
         throw new UnsupportedOperationException("Unimplemented method 'submitRun'");
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -179,7 +179,7 @@ public class FrameworkRuns implements IFrameworkRuns {
     public @NotNull IRun submitRun(String runType, String requestor, String bundleName,
             @NotNull String testName, String groupName, String mavenRepository, String obr, String stream,
             boolean local, boolean trace, Properties overrides, SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName,
-            String language, String runId) throws FrameworkException {
+            String language) throws FrameworkException {
         SubmitRunRequest runRequest = new SubmitRunRequest(
             runType,
             requestor,
@@ -194,14 +194,12 @@ public class FrameworkRuns implements IFrameworkRuns {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language,
-            runId
+            language
         );
         return submitRun(runRequest);
     }
 
     private boolean storeRun(String runName, SubmitRunRequest runRequest) throws DynamicStatusStoreException {
-        String runId = runRequest.getRasRunId();
         String bundleName = runRequest.getBundleName();
         String testName = runRequest.getTestName();
         String bundleTest = runRequest.getBundleTest();
@@ -244,8 +242,6 @@ public class FrameworkRuns implements IFrameworkRuns {
         } else {
             otherRunProperties.put(runPropertyPrefix + ".group", UUID.randomUUID().toString());
         }
-
-        otherRunProperties.put(runPropertyPrefix + ".rasrunid", runId);
         otherRunProperties.put(runPropertyPrefix + ".requestor", requestor);
 
         if (sharedEnvironmentPhase != null) {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -72,6 +72,9 @@ public class GherkinTestRunner extends BaseTestRunner {
 
         try {
 
+            String rasRunId = this.ras.calculateRasRunId();
+            storeRasRunIdInDss(dss, rasRunId);
+
             try {
                 String streamName = AbstractManager.nulled(run.getStream());
                 new MavenRepositoryListBuilder(this.mavenRepository, this.cps)

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
@@ -212,7 +212,6 @@ public class RunImpl implements IRun {
         return this.gherkin;
     }
     
-    @Override
     public String getRasRunId() {
         return this.rasRunId;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -80,6 +80,9 @@ public class TestRunner extends BaseTestRunner {
             
         try {
 
+            String rasRunId = this.ras.calculateRasRunId();
+            storeRasRunIdInDss(dss, rasRunId);
+
             Class<?> testClass ;
 
             try {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ValidateEcosystem.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ValidateEcosystem.java
@@ -7,7 +7,6 @@ package dev.galasa.framework;
 
 import java.time.Instant;
 import java.util.Properties;
-import java.util.UUID;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -71,8 +70,7 @@ public class ValidateEcosystem {
                     null, 
                     null, 
                     null, 
-                    null,
-                    UUID.randomUUID().toString());
+                    null);
             
             logger.info("Test CoreManagerIVT submitted as run " + testRun.getName());
             

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/SubmitRunRequest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/SubmitRunRequest.java
@@ -31,7 +31,6 @@ public class SubmitRunRequest {
     private String language = "java";
     private String bundleTest;
     private String gherkinTest;
-    private String rasRunId;
 
     public SubmitRunRequest(
         String runType,
@@ -47,8 +46,7 @@ public class SubmitRunRequest {
         Properties overrides,
         SharedEnvironmentPhase sharedEnvironmentPhase,
         String sharedEnvironmentRunName,
-        String language,
-        String runId
+        String language
     ) throws FrameworkException {
         setTestName(testName);
 
@@ -65,7 +63,6 @@ public class SubmitRunRequest {
         this.sharedEnvironmentPhase = sharedEnvironmentPhase;
         this.sharedEnvironmentRunName = sharedEnvironmentRunName;
         this.language = language;
-        this.rasRunId = runId;
     }
 
     public String getRunType() {
@@ -197,13 +194,5 @@ public class SubmitRunRequest {
 
     public void setGherkinTest(String gherkinTest) {
         this.gherkinTest = gherkinTest;
-    }
-
-    public String getRasRunId() {
-        return this.rasRunId;
-    }
-
-    public void setRasRunId(String rasRunId) {
-        this.rasRunId = rasRunId;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/TestRunInitStrategy.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/TestRunInitStrategy.java
@@ -6,7 +6,6 @@
 package dev.galasa.framework.internal.init;
 
 import java.util.Properties;
-import java.util.UUID;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -75,16 +74,15 @@ public class TestRunInitStrategy implements IFrameworkInitialisationStrategy {
         IRun run = null;
         IFrameworkRuns frameworkRuns = framework.getFrameworkRuns();
 
-        String runId = UUID.randomUUID().toString();
         switch(language) {
             case "java": 
                 String split[] = runBundleClass.split("/");
                 String bundle = split[0];
                 String test = split[1];
-                run = frameworkRuns.submitRun("local", null, bundle, test, null, null, null, null, true, false, null, null, null, language, runId);
+                run = frameworkRuns.submitRun("local", null, bundle, test, null, null, null, null, true, false, null, null, null, language);
                 break;
             case "gherkin":
-                run = frameworkRuns.submitRun("local", null, null, runBundleClass, null, null, null, null, true, false, null, null, null, language, runId);
+                run = frameworkRuns.submitRun("local", null, null, runBundleClass, null, null, null, null, true, false, null, null, null, language);
                 break;
             default:
                 throw new FrameworkException("Unknown language to create run");

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/FrameworkMultipleResultArchiveStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/FrameworkMultipleResultArchiveStore.java
@@ -124,4 +124,15 @@ public class FrameworkMultipleResultArchiveStore implements IResultArchiveStoreS
         return dirs;
     }
 
+    @Override
+    public String calculateRasRunId() {
+        
+        if (this.rasServices.size() > 0) {
+            return this.rasServices.get(0).calculateRasRunId();
+        }
+        
+        return null;
+    }
+    
+
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryResultArchiveStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryResultArchiveStoreService.java
@@ -222,4 +222,17 @@ public class DirectoryResultArchiveStoreService implements IResultArchiveStoreSe
         return dirs;
     }
 
+    @Override
+    public String calculateRasRunId() {
+        final String runName = this.framework.getTestRunName();
+        if (runName == null) {
+            return null;
+        }
+        
+        String id = DirectoryRASDirectoryService.ID_PREFIX + Base64.getEncoder().encodeToString(this.runDirectory.toString().getBytes(StandardCharsets.UTF_8));
+        
+        return id;
+    }
+
+
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
@@ -37,7 +37,7 @@ public interface IFrameworkRuns {
     @NotNull
     IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String runId) throws FrameworkException;
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language) throws FrameworkException;
 
     boolean delete(String runname) throws DynamicStatusStoreException;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStore.java
@@ -78,4 +78,7 @@ public interface IResultArchiveStore {
 
     @NotNull
     List<IResultArchiveStoreDirectoryService> getDirectoryServices();
+    
+    String calculateRasRunId();
+
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
@@ -52,6 +52,4 @@ public interface IRun {
     boolean isSharedEnvironment();
 
     public String getGherkin();
-
-    String getRasRunId();
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
@@ -56,7 +56,6 @@ public class FrameworkRunsTest {
 
         FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
 
-        String runId = "testId1";
         String runType = "unknown";
         String requestor = "me";
         String bundleName = "mybundle";
@@ -95,8 +94,7 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language,
-            runId
+            language
         );
 
         // Then...
@@ -133,7 +131,6 @@ public class FrameworkRunsTest {
 
         FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
 
-        String runId = "testId1";
         String runType = "unknown";
         String requestor = "me";
         String bundleName = "mybundle";
@@ -172,8 +169,7 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language,
-            runId
+            language
         );
 
         // Then...
@@ -212,7 +208,6 @@ public class FrameworkRunsTest {
 
         FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
 
-        String runId = "testId1";
         String runType = "unknown";
         String requestor = "me";
         String bundleName = "mybundle";
@@ -252,8 +247,7 @@ public class FrameworkRunsTest {
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
-                language,
-                runId
+                language
             );
         }, FrameworkException.class);
 
@@ -273,7 +267,6 @@ public class FrameworkRunsTest {
 
         String testName = null;
 
-        String runId = "testId1";
         String runType = "unknown";
         String requestor = "me";
         String bundleName = "mybundle";
@@ -306,8 +299,7 @@ public class FrameworkRunsTest {
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
-                language,
-                runId
+                language
             );
         }, FrameworkException.class);
 
@@ -327,7 +319,6 @@ public class FrameworkRunsTest {
 
         String bundleName = null;
         
-        String runId = "testId1";
         String testName = "mytest";
         String runType = "unknown";
         String requestor = "me";
@@ -360,8 +351,7 @@ public class FrameworkRunsTest {
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
-                language,
-                runId
+                language
             );
         }, FrameworkException.class);
 
@@ -381,7 +371,6 @@ public class FrameworkRunsTest {
 
         String language = null;
 
-        String runId = "testId1";
         String bundleName = "mybundle";
         String testName = "mytest";
         String runType = "unknown";
@@ -413,8 +402,7 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language,
-            runId
+            language
         );
 
         // Then...
@@ -433,8 +421,7 @@ public class FrameworkRunsTest {
         FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
 
         String runType = "local";
-
-        String runId = "testId1";
+        
         String language = "java";
         String bundleName = "mybundle";
         String testName = "mytest";
@@ -466,8 +453,7 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language,
-            runId
+            language
         );
 
         // Then...
@@ -487,7 +473,6 @@ public class FrameworkRunsTest {
 
         String language = "gherkin";
         
-        String runId = "testId1";
         String runType = "local";
         String bundleName = "mybundle";
         String testName = "mygherkintest";
@@ -519,8 +504,7 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language,
-            runId
+            language
         );
 
         // Then...
@@ -557,7 +541,6 @@ public class FrameworkRunsTest {
         SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.BUILD;
         String sharedEnvironmentRunName = "SHARED-RUN1";
 
-        String runId = "testId1";
         String language = "java";
         String runType = "local";
         String bundleName = "mybundle";
@@ -587,8 +570,7 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language,
-            runId
+            language
         );
 
         // Then...
@@ -626,7 +608,6 @@ public class FrameworkRunsTest {
         SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.BUILD;
         String sharedEnvironmentRunName = null;
 
-        String runId = "testId1";
         String language = "java";
         String runType = "local";
         String bundleName = "mybundle";
@@ -657,8 +638,7 @@ public class FrameworkRunsTest {
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
-                language,
-                runId
+                language
             );
         }, FrameworkException.class);
 
@@ -683,7 +663,6 @@ public class FrameworkRunsTest {
 
         SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.DISCARD;
 
-        String runId = "testId1";
         String language = "java";
         String runType = "local";
         String bundleName = "mybundle";
@@ -713,8 +692,7 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language,
-            runId
+            language
         );
 
         // Then...
@@ -744,7 +722,6 @@ public class FrameworkRunsTest {
 
         SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.BUILD;
 
-        String runId = "testId1";
         String language = "java";
         String runType = "local";
         String bundleName = "mybundle";
@@ -775,8 +752,7 @@ public class FrameworkRunsTest {
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
-                language,
-                runId
+                language
             );
         }, FrameworkException.class);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
@@ -124,11 +124,6 @@ public class MockRun implements IRun {
                throw new UnsupportedOperationException("Unimplemented method 'isSharedEnvironment'");
     }
 
-    @Override
-    public String getRasRunId() {
-        throw new UnsupportedOperationException("Unimplemented method 'getRasRunId'");
-    }
-
 
     
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIFrameworkRuns.java
@@ -63,7 +63,7 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
     @Override
     public @NotNull IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String runId)
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language)
             throws FrameworkException {
             if (stream.equals("null")){
                 throw new FrameworkException(language);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIResultArchiveStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIResultArchiveStore.java
@@ -39,6 +39,11 @@ public class MockIResultArchiveStore implements IResultArchiveStore {
         mockFS.setFileContents(mockFS.getPath("/my/stored/artifacts/root/framework/cps_record.properties"), "Dummy test content");
     }
 
+    @Override
+    public String calculateRasRunId() {
+        return this.runId;
+    }
+
     public List<TestStructure> getTestStructureHistory() {
         return this.testStructureHistory;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRASStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRASStoreService.java
@@ -65,4 +65,11 @@ public class MockRASStoreService implements IResultArchiveStoreService{
     public @NotNull List<IResultArchiveStoreDirectoryService> getDirectoryServices() {
         throw new UnsupportedOperationException("Unimplemented method 'getDirectoryServices'");
     }
+
+    @Override
+    public String calculateRasRunId() {
+        throw new UnsupportedOperationException("Unimplemented method 'calculateRasRunId'");
+    }
+
+    
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
@@ -175,10 +175,6 @@ public class MockRun implements IRun {
     public String getResult() {
         throw new UnsupportedOperationException("Unimplemented method 'getResult'");
     }
-    @Override
-    public String getRasRunId() {
-        throw new UnsupportedOperationException("Unimplemented method 'getRasRunId'");
-    }
 
 
     


### PR DESCRIPTION
This reverts commit 1909c8233211afcfa6697f85b77cd43e5258be9c due to re-runs no longer being assigned new run IDs when attempting to create new run documents in couchdb.