### PR TITLE
Use submission ID to track tests that have been submitted

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
@@ -49,6 +49,7 @@ import dev.galasa.framework.spi.ras.RasSearchCriteriaRunName;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaTestName;
 import dev.galasa.framework.spi.ras.RasSortField;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaStatus;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaSubmissionId;
 import dev.galasa.framework.spi.ras.RasTestClass;
 import dev.galasa.framework.spi.ras.ResultArchiveStoreFileStore;
 import dev.galasa.framework.spi.utils.GalasaGson;
@@ -491,9 +492,13 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
 
                 inArray(and, "bundle", sBundle.getBundles());
             } else if (searchCriteria instanceof RasSearchCriteriaGroup) {
-                RasSearchCriteriaGroup sBundle = (RasSearchCriteriaGroup) searchCriteria;
+                RasSearchCriteriaGroup sGroup = (RasSearchCriteriaGroup) searchCriteria;
 
-                inArray(and, "group", sBundle.getGroups());
+                inArray(and, "group", sGroup.getGroups());
+            } else if (searchCriteria instanceof RasSearchCriteriaSubmissionId) {
+                RasSearchCriteriaSubmissionId submissionIdCriteria = (RasSearchCriteriaSubmissionId) searchCriteria;
+
+                inArray(and, "submissionId", submissionIdCriteria.getSubmissionIds());
             } else if (searchCriteria instanceof RasSearchCriteriaResult) {
                 RasSearchCriteriaResult sResult = (RasSearchCriteriaResult) searchCriteria;
 

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImpl.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImpl.java
@@ -96,6 +96,7 @@ public class CouchdbValidatorImpl implements CouchdbValidator {
             checkIndex(httpClient, rasUri, 1, "galasa_run", "bundle", timeService);
             checkIndex(httpClient, rasUri, 1, "galasa_run", "result", timeService);
             checkIndex(httpClient, rasUri, 1, "galasa_run", "group", timeService);
+            checkIndex(httpClient, rasUri, 1, "galasa_run", "submissionId", timeService);
 
             logger.debug("RAS CouchDB at " + rasUri.toString() + " validated");
         } catch (CouchdbException e) {

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryServiceTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryServiceTest.java
@@ -28,7 +28,6 @@ import dev.galasa.extensions.common.couchdb.pojos.ViewRow;
 import dev.galasa.extensions.common.impl.HttpRequestFactoryImpl;
 import dev.galasa.extensions.common.mocks.BaseHttpInteraction;
 import dev.galasa.extensions.common.mocks.HttpInteraction;
-import dev.galasa.extensions.common.mocks.MockAsyncCloseableHttpClient;
 import dev.galasa.extensions.common.mocks.MockCloseableHttpClient;
 import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.spi.IRunResult;

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
@@ -320,6 +320,8 @@ public class CouchdbValidatorImplTest {
         interactions.add( new CheckIndexPOSTInteraction("result"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
         interactions.add( new CheckIndexPOSTInteraction("group"));
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("submissionId"));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
@@ -122,5 +122,9 @@ public class MockIRun implements IRun {
     public String getGherkin() {
         throw new UnsupportedOperationException("Unimplemented method 'getGherkin'");
     }
-    
+
+    @Override
+    public String getSubmissionId() {
+        throw new UnsupportedOperationException("Unimplemented method 'getSubmissionId'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -16,7 +16,7 @@ public enum ServletErrorMessage {
     GAL5006_INVALID_QUERY_PARAM_DUPLICATES            (5006,"E: Error parsing the query parameters. Duplicate instances of query parameter ''{0}'' found in the request URL. Expecting only one."),
     GAL5090_INVALID_QUERY_PARAM_NOT_BOOLEAN           (5090,"E: Error parsing the query parameter ''{0}'' in the request URL. Invalid value ''{1}''. Expecting a boolean."),
 
-    GAL5010_FROM_DATE_IS_REQUIRED                     (5010,"E: Error parsing the query parameters. 'from' time is a mandatory field if no 'runname' is supplied."),
+    GAL5010_FROM_DATE_IS_REQUIRED                     (5010,"E: Error parsing the query parameters. 'from' time is a mandatory field if no 'runname', 'group', or 'submissionId' is supplied."),
     GAL5011_SORT_VALUE_NOT_RECOGNIZED                 (5011,"E: Error parsing the query parameters. 'sort' value ''{0}'' not recognised. Expected query parameter in the format 'sort={fieldName}:{order}' where order is 'asc' for ascending or 'desc' for descending."),
     GAL5012_SORT_VALUE_MISSING                        (5012,"E: Error parsing the query parameters. 'sort' value was not supplied. Expected query parameter in the format 'sort={fieldName}:{order}' where order is 'asc' for ascending or 'desc' for descending."),
     GAL5013_RESULT_NAME_NOT_RECOGNIZED                (5013,"E: Error parsing the query parameters. 'result' value ''{0}'' not recognised. Expected result name to match one of the following ''{1}''."),

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
@@ -63,7 +63,7 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
     @Override
     public @NotNull IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language)
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId)
             throws FrameworkException {
             if (stream.equals("null")){
                 throw new FrameworkException(language);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
@@ -18,6 +18,8 @@ import dev.galasa.framework.spi.IRun;
 
 public class MockIFrameworkRuns implements IFrameworkRuns{
     protected String groupName;
+    private String mockSubmissionId = "submission1";
+
     List<IRun> runs ;
 
 
@@ -68,7 +70,7 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
             if (stream.equals("null")){
                 throw new FrameworkException(language);
             }
-        return new MockIRun("runname"+testName, type, requestor, testName, sharedEnvironmentRunName, bundleName, language, groupName);
+        return new MockIRun("runname"+testName, type, requestor, testName, sharedEnvironmentRunName, bundleName, language, groupName, this.mockSubmissionId);
     }
 
     @Override
@@ -84,5 +86,9 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
     @Override
     public boolean reset(String runname) throws DynamicStatusStoreException {
         return true;
+    }
+
+    public void setMockSubmissionId(String mockSubmissionId) {
+        this.mockSubmissionId = mockSubmissionId;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
@@ -146,5 +146,10 @@ public class MockIRun implements IRun{
     public String getGherkin() {
         throw new UnsupportedOperationException("Unimplemented method 'getGherkin'");
     }
+
+    @Override
+    public String getSubmissionId() {
+        throw new UnsupportedOperationException("Unimplemented method 'getSubmissionId'");
+    }
     
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
@@ -24,13 +24,24 @@ public class MockIRun implements IRun{
     private String bundle; 
     private String testClass;
     private String groupName;
+    private String submissionId;
     private String stream;
     private String repo;
     private String obr;
     private String result = "Passed";
 
     
-    public MockIRun(String runName, String runType, String requestor, String test, String runStatus, String bundle, String testClass, String groupName){
+    public MockIRun(
+        String runName,
+        String runType,
+        String requestor,
+        String test,
+        String runStatus,
+        String bundle,
+        String testClass,
+        String groupName,
+        String submissionId
+    ) {
         this.runName = runName;
         this.runType = runType;
         this.requestor = requestor;
@@ -39,6 +50,7 @@ public class MockIRun implements IRun{
         this.bundle = bundle;
         this.testClass = testClass;
         this.groupName = groupName;
+        this.submissionId = submissionId;
     }
 
     @Override
@@ -129,7 +141,7 @@ public class MockIRun implements IRun{
     @Override
     public Run getSerializedRun() {
         return new Run(runName, heartbeat, runType, groupName, testClass, bundle, test, runStatus, result, queued,
-                finished, waitUntil, requestor, stream, repo, obr, false, false, "cdb-"+runName);
+                finished, waitUntil, requestor, stream, repo, obr, false, false, "cdb-"+runName, submissionId);
     }
 
     @Override
@@ -143,13 +155,13 @@ public class MockIRun implements IRun{
     }
 
     @Override
-    public String getGherkin() {
-        throw new UnsupportedOperationException("Unimplemented method 'getGherkin'");
+    public String getSubmissionId() {
+        return this.submissionId;
     }
 
     @Override
-    public String getSubmissionId() {
-        throw new UnsupportedOperationException("Unimplemented method 'getSubmissionId'");
+    public String getGherkin() {
+        throw new UnsupportedOperationException("Unimplemented method 'getGherkin'");
     }
     
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1370,7 +1370,7 @@ paths:
         - name: submissionId
           in: query
           description: |
-            The submission Id allocated to this test run when the test run was submitted
+            The submission ID allocated to this test run when the test run was submitted
             It can be used to query all the runs and re-runs for a test.
             Similar to the groupId, but much more restricted to return a set of runs which are all a result of 
             the same request to run a test.

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
@@ -18,6 +18,7 @@ import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ServletError;
+import dev.galasa.framework.api.ras.internal.routes.RunQueryRoute;
 import dev.galasa.framework.spi.ras.RasSortField;
 
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
@@ -139,8 +140,13 @@ public class RasQueryParameters {
         return generalQueryParams.getMultipleString("runId", new ArrayList<String>());
     }
 
-    public boolean isFromTimeOrRunNameOrGroupPresent() throws InternalServletException {
-        return generalQueryParams.checkAtLeastOneQueryParameterPresent("from", "runname", "group");
+    public boolean isAtLeastOneMandatoryParameterPresent() throws InternalServletException {
+        return generalQueryParams.checkAtLeastOneQueryParameterPresent(
+            RunQueryRoute.QUERY_PARAMETER_FROM,
+            RunQueryRoute.QUERY_PARAMETER_RUNNAME,
+            RunQueryRoute.QUERY_PARAMETER_GROUP,
+            RunQueryRoute.QUERY_PARAMETER_SUBMISSION_ID
+        );
     }
 
     public int getSize(){

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
@@ -90,6 +90,10 @@ public class RasQueryParameters {
         return generalQueryParams.getSingleString("group", null);
     }
 
+    public String getSubmissionId() throws InternalServletException {
+        return generalQueryParams.getSingleString("submissionId", null);
+    }
+
     public String getTestName() throws InternalServletException {
         return generalQueryParams.getSingleString("testname", null);
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RunResultUtility.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RunResultUtility.java
@@ -65,9 +65,10 @@ public class RunResultUtility {
 	   Instant startTime = struc.getStartTime();
 	   Instant endTime = struc.getEndTime();
 	   String group = struc.getGroup();
+	   String submissionId = struc.getSubmissionId();
 	   List<RasTestMethod> rasMethods = convertMethods(methods);
 	   
-	   return new RasTestStructure(runName, bundle, testName, testShortName, requestor, status, result, queued, startTime, endTime, rasMethods,group);
+	   return new RasTestStructure(runName, bundle, testName, testShortName, requestor, status, result, queued, startTime, endTime, rasMethods, group, submissionId);
 	}
 	
 	private static List<RasTestMethod> convertMethods(List<TestMethod> methods){

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
@@ -512,9 +512,9 @@ public class RunQueryRoute extends RunsRoute {
 		int querysize = params.getSize();
 		Instant from = defaultFromTimestamp;
 		if (querysize > 0) {
-			if (!params.isFromTimeOrRunNameOrGroupPresent()) {
+			if (!params.isAtLeastOneMandatoryParameterPresent()) {
 				//  RULE: Throw exception because a query exists but no from date has been supplied
-				// EXCEPT: When a runname or group is present in the query
+				// EXCEPT: When a runname, group, or submission ID is present in the query
 				ServletError error = new ServletError(GAL5010_FROM_DATE_IS_REQUIRED);
 				throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
 			}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
@@ -35,6 +35,7 @@ import dev.galasa.framework.spi.ras.RasSearchCriteriaRequestor;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaResult;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaRunName;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaStatus;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaSubmissionId;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaTestName;
 import dev.galasa.framework.spi.ras.RasSortField;
 import dev.galasa.framework.spi.rbac.RBACException;
@@ -75,6 +76,7 @@ public class RunQueryRoute extends RunsRoute {
 	public static final String QUERY_PARAMETER_PAGE = "page";
 	public static final String QUERY_PARAMETER_SIZE = "size";
 	public static final String QUERY_PARAMETER_GROUP = "group";
+	public static final String QUERY_PARAMETER_SUBMISSION_ID = "submissionId";
 	public static final String QUERY_PARAMETER_INCLUDECURSOR = "includecursor";
 	public static final String QUERY_PARAMETER_CURSOR = "cursor";
 	public static final String QUERY_PARAMETER_RUNNAME = "runname";
@@ -83,8 +85,9 @@ public class RunQueryRoute extends RunsRoute {
 		QUERY_PARAMETER_SORT, QUERY_PARAMETER_RESULT, QUERY_PARAMETER_STATUS,
 		QUERY_PARAMETER_BUNDLE, QUERY_PARAMETER_REQUESTOR, QUERY_PARAMETER_FROM,
 		QUERY_PARAMETER_TO, QUERY_PARAMETER_TESTNAME, QUERY_PARAMETER_PAGE,
-		QUERY_PARAMETER_SIZE, QUERY_PARAMETER_GROUP, QUERY_PARAMETER_INCLUDECURSOR,
-		QUERY_PARAMETER_CURSOR, QUERY_PARAMETER_RUNNAME, QUERY_PARAMETER_RUNID
+		QUERY_PARAMETER_SIZE, QUERY_PARAMETER_GROUP, QUERY_PARAMETER_SUBMISSION_ID,
+		QUERY_PARAMETER_INCLUDECURSOR, QUERY_PARAMETER_CURSOR, QUERY_PARAMETER_RUNNAME,
+		QUERY_PARAMETER_RUNID
 	);
 
 
@@ -208,18 +211,63 @@ public class RunQueryRoute extends RunsRoute {
 		String testName = queryParams.getTestName();
 		String bundle = queryParams.getBundle();
 		List<String> result = queryParams.getResultsFromParameters(getResultNames());
-		List<TestRunLifecycleStatus> status = queryParams.getStatusesFromParameters();
+		List<TestRunLifecycleStatus> statuses = queryParams.getStatusesFromParameters();
 		String runName = queryParams.getRunName();
 		String group = queryParams.getGroup();
-
+		String submissionId = queryParams.getSubmissionId();
 		Instant to = queryParams.getToTime();
 
 		Instant defaultFromTime = Instant.now().minus(24,ChronoUnit.HOURS);
 		// from will error if no runname is specified as it is a mandatory field
 		Instant from = getQueriedFromTime(queryParams, defaultFromTime);
 
-		List<IRasSearchCriteria> criteria = getCriteria(requestor,testName,bundle,result,status,to, from, runName, group);
-		return criteria ;
+		List<IRasSearchCriteria> critList = new ArrayList<>();
+
+		if (from != null) {
+			RasSearchCriteriaQueuedFrom fromCriteria = new RasSearchCriteriaQueuedFrom(from);
+			critList.add(fromCriteria);
+		}
+
+		// Checking all parameters to apply to the search criteria
+		// The default for 'to' is null.
+		if (to != null) {
+			RasSearchCriteriaQueuedTo toCriteria = new RasSearchCriteriaQueuedTo(to);
+			critList.add(toCriteria);
+		}
+		if (requestor != null && !requestor.isEmpty()) {
+			RasSearchCriteriaRequestor requestorCriteria = new RasSearchCriteriaRequestor(requestor);
+			critList.add(requestorCriteria);
+		}
+		if (testName != null && !testName.isEmpty()) {
+			RasSearchCriteriaTestName testNameCriteria = new RasSearchCriteriaTestName(testName);
+			critList.add(testNameCriteria);
+		}
+		if (bundle != null && !bundle.isEmpty()) {
+			RasSearchCriteriaBundle bundleCriteria = new RasSearchCriteriaBundle(bundle);
+			critList.add(bundleCriteria);
+		}
+		if (result != null && !result.isEmpty()) {
+			RasSearchCriteriaResult resultCriteria = new RasSearchCriteriaResult(result.toArray(new String[0]));
+			critList.add(resultCriteria);
+		}
+		if (statuses != null && !statuses.isEmpty()){
+			RasSearchCriteriaStatus statusCriteria = new RasSearchCriteriaStatus(statuses);
+			critList.add(statusCriteria);
+		}
+		if (runName != null && !runName.isEmpty()) {
+			RasSearchCriteriaRunName runNameCriteria = new RasSearchCriteriaRunName(runName);
+			critList.add(runNameCriteria);
+		}
+		if (group != null && !group.isEmpty()) {
+			RasSearchCriteriaGroup groupCriteria = new RasSearchCriteriaGroup(group);
+			critList.add(groupCriteria);
+		}
+		if (submissionId != null && !submissionId.isEmpty()) {
+			RasSearchCriteriaSubmissionId submissionIdCriteria = new RasSearchCriteriaSubmissionId(submissionId);
+			critList.add(submissionIdCriteria);
+		}
+
+		return critList;
 	}
 
 	private String buildResponseBody(List<RasRunResult> runs, int pageNum, int pageSize) throws InternalServletException {
@@ -262,62 +310,6 @@ public class RunQueryRoute extends RunsRoute {
         pageJson.add("runs", tree);
 
         return gson.toJson(pageJson);
-	}
-
-	private List<IRasSearchCriteria> getCriteria(
-		String requestor,
-		String testName,
-		String bundle,
-		List<String> result,
-		List<TestRunLifecycleStatus> passedInStatuses,
-		Instant to,
-		Instant from,
-		String runName,
-		String group
-	) throws InternalServletException {
-
-		List<IRasSearchCriteria> critList = new ArrayList<>();
-
-		if (from != null) {
-			RasSearchCriteriaQueuedFrom fromCriteria = new RasSearchCriteriaQueuedFrom(from);
-			critList.add(fromCriteria);
-		}
-
-		// Checking all parameters to apply to the search criteria
-		// The default for 'to' is null.
-		if (to != null) {
-			RasSearchCriteriaQueuedTo toCriteria = new RasSearchCriteriaQueuedTo(to);
-			critList.add(toCriteria);
-		}
-		if (requestor != null && !requestor.isEmpty()) {
-			RasSearchCriteriaRequestor requestorCriteria = new RasSearchCriteriaRequestor(requestor);
-			critList.add(requestorCriteria);
-		}
-		if (testName != null && !testName.isEmpty()) {
-			RasSearchCriteriaTestName testNameCriteria = new RasSearchCriteriaTestName(testName);
-			critList.add(testNameCriteria);
-		}
-		if (bundle != null && !bundle.isEmpty()) {
-			RasSearchCriteriaBundle bundleCriteria = new RasSearchCriteriaBundle(bundle);
-			critList.add(bundleCriteria);
-		}
-		if (result != null && !result.isEmpty()) {
-			RasSearchCriteriaResult resultCriteria = new RasSearchCriteriaResult(result.toArray(new String[0]));
-			critList.add(resultCriteria);
-		}
-		if (passedInStatuses != null && !passedInStatuses.isEmpty()){
-			RasSearchCriteriaStatus statusCriteria = new RasSearchCriteriaStatus(passedInStatuses);
-			critList.add(statusCriteria);
-		}
-		if (runName != null && !runName.isEmpty()) {
-			RasSearchCriteriaRunName runNameCriteria = new RasSearchCriteriaRunName(runName);
-			critList.add(runNameCriteria);
-		}
-		if (group != null && !group.isEmpty()) {
-			RasSearchCriteriaGroup groupCriteria = new RasSearchCriteriaGroup(group);
-			critList.add(groupCriteria);
-		}
-		return critList;
 	}
 
 	private JsonObject pageToJson(List<RasRunResult> resultsInPage, int totalRuns, int pageNum, int pageSize, int numPages) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/RasServletTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/RasServletTest.java
@@ -21,23 +21,27 @@ public class RasServletTest extends BaseServletTest {
 
 	protected MockFileSystem mockFileSystem;
 
-	protected List<IRunResult> generateTestData(String runId, String runName, String runLog) {
-		return generateTestData(runId, runName, runLog, "galasa");
-	}
-
-	protected List<IRunResult> generateTestData(String runId, String runName, String runLog, String requestor) {
+	protected List<IRunResult> generateTestData(String runId, TestStructure testStructure, String runLog) {
 		List<IRunResult> mockInputRunResults = new ArrayList<IRunResult>();
 
-		// Build the results the DB will return.
-		TestStructure testStructure = new TestStructure();
-		testStructure.setRunName(runName);
-		testStructure.setRequestor(requestor);
-		testStructure.setResult("Passed");
-
+		String runName = testStructure.getRunName();
 		Path artifactRoot = new MockPath("/" + runName, this.mockFileSystem);
 		IRunResult result = new MockRunResult( runId, testStructure, artifactRoot, runLog);
 		mockInputRunResults.add(result);
 
 		return mockInputRunResults;
+	}
+
+	protected List<IRunResult> generateTestData(String runId, String runName, String runLog) {
+		return generateTestData(runId, runName, runLog, "galasa");
+	}
+
+	protected List<IRunResult> generateTestData(String runId, String runName, String runLog, String requestor) {
+		TestStructure testStructure = new TestStructure();
+		testStructure.setRunName(runName);
+		testStructure.setRequestor(requestor);
+		testStructure.setResult("Passed");
+
+		return generateTestData(runId, testStructure, runLog);
 	}
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
@@ -28,6 +28,7 @@ import dev.galasa.framework.spi.IResultArchiveStoreDirectoryService;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.rbac.Action;
+import dev.galasa.framework.spi.teststructure.TestStructure;
 
 import static org.assertj.core.api.Assertions.*;
 import static dev.galasa.framework.spi.rbac.BuiltInAction.*;
@@ -42,9 +43,9 @@ import javax.servlet.http.HttpServletResponse;
 
 public class TestRunDetailsRoute extends RasServletTest {
 
-    public String generateExpectedJson (String runId, String runName ){
+    public String generateExpectedJson (String runId, String runName, String submissionId) {
 
-		RasTestStructure testStructure = new RasTestStructure(runName, null, null, null, "galasa", null, "Passed", null, null, null, Collections.emptyList(), "none");
+		RasTestStructure testStructure = new RasTestStructure(runName, null, null, null, "galasa", null, "Passed", null, null, null, Collections.emptyList(), "none", submissionId);
 		RasRunResult rasRunResult = new RasRunResult(runId, Collections.emptyList(), testStructure);
 
 		testStructure.setRunName(runName);
@@ -264,8 +265,15 @@ public class TestRunDetailsRoute extends RasServletTest {
 		//Given..
 		String runId = "xx12345xx";
         String runName = "U123";
+		String submissionId = "submission1";
 
-		List<IRunResult> mockInputRunResults = generateTestData(runId, runName, null);
+		TestStructure testStructure = new TestStructure();
+		testStructure.setRunName(runName);
+		testStructure.setRequestor("galasa");
+		testStructure.setResult("Passed");
+		testStructure.setSubmissionId(submissionId);
+
+		List<IRunResult> mockInputRunResults = generateTestData(runId, testStructure, null);
 
 		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs/" + runId);
@@ -283,7 +291,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		// Then...
 		// Expecting this json:
 		// {
-		String expectedJson = generateExpectedJson(runId, runName);
+		String expectedJson = generateExpectedJson(runId, runName, submissionId);
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
@@ -294,8 +302,15 @@ public class TestRunDetailsRoute extends RasServletTest {
 		//Given..
 		String runId = "xx12345xx";
         String runName = "U123";
-
-		List<IRunResult> mockInputRunResults = generateTestData(runId, runName, null);
+		String submissionId = "submission1";
+		
+		TestStructure testStructure = new TestStructure();
+		testStructure.setRunName(runName);
+		testStructure.setRequestor("galasa");
+		testStructure.setResult("Passed");
+		testStructure.setSubmissionId(submissionId);
+		
+		List<IRunResult> mockInputRunResults = generateTestData(runId, testStructure, null);
 
 		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
 		Map<String, String> headerMap = new HashMap<String,String>();
@@ -313,7 +328,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		servlet.doGet(req,resp);
 
 		// Then...
-		String expectedJson = generateExpectedJson(runId, runName);
+		String expectedJson = generateExpectedJson(runId, runName, submissionId);
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(outStream.toString()).isEqualTo(expectedJson);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
@@ -348,11 +363,11 @@ public class TestRunDetailsRoute extends RasServletTest {
 	}
 
     @Test
-    public void testNoRunReturnsError() throws Exception {
+    public void testNoRunReturnsNotFoundError() throws Exception {
 		//Given..
 		String runId = "badRunId";
 
-		List<IRunResult> mockInputRunResults = generateTestData(null, null, null);
+		List<IRunResult> mockInputRunResults = new ArrayList<>();
 
 		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs/" + runId);
@@ -368,10 +383,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		servlet.doGet(req,resp);
 
 		// Then...
-		// Expecting this json:
-		// {
-        assertThat(resp.getStatus()).isEqualTo(500);
-        checkErrorStructure(outStream.toString() , 5000 , "GAL5000E" );
+        assertThat(resp.getStatus()).isEqualTo(404);
+        checkErrorStructure(outStream.toString() , 5091, "GAL5091E" );
         assertThat( resp.getContentType()).isEqualTo("application/json");
 	}
 
@@ -391,7 +404,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
@@ -427,7 +440,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT",headerMap);
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
@@ -461,7 +474,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
@@ -502,7 +515,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
@@ -543,7 +556,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
@@ -579,7 +592,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs) {
 			@Override
     		public boolean reset(String runname) throws DynamicStatusStoreException {
@@ -620,7 +633,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs) {
 			@Override
 			public boolean delete(String runname) throws DynamicStatusStoreException {
@@ -661,7 +674,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs) {
 			@Override
     		public boolean reset(String runname) throws DynamicStatusStoreException {
@@ -702,7 +715,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs) {
 			@Override
 			public boolean delete(String runname) throws DynamicStatusStoreException {
@@ -743,7 +756,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
@@ -8,6 +8,7 @@ package dev.galasa.framework.api.runs.common;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -100,16 +101,31 @@ public class GroupRuns extends ProtectedRoute {
                 }
             }
 
-            if(jwtRequestor == null){
+            if (jwtRequestor == null) {
                 jwtRequestor = request.getRequestor(); 
             }
+
             try {
-                IRun newRun = framework.getFrameworkRuns().submitRun(request.getRequestorType(), jwtRequestor, classNameSplit[0], classNameSplit[1],
-                        groupName, request.getMavenRepository(), request.getObr(), request.getTestStream(), false,
-                        request.isTrace(), request.getOverrides(), 
-                        senvPhase, 
-                        request.getSharedEnvironmentRunName(),
-                        "java");
+
+                String submissionId = UUID.randomUUID().toString();
+
+                IRun newRun = framework.getFrameworkRuns().submitRun(
+                    request.getRequestorType(),
+                    jwtRequestor,
+                    classNameSplit[0],
+                    classNameSplit[1],
+                    groupName,
+                    request.getMavenRepository(),
+                    request.getObr(),
+                    request.getTestStream(),
+                    false,
+                    request.isTrace(),
+                    request.getOverrides(), 
+                    senvPhase, 
+                    request.getSharedEnvironmentRunName(),
+                    "java",
+                    submissionId
+                );
                 
                 status.getRuns().add(newRun.getSerializedRun());
             } catch (FrameworkException fe) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -217,7 +217,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testGetRunsWithValidGroupNameReturnsOk() throws Exception {
         // Given...
 		String groupName = "framework";
-        addRun("name1", "type1", "requestor1", "test1", "FINISHED","bundle1", "testClass1", groupName);
+        String submissionId = "submission1";
+        addRun("name1", "type1", "requestor1", "test1", "FINISHED","bundle1", "testClass1", groupName, submissionId);
         setServlet("/"+groupName, groupName, this.runs);
 		MockRunsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
@@ -229,7 +230,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doGet(req, resp);
 
         // Then...
-        String expectedJson = generateExpectedJson(runs, "true");
+        String expectedJson = generateExpectedJson(runs, true);
         assertThat(resp.getStatus()).isEqualTo(200);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -238,8 +239,9 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testGetRunsWithValidGroupNameReturnsMultiple() throws Exception {
         // Given...
 		String groupName = "framework";
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName);
+        String submissionId = "submission1";
+        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId);
+        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId);
         setServlet("/"+groupName, groupName, this.runs);
 		MockRunsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
@@ -251,7 +253,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doGet(req, resp);
 
         // Then...
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(200);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -260,16 +262,17 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testGetRunsWithValidGroupNameMultipleWithFinishedRunReturnsCompleteFalse() throws Exception {
         // Given...
 		String groupName = "framework";
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName);
-        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName);
-        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName);
-        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName);
-        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName);
-        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName);
-        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName);
-        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName);
-        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName);
+        String submissionId = "submission1";
+        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId);
+        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId);
+        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId);
+        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId);
+        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId);
+        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId);
+        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId);
+        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId);
+        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId);
+        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId);
         setServlet("/"+groupName, groupName, this.runs);
 		MockRunsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
@@ -281,7 +284,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doGet(req, resp);
 
         // Then...
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(200);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -290,16 +293,17 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testGetRunsWithUUIDGroupNameMultipleWithFinishedRunReturnsCompleteFalse() throws Exception {
         // Given...
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName);
-        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName);
-        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName);
-        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName);
-        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName);
-        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName);
-        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName);
-        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName);
-        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName);
+        String submissionId = "submission1";
+        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId);
+        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId);
+        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId);
+        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId);
+        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId);
+        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId);
+        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId);
+        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId);
+        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId);
+        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId);
         setServlet("/"+groupName, groupName, this.runs);
 		MockRunsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
