### PR TITLE
Exclude completed pods from throttled pod count in engine controller

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -121,9 +121,7 @@ public class TestPodScheduler implements Runnable {
             while (true) {
                 // *** Check we are not at max engines
                 List<V1Pod> pods = getPods(this.api, this.settings);
-                
-                // Do not filter out active runs. Completed runs still consume memory. 
-                // We should limit active+inactive runs to the max threashold.
+                filterActiveRuns(pods);
 
                 logger.info("Active runs=" + pods.size() + ",max=" + settings.getMaxEngines());
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2201

Reverts changes made to the TestPodScheduler in https://github.com/galasa-dev/galasa/pull/221 so that only active pods are included in the throttled pod count. 