### PR TITLE
build-locally scripts can now build the galasa-boot-embedded image locally

### DIFF
--- a/modules/framework/build-locally.sh
+++ b/modules/framework/build-locally.sh
@@ -362,14 +362,14 @@ function build_framework_uml_diagrams {
 
 function make_sure_plantuml_tool_is_available {
     h2 "Making sure the plantuml tool is available"
-    mkdir -p temp || exit 1
+    mkdir -p "$BASEDIR/temp" || exit 1
     if [[ -e $BASEDIR/temp/plantuml.jar ]]; then
         info "Plantuml jar is already downloaded. No need to download it again"
     else 
         info "Downloading the plantuml tool..."
         url=https://github.com/plantuml/plantuml/releases/download/v1.2024.3/plantuml-epl-1.2024.3.jar
         cd "$BASEDIR/temp" || exit 1
-        curl -O $url
+        curl -LO $url
         rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to download the plantuml tool jar." ; exit 1 ; fi
         mv plantuml-*.jar plantuml.jar
         cd - || exit 1

--- a/modules/obr/build-locally.sh
+++ b/modules/obr/build-locally.sh
@@ -177,6 +177,17 @@ info "Log will be placed at ${log_file}"
 date > ${log_file}
 
 #------------------------------------------------------------------------------------
+function check_docker_installed {
+    which docker
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then
+        error "The docker CLI tool is not available on your path. Install docker and try again."
+        exit 1
+    fi
+    success "docker is installed. OK"
+}
+
+#------------------------------------------------------------------------------------
 function get_galasabld_binary_location {
     # What's the architecture-variable name of the build tool we want for this local build ?
     export ARCHITECTURE=$(uname -m) # arm64 or amd64
@@ -532,7 +543,7 @@ function build_boot_embedded_docker_image {
     JDK_IMAGE="ghcr.io/galasa-dev/openjdk:17"
 
     docker build -f "${BASEDIR}/dockerfiles/dockerfile.bootembedded" \
-    -t local-galasa-boot-embedded:latest \
+    -t galasa-boot-embedded:latest \
     --build-arg jdkImage="${JDK_IMAGE}" \
     ${BASEDIR}
 
@@ -570,6 +581,7 @@ if [[ "$detectsecrets" == "true" ]]; then
 fi
 
 if [[ "${is_docker_build_requested}" == "true" ]]; then
+    check_docker_installed
     build_boot_embedded_docker_image
 fi
 

--- a/modules/obr/build-locally.sh
+++ b/modules/obr/build-locally.sh
@@ -62,6 +62,7 @@ function usage {
     info "Syntax: build-locally.sh [OPTIONS]"
     cat << EOF
 Options are:
+--docker : Optional. Builds the Docker image for the OBR boot embedded build
 -s | --detectsecrets true|false : Do we want to detect secrets in the entire repo codebase ? Default is 'true'. Valid values are 'true' or 'false'
 -h | --help : Display this help text
 
@@ -97,10 +98,13 @@ function check_exit_code () {
 #-----------------------------------------------------------------------------------------
 # Process parameters
 #-----------------------------------------------------------------------------------------
-exportbuild_type=""
+is_docker_build_requested=""
 detectsecrets="true"
 while [ "$1" != "" ]; do
     case $1 in
+        --docker )              is_docker_build_requested="true"
+                                shift
+                                ;;
         -h | --help )           usage
                                 exit
                                 ;;
@@ -338,6 +342,36 @@ function construct_uber_obr_pom_xml {
 }
 
 #------------------------------------------------------------------------------------
+function construct_obr_generic_pom_xml {
+    h2 "Generating a pom.xml from the OBR generic template, using all the versions of everything..."
+
+    cd ${WORKSPACE_DIR}/${project}/obr-generic
+
+    # Check local build version
+    export GALASA_BUILD_TOOL_PATH=${WORKSPACE_DIR}/buildutils/bin/${GALASA_BUILD_TOOL_NAME}
+    info "Using galasabld tool ${GALASA_BUILD_TOOL_PATH}"
+
+    cmd="${GALASA_BUILD_TOOL_PATH} template \
+    --releaseMetadata ${framework_manifest_path} \
+    --releaseMetadata ${extensions_manifest_path} \
+    --releaseMetadata ${managers_manifest_path} \
+    --releaseMetadata ${WORKSPACE_DIR}/obr/release.yaml \
+    --template pom.template \
+    --output pom.xml \
+    --obr \
+    "
+    echo "Command is $cmd" >> ${log_file}
+    $cmd 2>&1 >> ${log_file}
+
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then
+        error "Failed to convert release.yaml files into a pom.xml ${project}. log file is ${log_file}"
+        exit 1
+    fi
+    success "pom.xml built ok - log is at ${log_file}"
+}
+
+#------------------------------------------------------------------------------------
 function check_developer_attribution_present {
     h2 "Checking that pom has developer attribution."
     cat ${BASEDIR}/galasa-bom/pom.template | grep "<developers>" >> /dev/null
@@ -387,7 +421,23 @@ function build_generated_uber_obr_pom {
     success "OK"
 }
 
+#------------------------------------------------------------------------------------
+function build_generated_obr_generic_pom {
+    h2 "Building the generated OBR generic pom.xml..."
+    cd ${BASEDIR}/obr-generic
 
+    mvn \
+    -Dgpg.passphrase=${GPG_PASSPHRASE} \
+    -Dgalasa.source.repo=${SOURCE_MAVEN} \
+    -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ install \
+    2>&1 >> ${log_file}
+
+    rc=$?; if [[ "${rc}" != "0" ]]; then
+        error "Failed to push OBR generic build into maven repo ${project}. log file is ${log_file}"
+        exit 1
+    fi
+    success "OK"
+}
 
 #------------------------------------------------------------------------------------
 function generate_javadoc_pom_xml {
@@ -476,6 +526,19 @@ function check_secrets_unless_supressed() {
     fi
 }
 
+#------------------------------------------------------------------------------------
+function build_boot_embedded_docker_image {
+    h2 "Building Galasa boot embedded Docker image..."
+    JDK_IMAGE="ghcr.io/galasa-dev/openjdk:17"
+
+    docker build -f "${BASEDIR}/dockerfiles/dockerfile.bootembedded" \
+    -t local-galasa-boot-embedded:latest \
+    --build-arg jdkImage="${JDK_IMAGE}" \
+    ${BASEDIR}
+
+    success "Boot embedded Docker image built OK"
+}
+
 # #------------------------------------------------------------------------------------
 # h2 "Packaging the javadoc into a docker file"
 # #------------------------------------------------------------------------------------
@@ -491,9 +554,11 @@ get_galasabld_binary_location
 check_dependencies_present
 construct_uber_obr_pom_xml
 construct_bom_pom_xml
+construct_obr_generic_pom_xml
 check_developer_attribution_present
 build_generated_uber_obr_pom
 build_generated_bom_pom
+build_generated_obr_generic_pom
 
 h1 "Building the javadoc using the OBR..."
 generate_javadoc_pom_xml
@@ -502,6 +567,10 @@ build_javadoc_pom
 if [[ "$detectsecrets" == "true" ]]; then
     $REPO_ROOT/tools/detect-secrets.sh 
     check_exit_code $? "Failed to detect secrets"
+fi
+
+if [[ "${is_docker_build_requested}" == "true" ]]; then
+    build_boot_embedded_docker_image
 fi
 
 success "Project ${project} built - OK - log is at ${log_file}"

--- a/modules/obr/build-locally.sh
+++ b/modules/obr/build-locally.sh
@@ -103,7 +103,6 @@ detectsecrets="true"
 while [ "$1" != "" ]; do
     case $1 in
         --docker )              is_docker_build_requested="true"
-                                shift
                                 ;;
         -h | --help )           usage
                                 exit
@@ -437,10 +436,11 @@ function build_generated_obr_generic_pom {
     h2 "Building the generated OBR generic pom.xml..."
     cd ${BASEDIR}/obr-generic
 
-    mvn \
+    mvn install \
     -Dgpg.passphrase=${GPG_PASSPHRASE} \
     -Dgalasa.source.repo=${SOURCE_MAVEN} \
-    -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ install \
+    -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+    dev.galasa:galasa-maven-plugin:$component_version:obrembedded \
     2>&1 >> ${log_file}
 
     rc=$?; if [[ "${rc}" != "0" ]]; then
@@ -546,6 +546,9 @@ function build_boot_embedded_docker_image {
     -t galasa-boot-embedded:latest \
     --build-arg jdkImage="${JDK_IMAGE}" \
     ${BASEDIR}
+
+    rc=$?
+    check_exit_code ${rc} "Failed to build the OBR boot embedded Docker image."
 
     success "Boot embedded Docker image built OK"
 }

--- a/modules/obr/obr-generic/.gitignore
+++ b/modules/obr/obr-generic/.gitignore
@@ -1,0 +1,2 @@
+pom.xml
+target/

--- a/tools/build-locally.sh
+++ b/tools/build-locally.sh
@@ -59,8 +59,9 @@ function usage {
     cat << EOF
 Options are:
 -h | --help : Display this help text
---module The name of the module to start building from
---chain true/false/yes/no/y/n
+--module <name> : The name of the module to start building from. Defaults to the first module in the build chain.
+--chain true/false/yes/no/y/n : Enables/disables the chaining of builds. Defaults to true.
+--docker : Enables the building of Docker images. If --docker is not provided, Docker images will not be built.
 EOF
 }
 
@@ -115,6 +116,7 @@ function check_module_name_is_supported() {
 #-----------------------------------------------------------------------------------------
 module_input="platform"
 chain_input="true"
+build_docker_flag=""
 while [ "$1" != "" ]; do
     case $1 in
         -h | --help )   usage
@@ -126,6 +128,10 @@ while [ "$1" != "" ]; do
                         ;;
 
         --chain )       chain_input="$2"
+                        shift
+                        ;;
+
+        --docker )      build_docker_flag="--docker"
                         shift
                         ;;
 
@@ -258,7 +264,7 @@ function build_module() {
     if [[ "$module" == "obr" ]]; then
         h2 "Building $module"
         cd ${PROJECT_DIR}/modules/$module
-        ${PROJECT_DIR}/modules/$module/build-locally.sh --detectsecrets false
+        ${PROJECT_DIR}/modules/$module/build-locally.sh --detectsecrets false ${build_docker_flag}
         rc=$? ;  if [[ "${rc}" != "0" ]]; then error "Failed to build module $module. rc=$rc" ; exit 1 ; fi
         success "Built module $module OK"
         if [[ "$chain" == "true" ]]; then 

--- a/tools/build-locally.sh
+++ b/tools/build-locally.sh
@@ -132,7 +132,6 @@ while [ "$1" != "" ]; do
                         ;;
 
         --docker )      build_docker_flag="--docker"
-                        shift
                         ;;
 
         * )             error "Unexpected argument $1"

--- a/tools/setup-local-docker-registry.sh
+++ b/tools/setup-local-docker-registry.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+#-----------------------------------------------------------------------------------------
+#
+# Objectives: Sets up and populates a local Docker registry with Docker images used for
+# Galasa development.
+#
+#-----------------------------------------------------------------------------------------
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+
+export ORIGINAL_DIR=$(pwd)
+
+cd "${BASEDIR}/.."
+PROJECT_DIR=$(pwd)
+
+#-----------------------------------------------------------------------------------------
+#
+# Set Colors
+#
+#-----------------------------------------------------------------------------------------
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------
+#
+# Headers and Logging
+#
+#-----------------------------------------------------------------------------------------
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ; }
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ; }
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ; }
+debug() { printf "${white}[.] %s${reset}\n" "$@" ; }
+info()  { printf "${white}[➜] %s${reset}\n" "$@" ; }
+success() { printf "${white}[${green}✔${white}] ${green}%s${reset}\n" "$@" ; }
+error() { printf "${white}[${red}✖${white}] ${red}%s${reset}\n" "$@" ; }
+warn() { printf "${white}[${tan}➜${white}] ${tan}%s${reset}\n" "$@" ; }
+bold() { printf "${bold}%s${reset}\n" "$@" ; }
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ; }
+
+#-----------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------
+function usage {
+    info "Syntax: setup-local-docker-registry.sh [OPTIONS]"
+    cat << EOF
+Options are:
+--build : Builds the Galasa Docker images as well as setting up a local Docker registry
+--minikube : Set up a local Docker registry for use by minikube
+-h | --help : Display this help text
+EOF
+}
+
+#-----------------------------------------------------------------------------------------
+# Process parameters
+#-----------------------------------------------------------------------------------------
+is_build_locally_requested=""
+is_configure_minikube_requested=""
+REGISTRY_NAME="local-galasa-registry"
+while [ "$1" != "" ]; do
+    case $1 in
+        --build )       is_build_locally_requested="true"
+                        shift
+                        ;;
+        --minikube )    is_configure_minikube_requested="true"
+                        shift
+                        ;;
+        -h | --help )   usage
+                        exit
+                        ;;
+        * )             error "Unexpected argument $1"
+                        usage
+                        exit 1
+    esac
+    shift
+done
+
+#-----------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------
+function clean_up_before_set_up {
+    h2 "Cleaning up any existing Docker containers..."
+
+    docker stop local-galasa-registry | xargs docker rm
+    docker stop docker-to-minikube-socat | xargs docker rm
+
+    success "Clean-up completed OK"
+}
+
+#-----------------------------------------------------------------------------------------
+function loop_get_url_until_success {
+    url=$1
+    h2 "Looping to wait for things to start up"
+    http_status=""
+    while [[ "$http_status" != "200" ]]; do
+        info "sleeping for 2 secs..."
+        sleep 2
+        info "querying $url to see if things are started yet..."
+        http_status=$(curl -s -o /dev/null -w "%{http_code}" $url)
+        info "returned http status code was $http_status"
+    done
+    success "Things are started"
+}
+
+#-----------------------------------------------------------------------------------------
+function check_exit_code () {
+    # This function takes 2 parameters in the form:
+    # $1 an integer value of the returned exit code
+    # $2 an error message to display if $1 is not equal to 0
+    if [[ "$1" != "0" ]]; then
+        error "$2"
+        exit 1
+    fi
+}
+
+#-----------------------------------------------------------------------------------------
+function check_tool_is_installed {
+    # This function expects the name of the tool to be passed in
+    tool_name=$1
+
+    which ${tool_name}
+    rc=$?
+    check_exit_code ${rc} "${tool_name} is not available on your path. Install ${tool_name} and try again."
+    success "${tool_name} is installed. OK"
+}
+
+#-----------------------------------------------------------------------------------------
+function check_docker_installed {
+    check_tool_is_installed "docker"
+}
+
+#-----------------------------------------------------------------------------------------
+function check_minikube_installed {
+    check_tool_is_installed "minikube"
+}
+
+#-----------------------------------------------------------------------------------------
+function start_local_docker_registry {
+    h2 "Starting local Docker registry..."
+
+    # Check if the docker registry is already started
+    container_count=$(docker ps -a | grep ${REGISTRY_NAME} | wc -l | xargs)
+    if [[ "${container_count}" == "1" ]]; then
+        info "local Docker registry container already exists."
+
+        docker start ${REGISTRY_NAME}
+        rc=$?
+        check_exit_code ${rc} "Failed to restart the existing Docker registry container on port 5000. Check that this port is not in use and try again."
+    else
+        info "Starting a new local Docker registry container..."
+        docker run -d -p 5000:5000 --name ${REGISTRY_NAME} registry:2
+        rc=$?
+        check_exit_code ${rc} "Failed to start a local Docker registry container on port 5000. Check that this port is not in use and try again."
+    fi
+    success "Started local Docker registry OK"
+}
+
+#-----------------------------------------------------------------------------------------
+function build_galasa_modules_and_images {
+    h2 "Building Galasa modules and all Docker images using build-locally.sh..."
+    ${BASEDIR}/build-locally.sh --module wrapping --docker
+
+    rc=$?
+    check_exit_code ${rc} "Failed to build the Galasa modules and all Docker images"
+    success "Galasa build-locally.sh completed OK"
+}
+
+#-----------------------------------------------------------------------------------------
+function push_galasa_images_to_local_registry {
+    h2 "Pushing built images to local registry..."
+
+    push_image_to_local_registry "galasa-boot-embedded:latest"
+
+    success "Images pushed OK"
+}
+
+#-----------------------------------------------------------------------------------------
+function push_image_to_local_registry {
+    # This function expects the name of the image to be pushed
+    image_name=$1
+    retagged_image_name="localhost:5000/${image_name}"
+
+    h2 "Retagging ${image_name} for local registry..."
+    docker tag ${image_name} ${retagged_image_name}
+
+    rc=$?
+    check_exit_code ${rc} "Failed to retag the ${image_name} to ${retagged_image_name}"
+    success "Image tagged OK"
+
+    h2 "Pushing image to local Docker registry..."
+    docker push ${retagged_image_name}
+
+    rc=$?
+    check_exit_code ${rc} "Failed to push the ${retagged_image_name} image to the local Docker registry"
+    success "Image ${retagged_image_name} pushed to local Docker registry OK"
+}
+
+#-----------------------------------------------------------------------------------------
+function setup_local_registry_for_minikube {
+    h2 "Configuring minikube to be able to pull images from a local Docker registry..."
+    minikube_ip=$(minikube ip)
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then
+        info "minikube is not running. Starting minikube now..."
+        minikube start
+
+        rc=$?
+        check_exit_code ${rc} "Failed to start minikube cluster"
+    fi
+
+    # See https://minikube.sigs.k8s.io/docs/handbook/registry
+    minikube addons enable registry
+
+    # Check if the socat container is running
+    socat_container_name="docker-to-minikube-socat"
+    container_count=$(docker ps -a | grep ${socat_container_name} | wc -l | xargs)
+    if [[ "${container_count}" == "1" ]]; then
+        docker stop ${socat_container_name}
+        docker start ${socat_container_name}
+        rc=$?
+        check_exit_code ${rc} "Failed to restart the existing docker-to-minikube registry mapping container"
+    else
+        docker run --name ${socat_container_name} -d --network=host alpine sh -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
+        rc=$?
+        check_exit_code ${rc} "Failed to start a container that exposes the local docker registry to minikube"
+    fi
+
+    info "Waiting for container to be ready for use..."
+    loop_get_url_until_success "http://localhost:5000"
+
+    success "minikube can now pull images from a local Docker registry OK"
+}
+
+#-----------------------------------------------------------------------------------------
+# Main logic
+#-----------------------------------------------------------------------------------------
+
+check_docker_installed
+clean_up_before_set_up
+
+if [[ "${is_configure_minikube_requested}" == "true" ]]; then
+    check_minikube_installed
+    setup_local_registry_for_minikube
+else
+    start_local_docker_registry
+fi
+
+if [[ "${is_build_locally_requested}" == "true" ]]; then
+    build_galasa_modules_and_images
+fi
+
+push_galasa_images_to_local_registry
+
+success "Local Docker registry has been successfully set up and populated with locally-built Galasa images!"

--- a/tools/setup-minikube-docker-registry.sh
+++ b/tools/setup-minikube-docker-registry.sh
@@ -253,3 +253,4 @@ fi
 push_galasa_images_to_local_registry
 
 success "Local Docker registry has been successfully set up and populated with locally-built Galasa images!"
+info "If you wish to install a local Galasa service on minikube using the Helm chart, set the 'galasaRegistry' Helm value to 'localhost:5000' so minikube can pull the images from the local registry."

--- a/tools/setup-minikube-docker-registry.sh
+++ b/tools/setup-minikube-docker-registry.sh
@@ -134,6 +134,9 @@ function check_tool_is_installed {
 #-----------------------------------------------------------------------------------------
 function check_docker_installed {
     check_tool_is_installed "docker"
+    docker version > /dev/null 2>&1
+    rc=$?
+    check_exit_code ${rc} "The docker daemon is not running. Start it and try again."
 }
 
 #-----------------------------------------------------------------------------------------


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2161

## Changes
- Added an optional `--docker` flag to the build-locally script in tools and the OBR module that results in the galasa-boot-embedded image being built locally
- Added a `setup-minikube-docker-registry.sh` script to perform the relevant setup required for minikube to be able to pull locally-built images when running a local Galasa service
