### PR TITLE
Return 500 when failing to get runs by group from etcd instead of 404

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
@@ -47,7 +47,7 @@ public class GroupRuns extends ProtectedRoute {
             runs = this.framework.getFrameworkRuns().getAllGroupedRuns(groupName);
         } catch (FrameworkException fe) {
             ServletError error = new ServletError(GAL5019_UNABLE_TO_RETRIEVE_RUNS, groupName);  
-            throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND, fe);
+            throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, fe);
         }
         return runs;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -161,7 +161,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         servlet.doGet(req, resp);
 
         // Then...
-        assertThat(resp.getStatus()).isEqualTo(404);
+        assertThat(resp.getStatus()).isEqualTo(500);
 
 		checkErrorStructure(
 			outStream.toString(),


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2182

## Changes
- When a failure occurs during an operation to get runs by group name from etcd, the API server will now correctly respond with a 500 response code instead of a 404.