### PR TITLE
Fix issue in the OBR build 

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -241,12 +241,6 @@ jobs:
           echo $(git log -1 --pretty=format:"%H" -- "modules/managers") > modules/obr/managers.githash
           echo $(git log -1 --pretty=format:"%H" -- "modules/obr") > modules/obr/obr.githash
 
-      - name: Upload obr artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: obr
-          path: modules/obr/repo
-
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
         env:
@@ -263,6 +257,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/obr-maven-artefacts
 
+      # Here we build a Docker image that contains all dev.galasa artifacts
+      # to deploy to a download site. It contains all artifacts listed in 
+      # the Uber OBR.
       - name: Build and push OBR image 
         id: build-obr
         uses: docker/build-push-action@v5
@@ -291,6 +288,23 @@ jobs:
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |
           docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:obr-${{ env.BRANCH }} --health --server argocd.galasa.dev
+
+      # Here we remove the artifacts built by the other modules (everything
+      # other than dev.galasa.uber.obr and galasa-bom) as otherwise when
+      # a workflow downloads this zip, the other module's artifacts are 
+      # overwritten by the contents of this zip.
+      - name: Remove other module's artifacts before uploading to workflow
+        working-directory: modules/obr/repo/dev/galasa
+        run: |
+          mkdir -p ../tmp && mv dev.galasa.uber.obr galasa-bom ../tmp/
+          rm -rf ./*
+          mv ../tmp/dev.galasa.uber.obr ../tmp/galasa-bom ./
+
+      - name: Upload OBR artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: obr
+          path: modules/obr/repo
 
   # For the release process build an image containing
   # the OBR artifacts and a galasabld executable used

--- a/.github/workflows/pr-obr.yaml
+++ b/.github/workflows/pr-obr.yaml
@@ -298,13 +298,10 @@ jobs:
           echo $(git log -1 --pretty=format:"%H" -- "modules/extensions") > modules/obr/extensions.githash
           echo $(git log -1 --pretty=format:"%H" -- "modules/managers") > modules/obr/managers.githash
           echo $(git log -1 --pretty=format:"%H" -- "modules/obr") > modules/obr/obr.githash
-
-      - name: Upload obr artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: obr
-          path: modules/obr/repo
       
+      # Here we build a Docker image that contains all dev.galasa artifacts
+      # to deploy to a download site. It contains all artifacts listed in 
+      # the Uber OBR.
       - name: Build OBR image for testing
         uses: docker/build-push-action@v5
         with:
@@ -315,6 +312,23 @@ jobs:
           build-args: |
             dockerRepository=${{ env.REGISTRY }}
             baseVersion=latest
+
+      # Here we remove the artifacts built by the other modules (everything
+      # other than dev.galasa.uber.obr and galasa-bom) as otherwise when
+      # a workflow downloads this zip, the other module's artifacts are 
+      # overwritten by the contents of this zip.
+      - name: Remove other module's artifacts before uploading to workflow
+        working-directory: modules/obr/repo/dev/galasa
+        run: |
+          mkdir -p ../tmp && mv dev.galasa.uber.obr galasa-bom ../tmp/
+          rm -rf ./*
+          mv ../tmp/dev.galasa.uber.obr ../tmp/galasa-bom ./
+
+      - name: Upload OBR artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: obr
+          path: modules/obr/repo
 
   build-obr-javadocs:
     name: Build OBR javadocs using galasabld image and maven


### PR DESCRIPTION
## Why?

PR builds that contained a change for the Managers + IVTs module was failing, as the IVTs were not picking up changes made to the Core Manager in that PR.

This is because the OBR hadn't changed in that PR and so the PR was downloading the "OBR artifacts" from the last successful Main Build workflow. This was causing issues though as the "OBR artifacts" contained all other dev.galasa artifacts too (including the dev.galasa.core.manager at Main with no changes). This meant the dev.galasa.core.manager downloaded from the PR was being overwritten by the dev.galasa.core.manager at Main.

I've updated the OBR workflow to delete everything other than dev.galasa.uber.obr and galasa-bom from the directory before uploading it as the "OBR artifacts". We do this after the docker build though so the OBR docker image still contains everything dev.galasa, but the "obr" artifact attached to the GitHub workflows should just contain things the OBR workflow built.