### PR TITLE
mcobbett test pod mem constraints

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -30,9 +30,11 @@ public class Settings implements Runnable {
     private String            configMapName;
     private String            engineLabel                 = "none";
     private String            engineImage                 = "none";
-    private int               engineMemory                = 100;
-    private int               engineMemoryRequest         = 150;
-    private int               engineMemoryLimit           = 200;
+    private int               engineMemoryHeapSizeMi      = 150;
+    private int               engineMemoryRequestMi       = 150;
+    private int               engineMemoryLimitMi         = 200;
+    private int               engineCPURequestM           = 400;
+    private int               engineCPULimitM             = 1000;
     private String            nodeArch                    = "";
     private String            nodePreferredAffinity       = "";
     private String            nodeTolerations             = "";
@@ -149,9 +151,12 @@ public class Settings implements Runnable {
         this.maxEngines = updateProperty(configMapData, "max_engines", 1, this.maxEngines);
         this.engineLabel = updateProperty(configMapData, "engine_label", "k8s-standard-engine", this.engineLabel);
         this.engineImage = updateProperty(configMapData, "engine_image", "ghcr.io/galasa-dev/galasa-boot-embedded-amd64", this.engineImage);
-        this.engineMemory = updateProperty(configMapData, "engine_memory", 300, this.engineMemory);
-        this.engineMemoryRequest = updateProperty(configMapData, "engine_memory_request", engineMemory + 50, this.engineMemoryRequest);
-        this.engineMemoryLimit = updateProperty(configMapData, "engine_memory_limit", engineMemory + 100, this.engineMemoryLimit);
+
+        this.engineMemoryRequestMi = updateProperty(configMapData, "engine_memory_request", engineMemoryRequestMi, this.engineMemoryRequestMi);
+        this.engineMemoryLimitMi = updateProperty(configMapData, "engine_memory_limit", engineMemoryLimitMi, this.engineMemoryLimitMi);
+        this.engineCPURequestM = updateProperty(configMapData, "engine_cpu_request", engineCPURequestM, this.engineCPURequestM);
+        this.engineCPULimitM = updateProperty(configMapData, "engine_cpu_limit", engineCPULimitM, this.engineCPULimitM);
+
         this.nodeArch = updateProperty(configMapData, "node_arch", "", this.nodeArch);
         this.nodePreferredAffinity = updateProperty(configMapData, "galasa_node_preferred_affinity", "", this.nodePreferredAffinity);
         this.nodeTolerations = updateProperty(configMapData, "galasa_node_tolerations", "", this.nodeTolerations);
@@ -315,16 +320,24 @@ public class Settings implements Runnable {
         return this.engineImage;
     }
 
-    public int getEngineMemoryRequest() {
-        return this.engineMemoryRequest;
+    public int getEngineMemoryRequestMegabytes() {
+        return this.engineMemoryRequestMi;
     }
 
-    public int getEngineMemoryLimit() {
-        return this.engineMemoryLimit;
+    public int getEngineCPURequestM() {
+        return this.engineCPURequestM;
     }
 
-    public int getEngineMemory() {
-        return this.engineMemory;
+    public int getEngineMemoryLimitMegabytes() {
+        return this.engineMemoryLimitMi;
+    }
+
+    public int getEngineMemoryHeapSizeMegabytes() {
+        return this.engineMemoryHeapSizeMi;
+    }
+
+    public int getEngineCPULimitM() {
+        return this.engineCPULimitM;
     }
 
     public String getBootstrap() {

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -340,6 +340,7 @@ public class TestPodScheduler implements Runnable {
         return tolerationsList;
     }
 
+
     private V1Container createTestContainer(String runName, String engineName, boolean isTraceEnabled) {
         V1Container container = new V1Container();
         container.setName("engine");
@@ -350,24 +351,8 @@ public class TestPodScheduler implements Runnable {
         container.setCommand(commands);
         commands.add("java");
 
-        ArrayList<String> args = new ArrayList<>();
+        ArrayList<String> args = createCommandLineArgs(settings, runName, isTraceEnabled);
         container.setArgs(args);
-
-        if (settings.getEngineMemoryHeapSizeMegabytes() != 0 ) {
-            args.add("-Xmx:"+Integer.toString(settings.getEngineMemoryHeapSizeMegabytes())+"m");
-        }
-        
-        args.add("-jar");
-        args.add("boot.jar");
-        args.add("--obr");
-        args.add("file:galasa.obr");
-        args.add("--bootstrap");
-        args.add(settings.getBootstrap());
-        args.add("--run");
-        args.add(runName);
-        if (isTraceEnabled) {
-            args.add("--trace");
-        }
 
         V1ResourceRequirements resources = new V1ResourceRequirements();
         container.setResources(resources);
@@ -395,6 +380,30 @@ public class TestPodScheduler implements Runnable {
         container.setVolumeMounts(createTestContainerVolumeMounts());
         container.setEnv(createTestContainerEnvVariables());
         return container;
+    }
+
+    // This method is protected so we can easily unit test it.
+    protected ArrayList<String> createCommandLineArgs(Settings settings, String runName, boolean isTraceEnabled) {
+        
+        ArrayList<String> args = new ArrayList<>();
+        
+        // Set the max heap size for the test pod...
+        if (settings.getEngineMemoryHeapSizeMegabytes() != 0 ) {
+            args.add("-Xmx:"+Integer.toString(settings.getEngineMemoryHeapSizeMegabytes())+"m");
+        }
+
+        args.add("-jar");
+        args.add("boot.jar");
+        args.add("--obr");
+        args.add("file:galasa.obr");
+        args.add("--bootstrap");
+        args.add(settings.getBootstrap());
+        args.add("--run");
+        args.add(runName);
+        if (isTraceEnabled) {
+            args.add("--trace");
+        }
+        return args ;
     }
 
     private List<V1Volume> createTestPodVolumes() {

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -29,6 +29,7 @@ import dev.galasa.framework.spi.IFrameworkRuns;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.SystemEnvironment;
 import dev.galasa.framework.spi.creds.FrameworkEncryptionService;
+import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Affinity;
@@ -366,15 +367,25 @@ public class TestPodScheduler implements Runnable {
         V1ResourceRequirements resources = new V1ResourceRequirements();
         container.setResources(resources);
 
-        // TODO reinstate
-        // System.out.println("requests=" +
-        // Integer.toString(this.settings.getEngineMemoryRequest()) + "Mi");
-        // System.out.println("limit=" +
-        // Integer.toString(this.settings.getEngineMemoryLimit()) + "Mi");
-        // resources.putRequestsItem("memory", new
-        // Quantity(Integer.toString(this.settings.getEngineMemoryRequest()) + "Mi"));
-        // resources.putLimitsItem("memory", new
-        // Quantity(Integer.toString(this.settings.getEngineMemoryLimit()) + "Mi"));
+        logger.info("requests=" + Integer.toString(this.settings.getEngineMemoryRequestMegabytes()) + "Mi");
+        resources.putRequestsItem("memory", new Quantity( Integer.toString(this.settings.getEngineMemoryRequestMegabytes()) + "Mi"));
+
+        logger.info("limit=" + Integer.toString(this.settings.getEngineMemoryLimitMegabytes()) + "Mi");
+        resources.putLimitsItem("memory", new Quantity(Integer.toString(this.settings.getEngineMemoryLimitMegabytes()) + "Mi"));
+
+        if (this.settings.getEngineCPURequestM() <= 0) {
+            logger.info("No requested CPU requirements set");
+        } else {
+            logger.info("requests=" + Integer.toString(this.settings.getEngineCPURequestM()) + "m");
+            resources.putRequestsItem("cpu", new Quantity( Integer.toString(this.settings.getEngineCPURequestM()) + "m"));
+        }
+
+        if (this.settings.getEngineCPULimitM() <= 0 ) {
+            logger.info("No maximum CPU requirements set");
+        } else {
+            logger.info("limit=" + Integer.toString(this.settings.getEngineCPULimitM()) + "m");
+            resources.putLimitsItem("cpu", new Quantity( Integer.toString(this.settings.getEngineCPULimitM()) + "m"));
+        }
 
         container.setVolumeMounts(createTestContainerVolumeMounts());
         container.setEnv(createTestContainerEnvVariables());
@@ -425,7 +436,7 @@ public class TestPodScheduler implements Runnable {
         // "galasa_maven_helper_repo"));
         //
         // envs.add(createValueEnv("GALASA_ENGINE_TYPE", engineLabel));
-        envs.add(createValueEnv("MAX_HEAP", Integer.toString(this.settings.getEngineMemory()) + "m"));
+        envs.add(createValueEnv("MAX_HEAP", Integer.toString(this.settings.getEngineMemoryHeapSizeMegabytes()) + "m"));
         envs.add(createValueEnv(RAS_TOKEN_ENV, env.getenv(RAS_TOKEN_ENV)));
         envs.add(createValueEnv(EVENT_TOKEN_ENV, env.getenv(EVENT_TOKEN_ENV)));
         envs.add(createValueEnv(ENCRYPTION_KEYS_PATH_ENV, env.getenv(ENCRYPTION_KEYS_PATH_ENV)));

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -352,6 +352,11 @@ public class TestPodScheduler implements Runnable {
 
         ArrayList<String> args = new ArrayList<>();
         container.setArgs(args);
+
+        if (settings.getEngineMemoryHeapSizeMegabytes() != 0 ) {
+            args.add("-Xmx:"+Integer.toString(settings.getEngineMemoryHeapSizeMegabytes())+"m");
+        }
+        
         args.add("-jar");
         args.add("boot.jar");
         args.add("--obr");

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -333,4 +333,41 @@ public class TestPodSchedulerTest {
     public void clearCounters() {
         CollectorRegistry.defaultRegistry.clear();
     }
+
+    public static final boolean TRACE_IS_ENABLED = true;
+
+    @Test
+    public void testMaxHeapSizeGetsSet() throws Exception {
+        // Given...
+        MockEnvironment mockEnvironment = new MockEnvironment();
+
+        MockK8sController controller = new MockK8sController();
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(new ArrayList<>());
+
+        V1ConfigMap mockConfigMap = createMockConfigMap();
+        MockSettings settings = new MockSettings(mockConfigMap, controller, null);
+        settings.init();
+        MockCPSStore mockCPS = new MockCPSStore(null);
+
+        TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, null, mockFrameworkRuns);
+
+        // When...
+        ArrayList<String> args = podScheduler.createCommandLineArgs(settings, "myRunName", TRACE_IS_ENABLED);
+
+        // Then...
+        assertThat(args).containsOnly(
+        "-Xmx:150m",
+                "-jar",
+                "boot.jar", 
+                "--obr",
+                "file:galasa.obr",
+                "--bootstrap",
+                "http://my.server/bootstrap",
+                "--run",
+                "myRunName",
+                "--trace"
+        );
+
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagementRunWatch.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagementRunWatch.java
@@ -52,9 +52,11 @@ public class ResourceManagementRunWatch  {
 
     public void shutdown() {
         logger.debug("ResourceManagementRunWatch: shutdown() entered.");
-        try {
-            this.watcher.stopWatching();
-        } catch (DynamicStatusStoreException e) {
+        if (this.watcher != null) {
+            try {
+                this.watcher.stopWatching();
+            } catch (DynamicStatusStoreException e) {
+            }
         }
         logger.debug("ResourceManagementRunWatch: shutdown() exiting.");
     }


### PR DESCRIPTION
# Why ?

See [Kubernetes pods should be launched with a min and max memory constraint.
#2164](https://github.com/galasa-dev/projectmanagement/issues/2164)

Added 4 settings in the configmap which the engine controller looks at:

- engine_memory_request - The amount of memory requested for the test pod. In Megabytes.
- engine_memory_limit - The memory limit of the pod, after which it errors. In Megabytes.
- engine_cpu_request - The amount of CPU (in thousandths of a CPU) we request for the test pod A 0 value means no value is set.
- engine_cpu_limit - The max amount of CPU the test can consume. A 0 value means no limit gets set.

Also protected the resource manager code from a null pointer when it shuts down and there is no etcd watcher set up yet.