### PR TITLE
Remove temporary change added in pr #245

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -45,8 +45,7 @@ jobs:
       managers_changed: ${{ steps.get-changed-modules.outputs.MANAGERS_CHANGED }}
       obr_changed: ${{ steps.get-changed-modules.outputs.OBR_CHANGED }}
       ivts_changed: ${{ steps.get-changed-modules.outputs.IVTS_CHANGED }}
-      # cli_changed: ${{ steps.get-changed-modules.outputs.CLI_CHANGED }}
-      cli_changed: "true"
+      cli_changed: ${{ steps.get-changed-modules.outputs.CLI_CHANGED }}
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Remove temporary change added in pr #245 to always build the CLI in Pull Requests

Diff of #245 was too large to tell what modules had changed, so had to set this to true to test the CLI PR build.