### PR TITLE
protect test runner from rogue manager

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -83,6 +83,7 @@ public class BaseTestRunner {
     }
 
     protected void shutdownFramework(IShuttableFramework framework) {
+        logger.debug("Cleaning up framework");
         try {
             framework.shutdown();
         } catch(Exception e) {
@@ -215,6 +216,7 @@ public class BaseTestRunner {
         IRun run = framework.getTestRun();
 
         try {
+            logger.debug("Deleting run from dss: "+testStructure.getStatus()+" result:"+testStructure.getResult());
             framework.getFrameworkRuns().delete(run.getName());
         } catch (FrameworkException e) {
             logger.error("Failed to delete run properties");

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -78,6 +78,12 @@ public class TestClassWrapper {
         this.testClass = testClass;
         this.testStructure = testStructure;
 
+        // Fill-in as much of the test structure as we can at this point.
+        // If any failures occur after this, they will at least have the correct test name/bundle...etc attached.
+        this.testStructure.setBundle(testBundle);
+        this.testStructure.setTestName(testClass.getName());
+        this.testStructure.setTestShortName(testClass.getSimpleName());
+
         this.continueOnTestFailure = this.testRunner.getContinueOnTestFailureFromCPS();
     }
 
@@ -88,6 +94,8 @@ public class TestClassWrapper {
      * @throws TestRunException
      */
     public void parseTestClass() throws TestRunException {
+
+        logger.debug("Parsing test class...");
 
         ArrayList<GenericMethodWrapper> temporaryBeforeMethods = new ArrayList<>();
         ArrayList<GenericMethodWrapper> temporaryAfterMethods = new ArrayList<>();
@@ -117,11 +125,7 @@ public class TestClassWrapper {
             .add(new TestMethodWrapper(method, this.testClass, temporaryBeforeMethods, temporaryAfterMethods));
         }
 
-        // *** Create the reporting Test Structure
-
-        this.testStructure.setBundle(testBundle);
-        this.testStructure.setTestName(testClass.getName());
-        this.testStructure.setTestShortName(testClass.getSimpleName());
+        // Populate more fields in the test structure so reporting has more information.
         ArrayList<TestMethod> structureMethods = new ArrayList<>();
         this.testStructure.setMethods(structureMethods);
 
@@ -355,6 +359,14 @@ public class TestClassWrapper {
     }
 
     protected void setResult(Result result) {
+        String from ;
+        if( this.result == null) {
+            from = "null";
+        } else {
+            from = this.result.getName();
+        }
+        logger.info("Result in test structure changed from "+from+" to "+result);
+        
         this.result = result;
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunLifecycleStatus.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunLifecycleStatus.java
@@ -23,7 +23,7 @@ public enum TestRunLifecycleStatus {
     UP("up"),
     STARTED("started"),
     PROVSTART("provstart"),
-    ENDING("ending")
+    ENDING("ending"),
     ;
 
     private String value ;  

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
@@ -160,7 +160,7 @@ public class TestRunManagers implements ITestRunManagers {
         for (IManager manager : allManagers) {
             try {
                 manager.initialise(framework, allManagers, activeManagers, galasaTest);
-            } catch (ManagerException e) {
+            } catch (Exception e) {
                 throw new FrameworkException("Unable to initialise Manager " + manager.getClass().getName(), e);
             }
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TestRunnerDataProvider.java
@@ -99,8 +99,8 @@ public class TestRunnerDataProvider implements ITestRunnerDataProvider {
         ITestRunManagers managers ;
         try {
             managers = new TestRunManagers(this.framework, galasaTest);
-        } catch (FrameworkException e) {
-            String msg = "FrameworkException Exception caught. "+e.getMessage();
+        } catch (Exception e) {
+            String msg = "Exception Exception caught. "+e.getMessage();
             throw new TestRunException(msg,e);
         }
         return managers;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestRunner.java
@@ -22,6 +22,7 @@ import dev.galasa.framework.maven.repository.spi.IMavenRepository;
 import dev.galasa.framework.mocks.*;
 import dev.galasa.framework.mocks.MockTestRunnerEventsProducer.ProducedEvent;
 import dev.galasa.framework.spi.*;
+import dev.galasa.framework.spi.language.GalasaTest;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class TestTestRunner {
@@ -48,17 +49,7 @@ public class TestTestRunner {
         Properties overrideProps = new Properties();
         MockIResultArchiveStore ras = new MockIResultArchiveStore("myRunId", mockFileSystem ); 
 
-        MockIDynamicStatusStoreService dss = new MockIDynamicStatusStoreService() {
-            @Override
-            public Map<String, String> getPrefix(@NotNull String keyPrefix) throws DynamicStatusStoreException {
-                return new HashMap<String,String>();
-            }
-
-            @Override
-            public void put(@NotNull String key, @NotNull String value) throws DynamicStatusStoreException {
-                // Do nothing.
-            }
-        };
+        MockIDynamicStatusStoreService dss = new MockDSSWhichDoesNothing();
 
         IRun run = new MockRun(
             TEST_BUNDLE_NAME, 
@@ -273,5 +264,173 @@ public class TestTestRunner {
             .contains(TEST_RUN_NAME,"TestRunLifecycleStatusChangedEvent",TestRunLifecycleStatus.FINISHED);
         assertThat(events.get(8)).extracting("testRunName","eventType","testRunLifecycleStatus")
             .contains(TEST_RUN_NAME,"TestHeartbeatStoppedEvent",null);
+    }
+
+
+    class MockDSSWhichDoesNothing extends MockIDynamicStatusStoreService {
+        @Override
+        public Map<String, String> getPrefix(@NotNull String keyPrefix) throws DynamicStatusStoreException {
+            return new HashMap<String,String>();
+        }
+
+        @Override
+        public void put(@NotNull String key, @NotNull String value) throws DynamicStatusStoreException {
+            // Do nothing.
+        }
+    };
+
+    @Test
+    public void testCanCleanupOkIfManagerLoadFails() throws Exception {
+
+        String TEST_STREAM_REPO_URL = "http://myhost/myRepositoryForMyRun";
+        String TEST_BUNDLE_NAME = "myTestBundle";
+        String TEST_CLASS_NAME = MyActualTestClass.class.getName();
+        String TEST_RUN_NAME = "myTestRun";
+        String TEST_STREAM = "myStreamForMyRun";
+        String TEST_STREAM_OBR = "http://myhost/myObrForMyRun";
+        String TEST_REQUESTOR_NAME = "daffyduck";
+        boolean TEST_IS_LOCAL_RUN_TRUE = true;
+        boolean IGNORE_TEST_CLASS_FALSE = false;
+
+        MockFileSystem mockFileSystem = new MockFileSystem();
+        Properties overrideProps = new Properties();
+        MockIResultArchiveStore ras = new MockIResultArchiveStore("myRunId", mockFileSystem ); 
+
+        MockIDynamicStatusStoreService dss = new MockDSSWhichDoesNothing();
+
+        IRun run = new MockRun(
+            TEST_BUNDLE_NAME, 
+            TEST_CLASS_NAME , 
+            TEST_RUN_NAME, 
+            TEST_STREAM, 
+            TEST_STREAM_OBR , 
+            TEST_STREAM_REPO_URL,
+            TEST_REQUESTOR_NAME,
+            TEST_IS_LOCAL_RUN_TRUE
+        );
+
+
+        MockIFrameworkRuns frameworkRuns = new MockIFrameworkRuns( "myRunsGroup", List.of(run));
+
+        MockShutableFramework framework = new MockShutableFramework(ras,dss,TEST_RUN_NAME, run, frameworkRuns );
+        IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
+
+
+
+        IMavenRepository mockMavenRepo = new MockMavenRepository();
+
+        Repository repo1 = new MockRepository(TEST_STREAM_REPO_URL);
+        List<Repository> repositories = List.of(repo1);
+
+        boolean IS_RESOLVER_GOING_TO_RESOLVE_TEST_BUNDLE = true;
+        Resolver resolver = new MockResolver( IS_RESOLVER_GOING_TO_RESOLVE_TEST_BUNDLE );
+        Resource mockResource = new MockResource(TEST_STREAM_OBR);
+
+        MockRepositoryAdmin mockRepoAdmin = new MockRepositoryAdmin(repositories, resolver) {
+            @Override
+            public Resource[] discoverResources(String filterExpr) throws InvalidSyntaxException {
+                Resource[] results = new Resource[1];
+                results[0] = mockResource ;
+                return results;
+            }
+        };
+
+        MockBundleManager mockBundleManager = new MockBundleManager();
+
+        Map<String,MockServiceReference<?>> servicesMap = new HashMap<>();
+
+        Map<String,Class<?>> loadedClasses = Map.of( TEST_CLASS_NAME , MyActualTestClass.class );
+        MockBundle myBundle1 = new MockBundle( loadedClasses , TEST_BUNDLE_NAME );
+        List<Bundle> bundles = List.of(myBundle1);
+        MockBundleContext mockBundleContext = new MockBundleContext(servicesMap, bundles);
+
+
+        class MockAnnotationExtractor implements IAnnotationExtractor {
+
+            Map<String, Annotation> annotationToReturnMap = new HashMap<>();
+
+            public <A, B extends Annotation> void addAnnotation( Class<A> testClass, Class<B> annotationClass , B toReturn) {
+                String key = testClass.getName()+"-"+annotationClass.getName();
+                annotationToReturnMap.put( key, toReturn );
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public <A, B extends Annotation> B getAnnotation(Class<A> testClass, Class<B> annotationClass) {
+                String key = testClass.getName()+"-"+annotationClass.getName();
+                // The following type-cast is unsafe, or would be were we not in full control of all the 
+                // inputs and outputs in a unit test setting...
+                return  (B) annotationToReturnMap.get(key);
+            }
+        }
+
+        MockAnnotationExtractor mockAnnotationExtractor = new MockAnnotationExtractor();
+        dev.galasa.Test annotationToReturn = MyActualTestClass.class.getAnnotation(dev.galasa.Test.class);
+        assertThat(annotationToReturn).isNotNull();
+
+        mockAnnotationExtractor.addAnnotation(
+            MyActualTestClass.class, 
+            dev.galasa.Test.class,
+            annotationToReturn
+        );
+
+        TestRunner runner = new TestRunner() ;
+
+        runner.mavenRepository = mockMavenRepo;
+        runner.repositoryAdmin = mockRepoAdmin;
+
+        // Inject the bundle context before we run the test.
+        runner.activate(mockBundleContext);
+
+        Result testResult = Result.passed();
+
+        MockTestRunManagers mockTestRunManagers = new MockTestRunManagers(IGNORE_TEST_CLASS_FALSE, testResult );
+
+        MockTestRunnerEventsProducer mockEventsPublisher = new MockTestRunnerEventsProducer();
+
+        MockTestRunnerDataProvider testRunData = new MockTestRunnerDataProvider(
+            cps,
+            dss,
+            ras,
+            run,
+            framework,
+            overrideProps,
+            mockAnnotationExtractor,
+            mockBundleManager,
+            mockTestRunManagers,
+            mockFileSystem,
+            mockEventsPublisher
+        ) {
+
+            // *********** this is the 'spicey bit' for this test, where we simulate a failure.
+            @Override
+            public ITestRunManagers createTestRunManagers(GalasaTest galasaTest) throws TestRunException {
+                throw new NullPointerException("Simulating a bad failure in a custom manager");
+            }
+        };
+
+        // When...
+        TestRunException ex = catchThrowableOfType( ()->runner.runTest(testRunData), TestRunException.class);
+
+        /// Then...
+        assertThat(ex).isNotNull();      
+
+        // Check the RAS history
+        // We expect started->generating->building->provstart->running->rundone->ending->finished
+        List<TestStructure> rasHistory = ras.getTestStructureHistory();
+        assertThat(rasHistory).hasSize(3);
+
+        // initial setup.
+        assertThat(rasHistory.get(0)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
+            .containsExactly("myTestRun",null,null, null, "daffyduck", null,null);
+
+        // status = started
+        assertThat(rasHistory.get(1)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
+            .containsExactly("myTestRun",null,null, null, "daffyduck", "started",null);
+
+        // status = finished
+        assertThat(rasHistory.get(2)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
+            .containsExactly("myTestRun","myTestBundle","dev.galasa.framework.MyActualTestClass", "MyActualTestClass", "daffyduck", "finished","EnvFail");
+
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/ProductVersion.java
+++ b/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/ProductVersion.java
@@ -73,7 +73,7 @@ public class ProductVersion implements Comparable<ProductVersion> {
 
     /**
      * Note. Using this method is less efficient than using the class constructor.
-     * @param version A version number. Negative numbers are treated as 0.
+     * @param release A version number. Negative numbers are treated as 0.
      * @return A ProductVersion which has the the specified release
      */
     public ProductVersion r(int release) {
@@ -88,7 +88,7 @@ public class ProductVersion implements Comparable<ProductVersion> {
 
     /**
      * Note. Using this method is less efficient than using the class constructor.
-     * @param version A version number. Negative numbers are treated as 0.
+     * @param modification A version number. Negative numbers are treated as 0.
      * @return A ProductVersion which has the the specified modification level
      */
     public ProductVersion m(int modification) {


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?

A manager was throwing an NPE inside a method, which wasn't caught at all, and bombed the test out leaving lots of resources owned by other managers to not be cleaned up.

Now we have a finally block which cleans up the managers.