@@ -311,7 +315,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doGet(req, resp);
 
         // Then...
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(200);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -475,6 +479,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testPostRunsWithValidBodyGoodEnvPhaseReturnsOK() throws Exception {
         // Given...
 		String groupName = "valid";
+        String submissionId = "submission1";
         String payload = "{\"classNames\": [\"Class/name\"]," +
         "\"requestorType\": \"requestorType\"," +
         "\"requestor\": \"testRequestor\"," +
@@ -486,7 +491,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         "\"overrides\": {}," +
         "\"trace\": true }";
         addRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted",
-               "Class", "java", groupName);
+               "Class", "java", groupName, submissionId);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -500,7 +505,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
 
         // Then...
         assertThat(resp.getStatus()).isEqualTo(201);
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(201);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -510,7 +515,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "valid";
         String[] classes = new String[]{"Class/name"};
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null);
+        String submissionId = "submission1";
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -523,7 +529,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doPost(req, resp);
 
         // Then...
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(201);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -533,7 +539,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "valid";
         String[] classes = new String[]{"Class/name"};
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, null, groupName, null);
+        String submissionId = "submission1";
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, null, groupName, null, submissionId);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -558,7 +565,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "valid";
         String[] classes = new String[]{"Class1/name", "Class2/name"};
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null);
+        String submissionId = "submission1";
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -571,7 +579,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doPost(req, resp);
 
         // Then...
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(201);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -581,7 +589,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
         String[] classes = new String[]{"Class1/name", "Class2/name"};
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null);
+        String submissionId = "submission1";
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -594,7 +603,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doPost(req, resp);
 
         // Then...
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(201);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -607,6 +616,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testPostRunsWithValidBodyGoodEnvPhaseAndJWTReturnsOKWithRequestorFromJWT() throws Exception {
         // Given...
 		String groupName = "valid";
+        String submissionId = "submission1";
         String payload = "{\"classNames\": [\"Class/name\"]," +
         "\"requestorType\": \"requestorType\"," +
         "\"requestor\": \"testRequestor\"," +
@@ -619,7 +629,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         "\"trace\": true }";
 
         addRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted",
-               "Class", "java", groupName);
+               "Class", "java", groupName, submissionId);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -633,7 +643,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
 
         // Then...
         assertThat(resp.getStatus()).isEqualTo(201);
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(201);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -643,7 +653,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "valid";
         String[] classes = new String[]{"Class/name"};
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor");
+        String submissionId = "submission1";
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -656,7 +667,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doPost(req, resp);
 
         // Then...
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(201);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -665,8 +676,9 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testPostRunsWithValidBodyAndMultipleClassesReturnsWithRequestorFromJWT() throws Exception {
         // Given...
 		String groupName = "valid";
+        String submissionId = "submission1";
         String[] classes = new String[]{"Class1/name", "Class2/name"};
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor");
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -679,7 +691,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doPost(req, resp);
 
         // Then...
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(201);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }
@@ -689,7 +701,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
         String[] classes = new String[]{"Class1/name", "Class2/name"};
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor");
+        String submissionId = "submission1";
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -702,7 +715,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doPost(req, resp);
 
         // Then...
