### PR TITLE
Better docs of the overrides properties in the runs submission REST call.

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -2087,6 +2087,14 @@ paths:
 
         Requests to this endpoint require a valid bearer token in JWT format to be provided
         in the 'Authorization' header (e.g. 'Authorization: Bearer <bearer-token>').
+
+        The 'overrides' property is a java Property object, so looks like this: 
+            {
+              "propA" : "myValue1",
+              "propB" : "myValue2"
+            }
+        ie: It's an object containing a list of underfined property names, each having a value.
+        It has only one set of {...} brackets to indicate this property is an object.
       operationId: postSubmitTestRuns
       tags:
       - Runs API
@@ -2864,6 +2872,14 @@ components:
         sharedEnvironmentRunName:
           type: string
         overrides:
+          description: |-
+            This is a java Property object, so looks like this: 
+            {
+              "propA" : "myValue1",
+              "propB" : "myValue2"
+            }
+            ie: It's an object containing a list of underfined property names, each having a value.
+            It has only one set of {...} brackets to indicate this property is an object.
           type: object
         trace:
           type: boolean


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
@Tom-Slattery was pointing out that the format of the overrides flag on the runs submit REST call is not clear from our documentation.

Added notes to the openapi.yaml file wich describes what is currently passed.

He has seen the draft changes and is happy.

Why is the same text repeated twice ? Some tools use the description next to the overrides flag fine, others ignore it, so the information needs to go elsewhere also.