### PR TITLE
Add experimental processing of SSCP-LU-DATA datastreams in 3270 manager

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/comms/SSCPLUDataTransform.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/comms/SSCPLUDataTransform.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.zos3270.internal.comms;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.codec.binary.Hex;
+
+import dev.galasa.zos3270.IDatastreamListener.DatastreamDirection;
+import dev.galasa.zos3270.internal.datastream.AbstractOrder;
+import dev.galasa.zos3270.internal.datastream.OrderText;
+import dev.galasa.zos3270.internal.datastream.WriteControlCharacter;
+import dev.galasa.zos3270.spi.DatastreamException;
+import dev.galasa.zos3270.spi.NetworkException;
+import dev.galasa.zos3270.spi.Screen;
+
+/**
+ * Provides utilities to process and transform SSCP-LU-DATA datastreams into
+ * 3270 datastreams that the Galasa 3270 manager can recognise.
+ */
+public class SSCPLUDataTransform {
+
+    private Screen screen;
+
+    public SSCPLUDataTransform(Screen screen) {
+        this.screen = screen;
+    }
+
+    public Inbound3270Message processSSCPLUData(ByteBuffer buffer) throws NetworkException {
+
+        String inboundHex = new String(Hex.encodeHex(buffer.array()));
+        screen.setDatastreamListenersDirection(inboundHex, DatastreamDirection.INBOUND);
+
+        return processSSCPLUDatastream(buffer, screen.getCodePage());
+    }
+
+    private Inbound3270Message processSSCPLUDatastream(ByteBuffer buffer, Charset codePage) throws DatastreamException {
+
+        Inbound3270Message messageToReturn;
+        if (!buffer.hasRemaining()) {
+            messageToReturn = new Inbound3270Message(null, null, null);
+        } else {
+            
+            // SSCP-LU-DATA datastreams don't seem to have a write control character,
+            // so make a basic one that keeps the keyboard unlocked...
+            boolean unlockKeyboard = true;
+            WriteControlCharacter writeControlCharacter = new WriteControlCharacter(
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                unlockKeyboard,
+                false
+            );
+
+            // The display screen in an SSCP-LU session is unformatted, so just 
+            // convert the datastream into a list of 3270 text orders
+            List<AbstractOrder> orders = convertToTextOrders(buffer, codePage);
+            messageToReturn = new Inbound3270Message(null, writeControlCharacter, orders);
+        }
+
+        return messageToReturn;
+    }
+
+    private List<AbstractOrder> convertToTextOrders(ByteBuffer buffer, Charset codePage) throws DatastreamException {
+        List<AbstractOrder> orders = new ArrayList<>();
+        while (buffer.remaining() > 0) {
+            byte currentByte = buffer.get();
+
+            OrderText orderText = new OrderText(codePage);
+            orders.add(orderText);
+
+            orderText.append(currentByte);
+        }
+        return orders;
+    }
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Screen.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Screen.java
@@ -278,7 +278,9 @@ public class Screen {
                     throw new DatastreamException("Unrecognised Buffer Holder - " + bh.getClass().getName());
                 }
             }