-        String expectedJson = generateExpectedJson(runs, "false");
+        String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(201);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockFrameworkRuns.java
@@ -46,7 +46,7 @@ public class MockFrameworkRuns implements IFrameworkRuns {
     @Override
     public @NotNull IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language)
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId)
             throws FrameworkException {
         throw new UnsupportedOperationException("Unimplemented method 'submitRun'");
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -188,7 +188,8 @@ public class BaseTestRunner {
         TestStructure testStructure = new TestStructure();
 
         String runName = run.getName();
-        String group = run.getGroup();         
+        String group = run.getGroup();
+        String submissionId = run.getSubmissionId();
         Instant queuedAt = run.getQueued();
         String requestor = AbstractManager.defaultString(run.getRequestor(), "unknown");         
 
@@ -197,6 +198,7 @@ public class BaseTestRunner {
         testStructure.setRunName(runName);
         testStructure.setRequestor(requestor);
         testStructure.setGroup(group);
+        testStructure.setSubmissionId(submissionId);
         return testStructure;
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -179,13 +179,14 @@ public class FrameworkRuns implements IFrameworkRuns {
     public @NotNull IRun submitRun(String runType, String requestor, String bundleName,
             @NotNull String testName, String groupName, String mavenRepository, String obr, String stream,
             boolean local, boolean trace, Properties overrides, SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName,
-            String language) throws FrameworkException {
+            String language, String submissionId) throws FrameworkException {
         SubmitRunRequest runRequest = new SubmitRunRequest(
             runType,
             requestor,
             bundleName,
             testName,
             groupName,
+            submissionId,
             mavenRepository,
             obr,
             stream,
@@ -209,6 +210,7 @@ public class FrameworkRuns implements IFrameworkRuns {
         String obr = runRequest.getObr();
         String stream = runRequest.getStream();
         String groupName = runRequest.getGroupName();
+        String submissionId = runRequest.getSubmissionId();
         String requestor = runRequest.getRequestor();
         SharedEnvironmentPhase sharedEnvironmentPhase = runRequest.getSharedEnvironmentPhase();
         Properties overrides = runRequest.getOverrides();
@@ -242,6 +244,8 @@ public class FrameworkRuns implements IFrameworkRuns {
         } else {
             otherRunProperties.put(runPropertyPrefix + ".group", UUID.randomUUID().toString());
         }
+
+        otherRunProperties.put(runPropertyPrefix + ".submissionId", submissionId);
         otherRunProperties.put(runPropertyPrefix + ".requestor", requestor);
 
         if (sharedEnvironmentPhase != null) {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
@@ -19,6 +19,7 @@ public class RunImpl implements IRun {
     private final Instant heartbeat;
     private final String  type;
     private final String  group;
+    private final String  submissionId;
     private final String  test;
     private final String  bundleName;
     private final String  testName;
@@ -60,6 +61,7 @@ public class RunImpl implements IRun {
         repo = runProperties.get(prefix + "repository");
         obr = runProperties.get(prefix + "obr");
         group = runProperties.get(prefix + "group");
+        submissionId = runProperties.get(prefix + "submissionId");
         rasRunId = runProperties.get(prefix + "rasrunid");
         local = Boolean.parseBoolean(runProperties.get(prefix + "local"));
         trace = Boolean.parseBoolean(runProperties.get(prefix + "trace"));
@@ -159,6 +161,11 @@ public class RunImpl implements IRun {
     @Override
     public String getGroup() {
         return this.group;
+    }
+
+    @Override
+    public String getSubmissionId() {
+        return this.submissionId;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
@@ -201,7 +201,7 @@ public class RunImpl implements IRun {
     @Override
     public Run getSerializedRun() {
         return new Run(name, heartbeat, type, group, test, bundleName, testName, status, result, queued,
-                finished, waitUntil, requestor, stream, repo, obr, local, trace, rasRunId);
+                finished, waitUntil, requestor, stream, repo, obr, local, trace, rasRunId, submissionId);
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ValidateEcosystem.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ValidateEcosystem.java
@@ -7,6 +7,7 @@ package dev.galasa.framework;
 
 import java.time.Instant;
 import java.util.Properties;
+import java.util.UUID;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -56,6 +57,7 @@ public class ValidateEcosystem {
             logger.info("Bypassing engine test");
         } else {
             IFrameworkRuns frameworkRuns = framework.getFrameworkRuns();
+            String submissionId = UUID.randomUUID().toString();
             
             IRun testRun = frameworkRuns.submitRun(null, 
                     "validateeco", 
@@ -70,7 +72,8 @@ public class ValidateEcosystem {
                     null, 
                     null, 
                     null, 
-                    null);
+                    null,
+                    submissionId);
             
             logger.info("Test CoreManagerIVT submitted as run " + testRun.getName());
             

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/SubmitRunRequest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/SubmitRunRequest.java
@@ -20,6 +20,7 @@ public class SubmitRunRequest {
     private String bundleName;
     private String testName;
     private String groupName;
+    private String submissionId;
     private String mavenRepository;
     private String obr;
     private String stream;
@@ -38,6 +39,7 @@ public class SubmitRunRequest {
         String bundleName,
         String testName,
         String groupName,
+        String submissionId,
         String mavenRepository,
         String obr,
         String stream,
@@ -54,6 +56,7 @@ public class SubmitRunRequest {
         this.requestor = requestor;
         this.bundleName = bundleName;
         this.groupName = groupName;
+        this.submissionId = submissionId;
         this.mavenRepository = mavenRepository;
         this.obr = obr;
         this.stream = stream;
@@ -194,5 +197,13 @@ public class SubmitRunRequest {
 
     public void setGherkinTest(String gherkinTest) {
         this.gherkinTest = gherkinTest;
+    }
+
+    public String getSubmissionId() {
+        return submissionId;
+    }
+
+    public void setSubmissionId(String submissionId) {
+        this.submissionId = submissionId;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/TestRunInitStrategy.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/TestRunInitStrategy.java
@@ -6,6 +6,7 @@
 package dev.galasa.framework.internal.init;
 
 import java.util.Properties;
+import java.util.UUID;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -73,16 +74,17 @@ public class TestRunInitStrategy implements IFrameworkInitialisationStrategy {
     protected String submitRun(IFramework framework, String runBundleClass, String language) throws FrameworkException {
         IRun run = null;
         IFrameworkRuns frameworkRuns = framework.getFrameworkRuns();
+        String submissionId = UUID.randomUUID().toString();
 
         switch(language) {
             case "java": 
                 String split[] = runBundleClass.split("/");
                 String bundle = split[0];
                 String test = split[1];
-                run = frameworkRuns.submitRun("local", null, bundle, test, null, null, null, null, true, false, null, null, null, language);
+                run = frameworkRuns.submitRun("local", null, bundle, test, null, null, null, null, true, false, null, null, null, language, submissionId);
                 break;
             case "gherkin":
-                run = frameworkRuns.submitRun("local", null, null, runBundleClass, null, null, null, null, true, false, null, null, null, language);
+                run = frameworkRuns.submitRun("local", null, null, runBundleClass, null, null, null, null, true, false, null, null, null, language, submissionId);
                 break;
             default:
                 throw new FrameworkException("Unknown language to create run");

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
@@ -37,7 +37,7 @@ public interface IFrameworkRuns {
     @NotNull
     IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language) throws FrameworkException;
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId) throws FrameworkException;
 
     boolean delete(String runname) throws DynamicStatusStoreException;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
@@ -33,6 +33,8 @@ public interface IRun {
 
     String getGroup();
 
+    String getSubmissionId();
+
     Instant getQueued();
 
     String getRepository();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaSubmissionId.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaSubmissionId.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.ras;
+
+import javax.validation.constraints.NotNull;
+
+import dev.galasa.framework.spi.teststructure.TestStructure;
+
+public class RasSearchCriteriaSubmissionId implements IRasSearchCriteria {
+
+	private final String[] submissionIds;
+
+	public RasSearchCriteriaSubmissionId(@NotNull String... submissionIdCriteria) {
+		this.submissionIds = submissionIdCriteria;
+	}
+
+	@Override
+	public boolean criteriaMatched(@NotNull TestStructure structure) {
+
+		boolean isMatched = false;
+		if (structure != null && submissionIds != null) {
+			for (String submissionId : submissionIds) {
+				if (submissionId.equals(structure.getSubmissionId())) {
+					isMatched = true;
+					break;
+				}
+			}
+		}
+
+		return isMatched;
+	}
+
+    public String[] getSubmissionIds() {
+        return this.submissionIds;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/teststructure/TestStructure.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/teststructure/TestStructure.java
@@ -30,6 +30,7 @@ public class TestStructure {
     private String           status;
     private String           result;
     private String           group = "none";
+    private String           submissionId;
 
     private Instant          queued;
 
@@ -51,6 +52,7 @@ public class TestStructure {
             this.runName = source.runName;
             this.bundle = source.bundle;
             this.testName = source.testName;
+            this.submissionId = source.submissionId;
             this.testShortName = source.testShortName;
             this.requestor = source.requestor;
             this.status = source.status;
@@ -74,6 +76,14 @@ public class TestStructure {
                 this.artifactRecordIds.addAll(source.artifactRecordIds);
             }
         }
+    }
+
+    public String getSubmissionId() {
+        return submissionId;
+    }
+
+    public void setSubmissionId(String submissionId) {
+        this.submissionId = submissionId;
     }
 
     public String getBundle() {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
@@ -56,6 +56,7 @@ public class FrameworkRunsTest {
 
         FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
 
+        String submissionId = "submission1";
         String runType = "unknown";
         String requestor = "me";
         String bundleName = "mybundle";
@@ -94,7 +95,8 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language
+            language,
+            submissionId
         );
 
         // Then...
@@ -131,6 +133,7 @@ public class FrameworkRunsTest {
 
         FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
 
+        String submissionId = "submission1";
         String runType = "unknown";
         String requestor = "me";
         String bundleName = "mybundle";
@@ -169,7 +172,8 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language
+            language,
+            submissionId
         );
 
         // Then...
@@ -208,6 +212,7 @@ public class FrameworkRunsTest {
 
         FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
 
+        String submissionId = "submission1";
         String runType = "unknown";
         String requestor = "me";
         String bundleName = "mybundle";
@@ -247,7 +252,8 @@ public class FrameworkRunsTest {
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
-                language
+                language,
+                submissionId
             );
         }, FrameworkException.class);
 
@@ -267,6 +273,7 @@ public class FrameworkRunsTest {
 
         String testName = null;
 
+        String submissionId = "submission1";
         String runType = "unknown";
         String requestor = "me";
         String bundleName = "mybundle";
@@ -299,7 +306,8 @@ public class FrameworkRunsTest {
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
-                language
+                language,
+                submissionId
             );
         }, FrameworkException.class);
 
@@ -320,6 +328,7 @@ public class FrameworkRunsTest {
         String bundleName = null;
         
         String testName = "mytest";
+        String submissionId = "submission1";
         String runType = "unknown";
         String requestor = "me";
         String groupName = "my.group";
@@ -351,7 +360,8 @@ public class FrameworkRunsTest {
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
-                language
+                language,
+                submissionId
             );
         }, FrameworkException.class);
 
@@ -373,6 +383,7 @@ public class FrameworkRunsTest {
 
         String bundleName = "mybundle";
         String testName = "mytest";
+        String submissionId = "submission1";
         String runType = "unknown";
         String requestor = "me";
         String groupName = "my.group";
@@ -402,7 +413,8 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language
+            language,
+            submissionId
         );
 
         // Then...
@@ -422,6 +434,7 @@ public class FrameworkRunsTest {
 
         String runType = "local";
         
+        String submissionId = "submission1";
         String language = "java";
         String bundleName = "mybundle";
         String testName = "mytest";
@@ -453,7 +466,8 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language
+            language,
+            submissionId
         );
 
         // Then...
@@ -473,6 +487,7 @@ public class FrameworkRunsTest {
 
         String language = "gherkin";
         
+        String submissionId = "submission1";
         String runType = "local";
         String bundleName = "mybundle";
         String testName = "mygherkintest";
@@ -504,7 +519,8 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language
+            language,
+            submissionId
         );
 
         // Then...
@@ -541,6 +557,7 @@ public class FrameworkRunsTest {
         SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.BUILD;
         String sharedEnvironmentRunName = "SHARED-RUN1";
 
+        String submissionId = "submission1";
         String language = "java";
         String runType = "local";
         String bundleName = "mybundle";
@@ -570,7 +587,8 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language
+            language,
+            submissionId
         );
 
         // Then...
@@ -608,6 +626,7 @@ public class FrameworkRunsTest {
         SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.BUILD;
         String sharedEnvironmentRunName = null;
 
+        String submissionId = "submission1";
         String language = "java";
         String runType = "local";
         String bundleName = "mybundle";
@@ -638,7 +657,8 @@ public class FrameworkRunsTest {
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
-                language
+                language,
+                submissionId
             );
         }, FrameworkException.class);
 
@@ -663,6 +683,7 @@ public class FrameworkRunsTest {
 
         SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.DISCARD;
 
+        String submissionId = "submission1";
         String language = "java";
         String runType = "local";
         String bundleName = "mybundle";
@@ -692,7 +713,8 @@ public class FrameworkRunsTest {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language
+            language,
+            submissionId
         );
 
         // Then...
@@ -722,6 +744,7 @@ public class FrameworkRunsTest {
 
         SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.BUILD;
 
+        String submissionId = "submission1";
         String language = "java";
         String runType = "local";
         String bundleName = "mybundle";
@@ -752,7 +775,8 @@ public class FrameworkRunsTest {
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
-                language
+                language,
+                submissionId
             );
         }, FrameworkException.class);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
@@ -124,6 +124,8 @@ public class MockRun implements IRun {
                throw new UnsupportedOperationException("Unimplemented method 'isSharedEnvironment'");
     }
 
-
-    
+    @Override
+    public String getSubmissionId() {
+        throw new UnsupportedOperationException("Unimplemented method 'getSubmissionId'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIFrameworkRuns.java
@@ -63,7 +63,7 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
     @Override
     public @NotNull IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language)
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId)
             throws FrameworkException {
             if (stream.equals("null")){
                 throw new FrameworkException(language);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
@@ -6,6 +6,7 @@
 package dev.galasa.framework.mocks;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import dev.galasa.api.run.Run;
 import dev.galasa.framework.spi.IRun;
@@ -22,6 +23,7 @@ public class MockRun implements IRun {
     private String gherkinUrl;
     private Instant heartbeat;
     private String group;
+    private String submissionId;
 
     public MockRun(
         String testBundleName, 
@@ -34,14 +36,14 @@ public class MockRun implements IRun {
             testClassName, testRunName , 
             testStream, testStreamOBR, 
             testStreamRepoUrl, requestorName, 
-            isRunLocal ,null, null);
+            isRunLocal ,null, null, UUID.randomUUID().toString());
     }
     public MockRun(
         String testBundleName, 
         String testClassName, String testRunName , 
         String testStream, String testStreamOBR, 
         String testStreamRepoUrl, String requestorName, 
-        boolean isRunLocal , String gherkinUrl, String group
+        boolean isRunLocal , String gherkinUrl, String group, String submissionId
     ) {
         this.testBundleName = testBundleName;
         this.testClassName = testClassName ;
@@ -52,6 +54,7 @@ public class MockRun implements IRun {
         this.requestorName = requestorName;
         this.isRunLocal = isRunLocal;
         this.gherkinUrl = gherkinUrl;
+        this.submissionId = submissionId;
     }
 
     // Shared environment not used very often so not adding
@@ -111,6 +114,10 @@ public class MockRun implements IRun {
         return this.group;
     }
 
+    @Override
+    public String getSubmissionId() {
+        return this.submissionId;
+    }
 
     @Override
     public boolean isLocal() {
@@ -175,7 +182,4 @@ public class MockRun implements IRun {
     public String getResult() {
         throw new UnsupportedOperationException("Unimplemented method 'getResult'");
     }
-
-
-    
 }

--- a/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/api/ras/RasTestStructure.java
+++ b/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/api/ras/RasTestStructure.java
@@ -19,13 +19,16 @@ public class RasTestStructure {
    private String status;
    private String result;
    private String group;
+   private String submissionId;
    private Instant queued;
    private Instant startTime;
    private Instant endTime;
    private List<RasTestMethod> methods;
    
    public RasTestStructure(String runName, String bundle, String testName, String testShortName, String requestor,
-         String status, String result, Instant queued, Instant startTime, Instant endTime, List<RasTestMethod> methods, String group) {
+         String status, String result, Instant queued, Instant startTime, Instant endTime, List<RasTestMethod> methods,
+         String group, String submissionId
+   ) {
       this.runName = runName;
       this.bundle = bundle;
       this.testName = testName;
@@ -38,6 +41,7 @@ public class RasTestStructure {
       this.endTime = endTime;
       this.methods = methods;
       this.group = group;
+      this.submissionId = submissionId;
    }
 
    public String getRunName() {
@@ -86,6 +90,14 @@ public class RasTestStructure {
 
    public void setGroup(String group) {
       this.group = group;
+   }
+
+   public String getSubmissionId() {
+      return this.submissionId;
+   }
+
+   public void setSubmissionId(String submissionId) {
+      this.submissionId = submissionId;
    }
 
    public String getStatus() {

--- a/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/api/run/Run.java
+++ b/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/api/run/Run.java
@@ -12,6 +12,7 @@ public class Run {
     private Instant heartbeat;
     private String  type;
     private String  group;
+    private String  submissionId;
     private String  test;
     private String  bundleName;
     private String  testName;
@@ -31,11 +32,14 @@ public class Run {
 
     public Run(String name, Instant heartbeat, String type, String group, String test, String bundleName,
             String testName, String status, String result, Instant queued, Instant finished, Instant waitUntil,
-            String requestor, String stream, String repo, String obr, boolean isLocal, boolean isTraceEnabled, String rasRunId) {
+            String requestor, String stream, String repo, String obr, boolean isLocal, boolean isTraceEnabled,
+            String rasRunId, String submissionId
+    ) {
         this.name = name;
         this.heartbeat = heartbeat;
         this.type = type;
         this.group = group;
+        this.submissionId = submissionId;
         this.test = test;
         this.bundleName = bundleName;
         this.testName = testName;
@@ -67,6 +71,10 @@ public class Run {
 
     public String getGroup() {
         return group;
+    }
+
+    public String getSubmissionId() {
+        return submissionId;
     }
 
     public String getTest() {


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2167

## Changes
- Added `submissionId` field to the test structures and runs that gets assigned as a random UUID when tests are first submitted
- Added `submissionId` query parameter to the /ras/runs endpoint to be able to query runs by submission ID
  - The `submissionId` query parameter can be given on its own and does not require a `from` time to be given