### PR TITLE
Iss1920 - Ability to obtain test result from within a Galasa test

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
@@ -159,4 +159,7 @@ public class GenericMethodWrapper {
         return this.excecutionMethod.getName();
     }
 
+    public Type getType() {
+        return this.type;
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IResult.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IResult.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+public interface IResult {
+    public boolean isPassed();
+    public boolean isFailed();
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ITestRunManagers.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ITestRunManagers.java
@@ -19,6 +19,12 @@ public interface ITestRunManagers {
     public List<IManager> getActiveManagers();
     public void provisionGenerate() throws FrameworkException ;
     public void provisionBuild() throws FrameworkException ;
+
+    /**
+     * Tells the managers about the final end-result of the test. 
+     * All other methods on the test have been called that are going to be called.
+     * This method is called only once, after the @AfterClass methods.
+     */
     public void testClassResult(@NotNull Result finalResult, Throwable finalException);
 
     public Result endOfTestClass(@NotNull Result result, Throwable currentException) throws FrameworkException ;
@@ -32,6 +38,15 @@ public interface ITestRunManagers {
     public Result anyReasonTestMethodShouldBeIgnored(@NotNull GalasaMethod galasaMethod) throws FrameworkException;
     public void fillAnnotatedFields(Object testClassObject) throws FrameworkException;
     public void startOfTestMethod(@NotNull GalasaMethod galasaMethod) throws FrameworkException;
-    public Result endOfTestMethod(@NotNull GalasaMethod galasaMethod, @NotNull Result currentResult, Throwable currentException)
-    throws FrameworkException ;
+    public Result endOfTestMethod(@NotNull GalasaMethod galasaMethod, @NotNull Result currentResult, Throwable currentException) throws FrameworkException ;
+
+    /**
+     * The result has changed, it could change again. It could be set the the same thing multiple times.
+     * This call is used to propogate the very latest overall test result state down to the managers, so they know the test state.
+     * This can be used by the @TestResultProvider annotation for example, to maintain a 'current test result' which tests themselves, 
+     * and @AfterClass methods can use.
+     * 
+     * @since 0.41.0
+     */
+    default void setResultSoFar(IResult newResult) {}
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -14,6 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
 
 import org.apache.bcel.classfile.AnnotationEntry;
 import org.apache.commons.lang3.StringUtils;
@@ -41,7 +42,7 @@ public class TestClassWrapper {
     private final Class<?>                  testClass;
     private Object                          testClassObject;
 
-    private Result                          result;
+    private Result                          resultData;
 
     private ArrayList<GenericMethodWrapper> beforeClassMethods = new ArrayList<>();
     private ArrayList<TestMethodWrapper>    testMethods        = new ArrayList<>();
@@ -170,7 +171,7 @@ public class TestClassWrapper {
      * 
      * @throws TestRunException
      */
-    public void runTestMethods(@NotNull ITestRunManagers managers, IDynamicStatusStoreService dss, String runName) throws TestRunException {
+    public void runMethods(@NotNull ITestRunManagers managers, IDynamicStatusStoreService dss, String runName) throws TestRunException {
 
         logger.info(LOG_STARTING + LOG_START_LINE + LOG_ASTERS + LOG_START_LINE + "*** Start of test class "
                 + testClass.getName() + LOG_START_LINE + LOG_ASTERS);
@@ -182,84 +183,94 @@ public class TestClassWrapper {
         }
 
         // Run @BeforeClass methods
-        for (GenericMethodWrapper beforeClassMethod : beforeClassMethods) {
-            beforeClassMethod.invoke(managers, this.testClassObject, null);
-            if (beforeClassMethod.fullStop()) {
-                this.result = Result.failed("BeforeClass method failed");
-                break;
-            }
-        }
+        runGenericMethods(managers, beforeClassMethods);
 
-        if (result == null) {
-            // Run test methods
-
-            try {
-                dss.put("run." + runName + ".method.total", Integer.toString(this.testMethods.size()));
-
-                int actualMethod = 0;
-                for (TestMethodWrapper testMethod : this.testMethods) {
-                    actualMethod++;
-                    dss.put("run." + runName + ".method.current", Integer.toString(actualMethod));
-                    dss.put("run." + runName + ".method.name", testMethod.getName());
-                    // Run @Test method
-                    testMethod.invoke(managers, this.testClassObject, this.continueOnTestFailure);
-                    if (testMethod.fullStop()) {
-                        break;
-                    }
-                }
-
-                for (TestMethodWrapper testMethod : this.testMethods) {
-                    Result testMethodResult = testMethod.getResult();
-                    if (testMethodResult != null && testMethodResult.isFailed()) {
-                        this.result = Result.failed("A Test failed");
-                        break;
-                    }
-                }
-
-                if (this.result == null) {
-                    this.result = Result.passed();
-                }
-                
-                dss.delete("run." + runName + ".method.name");
-                dss.delete("run." + runName + ".method.total");
-                dss.delete("run." + runName + ".method.current");
-            } catch (DynamicStatusStoreException e) {
-                throw new TestRunException("Failed to update the run status", e);
-            }     
+        // Proceed with the @Test methods only if the result is null (there were no @BeforeClass methods) OR
+        // the result is not a full stop (i.e. a failed or env failed result).
+        if (getResult() == null || !getResult().isFullStop()) {
+            // Run @Test methods
+            runTestMethods(managers, dss, runName);
         }
 
         // Run @AfterClass methods
-        for (GenericMethodWrapper afterClassMethod : afterClassMethods) {
-            afterClassMethod.invoke(managers, this.testClassObject, null);
-            if (afterClassMethod.fullStop()) {
-                if (this.result == null) {
-                    this.result = Result.failed("AfterClass method failed");
-                }
-            }
-        }
+        runGenericMethods(managers, afterClassMethods);
 
         try {
-            Result newResult = managers.endOfTestClass(this.result, null); // TODO pass the class level exception
+            Result newResult = managers.endOfTestClass(getResult(), null); // TODO pass the class level exception
             if (newResult != null) {
                 logger.info("Result of test run overridden to " + newResult.getName());
-                this.result = newResult;
+                setResult(newResult, managers);
             }
         } catch (FrameworkException e) {
             throw new TestRunException("Problem with end of test class", e);
         }
 
         // Test result
-        logger.info(LOG_ENDING + LOG_START_LINE + LOG_ASTERS + LOG_START_LINE + "*** " + this.result.getName()
+        logger.info(LOG_ENDING + LOG_START_LINE + LOG_ASTERS + LOG_START_LINE + "*** " + getResult().getName()
         + " - Test class " + testClass.getName() + LOG_START_LINE + LOG_ASTERS);
 
-        this.testStructure.setResult(this.result.getName());
+        this.testStructure.setResult(getResult().getName());
 
-        managers.testClassResult(this.result, null);
+        managers.testClassResult(getResult(), null);
 
         String report = this.testStructure.report(LOG_START_LINE);
         logger.trace("Finishing Test Class structure:-" + report);
 
         return;
+    }
+
+    /**
+     * Run generic methods. These are methods annotated with @BeforeClass or @AfterClass.
+     * The result is set in this test class wrapper at the end of every generic method.
+     * @param managers
+     * @param genericMethods
+     * @throws TestRunException
+     */
+    private void runGenericMethods(@NotNull ITestRunManagers managers, ArrayList<GenericMethodWrapper> genericMethods) throws TestRunException {
+        for (GenericMethodWrapper genericMethod : genericMethods) {
+            genericMethod.invoke(managers, this.testClassObject, null);
+            // Set the result so far after every generic method
+            Result beforeClassMethodResult = genericMethod.getResult();
+            setResult(beforeClassMethodResult, managers);
+            if (genericMethod.fullStop()) {
+                setResult(Result.failed(genericMethod.getType().toString() + " method failed"), managers);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Run the test methods. These are methods annotated with @Test.
+     * The result is set in this test class wrapper from the
+     * test method wrapper after each @Test method.
+     * @param managers
+     * @param dss
+     * @param runName
+     * @throws TestRunException
+     */
+    private void runTestMethods(@NotNull ITestRunManagers managers, IDynamicStatusStoreService dss, String runName) throws TestRunException {
+        try {
+            dss.put("run." + runName + ".method.total", Integer.toString(this.testMethods.size()));
+
+            int actualMethod = 0;
+            for (TestMethodWrapper testMethod : this.testMethods) {
+                actualMethod++;
+                dss.put("run." + runName + ".method.current", Integer.toString(actualMethod));
+                dss.put("run." + runName + ".method.name", testMethod.getName());
+                // Run @Test method
+                testMethod.invoke(managers, this.testClassObject, this.continueOnTestFailure, this);
+                // Setting the result so far after every @Test 
+                // method happens inside the testMethod class.
+                if (testMethod.fullStop()) {
+                    break;
+                }
+            }
+            dss.delete("run." + runName + ".method.name");
+            dss.delete("run." + runName + ".method.total");
+            dss.delete("run." + runName + ".method.current");
+        } catch (DynamicStatusStoreException e) {
+            throw new TestRunException("Failed to update the run status", e);
+        }
     }
 
     /**
@@ -358,20 +369,33 @@ public class TestClassWrapper {
         }
     }
 
-    protected void setResult(Result result) {
-        String from ;
-        if( this.result == null) {
-            from = "null";
-        } else {
-            from = this.result.getName();
+    protected void setResult(@Null Result newResult, @Null ITestRunManagers managers) {
+        // If the result is already full stop (i.e. a failed or env failed result),
+        // do not update the result again after this. The test methods can proceed,
+        // if ContinueOnTestFailure is specified, but the result should stay as failed,
+        // or it could accidentally get changed back to passed.
+        if (getResult() != null && getResult().isFullStop()){
+            return;
         }
-        logger.info("Result in test structure changed from "+from+" to "+result);
-        
-        this.result = result;
+
+        if (newResult != null) {
+            String from;
+            if (this.resultData == null) {
+                from = "null";
+            } else {
+                from = this.resultData.getName();
+            }
+            logger.info("Result in test class wrapper changed from " + from + " to " + newResult.getName());
+            
+            this.resultData = newResult;
+            if (managers != null ) {
+                managers.setResultSoFar(newResult);
+            }
+        }
     }
 
     protected Result getResult() {
-        return this.result;
+        return this.resultData;
     }
 
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
@@ -46,10 +46,11 @@ public class TestMethodWrapper {
         return;
     }
 
-    public void invoke(@NotNull ITestRunManagers managers, Object testClassObject, boolean continueOnTestFailure) throws TestRunException {
+    public void invoke(@NotNull ITestRunManagers managers, Object testClassObject, boolean continueOnTestFailure, TestClassWrapper testClassWrapper) throws TestRunException {
         // run all the @Befores before the test method
         for (GenericMethodWrapper before : this.befores) {
             before.invoke(managers, testClassObject, testMethod);
+            testClassWrapper.setResult(before.getResult(), managers);
             if (before.getResult().isFullStop()) {
                 this.fullStop = true;
                 this.result = Result.failed("Before method failed");
@@ -59,6 +60,7 @@ public class TestMethodWrapper {
 
         if (this.result == null) {
             testMethod.invoke(managers, testClassObject, null);
+            testClassWrapper.setResult(testMethod.getResult(), managers);
             if (this.testMethod.fullStop()) {
                 if (continueOnTestFailure) {
                     logger.warn("Test method failed, however, continue on test failure was requested, so carrying on");
@@ -74,6 +76,7 @@ public class TestMethodWrapper {
         Result afterResult = null;
         for (GenericMethodWrapper after : this.afters) {
             after.invoke(managers, testClassObject, testMethod);
+            testClassWrapper.setResult(after.getResult(), managers);
             if (after.fullStop()) {
                 this.fullStop = true;
                 if (afterResult == null) {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
@@ -646,4 +646,15 @@ public class TestRunManagers implements ITestRunManagers {
         return this.activeManagers;
     }
 
+    @Override
+    public void setResultSoFar(IResult newResult) {
+        for (IManager manager : activeManagers) {
+            try {
+                manager.setResultSoFar(newResult);
+            } catch (Exception e) {
+                logger.warn("Problem in test class result for manager " + manager.getClass().getName(), e);
+            }
+        }
+    }
+
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -358,7 +358,7 @@ public class TestRunner extends BaseTestRunner {
 
         if (invalidManager) {
             logger.error("There are Managers that do not support Shared Environment builds");
-            testClassWrapper.setResult(Result.failed("Invalid Shared Environment build"));
+            testClassWrapper.setResult(Result.failed("Invalid Shared Environment build"), managers);
             testStructure.setResult(testClassWrapper.getResult().getName());
             isRunOK = false;
         }
@@ -379,7 +379,7 @@ public class TestRunner extends BaseTestRunner {
                 if (e instanceof FrameworkResourceUnavailableException) {
                     this.isResourcesAvailable = false;
                 }
-                testClassWrapper.setResult(Result.envfail(e));
+                testClassWrapper.setResult(Result.envfail(e), managers);
                 if (isResourcesAvailable) {
                     managers.testClassResult(testClassWrapper.getResult(), e);
                 }
@@ -411,7 +411,7 @@ public class TestRunner extends BaseTestRunner {
                         if (e instanceof FrameworkResourceUnavailableException) {
                             this.isResourcesAvailable = false;
                         }
-                        testClassWrapper.setResult(Result.envfail(e));
+                        testClassWrapper.setResult(Result.envfail(e), managers);
                         if (this.isResourcesAvailable) {
                             managers.testClassResult(testClassWrapper.getResult(), e);
                         }
@@ -449,7 +449,7 @@ public class TestRunner extends BaseTestRunner {
                         if (e instanceof FrameworkResourceUnavailableException) {
                             this.isResourcesAvailable = false;
                         }
-                        testClassWrapper.setResult(Result.envfail(e));
+                        testClassWrapper.setResult(Result.envfail(e), managers);
                         testStructure.setResult(testClassWrapper.getResult().getName());
                         return;
                     }
@@ -481,7 +481,7 @@ public class TestRunner extends BaseTestRunner {
                 updateStatus(TestRunLifecycleStatus.RUNNING, null);
                 try {
                     logger.info("Running the test class");
-                    testClassWrapper.runTestMethods(managers, dss, runName);
+                    testClassWrapper.runMethods(managers, dss, runName);
                 } finally {
                     updateStatus(TestRunLifecycleStatus.RUNDONE, null);
                 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IManager.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IManager.java
@@ -10,6 +10,7 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 
 import dev.galasa.ManagerException;
+import dev.galasa.framework.IResult;
 import dev.galasa.framework.spi.language.GalasaMethod;
 import dev.galasa.framework.spi.language.GalasaTest;
 
@@ -342,5 +343,17 @@ public interface IManager {
      * other Managers in this method as they may have shutdown already.  Calls to the Framework, CPS, RAS etc will be safe.
      */
     void shutdown();
+
+    /**
+     * The result has changed, it could change again. It could be set the the same thing multiple times.
+     * This call is used to propogate the very latest overall test result state down to the managers, so they know the test state.
+     * This can be used by the @TestResultProvider annotation for example, to maintain a 'current test result' which tests themselves, 
+     * and @AfterClass methods can use.
+     * 
+     * @param newResult
+     * 
+     * @since 0.41.0
+     */
+    default void setResultSoFar(IResult newResult) {}
 
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/Result.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/Result.java
@@ -10,7 +10,9 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
-public class Result {
+import dev.galasa.framework.IResult;
+
+public class Result implements IResult {
 
     private static final String IGNORED     = "Ignored";
     private static final String PASSED      = "Passed";
@@ -144,10 +146,12 @@ public class Result {
         return this.reason;
     }
 
+    @Override
     public boolean isPassed() {
         return this.passed;
     }
 
+    @Override
     public boolean isFailed() {
         return this.failed;
     }

--- a/modules/ivts/galasa-ivts-parent/buildSrc/src/main/groovy/galasa.ivt.gradle
+++ b/modules/ivts/galasa-ivts-parent/buildSrc/src/main/groovy/galasa.ivt.gradle
@@ -8,11 +8,11 @@ plugins {
 // This section tells gradle where it should look for any dependencies
 repositories {
     mavenLocal()
-    mavenCentral()
     // To use the bleeding edge version of galasa's obr plugin, use the development obr
     maven {
        url = "$sourceMaven"
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/bnd.bnd
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/bnd.bnd
@@ -1,5 +1,8 @@
 -snapshot: ${tstamp}
 Bundle-Name: dev.galasa.ivts.core
-Export-Package: dev.galasa.core.manager.ivt
-Import-Package: !javax.validation.constraints, \
-                *
+Export-Package: dev.galasa.ivts.core*
+Import-Package: !javax.validation.constraints,\
+                dev.galasa,\
+                dev.galasa.core.manager,\
+                org.apache.commons.logging,\
+                org.assertj.core.api

--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/TestSleep.java
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/TestSleep.java
@@ -9,10 +9,7 @@ import org.apache.commons.logging.Log;
 
 import dev.galasa.Summary;
 import dev.galasa.Test;
-import dev.galasa.core.manager.CoreManager;
-import dev.galasa.core.manager.ICoreManager;
 import dev.galasa.core.manager.Logger;
-import dev.galasa.core.manager.RunName;
 
 @Test
 @Summary("A basic test with a sleep so there is sufficient time to test the `galasactl runs reset` command")

--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/TestTestResultProvider.java
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/TestTestResultProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.ivts.core;
+
+import java.time.Instant;
+
+import java.util.List;
+import java.util.Random;
+
+import org.apache.commons.logging.Log;
+
+import org.assertj.core.api.Fail;
+
+import dev.galasa.After;
+import dev.galasa.AfterClass;
+import dev.galasa.Before;
+import dev.galasa.BeforeClass;
+import dev.galasa.ContinueOnTestFailure;
+import dev.galasa.Summary;
+import dev.galasa.Test;
+import dev.galasa.core.manager.ITestResultProvider;
+import dev.galasa.core.manager.TestResultProvider;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.core.manager.Logger;
+
+// Commenting out this @Test annotation so this test doesn't run as part of the regression test suite.
+// Can be uncommented and ran locally to test any changes to the TestResultProvider.
+// @Test
+@ContinueOnTestFailure
+@Summary("A basic test with a forced Failure to test that AfterClass calls the custom cleanup method")
+public class TestTestResultProvider {
+
+    @Logger
+    public Log logger;
+
+    @TestResultProvider
+    public ITestResultProvider testResult;
+
+    @BeforeClass
+    public void beforeClassMethod() {
+        logger.info("In the beforeClassMethod - is the test currently Passed? " + testResult.getResult().isPassed());
+        logger.info("In the beforeClassMethod - is the test currently Failed? " + testResult.getResult().isFailed());
+    }
+
+    @Before
+    public void beforeMethod() {
+        logger.info("In the beforeMethod - is the test currently Passed? " + testResult.getResult().isPassed());
+        logger.info("In the beforeMethod - is the test currently Failed? " + testResult.getResult().isFailed());
+    }
+
+    @Test
+    public void testMethod1() {
+        logger.info("In the testMethod1 - is the test currently Passed? " + testResult.getResult().isPassed());
+        logger.info("In the testMethod1 - is the test currently Failed? " + testResult.getResult().isFailed());
+    }
+
+    @Test
+    public void testMethod2() throws Exception {
+        logger.info("In the testMethod2 - is the test currently Passed? " + testResult.getResult().isPassed());
+        logger.info("In the testMethod2 - is the test currently Failed? " + testResult.getResult().isFailed());
+        logger.info("About to force a Failure...");
+        Fail.fail("Forcing this test to Fail to test if the AfterClass method calls the custom cleanup method that is only called for Failures");
+    }
+
+    @Test
+    public void testMethod3() throws Exception {
+        logger.info("In the testMethod3 - is the test currently Passed? " + testResult.getResult().isPassed());
+        logger.info("In the testMethod3 - is the test currently Failed? " + testResult.getResult().isFailed());
+    }
+
+    @After
+    public void afterMethod() {
+        logger.info("In the afterMethod - is the test currently Passed? " + testResult.getResult().isPassed());
+        logger.info("In the afterMethod - is the test currently Failed? " + testResult.getResult().isFailed());
+    }
+
+    @AfterClass
+    public void afterClassMethod() throws FrameworkException {
+        logger.info("In the afterClassMethod - is the test currently Passed? " + testResult.getResult().isPassed());
+        logger.info("In the afterClassMethod - is the test currently Failed? " + testResult.getResult().isFailed());
+        if (testResult.getResult().isFailed()) {
+            customCleanUpMethod();
+        }
+    }
+
+    private void customCleanUpMethod() {
+        logger.info("This is the custom clean up method that we expected to be called - YAY!");
+    }
+
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/src/main/java/dev/galasa/core/manager/ITestResultProvider.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/src/main/java/dev/galasa/core/manager/ITestResultProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.core.manager;
+
+import javax.validation.constraints.NotNull;
+
+import dev.galasa.framework.IResult;
+
+/**
+ * Implementations of this interface can provide a test result when asked.
+ * 
+ * This is used by a Galasa test to find out what the current test result is.
+ */
+public interface ITestResultProvider {
+
+    /**
+     * Gets the test result.
+     * 
+     * @return The IResult which can be queried for whether the test has passed or failed at this point.
+     * It will never be null.
+     * 
+     * The returned result can be neither passing nor failing. If the test has not completed, then it won't have passed yet.
+     */
+    @NotNull IResult getResult();
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/src/main/java/dev/galasa/core/manager/TestResultProvider.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/src/main/java/dev/galasa/core/manager/TestResultProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.core.manager;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import dev.galasa.framework.spi.ValidAnnotatedFields;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+@ValidAnnotatedFields({ ITestResultProvider.class })
+@CoreManagerField
+public @interface TestResultProvider {
+
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/src/main/java/dev/galasa/core/manager/internal/TestResultProviderImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/src/main/java/dev/galasa/core/manager/internal/TestResultProviderImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.core.manager.internal;
+
+import javax.validation.constraints.NotNull;
+
+import dev.galasa.core.manager.ITestResultProvider;
+import dev.galasa.framework.IResult;
+
+public class TestResultProviderImpl implements ITestResultProvider {
+
+    /** 
+     * A simple implementation of a result which is neither pass or failed. So we never return null.
+     */
+    private class ResultNotSetYetResult implements IResult {
+
+        @Override
+        public boolean isPassed() {
+            return false;
+        }
+
+        @Override
+        public boolean isFailed() {
+            return false;
+        }
+    }
+
+    private IResult result = new ResultNotSetYetResult();
+
+    public void setResult(IResult newResult) {
+        this.result = newResult;
+    }
+
+    @Override
+    public @NotNull IResult getResult() {
+        return this.result;
+    }
+
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/src/test/java/dev/galasa/core/manager/internal/CoreManagerImplTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/src/test/java/dev/galasa/core/manager/internal/CoreManagerImplTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.core.manager.internal;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+
+import dev.galasa.framework.spi.Result;
+import dev.galasa.core.manager.ITestResultProvider;
+
+public class CoreManagerImplTest {
+
+    @Test
+    public void testCanConstructAnInstance() {
+        new CoreManagerImpl();
+    }
+
+    @Test
+    public void testCanSeeATestFailureViaTheTestResultProvider() {
+        // Given...
+        CoreManagerImpl coreManager = new CoreManagerImpl();
+        ITestResultProvider resultProvider = coreManager.createTestResultProvider(null,null);
+        
+        // When...
+        coreManager.setResultSoFar(Result.failed("Simulating a failure"));
+
+        // Then...
+        assertThat( resultProvider.getResult().isFailed()).isTrue();
+        assertThat( resultProvider.getResult().isPassed()).isFalse();
+    }
+
+    @Test
+    public void testCanSeeATestPassViaTheTestResultProvider() {
+        // Given...
+        CoreManagerImpl coreManager = new CoreManagerImpl();
+        ITestResultProvider resultProvider = coreManager.createTestResultProvider(null,null);
+        
+        // When...
+        coreManager.setResultSoFar(Result.passed());
+
+        // Then...
+        assertThat( resultProvider.getResult().isPassed()).isTrue();
+        assertThat( resultProvider.getResult().isFailed()).isFalse();
+    }
+
+
+    @Test
+    public void testCanSeeATestNeitherFailedNorPassedViaTheTestResultProvider() {
+        // Given...
+        CoreManagerImpl coreManager = new CoreManagerImpl();
+        ITestResultProvider resultProvider = coreManager.createTestResultProvider(null,null);
+        
+        // When...
+        // WE DON'T INJECT A RESULT
+
+        // Then...
+        assertThat( resultProvider.getResult().isPassed()).isFalse();
+        assertThat( resultProvider.getResult().isFailed()).isFalse();
+    }
+
+}


### PR DESCRIPTION
**Recreating changes from PR #239 as it was accidentally closed as branch was deleted**

## Why?

For https://github.com/galasa-dev/projectmanagement/issues/1920

- New annotation TestResultProvider to inject a TestResultProvider into a test case, to access the result at any point in a Galasa test, to run custom code in the event of a test failure.

- The TestClassWrapper and TestRunner now inform the active managers about the "result so far" of a test case, instead of only making the result available after the lifecycle of the test.

- Unit tests for this change set in CoreManagerImplTest.

- Galasa test that exercises this change in TestTestResultProvider - but perhaps not a good idea to deliver this with the @Test annotation as it will always fail and report a failure in our IVTs stream. Happy to remove for this reason. Annotation can be added when testing locally.