### PR TITLE
protect against trailing slashes in the streams repo path

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     compileOnly project(':dev.galasa.framework.maven.repository.spi')
     implementation 'org.apache.maven:maven-repository-metadata'
     implementation 'org.codehaus.plexus:plexus-utils'
+
+    testImplementation(testFixtures(project(':dev.galasa.framework')))
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/test/java/dev/galasa/framework/maven/repository/internal/GalasaMavenUrlHandlerServiceTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/test/java/dev/galasa/framework/maven/repository/internal/GalasaMavenUrlHandlerServiceTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.maven.repository.internal;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.net.URL;
+import org.junit.Test;
+
+public class GalasaMavenUrlHandlerServiceTest {
+
+    
+    @Test
+    public void TestCanCreateHandlerServiceObject() {
+        new GalasaMavenUrlHandlerService();
+    }
+
+    @Test 
+    public void TestCanBuildAnArtifactURLWithoutTrailingSlashOnOBR() throws Exception {
+        GalasaMavenUrlHandlerService service = new GalasaMavenUrlHandlerService();
+
+        URL repositoryUrl = new URL("http://myhost/myrepository");
+
+        URL url = service.buildArtifactUrl(repositoryUrl, "myGroupId", "myArtifactId", "0.myVersion.0", "myFileName");
+
+        assertThat(url.toString()).doesNotContain("//myGroupId");
+    }
+
+    @Test 
+    public void TestCanBuildAnArtifactURLWithTrailingSlashOnOBR() throws Exception {
+        GalasaMavenUrlHandlerService service = new GalasaMavenUrlHandlerService();
+
+        URL repositoryUrl = new URL("http://myhost/myrepository/");
+
+        URL url = service.buildArtifactUrl(repositoryUrl, "myGroupId", "myArtifactId", "0.myVersion.0", "myFileName");
+
+        assertThat(url.toString()).doesNotContain("//myGroupId");
+    }
+}


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
If the repository part of the streams definition contains a URL which ends in a slash, none o f the tests can load, as the loading code creates a URL with '//' (double-slash) in the path, which causes the load code to hang.

Solution: Be more careful when constructing the URL path for a test class we want to load
and avoid double-slashes in a path into the maven repo location.