### PR TITLE
Delete run DSS properties for local runs only and delete test pods for finished runs

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/IKubernetesProtoClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/IKubernetesProtoClient.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.k8s.controller;
+
+import java.io.IOException;
+
+import io.kubernetes.client.openapi.ApiException;
+
+public interface IKubernetesProtoClient {
+    void deletePod(String namespace, String podName) throws ApiException, IOException;
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
@@ -23,7 +23,6 @@ import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IFramework;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.Configuration;
-import io.kubernetes.client.ProtoClient;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.util.Config;
 import io.prometheus.client.exporter.HTTPServer;
@@ -86,7 +85,7 @@ public class K8sController {
                 throw new FrameworkException("Unable to load Kubernetes API", e);
             }
             Configuration.setDefaultApiClient(client);
-            ProtoClient pc = new ProtoClient(client);
+            IKubernetesProtoClient protoClient = new KubernetesProtoClient(client);
             CoreV1Api api = new CoreV1Api();
 
             // *** Fetch the settings
@@ -141,7 +140,7 @@ public class K8sController {
                 logger.info("Health monitoring disabled");
             }
             // *** Start the run polling
-            runCleanup = new RunPodCleanup(settings, api, pc, framework.getFrameworkRuns());
+            runCleanup = new RunPodCleanup(settings, api, protoClient, framework.getFrameworkRuns());
             schedulePodCleanup();
             podScheduler = new TestPodScheduler(dss, cps, settings, api, framework.getFrameworkRuns());
             schedulePoll();

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/KubernetesProtoClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/KubernetesProtoClient.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.k8s.controller;
+
+import java.io.IOException;
+
+import io.kubernetes.client.ProtoClient;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.proto.V1.Namespace;
+
+public class KubernetesProtoClient implements IKubernetesProtoClient {
+
+    private ProtoClient client;
+
+    public KubernetesProtoClient(ApiClient apiClient) {
+        this.client = new ProtoClient(apiClient);
+    }
+
+    @Override
+    public void deletePod(String namespace, String podName) throws ApiException, IOException {
+        client.delete(Namespace.newBuilder(), "/api/v1/namespaces/" + namespace + "/pods/" + podName);
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunPodCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunPodCleanup.java
@@ -12,26 +12,28 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.TestRunLifecycleStatus;
+import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.IFrameworkRuns;
 import dev.galasa.framework.spi.IRun;
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.ProtoClient;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.proto.V1.Namespace;
 
 public class RunPodCleanup implements Runnable {
+
+    public static final String GALASA_RUN_POD_LABEL = "galasa-run";
+
     private final Log            logger = LogFactory.getLog(getClass());
 
     private final Settings       settings;
     private final CoreV1Api      api;
-    private final ProtoClient    pc;
+    private final IKubernetesProtoClient protoClient;
     private final IFrameworkRuns runs;
 
-    public RunPodCleanup(Settings settings, CoreV1Api api, ProtoClient pc, IFrameworkRuns runs) {
+    public RunPodCleanup(Settings settings, CoreV1Api api, IKubernetesProtoClient protoClient, IFrameworkRuns runs) {
         this.settings = settings;
         this.api = api;
-        this.pc = pc;
+        this.protoClient = protoClient;
         this.runs = runs;
     }
 
@@ -43,32 +45,36 @@ public class RunPodCleanup implements Runnable {
             List<V1Pod> pods = TestPodScheduler.getPods(api, settings);
             TestPodScheduler.filterTerminated(pods);
 
-            for (V1Pod pod : pods) {
-                Map<String, String> labels = pod.getMetadata().getLabels();
-                String runName = labels.get("galasa-run");
-
-                if (runName != null) {
-                    IRun run = runs.getRun(runName);
-                    if (run != null) {
-
-                        // There is a completed pod for a run in the DSS, delete the pod if the run has finished
-                        TestRunLifecycleStatus runStatus = TestRunLifecycleStatus.getFromString(run.getStatus());
-                        if (runStatus == TestRunLifecycleStatus.FINISHED) {
-                            logger.info("Deleting pod " + pod.getMetadata().getName() + " as the run has finished");
-                            deletePod(pod);                        
-                        }
-                    } else {
-
-                        // The run for the completed pod no longer exists in the DSS, so just delete the pod
-                        logger.info("Deleting pod " + pod.getMetadata().getName() + " as the run has been deleted from the DSS");
-                        deletePod(pod);
-                    }
-                }
-            }
+            deletePodsForCompletedRuns(pods);
 
             logger.info("Finished run pod cleanup scan");
         } catch (Exception e) {
             logger.error("Problem with run pod cleanup scan", e);
+        }
+    }
+
+    void deletePodsForCompletedRuns(List<V1Pod> terminatedPods) throws DynamicStatusStoreException {
+        for (V1Pod pod : terminatedPods) {
+            Map<String, String> labels = pod.getMetadata().getLabels();
+            String runName = labels.get(GALASA_RUN_POD_LABEL);
+
+            if (runName != null) {
+                IRun run = runs.getRun(runName);
+                if (run != null) {
+
+                    // There is a completed pod for a run in the DSS, delete the pod if the run has finished
+                    TestRunLifecycleStatus runStatus = TestRunLifecycleStatus.getFromString(run.getStatus());
+                    if (runStatus == TestRunLifecycleStatus.FINISHED) {
+                        logger.info("Deleting pod " + pod.getMetadata().getName() + " as the run has finished");
+                        deletePod(pod);                        
+                    }
+                } else {
+
+                    // The run for the completed pod no longer exists in the DSS, so just delete the pod
+                    logger.info("Deleting pod " + pod.getMetadata().getName() + " as the run has been deleted from the DSS");
+                    deletePod(pod);
+                }
+            }
         }
     }
 
@@ -77,7 +83,7 @@ public class RunPodCleanup implements Runnable {
             String podName = pod.getMetadata().getName();
             logger.info("Deleting pod " + podName);
             // *** Have to use the ProtoClient as the deleteNamespacedPod does not work
-            pc.delete(Namespace.newBuilder(), "/api/v1/namespaces/" + settings.getNamespace() + "/pods/" + podName);
+            protoClient.deletePod(settings.getNamespace(), podName);
         } catch (ApiException e) {
             logger.error("Failed to delete engine pod :-\n" + e.getResponseBody(), e);
         } catch (Exception e) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -119,7 +119,7 @@ public class Settings implements Runnable {
         return returnValue;
     }
 
-    V1ConfigMap retrieveConfigMap() throws K8sControllerException {
+    protected V1ConfigMap retrieveConfigMap() throws K8sControllerException {
         V1ConfigMap configMap = null;
         try {
             configMap = api.readNamespacedConfigMap(configMapName, namespace).pretty("true").execute();

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunPodCleanupTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunPodCleanupTest.java
@@ -133,8 +133,6 @@ public class RunPodCleanupTest {
 
         List<V1Pod> mockPods = new ArrayList<>(mockTerminatedPods);
 
-        // Simulate a situation where the runs have been deleted from the DSS but the pods still exist,
-        // so the pods should get deleted
         List<IRun> mockRuns = new ArrayList<>();
 
         MockKubernetesProtoClient mockProtoClient = new MockKubernetesProtoClient(mockPods);

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunPodCleanupTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunPodCleanupTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.k8s.controller;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import dev.galasa.framework.TestRunLifecycleStatus;
+import dev.galasa.framework.k8s.controller.mocks.MockKubernetesProtoClient;
+import dev.galasa.framework.k8s.controller.mocks.MockSettings;
+import dev.galasa.framework.mocks.MockIFrameworkRuns;
+import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.spi.IRun;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+
+public class RunPodCleanupTest {
+
+    private V1Pod createMockTestPod(String runName) {
+        V1Pod mockPod = new V1Pod();
+
+        V1ObjectMeta podMetadata = new V1ObjectMeta();
+        podMetadata.putLabelsItem(RunPodCleanup.GALASA_RUN_POD_LABEL, runName);
+        podMetadata.setName(runName);
+
+        mockPod.setMetadata(podMetadata);
+        return mockPod;
+    }
+
+    private MockRun createMockRun(String runName, String status) {
+        // We only care about the run's name and status
+        MockRun mockRun = new MockRun(
+            "bundle",
+            "testclass",
+            runName,
+            "testStream",
+            "testStreamOBR",
+            "testStreamMavenRepo",
+            "requestor",
+            false
+        );
+
+        mockRun.setStatus(status);
+        return mockRun;
+    }
+
+    @Test
+    public void testPodsForFinishedRunsAreDeletedOk() throws Exception {
+        // Given...
+        String runName1 = "run1";
+        String runName2 = "run2";
+        String runName3 = "run3";
+
+        // Create terminated pods
+        List<V1Pod> mockTerminatedPods = new ArrayList<>();
+        mockTerminatedPods.add(createMockTestPod(runName1));
+        mockTerminatedPods.add(createMockTestPod(runName2));
+
+        // Create a list of all pods to also simulate running pods
+        List<V1Pod> mockPods = new ArrayList<>(mockTerminatedPods);
+        V1Pod runningPod = createMockTestPod(runName3);
+        mockPods.add(runningPod);
+
+        // Create runs associated with the pods
+        List<IRun> mockRuns = new ArrayList<>();
+        mockRuns.add(createMockRun(runName1, TestRunLifecycleStatus.FINISHED.toString()));
+        mockRuns.add(createMockRun(runName2, TestRunLifecycleStatus.FINISHED.toString()));
+        mockRuns.add(createMockRun(runName3, TestRunLifecycleStatus.RUNNING.toString()));
+
+        MockKubernetesProtoClient mockProtoClient = new MockKubernetesProtoClient(mockPods);
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(mockRuns);
+
+        MockSettings mockSettings = new MockSettings(null, null, null);
+        RunPodCleanup runPodCleanup = new RunPodCleanup(mockSettings, null, mockProtoClient, mockFrameworkRuns);
+
+        // When...
+        runPodCleanup.deletePodsForCompletedRuns(mockTerminatedPods);
+
+        // Then...
+        List<V1Pod> remainingPods = mockProtoClient.getMockPods();
+        assertThat(remainingPods).hasSize(1);
+        assertThat(remainingPods.get(0)).usingRecursiveComparison().isEqualTo(runningPod);
+
+        // No runs should have been deleted, only their pods
+        assertThat(mockFrameworkRuns.getAllRuns()).hasSize(3);
+    }
+
+    @Test
+    public void testPodsForTerminatedRunsAreDeletedOk() throws Exception {
+        // Given...
+        String runName1 = "run1";
+        String runName2 = "run2";
+
+        // Create terminated pods
+        List<V1Pod> mockTerminatedPods = new ArrayList<>();
+        mockTerminatedPods.add(createMockTestPod(runName1));
+        mockTerminatedPods.add(createMockTestPod(runName2));
+
+        List<V1Pod> mockPods = new ArrayList<>(mockTerminatedPods);
+
+        // Simulate a situation where the runs have been deleted from the DSS but the pods still exist,
+        // so the pods should get deleted
+        List<IRun> mockRuns = new ArrayList<>();
+
+        MockKubernetesProtoClient mockProtoClient = new MockKubernetesProtoClient(mockPods);
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(mockRuns);
+
+        MockSettings mockSettings = new MockSettings(null, null, null);
+        RunPodCleanup runPodCleanup = new RunPodCleanup(mockSettings, null, mockProtoClient, mockFrameworkRuns);
+
+        // When...
+        runPodCleanup.deletePodsForCompletedRuns(mockTerminatedPods);
+
+        // Then...
+        assertThat(mockProtoClient.getMockPods()).isEmpty();
+    }
+
+    @Test
+    public void testPodWithNoRunNameShouldNotBeDeleted() throws Exception {
+        // Given...
+        // Simulate a situation where the current kubernetes namespace has a terminated pod, which may
+        // not be a Galasa-related pod, so it doesn't have a "galasa-run" label with a run name.
+        List<V1Pod> mockTerminatedPods = new ArrayList<>();
+        V1Pod podWithNoRunName = createMockTestPod(null);
+        mockTerminatedPods.add(podWithNoRunName);
+
+        List<V1Pod> mockPods = new ArrayList<>(mockTerminatedPods);
+
+        // Simulate a situation where the runs have been deleted from the DSS but the pods still exist,
+        // so the pods should get deleted
+        List<IRun> mockRuns = new ArrayList<>();
+
+        MockKubernetesProtoClient mockProtoClient = new MockKubernetesProtoClient(mockPods);
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(mockRuns);
+
+        MockSettings mockSettings = new MockSettings(null, null, null);
+        RunPodCleanup runPodCleanup = new RunPodCleanup(mockSettings, null, mockProtoClient, mockFrameworkRuns);
+
+        // When...
+        runPodCleanup.deletePodsForCompletedRuns(mockTerminatedPods);
+
+        // Then...
+        List<V1Pod> pods = mockProtoClient.getMockPods();
+        assertThat(pods).hasSize(1);
+        assertThat(pods.get(0)).usingRecursiveComparison().isEqualTo(podWithNoRunName);
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -15,12 +15,12 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.After;
 
+import dev.galasa.framework.k8s.controller.mocks.MockSettings;
 import dev.galasa.framework.mocks.MockCPSStore;
 import dev.galasa.framework.mocks.MockEnvironment;
 import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
 import dev.galasa.framework.mocks.MockIFrameworkRuns;
 import dev.galasa.framework.spi.creds.FrameworkEncryptionService;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
@@ -36,21 +36,6 @@ import io.kubernetes.client.openapi.models.V1VolumeMount;
 import io.prometheus.client.CollectorRegistry;
 
 public class TestPodSchedulerTest {
-
-    class MockSettings extends Settings {
-
-        private V1ConfigMap mockConfigMap;
-
-        public MockSettings(V1ConfigMap configMap, K8sController controller, CoreV1Api api) throws K8sControllerException {
-            super(controller, api);
-            this.mockConfigMap = configMap;
-        }
-
-        @Override
-        V1ConfigMap retrieveConfigMap() {
-            return mockConfigMap;
-        }
-    }
 
     class MockK8sController extends K8sController {
         @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockKubernetesProtoClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockKubernetesProtoClient.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.k8s.controller.mocks;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.galasa.framework.k8s.controller.IKubernetesProtoClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1Pod;
+
+public class MockKubernetesProtoClient implements IKubernetesProtoClient {
+
+    private List<V1Pod> mockPods = new ArrayList<>();
+
+    public MockKubernetesProtoClient(List<V1Pod> mockPods) {
+        this.mockPods = mockPods;
+    }
+
+    @Override
+    public void deletePod(String namespace, String podName) throws ApiException, IOException {
+        V1Pod podToDelete = null;
+        for (V1Pod pod : mockPods) {
+            String currentPodName = pod.getMetadata().getName();
+            if (podName.equals(currentPodName)) {
+                podToDelete = pod;
+                break;
+            }
+        }
+        mockPods.remove(podToDelete);
+    }
+
+    public List<V1Pod> getMockPods() {
+        return this.mockPods;
+    }
+    
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockSettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockSettings.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.k8s.controller.mocks;
+
+import dev.galasa.framework.k8s.controller.K8sController;
+import dev.galasa.framework.k8s.controller.K8sControllerException;
+import dev.galasa.framework.k8s.controller.Settings;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+
+public class MockSettings extends Settings {
+
+    private V1ConfigMap mockConfigMap;
+
+    public MockSettings(V1ConfigMap configMap, K8sController controller, CoreV1Api api) throws K8sControllerException {
+        super(controller, api);
+        this.mockConfigMap = configMap;
+    }
+
+    @Override
+    protected V1ConfigMap retrieveConfigMap() {
+        return mockConfigMap;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -227,7 +227,7 @@ public class TestRunner extends BaseTestRunner {
         // *** time for things like jenkins and other run requesters to obtain the
         // result and RAS id before
         // *** deleting, default is to keep the automation run properties for 5 minutes
-        if (!markedWaiting) {
+        if (this.run.isLocal() && !markedWaiting) {
             deleteRunProperties(this.framework);
         }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIFrameworkRuns.java
@@ -31,6 +31,23 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
     }
 
     @Override
+    public IRun getRun(String runname) throws DynamicStatusStoreException {
+        IRun matchingRun = null;
+        for (IRun run : this.runs) {
+            if (runname.equals(run.getName())) {
+                matchingRun = run;
+                break;
+            }
+        }
+        return matchingRun;
+    }
+
+    @Override
+    public @NotNull List<IRun> getAllRuns() throws FrameworkException {
+        return this.runs;
+    }
+
+    @Override
     public @NotNull List<IRun> getActiveRuns() throws FrameworkException {
         throw new UnsupportedOperationException("Unimplemented method 'getActiveRuns'");
     }
@@ -38,11 +55,6 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
     @Override
     public @NotNull List<IRun> getQueuedRuns() throws FrameworkException {
         throw new UnsupportedOperationException("Unimplemented method 'getQueuedRuns'");
-    }
-
-    @Override
-    public @NotNull List<IRun> getAllRuns() throws FrameworkException {
-        throw new UnsupportedOperationException("Unimplemented method 'getAllRuns'");
     }
 
     @Override
@@ -75,11 +87,6 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
     @Override
     public boolean delete(String runname) throws DynamicStatusStoreException {
         return true;
-    }
-
-    @Override
-    public IRun getRun(String runname) throws DynamicStatusStoreException {
-        throw new UnsupportedOperationException("Unimplemented method 'getRun'");
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
@@ -24,6 +24,7 @@ public class MockRun implements IRun {
     private Instant heartbeat;
     private String group;
     private String submissionId;
+    private String status;
 
     public MockRun(
         String testBundleName, 
@@ -140,6 +141,15 @@ public class MockRun implements IRun {
         return this.heartbeat ;
     }
 
+    @Override
+    public String getStatus() {
+        return this.status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
     // ------------- un-implemented methods follow ----------------
 
     @Override
@@ -151,12 +161,6 @@ public class MockRun implements IRun {
     public String getTest() {
         throw new UnsupportedOperationException("Unimplemented method 'getTest'");
     }
-
-    @Override
-    public String getStatus() {
-        throw new UnsupportedOperationException("Unimplemented method 'getStatus'");
-    }
-
 
     @Override
     public boolean isTrace() {


### PR DESCRIPTION
## Why?
Relates to https://github.com/galasa-dev/projectmanagement/issues/2181

Test runs are being removed from the DSS too quickly for clients to track, which has been causing issues in various areas of Galasa. By deleting a run from the DSS while the resource monitor is down, there is also a risk that resources provisioned for that run do not get cleaned up properly when the resource monitor comes back up - this PR reverts to keeping DSS properties for a run around so that the resource monitor can clean them up after a certain period of time.

Keeping the DSS properties does mean that the engine controller would keep the Kubernetes pods associated with runs around until the resource monitor deletes the DSS properties for the runs, which in turn triggers the engine controller's "deleted runs" scan to delete the pods. To avoid a build-up of completed test pods in Kubernetes, the engine controller now deletes pods for runs that have finished.

## Changes
- The test runner no longer deletes the run's DSS properties at the end of a run, the deletion of a run's DSS properties is now handled by the resource monitor
- The engine controller thread that cleans up Kubernetes pods for test runs now deletes pods for runs that have finished as well as runs that no longer exist in the DSS (same as it was before)