-            writeTrace(outboundBuffer);
+            String outboundHex = new String(Hex.encodeHex(outboundBuffer.toByteArray()));
+            setDatastreamListenersDirection(outboundHex, DatastreamDirection.OUTBOUND);
+
             this.network.sendDatastream(outboundBuffer.toByteArray());
         } catch(Exception e) {
             throw new DatastreamException("Error whilst processing READ BUFFER", e);
@@ -286,19 +288,17 @@ public class Screen {
 
     }
 
-    private void writeTrace(ByteArrayOutputStream outboundBuffer) {
-        if (logger.isTraceEnabled() || !this.datastreamListeners.isEmpty()) {
-            String hex = new String(Hex.encodeHex(outboundBuffer.toByteArray()));
-            if (logger.isTraceEnabled()) {
-                logger.trace("outbound=" + hex);
-            }
+    public void setDatastreamListenersDirection(String datastreamHex, DatastreamDirection direction) {
+        if (logger.isTraceEnabled()) {
+            logger.trace(direction.toString() + "=" + datastreamHex);
+        }
 
-            for(IDatastreamListener listener : this.datastreamListeners) {
-                listener.datastreamUpdate(DatastreamDirection.OUTBOUND, hex);
-            }
+        for (IDatastreamListener listener : this.datastreamListeners) {
+            listener.datastreamUpdate(direction, datastreamHex);
         }
     }
 
+    
     private synchronized void processReadModified(boolean all) throws DatastreamException {
         try {
             ByteArrayOutputStream outboundBuffer = new ByteArrayOutputStream();
@@ -316,7 +316,10 @@ public class Screen {
 
                 readModifiedBuffer(outboundBuffer);
             }
-            writeTrace(outboundBuffer);
+
+            String outboundHex = new String(Hex.encodeHex(outboundBuffer.toByteArray()));
+            setDatastreamListenersDirection(outboundHex, DatastreamDirection.OUTBOUND);
+
             this.network.sendDatastream(outboundBuffer.toByteArray());
         } catch(Exception e) {
             throw new DatastreamException("Error whilst processing READ BUFFER", e);
@@ -792,18 +795,35 @@ public class Screen {
 
     }
 
-    public String printScreen() {
+    private String buildRawScreenStringFromBuffer() {
         StringBuilder sb = new StringBuilder();
+        int currentColumn = 0;
         for (int i = 0; i < this.buffer.length; i++) {
-            if (this.buffer[i] == null) {
-                sb.append(" ");
+            IBufferHolder currentBufferHolder = this.buffer[i];
+            String currentBufferStr = null;
+            if (currentBufferHolder == null) {
+                currentBufferStr = " ";
             } else {
-                sb.append(this.buffer[i].getStringWithoutNulls());
+                currentBufferStr = currentBufferHolder.getStringWithoutNulls();
+            }
+
+            // Replace newline characters with spaces until the end of the row
+            if (currentBufferStr.equals("\n")) {
+                String screenLineBreak = " ".repeat(this.columns - currentColumn);
+                sb.append(screenLineBreak);
+                currentColumn = 0;
+            } else {
+                sb.append(currentBufferStr);
+                currentColumn++;
             }
         }
 
+        return sb.toString();
+    }
+
+    public String printScreen() {
         StringBuilder screenSB = new StringBuilder();
-        String screenString = sb.toString();
+        String screenString = buildRawScreenStringFromBuffer();
         for (int i = 0; i < this.screenSize; i += this.columns) {
             screenSB.append(screenString.substring(i, i + this.columns));
             screenSB.append('\n');
@@ -815,17 +835,8 @@ public class Screen {
         int cursorRow = screenCursor / columns;
         int cursorCol = screenCursor % columns;
 
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < this.buffer.length; i++) {
-            if (this.buffer[i] == null) {
-                sb.append(" ");
-            } else {
-                sb.append(this.buffer[i].getStringWithoutNulls());
-            }
-        }
-
         StringBuilder screenSB = new StringBuilder();
-        String screenString = sb.toString();
+        String screenString = buildRawScreenStringFromBuffer();
         int row = 0;
         for (int i = 0; i < this.screenSize; i += this.columns) {
             screenSB.append("=|");
@@ -1823,7 +1834,9 @@ public class Screen {
                 outboundBuffer.write(cursor.getCharRepresentation());
                 readModifiedBuffer(outboundBuffer);
             }
-            writeTrace(outboundBuffer);
+
+            String outboundHex = new String(Hex.encodeHex(outboundBuffer.toByteArray()));
+            setDatastreamListenersDirection(outboundHex, DatastreamDirection.OUTBOUND);
 
             for (IScreenUpdateListener listener : updateListeners) {
                 listener.screenUpdated(Direction.SENDING, aid);

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Screen.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Screen.java
@@ -808,6 +808,7 @@ public class Screen {
             }
 
             // Replace newline characters with spaces until the end of the row
+            // to display the rest of the screen correctly
             if (currentBufferStr.equals("\n")) {
                 String screenLineBreak = " ".repeat(this.columns - currentColumn);
                 sb.append(screenLineBreak);

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Screen.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Screen.java
@@ -797,7 +797,6 @@ public class Screen {
 
     private String buildRawScreenStringFromBuffer() {
         StringBuilder sb = new StringBuilder();
-        int currentColumn = 0;
         for (int i = 0; i < this.buffer.length; i++) {
             IBufferHolder currentBufferHolder = this.buffer[i];
             String currentBufferStr = null;
@@ -807,16 +806,7 @@ public class Screen {
                 currentBufferStr = currentBufferHolder.getStringWithoutNulls();
             }
 
-            // Replace newline characters with spaces until the end of the row
-            // to display the rest of the screen correctly
-            if (currentBufferStr.equals("\n")) {
-                String screenLineBreak = " ".repeat(this.columns - currentColumn);
-                sb.append(screenLineBreak);
-                currentColumn = 0;
-            } else {
-                sb.append(currentBufferStr);
-                currentColumn++;
-            }
+            sb.append(currentBufferStr);
         }
 
         return sb.toString();

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/terminal/ScreenTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/terminal/ScreenTest.java
@@ -68,18 +68,16 @@ public class ScreenTest extends Zos3270TestBase {
     }
 
     @Test
-    public void testPrintScreenWithNewlinesRendersScreenCorrectly() throws Exception {
+    public void testPrintScreenWithMultipleRowsRendersScreenCorrectly() throws Exception {
         // Given...
-        int columns = 28;
-        int rows = 2;
+        String screenText = "1st2nd3rd";
+        int columns = 3;
+        int rows = 3;
+
         Screen screen = CreateTestScreen(columns, rows, null);
         ArrayList<AbstractOrder> orders = new ArrayList<>();
 
         Charset codePage = Charset.forName("1047");
-        String firstRowText = "Hello world!";
-        String secondRowText = "This should be on a new line";
-        String screenText = firstRowText + "\n" + secondRowText;
-
         orders.add(new OrderText(screenText, codePage));
 
         WriteControlCharacter writeControlCharacter = new WriteControlCharacter();
@@ -90,24 +88,25 @@ public class ScreenTest extends Zos3270TestBase {
         String printedScreen = screen.printScreen();
 
         // Then...
-        String expectedSpacesOnFirstRow = " ".repeat(columns - firstRowText.length());
-        String expectedScreenText = firstRowText + expectedSpacesOnFirstRow + "\n" + secondRowText + "\n";
-        assertThat(printedScreen).isEqualTo(expectedScreenText);
+        String expectedScreen =
+            "1st\n"+
+            "2nd\n"+
+            "3rd\n";
+        assertThat(printedScreen).isEqualTo(expectedScreen);
     }
 
     @Test
     public void testPrintScreenWithCursorRendersScreenCorrectly() throws Exception {
         // Given...
-        int columns = 28;
-        int rows = 2;
+        String screenText = "1st   2nd   3rd";
+        int columns = 6;
+        int rows = 3;
+
         Network network = new Network("host", 123, "terminalId");
         Screen screen = CreateTestScreen(columns, rows, network);
         ArrayList<AbstractOrder> orders = new ArrayList<>();
 
         Charset codePage = Charset.forName("1047");
-        String firstRowText = "Hello world!";
-        String secondRowText = "This should be on a new line";
-        String screenText = firstRowText + "\n" + secondRowText;
 
         orders.add(new OrderText(screenText, codePage));
 
@@ -123,10 +122,11 @@ public class ScreenTest extends Zos3270TestBase {
 
         // Then...
         String expectedScreen =
-            "=|Hello world!                |\n"+
-            "=|This should be on a new line|\n"+
+            "=|1st   |\n"+
+            "=|2nd   |\n"+
             "^| ^\n"+
-            "!| Disconnected-Plain Size=2x28 Cursor=29,2x1 Keyboard Unlocked\n";
+            "=|3rd   |\n"+
+            "!| Disconnected-Plain Size=3x6 Cursor=7,2x1 Keyboard Unlocked\n";
 
         assertThat(printedScreen).isEqualTo(expectedScreen);
     }

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/terminal/ScreenTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/terminal/ScreenTest.java
@@ -5,12 +5,15 @@
  */
 package dev.galasa.zos3270.terminal;
 
+import static org.assertj.core.api.Assertions.*;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 
 import org.junit.Assert;
@@ -23,6 +26,7 @@ import dev.galasa.zos3270.internal.comms.NetworkThread;
 import dev.galasa.zos3270.internal.datastream.AbstractOrder;
 import dev.galasa.zos3270.internal.datastream.BufferAddress;
 import dev.galasa.zos3270.internal.datastream.CommandEraseWrite;
+import dev.galasa.zos3270.internal.datastream.CommandWrite;
 import dev.galasa.zos3270.internal.datastream.CommandWriteStructured;
 import dev.galasa.zos3270.internal.datastream.OrderInsertCursor;
 import dev.galasa.zos3270.internal.datastream.OrderRepeatToAddress;
@@ -38,6 +42,94 @@ import dev.galasa.zos3270.spi.Screen;
 import dev.galasa.zos3270.util.Zos3270TestBase;
 
 public class ScreenTest extends Zos3270TestBase {
+
+    @Test
+    public void testPrintScreenRendersScreenCorrectly() throws Exception {
+        // Given...
+        String screenText = "Hello world!";
+        int columns = screenText.length();
+        int rows = 1;
+
+        Screen screen = CreateTestScreen(columns, rows, null);
+        ArrayList<AbstractOrder> orders = new ArrayList<>();
+
+        Charset codePage = Charset.forName("1047");
+        orders.add(new OrderText(screenText, codePage));
+
+        WriteControlCharacter writeControlCharacter = new WriteControlCharacter();
+        Inbound3270Message inboundMessage = new Inbound3270Message(new CommandWrite(), writeControlCharacter, orders);
+        
+        // When...
+        screen.processInboundMessage(inboundMessage);
+        String printedScreen = screen.printScreen();
+
+        // Then...
+        assertThat(printedScreen).isEqualTo(screenText + "\n");
+    }
+
+    @Test
+    public void testPrintScreenWithNewlinesRendersScreenCorrectly() throws Exception {
+        // Given...
+        int columns = 28;
+        int rows = 2;
+        Screen screen = CreateTestScreen(columns, rows, null);
+        ArrayList<AbstractOrder> orders = new ArrayList<>();
+
+        Charset codePage = Charset.forName("1047");
+        String firstRowText = "Hello world!";
+        String secondRowText = "This should be on a new line";
+        String screenText = firstRowText + "\n" + secondRowText;
+
+        orders.add(new OrderText(screenText, codePage));
+
+        WriteControlCharacter writeControlCharacter = new WriteControlCharacter();
+        Inbound3270Message inboundMessage = new Inbound3270Message(new CommandWrite(), writeControlCharacter, orders);
+        
+        // When...
+        screen.processInboundMessage(inboundMessage);
+        String printedScreen = screen.printScreen();
+
+        // Then...
+        String expectedSpacesOnFirstRow = " ".repeat(columns - firstRowText.length());
+        String expectedScreenText = firstRowText + expectedSpacesOnFirstRow + "\n" + secondRowText + "\n";
+        assertThat(printedScreen).isEqualTo(expectedScreenText);
+    }
+
+    @Test
+    public void testPrintScreenWithCursorRendersScreenCorrectly() throws Exception {
+        // Given...
+        int columns = 28;
+        int rows = 2;
+        Network network = new Network("host", 123, "terminalId");
+        Screen screen = CreateTestScreen(columns, rows, network);
+        ArrayList<AbstractOrder> orders = new ArrayList<>();
+
+        Charset codePage = Charset.forName("1047");
+        String firstRowText = "Hello world!";
+        String secondRowText = "This should be on a new line";
+        String screenText = firstRowText + "\n" + secondRowText;
+
+        orders.add(new OrderText(screenText, codePage));
+
+        boolean unlockKeyboard = true;
+        WriteControlCharacter writeControlCharacter = new WriteControlCharacter(false, false, false, false, false, false, unlockKeyboard, false);
+        Inbound3270Message inboundMessage = new Inbound3270Message(new CommandWrite(), writeControlCharacter, orders);
+        
+        // When...
+        screen.processInboundMessage(inboundMessage);
+        screen.cursorDown();
+        screen.cursorRight();
+        String printedScreen = screen.printScreenTextWithCursor();
+
+        // Then...
+        String expectedScreen =
+            "=|Hello world!                |\n"+
+            "=|This should be on a new line|\n"+
+            "^| ^\n"+
+            "!| Disconnected-Plain Size=2x28 Cursor=29,2x1 Keyboard Unlocked\n";
+
+        assertThat(printedScreen).isEqualTo(expectedScreen);
+    }
 
     @Test
     public void testScreenSize() throws TerminalInterruptedException {


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/1844

## Changes
- The 3270 manager now processes SSCP-LU-DATA datastreams onto the screen by converting such inbound datastreams into 3270 datastreams made up of text orders only to display the received data (i.e. no special commands/orders)
  - From the datastream provided in the customer's run.log, only standard EBCDIC-encoded text and newline characters can be seen, so an assumption has been made in that SSCP-LU-DATA datastreams can only contain text. This may require further changes if we find out more about SSCP-LU-DATA datastreams, but the changes in this PR will allow the 3270 manager to process the customer's datastream.