### PR TITLE
Iss2165 - Call the CLI's build workflow in the release build

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -138,3 +138,9 @@ jobs:
     secrets: inherit
     with:
       galasa-version: "${{ needs.set-build-properties.outputs.galasa-version }}"
+
+  build-cli:
+    name: Build the 'cli' module
+    needs: [build-obr]
+    uses: ./.github/workflows/cli.yaml
+    secrets: inherit


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2165

CLI's build workflow should now be called as part of the Release Build Orchestrator as it lives in the mono repo.