### PR TITLE
Return 404 instead of 500 when Kubernetes fails to find a matching deployment

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/KubernetesApiClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/KubernetesApiClient.java
@@ -8,6 +8,8 @@ package dev.galasa.framework.api.monitors.internal;
 import java.io.IOException;
 import java.util.List;
 
+import javax.servlet.http.HttpServletResponse;
+
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
@@ -43,6 +45,15 @@ public class KubernetesApiClient implements IKubernetesApiClient {
 
     @Override
     public V1Deployment getDeploymentByName(String name, String namespace) throws ApiException {
-        return kubeApiClient.readNamespacedDeployment(name, namespace).execute();
+        V1Deployment matchingDeployment = null;
+        try {
+            matchingDeployment = kubeApiClient.readNamespacedDeployment(name, namespace).execute();
+        } catch (ApiException ex) {
+            // If a deployment with the given name doesn't exist, return null
+            if (ex.getCode() != HttpServletResponse.SC_NOT_FOUND) {
+                throw ex;
+            }
+        }
+        return matchingDeployment;
     }
 }


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/galasa/pull/238

Fixes the response code returned when a given monitor couldn't be found in the Kubernetes namespace. The Kubernetes API client was returning an ApiException with a 404 code, so this PR catches the exception and returns null if a 404 was encountered, which will then get handled correctly by the monitors servlet.