### PR TITLE
Add REST API to scale resource monitor deployments in Kubernetes

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -179,6 +179,7 @@ public enum ServletErrorMessage {
     GAL5421_ERROR_GETTING_MONITOR_DEPLOYMENTS         (5421, "E: Error occurred when getting the Galasa monitor deployments from Kubernetes. Report the problem to your Galasa systems administrator."),
     GAL5422_ERROR_MONITOR_NOT_FOUND_BY_NAME           (5422, "E: Unable to retrieve a monitor with the given name. No such monitor exists. Check your request parameters and try again."),
     GAL5423_INVALID_MONITOR_NAME_PROVIDED             (5423, "E: Invalid monitor name provided. Check that the name provided only contains characters in the ranges 'a'-'z', 'A'-'Z', 0-9, '-' (hyphens), '_' (underscores), and '.' (dots)."),
+    GAL5424_FAILED_TO_UPDATE_MONITOR                  (5424, "E: Error occurred when attempting to update the Galasa monitor deployment in Kubernetes. Report the problem to your Galasa systems administrator.")
     ;
 
     // >>>
@@ -187,7 +188,7 @@ public enum ServletErrorMessage {
     // >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
     // >>>       If you do use this number for a new error template, please incriment this value.
     // >>>
-    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5424;
+    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5425;
 
 
     private String template ;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -179,7 +179,8 @@ public enum ServletErrorMessage {
     GAL5421_ERROR_GETTING_MONITOR_DEPLOYMENTS         (5421, "E: Error occurred when getting the Galasa monitor deployments from Kubernetes. Report the problem to your Galasa systems administrator."),
     GAL5422_ERROR_MONITOR_NOT_FOUND_BY_NAME           (5422, "E: Unable to retrieve a monitor with the given name. No such monitor exists. Check your request parameters and try again."),
     GAL5423_INVALID_MONITOR_NAME_PROVIDED             (5423, "E: Invalid monitor name provided. Check that the name provided only contains characters in the ranges 'a'-'z', 'A'-'Z', 0-9, '-' (hyphens), '_' (underscores), and '.' (dots)."),
-    GAL5424_FAILED_TO_UPDATE_MONITOR                  (5424, "E: Error occurred when attempting to update the Galasa monitor deployment in Kubernetes. Report the problem to your Galasa systems administrator.")
+    GAL5424_FAILED_TO_UPDATE_MONITOR                  (5424, "E: Error occurred when attempting to update the Galasa monitor deployment in Kubernetes. Report the problem to your Galasa systems administrator."),
+    GAL5425_ERROR_MONITOR_UPDATE_MISSING_DATA         (5425, "E: Invalid request payload. The request body is missing the ''data'' field. Check your request parameters and try again."),
     ;
 
     // >>>
@@ -188,7 +189,7 @@ public enum ServletErrorMessage {
     // >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
     // >>>       If you do use this number for a new error template, please incriment this value.
     // >>>
-    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5425;
+    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5426;
 
 
     private String template ;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/IKubernetesApiClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/IKubernetesApiClient.java
@@ -16,5 +16,5 @@ public interface IKubernetesApiClient {
 
     V1Deployment getDeploymentByName(String name, String namespace) throws ApiException;
 
-    void replaceDeployment(String namespace, String deploymentName, V1Deployment newDeployment) throws ApiException;
+    V1Deployment replaceDeployment(String namespace, String deploymentName, V1Deployment newDeployment) throws ApiException;
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/IKubernetesApiClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/IKubernetesApiClient.java
@@ -12,7 +12,9 @@ import io.kubernetes.client.openapi.models.V1Deployment;
 
 public interface IKubernetesApiClient {
 
-    List<V1Deployment> getNamespacedDeployments(String namespace, String labelSelector) throws ApiException;
+    List<V1Deployment> getDeployments(String namespace, String labelSelector) throws ApiException;
 
     V1Deployment getDeploymentByName(String name, String namespace) throws ApiException;
+
+    void replaceDeployment(String namespace, String deploymentName, V1Deployment newDeployment) throws ApiException;
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/KubernetesApiClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/KubernetesApiClient.java
@@ -28,8 +28,8 @@ public class KubernetesApiClient implements IKubernetesApiClient {
     }
 
     @Override
-    public void replaceDeployment(String namespace, String deploymentName, V1Deployment newDeployment) throws ApiException {
-        kubeApiClient.replaceNamespacedDeployment(deploymentName, namespace, newDeployment)
+    public V1Deployment replaceDeployment(String namespace, String deploymentName, V1Deployment newDeployment) throws ApiException {
+        return kubeApiClient.replaceNamespacedDeployment(deploymentName, namespace, newDeployment)
             .execute();
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/KubernetesApiClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/KubernetesApiClient.java
@@ -28,7 +28,13 @@ public class KubernetesApiClient implements IKubernetesApiClient {
     }
 
     @Override
-    public List<V1Deployment> getNamespacedDeployments(String namespace, String labelSelector) throws ApiException {
+    public void replaceDeployment(String namespace, String deploymentName, V1Deployment newDeployment) throws ApiException {
+        kubeApiClient.replaceNamespacedDeployment(deploymentName, namespace, newDeployment)
+            .execute();
+    }
+
+    @Override
+    public List<V1Deployment> getDeployments(String namespace, String labelSelector) throws ApiException {
         return kubeApiClient.listNamespacedDeployment(namespace)
             .labelSelector(labelSelector)
             .execute()

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/UpdateMonitorRequestValidator.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/UpdateMonitorRequestValidator.java
@@ -9,17 +9,17 @@ import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 import javax.servlet.http.HttpServletResponse;
 
-import dev.galasa.framework.api.beans.generated.GalasaMonitor;
-import dev.galasa.framework.api.beans.generated.GalasaMonitordata;
+import dev.galasa.framework.api.beans.generated.UpdateGalasaMonitorRequest;
+import dev.galasa.framework.api.beans.generated.UpdateGalasaMonitorRequestdata;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.api.common.resources.GalasaResourceValidator;
 
-public class UpdateMonitorRequestValidator extends GalasaResourceValidator<GalasaMonitor> {
+public class UpdateMonitorRequestValidator extends GalasaResourceValidator<UpdateGalasaMonitorRequest> {
 
     @Override
-    public void validate(GalasaMonitor monitor) throws InternalServletException {
-        GalasaMonitordata requestData = monitor.getdata();
+    public void validate(UpdateGalasaMonitorRequest monitor) throws InternalServletException {
+        UpdateGalasaMonitorRequestdata requestData = monitor.getdata();
 
         if (requestData == null) {
             ServletError error = new ServletError(GAL5425_ERROR_MONITOR_UPDATE_MISSING_DATA);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/UpdateMonitorRequestValidator.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/UpdateMonitorRequestValidator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.monitors.internal;
+
+import static dev.galasa.framework.api.common.ServletErrorMessage.*;
+
+import javax.servlet.http.HttpServletResponse;
+
+import dev.galasa.framework.api.beans.generated.GalasaMonitor;
+import dev.galasa.framework.api.beans.generated.GalasaMonitordata;
+import dev.galasa.framework.api.common.InternalServletException;
+import dev.galasa.framework.api.common.ServletError;
+import dev.galasa.framework.api.common.resources.GalasaResourceValidator;
+
+public class UpdateMonitorRequestValidator extends GalasaResourceValidator<GalasaMonitor> {
+
+    @Override
+    public void validate(GalasaMonitor monitor) throws InternalServletException {
+        GalasaMonitordata requestData = monitor.getdata();
+
+        if (requestData == null) {
+            ServletError error = new ServletError(GAL5425_ERROR_MONITOR_UPDATE_MISSING_DATA);
+            throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRoute.java
@@ -17,7 +17,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.api.beans.generated.GalasaMonitor;
-import dev.galasa.framework.api.beans.generated.GalasaMonitordata;
+import dev.galasa.framework.api.beans.generated.UpdateGalasaMonitorRequest;
+import dev.galasa.framework.api.beans.generated.UpdateGalasaMonitorRequestdata;
 import dev.galasa.framework.api.common.HttpRequestContext;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.MimeType;
@@ -104,7 +105,7 @@ public class MonitorsDetailsRoute extends ProtectedRoute {
         HttpServletRequest request = requestContext.getRequest();
 
         String monitorName = getMonitorNameFromPath(pathInfo);
-        GalasaMonitor updateRequest = parseRequestBody(request, GalasaMonitor.class);
+        UpdateGalasaMonitorRequest updateRequest = parseRequestBody(request, UpdateGalasaMonitorRequest.class);
         validator.validate(updateRequest);
 
         V1Deployment matchingDeployment = getDeploymentByName(monitorName);
@@ -127,11 +128,11 @@ public class MonitorsDetailsRoute extends ProtectedRoute {
         return getResponseBuilder().buildResponse(request, response, MimeType.APPLICATION_JSON.toString(), monitorJson, HttpServletResponse.SC_OK);
     }
 
-    private V1Deployment updateDeployment(GalasaMonitor updateRequest, V1Deployment matchingDeployment) throws InternalServletException {
+    private V1Deployment updateDeployment(UpdateGalasaMonitorRequest updateRequest, V1Deployment matchingDeployment) throws InternalServletException {
         V1Deployment upToDateDeployment = matchingDeployment;
 
         int replicas = 0;
-        GalasaMonitordata updateRequestData = updateRequest.getdata();
+        UpdateGalasaMonitorRequestdata updateRequestData = updateRequest.getdata();
         if (updateRequestData.getIsEnabled()) {
             replicas = 1;
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRoute.java
@@ -106,7 +106,7 @@ public class MonitorsDetailsRoute extends ProtectedRoute {
         V1Deployment matchingDeployment = getDeploymentByName(monitorName);
 
         if (matchingDeployment == null) {
-            ServletError error = new ServletError(GAL5419_ERROR_MONITOR_NOT_FOUND_BY_NAME);
+            ServletError error = new ServletError(GAL5422_ERROR_MONITOR_NOT_FOUND_BY_NAME);
             throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
         } else {
             updateDeployment(updateRequest, matchingDeployment);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRoute.java
@@ -123,19 +123,24 @@ public class MonitorsDetailsRoute extends ProtectedRoute {
             replicas = 1;
         }
 
-        matchingDeployment.getSpec().setReplicas(replicas);
-        logger.info("Deployment replicas set to: " + replicas);
-
-        String deploymentName = matchingDeployment.getMetadata().getName();
-
-        try {
-            kubeApiClient.replaceDeployment(kubeNamespace, deploymentName, matchingDeployment);
-        } catch (ApiException e) {
-            ServletError error = new ServletError(GAL5424_FAILED_TO_UPDATE_MONITOR);
-            throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
+        if (matchingDeployment.getSpec().getReplicas() == replicas) {
+            logger.info("Requested deployment replica count is unchanged, there is nothing to update");
+        } else {
+            matchingDeployment.getSpec().setReplicas(replicas);
+            logger.info("Deployment replicas set to: " + replicas);
+    
+            String deploymentName = matchingDeployment.getMetadata().getName();
+    
+            try {
+                kubeApiClient.replaceDeployment(kubeNamespace, deploymentName, matchingDeployment);
+            } catch (ApiException e) {
+                ServletError error = new ServletError(GAL5424_FAILED_TO_UPDATE_MONITOR);
+                throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
+            }
+    
+            logger.info("Deployment updated OK");
         }
 
-        logger.info("Deployment updated OK");
     }
 
     private V1Deployment getDeploymentByName(String monitorName) throws InternalServletException {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsRoute.java
@@ -69,7 +69,7 @@ public class MonitorsRoute extends ProtectedRoute {
         HttpServletRequest request = requestContext.getRequest();
         List<GalasaMonitor> monitors = new ArrayList<>();
         try {
-            List<V1Deployment> deploymentsList = kubeApiClient.getNamespacedDeployments(kubeNamespace, MONITOR_DEPLOYMENT_LABEL);
+            List<V1Deployment> deploymentsList = kubeApiClient.getDeployments(kubeNamespace, MONITOR_DEPLOYMENT_LABEL);
 
             for (V1Deployment deployment : deploymentsList) {
                 GalasaMonitor monitor = monitorTransform.createGalasaMonitorBeanFromDeployment(deployment);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRouteTest.java
@@ -254,8 +254,8 @@ public class MonitorsDetailsRouteTest extends MonitorsServletTest {
         assertThat(servletResponse.getStatus()).isEqualTo(500);
         checkErrorStructure(
             outStream.toString(),
-            5418,
-            "GAL5418E", "Error occurred when getting the Galasa monitor deployments from Kubernetes"
+            5421,
+            "GAL5421E", "Error occurred when getting the Galasa monitor deployments from Kubernetes"
         );
     }
 
@@ -291,6 +291,6 @@ public class MonitorsDetailsRouteTest extends MonitorsServletTest {
 
         // Then...
         assertThat(servletResponse.getStatus()).isEqualTo(404);
-        checkErrorStructure(outStream.toString(), 5419, "GAL5419E", "No such monitor exists");
+        checkErrorStructure(outStream.toString(), 5422, "GAL5422E", "No such monitor exists");
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRouteTest.java
@@ -16,7 +16,8 @@ import javax.servlet.ServletOutputStream;
 import org.junit.Test;
 
 import dev.galasa.framework.api.beans.generated.GalasaMonitor;
-import dev.galasa.framework.api.beans.generated.GalasaMonitordata;
+import dev.galasa.framework.api.beans.generated.UpdateGalasaMonitorRequest;
+import dev.galasa.framework.api.beans.generated.UpdateGalasaMonitorRequestdata;
 import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.HttpMethod;
 import dev.galasa.framework.api.common.mocks.MockFramework;
@@ -30,8 +31,8 @@ import io.kubernetes.client.openapi.models.V1Deployment;
 public class MonitorsDetailsRouteTest extends MonitorsServletTest {
 
     private String createUpdateRequestJson(boolean isEnabled) {
-        GalasaMonitor updateRequest = new GalasaMonitor();
-        GalasaMonitordata requestData = new GalasaMonitordata();
+        UpdateGalasaMonitorRequest updateRequest = new UpdateGalasaMonitorRequest();
+        UpdateGalasaMonitorRequestdata requestData = new UpdateGalasaMonitorRequestdata();
 
         requestData.setIsEnabled(isEnabled);
         updateRequest.setdata(requestData);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRouteTest.java
@@ -169,6 +169,40 @@ public class MonitorsDetailsRouteTest extends MonitorsServletTest {
     }
 
     @Test
+    public void testEnableAlreadyEnabledMonitorDoesNotErrorOut() throws Exception {
+        // Given...
+        MockFramework mockFramework = new MockFramework();
+
+        MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient();
+
+        String monitorName = "system";
+        String stream = "myStream";
+        int replicas = 1;
+        List<String> includes = List.of("*");
+        List<String> excludes = new ArrayList<>();
+
+        V1Deployment deployment = createMockDeployment(monitorName, stream, replicas, includes, excludes);
+        mockApiClient.addMockDeployment(deployment);
+
+        MockMonitorsServlet servlet = new MockMonitorsServlet(mockFramework, mockApiClient);
+
+        boolean isEnabled = true;
+        String requestBodyJson = createUpdateRequestJson(isEnabled);
+
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/" + monitorName, requestBodyJson, HttpMethod.PUT.toString(), REQUEST_HEADERS);
+
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+
+        // When...
+        servlet.init();
+        servlet.doPut(mockRequest, servletResponse);
+
+        // Then...
+        assertThat(servletResponse.getStatus()).isEqualTo(204);
+        assertThat(deployment.getSpec().getReplicas()).isEqualTo(1);
+    }
+
+    @Test
     public void testDisableMonitorUpdatesDeploymentReplicasOk() throws Exception {
         // Given...
         MockFramework mockFramework = new MockFramework();

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsRouteTest.java
@@ -39,8 +39,6 @@ public class MonitorsRouteTest extends MonitorsServletTest {
         Pattern routePattern = new MonitorsRoute(null, null, null, null).getPathRegex();
 
         // Then...
-        // The servlet's whiteboard pattern will match /secrets, so the secrets route
-        // should only allow an optional / or an empty string (no suffix after "/secrets")
         assertThat(routePattern.matcher("/").matches()).isTrue();
         assertThat(routePattern.matcher("").matches()).isTrue();
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/mocks/MockKubernetesApiClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/mocks/MockKubernetesApiClient.java
@@ -53,8 +53,8 @@ public class MockKubernetesApiClient implements IKubernetesApiClient {
     }
 
     @Override
-    public void replaceDeployment(String namespace, String deploymentName, V1Deployment newDeployment)
+    public V1Deployment replaceDeployment(String namespace, String deploymentName, V1Deployment newDeployment)
             throws ApiException {
-        // Do nothing...
+        return newDeployment;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/mocks/MockKubernetesApiClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/test/java/dev/galasa/framework/api/monitors/mocks/MockKubernetesApiClient.java
@@ -23,7 +23,7 @@ public class MockKubernetesApiClient implements IKubernetesApiClient {
     }
 
     @Override
-    public List<V1Deployment> getNamespacedDeployments(String namespace, String labelSelector) throws ApiException {
+    public List<V1Deployment> getDeployments(String namespace, String labelSelector) throws ApiException {
         throwApiExceptionIfEnabled();
         return mockDeployments;
     }
@@ -50,5 +50,11 @@ public class MockKubernetesApiClient implements IKubernetesApiClient {
             }
         }
         return matchingDeployment;
+    }
+
+    @Override
+    public void replaceDeployment(String namespace, String deploymentName, V1Deployment newDeployment)
+            throws ApiException {
+        // Do nothing...
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1202,7 +1202,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GalasaProperty'
+              $ref: '#/components/schemas/UpdateGalasaMonitorRequest'
       tags:
         - Monitors API
       responses:

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1202,12 +1202,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateGalasaMonitorRequest'
+              $ref: '#/components/schemas/GalasaMonitor'
       tags:
         - Monitors API
       responses:
         '204':
           description: The Galasa Monitor was successfully enabled or disabled
+        '400':
+          $ref: "#/components/responses/BadRequest"
         '401':
           $ref: "#/components/responses/Unauthorized"
         '403':
@@ -2822,12 +2824,6 @@ components:
           type: object
         trace:
           type: boolean
-    UpdateGalasaMonitorRequest:
-      type: object
-      properties:
-        isEnabled:
-          type: boolean
-          description: A boolean value that represents whether the Galasa monitor should be enabled or disabled.
     UpdateRunStatusRequest:
       type: object
       properties:

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1202,7 +1202,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GalasaMonitor'
+              $ref: '#/components/schemas/UpdateGalasaMonitorRequest'
       tags:
         - Monitors API
       responses:
@@ -2824,6 +2824,15 @@ components:
           type: object
         trace:
           type: boolean
+    UpdateGalasaMonitorRequest:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            isEnabled:
+              type: boolean
+              description: A boolean value that represents whether the Galasa monitor should be enabled or disabled.
     UpdateRunStatusRequest:
       type: object
       properties:

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1183,6 +1183,31 @@ paths:
                 $ref: '#/components/schemas/GalasaMonitor'
         '400':
           $ref: "#/components/responses/BadRequest"
+    put:
+      operationId: setMonitorStatus
+      summary: Enables or disables the given Galasa monitor
+      description: |
+        Enables or disables the given Galasa monitor by scaling its associated Kubernetes deployment's replicas
+        to 1 when enabled, or 0 when disabled.
+      parameters:
+        - name: monitorName
+          in: path
+          description: The Galasa monitor that to be enabled or disabled.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        description: The setting to enable or disable the Galasa monitor
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GalasaProperty'
+      tags:
+        - Monitors API
+      responses:
+        '204':
+          description: The Galasa Monitor was successfully enabled or disabled
         '401':
           $ref: "#/components/responses/Unauthorized"
         '403':
@@ -2797,6 +2822,12 @@ components:
           type: object
         trace:
           type: boolean
+    UpdateGalasaMonitorRequest:
+      type: object
+      properties:
+        isEnabled:
+          type: boolean
+          description: A boolean value that represents whether the Galasa monitor should be enabled or disabled.
     UpdateRunStatusRequest:
       type: object
       properties:


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2067

Note: This PR builds from changes in https://github.com/galasa-dev/galasa/pull/237 - once that PR is delivered, this branch will be rebased to remove the duplicate changes and make reviewing this PR easier.

## Changes
- Added `PUT /monitors/{monitor-name}` REST API endpoint that can be used as shown below to update the number of replicas for the given monitor's Kubernetes deployment to 0 or 1 based on the boolean value provided in the `isEnabled` request body parameter:
    ```json
    > PUT /monitors/my-custom-monitor

    {
        "data": {
            "isEnabled": true
        }
    }

    > Response: 200 with the updated deployment JSON
    ```