### PR TITLE
Fix ContinueOnTestFailure annotation not behaving as expected

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import dev.galasa.ContinueOnTestFailure;
 import dev.galasa.framework.GenericMethodWrapper.Type;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
@@ -85,7 +86,7 @@ public class TestClassWrapper {
         this.testStructure.setTestName(testClass.getName());
         this.testStructure.setTestShortName(testClass.getSimpleName());
 
-        this.continueOnTestFailure = this.testRunner.getContinueOnTestFailureFromCPS();
+        this.continueOnTestFailure = isContinueOnTestFailureSet();
     }
 
     /**
@@ -396,6 +397,18 @@ public class TestClassWrapper {
 
     protected Result getResult() {
         return this.resultData;
+    }
+
+    protected boolean isContinueOnTestFailureSet() {
+        boolean isContinueOnTestFailureSet = false;
+        ContinueOnTestFailure continueOnTestFailureAnnotation = testClass.getAnnotation(ContinueOnTestFailure.class);
+
+        if (continueOnTestFailureAnnotation != null) {
+            isContinueOnTestFailureSet = true;
+        } else {
+            isContinueOnTestFailureSet = this.testRunner.getContinueOnTestFailureFromCPS();
+        }
+        return isContinueOnTestFailureSet;
     }
 
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestClassWrapper.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+
+import dev.galasa.ContinueOnTestFailure;
+import dev.galasa.framework.mocks.MockIConfigurationPropertyStoreService;
+import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
+import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.mocks.MockTestRunnerDataProvider;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.IRun;
+import dev.galasa.framework.spi.teststructure.TestStructure;
+
+public class TestTestClassWrapper {
+
+    @ContinueOnTestFailure
+    class MockTestClassWithContinueOnTestFailure {
+    }
+
+    class MockTestClassWithoutContinueOnTestFailure {
+    }
+
+    private IRun createMockRun(Class<?> testClass) {
+        String TEST_STREAM_REPO_URL = "http://myhost/myRepositoryForMyRun";
+        String TEST_BUNDLE_NAME = "myTestBundle";
+        String TEST_CLASS_NAME = testClass.getName();
+        String TEST_RUN_NAME = "myTestRun";
+        String TEST_STREAM = "myStreamForMyRun";
+        String TEST_STREAM_OBR = "http://myhost/myObrForMyRun";
+        String TEST_REQUESTOR_NAME = "daffyduck";
+        boolean TEST_IS_LOCAL_RUN_TRUE = true;
+
+        return new MockRun(
+            TEST_BUNDLE_NAME, 
+            TEST_CLASS_NAME , 
+            TEST_RUN_NAME, 
+            TEST_STREAM, 
+            TEST_STREAM_OBR , 
+            TEST_STREAM_REPO_URL,
+            TEST_REQUESTOR_NAME,
+            TEST_IS_LOCAL_RUN_TRUE
+        );
+    }
+
+    @Test
+    public void testClassAnnotatedWithContinueOnTestFailureReturnsTrue() throws Exception {
+        // Given...
+        TestRunner testRunner = new TestRunner();
+
+        IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
+        MockIDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        
+        MockTestRunnerDataProvider mockDataProvider = new MockTestRunnerDataProvider();
+        mockDataProvider.setCps(cps);
+        mockDataProvider.setDss(dss);
+        mockDataProvider.setRun(createMockRun(MockTestClassWithContinueOnTestFailure.class));
+
+        testRunner.init(mockDataProvider);
+
+        TestStructure testStructure = new TestStructure();
+
+        String testBundle = "my/testbundle";
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClassWithContinueOnTestFailure.class, testStructure);
+
+        // When...
+        boolean isContinueOnTestFailure = testClassWrapper.isContinueOnTestFailureSet();
+
+        // Then...
+        assertThat(isContinueOnTestFailure).isTrue();
+    }
+
+    @Test
+    public void testClassWithoutContinueOnTestFailureReturnsFalse() throws Exception {
+        // Given...
+        TestRunner testRunner = new TestRunner();
+
+        IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
+        MockIDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        
+        MockTestRunnerDataProvider mockDataProvider = new MockTestRunnerDataProvider();
+        mockDataProvider.setCps(cps);
+        mockDataProvider.setDss(dss);
+        mockDataProvider.setRun(createMockRun(MockTestClassWithoutContinueOnTestFailure.class));
+
+        testRunner.init(mockDataProvider);
+
+        TestStructure testStructure = new TestStructure();
+
+        String testBundle = "my/testbundle";
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClassWithoutContinueOnTestFailure.class, testStructure);
+
+        // When...
+        boolean isContinueOnTestFailure = testClassWrapper.isContinueOnTestFailureSet();
+
+        // Then...
+        assertThat(isContinueOnTestFailure).isFalse();
+    }
+
+    @Test
+    public void testClassWithCPSContinueOnTestFailureReturnsTrue() throws Exception {
+        // Given...
+        TestRunner testRunner = new TestRunner();
+
+        IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
+        cps.setProperty("continue.on.test.failure", "true");
+
+        MockIDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        
+        MockTestRunnerDataProvider mockDataProvider = new MockTestRunnerDataProvider();
+        mockDataProvider.setCps(cps);
+        mockDataProvider.setDss(dss);
+        mockDataProvider.setRun(createMockRun(MockTestClassWithoutContinueOnTestFailure.class));
+
+        testRunner.init(mockDataProvider);
+
+        TestStructure testStructure = new TestStructure();
+
+        String testBundle = "my/testbundle";
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClassWithoutContinueOnTestFailure.class, testStructure);
+
+        // When...
+        boolean isContinueOnTestFailure = testClassWrapper.isContinueOnTestFailureSet();
+
+        // Then...
+        assertThat(isContinueOnTestFailure).isTrue();
+    }
+
+    @Test
+    public void testClassWithCPSContinueOnTestFailureSetToFalseReturnsFalse() throws Exception {
+        // Given...
+        TestRunner testRunner = new TestRunner();
+
+        IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
+        cps.setProperty("continue.on.test.failure", "false");
+
+        MockIDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        
+        MockTestRunnerDataProvider mockDataProvider = new MockTestRunnerDataProvider();
+        mockDataProvider.setCps(cps);
+        mockDataProvider.setDss(dss);
+        mockDataProvider.setRun(createMockRun(MockTestClassWithoutContinueOnTestFailure.class));
+
+        testRunner.init(mockDataProvider);
+
+        TestStructure testStructure = new TestStructure();
+
+        String testBundle = "my/testbundle";
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClassWithoutContinueOnTestFailure.class, testStructure);
+
+        // When...
+        boolean isContinueOnTestFailure = testClassWrapper.isContinueOnTestFailureSet();
+
+        // Then...
+        assertThat(isContinueOnTestFailure).isFalse();
+    }
+
+    @Test
+    public void testClassWithAnnotationAndCPSContinueOnTestFailureSetToFalseReturnsTrue() throws Exception {
+        // Given...
+        TestRunner testRunner = new TestRunner();
+
+        IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
+        cps.setProperty("continue.on.test.failure", "false");
+
+        MockIDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        
+        MockTestRunnerDataProvider mockDataProvider = new MockTestRunnerDataProvider();
+        mockDataProvider.setCps(cps);
+        mockDataProvider.setDss(dss);
+        mockDataProvider.setRun(createMockRun(MockTestClassWithoutContinueOnTestFailure.class));
+
+        testRunner.init(mockDataProvider);
+
+        TestStructure testStructure = new TestStructure();
+
+        String testBundle = "my/testbundle";
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClassWithContinueOnTestFailure.class, testStructure);
+
+        // When...
+        boolean isContinueOnTestFailure = testClassWrapper.isContinueOnTestFailureSet();
+
+        // Then...
+        assertThat(isContinueOnTestFailure).isTrue();
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIConfigurationPropertyStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIConfigurationPropertyStoreService.java
@@ -27,7 +27,7 @@ public class MockIConfigurationPropertyStoreService implements IConfigurationPro
     @Override
     public @Null String getProperty(@NotNull String prefix, @NotNull String suffix, String... infixes)
             throws ConfigurationPropertyStoreException {
-        String propertyKey = prefix + "." + suffix;;
+        String propertyKey = prefix + "." + suffix;
         if (infixes.length > 0) {
             propertyKey = prefix + "." + String.join(".", infixes) + "." + suffix;
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIConfigurationPropertyStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIConfigurationPropertyStoreService.java
@@ -27,7 +27,11 @@ public class MockIConfigurationPropertyStoreService implements IConfigurationPro
     @Override
     public @Null String getProperty(@NotNull String prefix, @NotNull String suffix, String... infixes)
             throws ConfigurationPropertyStoreException {
-        return null ;
+        String propertyKey = prefix + "." + suffix;;
+        if (infixes.length > 0) {
+            propertyKey = prefix + "." + String.join(".", infixes) + "." + suffix;
+        }
+        return this.properties.get(propertyKey);
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockTestRunnerDataProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockTestRunnerDataProvider.java
@@ -31,6 +31,10 @@ public class MockTestRunnerDataProvider implements ITestRunnerDataProvider {
     private IFileSystem fileSystem;
     private ITestRunnerEventsProducer eventsPublisher;
 
+    public MockTestRunnerDataProvider() {
+        // Do nothing...
+    }
+
     public MockTestRunnerDataProvider(
         IConfigurationPropertyStoreService cps,
         IDynamicStatusStoreService         dss,
@@ -103,5 +107,49 @@ public class MockTestRunnerDataProvider implements ITestRunnerDataProvider {
     @Override
     public ITestRunnerEventsProducer getEventsProducer() {
         return this.eventsPublisher;
+    }
+
+    public void setCps(IConfigurationPropertyStoreService cps) {
+        this.cps = cps;
+    }
+
+    public void setDss(IDynamicStatusStoreService dss) {
+        this.dss = dss;
+    }
+
+    public void setRas(IResultArchiveStore ras) {
+        this.ras = ras;
+    }
+
+    public void setRun(IRun run) {
+        this.run = run;
+    }
+
+    public void setFramework(IShuttableFramework framework) {
+        this.framework = framework;
+    }
+
+    public void setOverrideProperties(Properties overrideProperties) {
+        this.overrideProperties = overrideProperties;
+    }
+
+    public void setAnnotationExtractor(IAnnotationExtractor annotationExtractor) {
+        this.annotationExtractor = annotationExtractor;
+    }
+
+    public void setBundleManager(IBundleManager bundleManager) {
+        this.bundleManager = bundleManager;
+    }
+
+    public void setTestRunManagers(ITestRunManagers testRunManagers) {
+        this.testRunManagers = testRunManagers;
+    }
+
+    public void setFileSystem(IFileSystem fileSystem) {
+        this.fileSystem = fileSystem;
+    }
+
+    public void setEventsPublisher(ITestRunnerEventsProducer eventsPublisher) {
+        this.eventsPublisher = eventsPublisher;
     }
 }


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2193

Previously, the `@ContinueOnTestFailure` annotation was defined but wasn't used anywhere in the Galasa code, effectively rendering it useless. Now, the test class wrapper checks whether the annotation is provided, and if it is, the test class will continue to run regardless of any failures and regardless of what the `framework.continue.on.test.failure` CPS property is set to.

## Changes
- When a test class is annotated with `@ContinueOnTestFailure` and the CPS property `framework.continue.on.test.failure` is set to `false`, the test class will now correctly continue to run regardless of test failures