### PR TITLE
mcobbett test run complete deletes pod quicker

### DIFF
--- a/modules/framework/docs/design/submission-ids/001-submission-sequence.plantuml
+++ b/modules/framework/docs/design/submission-ids/001-submission-sequence.plantuml
@@ -1,0 +1,69 @@
+@startuml 001-submission-sequence
+title "Submission"
+
+participant CLI
+participant API
+participant DSS
+participant Engine
+participant Test
+participant CouchDB
+
+CLI -> API : Submit test
+API -> DSS : put(submission-id, groupid, state=queued)
+API --> CLI : Response(submission-id)
+
+Engine -> DSS : Poll-for-queued
+DSS --> Engine: Response(submission id, groupid , state=queued)
+
+Engine->Engine: create runName like U456
+
+Engine->Test : launch(runName, groupid, submission id, state=started)
+
+Test-> CouchDB : Create()
+CouchDB --> Test : doc id a.k.a run-id.
+Test -> DSS : update(+doc id/run-id)
+
+Test-> Test: runs test
+Test-> CouchDB : updates document as test state changes
+Test-> CouchDB : updates document as test state changes
+Test-> CouchDB : updates document as test state changes
+Test-> CouchDB: Finished
+
+Test->DSS : Delete(runId=U456)
+
+
+
+
+CLI -> API : Submit test
+API -> DSS : put(submission-id, groupid, state=queued)
+API --> CLI : Response(submission-id)
+
+Engine -> DSS : Poll-for-queued
+DSS --> Engine: Response(submission id, groupid , state=queued)
+
+Engine->Engine: create runName like U456
+
+Engine->Test : launch(runName, groupid, submission id, state=started)
+
+Test-> CouchDB : Create()
+CouchDB --> Test : doc id a.k.a run-id.
+Test -> DSS : update(+doc id/run-id)
+
+Test-> Test: runs test
+Test-> CouchDB : updates document as test state changes
+
+note right
+No resources
+end note
+
+Test->DSS : create(runName, groupId, submissionId, state=queued, no runId)
+
+
+Engine -> DSS : Poll-for-queued
+DSS --> Engine: Response(submission id, groupid , state=queued)
+
+Engine->Engine: create runName like U456
+
+Engine->Test : launch(runName, groupid, submission id, state=started)
+
+@enduml

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -29,6 +29,7 @@ import dev.galasa.framework.spi.IFrameworkRuns;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.SystemEnvironment;
 import dev.galasa.framework.spi.creds.FrameworkEncryptionService;
+// import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Affinity;
@@ -365,12 +366,7 @@ public class TestPodScheduler implements Runnable {
 
         V1ResourceRequirements resources = new V1ResourceRequirements();
         container.setResources(resources);
-
-        // TODO reinstate
-        // System.out.println("requests=" +
-        // Integer.toString(this.settings.getEngineMemoryRequest()) + "Mi");
-        // System.out.println("limit=" +
-        // Integer.toString(this.settings.getEngineMemoryLimit()) + "Mi");
+  
         // resources.putRequestsItem("memory", new
         // Quantity(Integer.toString(this.settings.getEngineMemoryRequest()) + "Mi"));
         // resources.putLimitsItem("memory", new

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunFinishedRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunFinishedRuns.java
@@ -44,14 +44,14 @@ public class RunFinishedRuns implements Runnable {
 
     @Override
     public void run() {
-        int defaultFinishedDelete = 300; // ** 5 minutes
+        int defaultFinishedDeleteSeconds = 2; 
         try { // TODO do we need a different timeout for automation run reset?
             String overrideTime = AbstractManager.nulled(cps.getProperty("resource.management", "finished.timeout"));
             if (overrideTime != null) {
-                defaultFinishedDelete = Integer.parseInt(overrideTime);
+                defaultFinishedDeleteSeconds = Integer.parseInt(overrideTime);
             }
         } catch (Exception e) {
-            logger.error("Problem with resource.management.finished.timeout, using default " + defaultFinishedDelete,
+            logger.error("Problem with resource.management.finished.timeout, using default " + defaultFinishedDeleteSeconds,
                     e);
         }
 
@@ -67,7 +67,7 @@ public class RunFinishedRuns implements Runnable {
                 }
 
                 Instant finished = run.getFinished();
-                Instant expires = finished.plusSeconds(defaultFinishedDelete);
+                Instant expires = finished.plusSeconds(defaultFinishedDeleteSeconds);
                 Instant now = Instant.now();
                 if (expires.compareTo(now) <= 0) {
                     String sFinished = dtf.format(LocalDateTime.ofInstant(finished, ZoneId.systemDefault()));

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunResourceManagement.java
@@ -62,7 +62,7 @@ public class RunResourceManagement implements IResourceManagementProvider {
         try {
             this.resourceManagement.getScheduledExecutorService().scheduleWithFixedDelay(
                     new RunFinishedRuns(this.framework, this.resourceManagement, this.dss, this, cps),
-                    this.framework.getRandom().nextInt(20), 20, TimeUnit.SECONDS);
+                    this.framework.getRandom().nextInt(20), 1, TimeUnit.SECONDS);
         } catch (FrameworkException e) {
             logger.error("Unable to initialise Finished Run monitor", e);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -212,10 +212,6 @@ public class BaseTestRunner {
 
         IRun run = framework.getTestRun();
 
-        if (!run.isLocal()) { // *** Not interested in non-local runs
-            return;
-        }
-
         try {
             framework.getFrameworkRuns().delete(run.getName());
         } catch (FrameworkException e) {


### PR DESCRIPTION
- **A test run deletes it's dss core properties before it exits to clean up the k8s pod quickly after that**
- **reduce frequency of checks for completed runs from 5 mins to seconds.**
