### PR TITLE
mcobbett tags in test structure

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -41,6 +41,30 @@ jobs:
         # gradle-home-cache-excludes: |
         #   caches/modules-2/files-2.1/dev.galasa/**
 
+      - name: Download platform from this workflow
+        id: download-platform
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts
+
+      - name: Download obr artifacts from this workflow
+        id: download-obr
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: obr
+          path: modules/artifacts
+
 
       # Pull down dependencies with Gradle and put them in the right places.
       - name: Gather dependencies using Gradle
@@ -49,7 +73,7 @@ jobs:
           set -o pipefail
           gradle -b build.gradle installJarsIntoTemplates --info \
           --no-daemon --console plain \
-          -PsourceMaven=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
           -PtargetMaven=${{ github.workspace }}/repo 2>&1 | tee build.log
 

--- a/.github/workflows/pr-cli.yaml
+++ b/.github/workflows/pr-cli.yaml
@@ -81,32 +81,32 @@ jobs:
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
 
-      - name: Download platform from last successful workflow
-        if: ${{ steps.download-platform.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.artifact-id }}
+      # - name: Download platform from last successful workflow
+      #   if: ${{ steps.download-platform.outcome == 'failure' }}
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: platform
+      #     path: modules/artifacts
+      #     github-token: ${{ github.token }}
+      #     run-id: ${{ inputs.artifact-id }}
 
-      - name: Download framework artifacts from last successful workflow
-        if: ${{ steps.download-framework.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-            name: framework
-            path: modules/artifacts
-            github-token: ${{ github.token }}
-            run-id: ${{ inputs.artifact-id }}
+      # - name: Download framework artifacts from last successful workflow
+      #   if: ${{ steps.download-framework.outcome == 'failure' }}
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #       name: framework
+      #       path: modules/artifacts
+      #       github-token: ${{ github.token }}
+      #       run-id: ${{ inputs.artifact-id }}
 
-      - name: Download obr artifacts from last successful workflow
-        if: ${{ steps.download-obr.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-            name: obr
-            path: modules/artifacts
-            github-token: ${{ github.token }}
-            run-id: ${{ inputs.artifact-id }}
+      # - name: Download obr artifacts from last successful workflow
+      #   if: ${{ steps.download-obr.outcome == 'failure' }}
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #       name: obr
+      #       path: modules/artifacts
+      #       github-token: ${{ github.token }}
+      #       run-id: ${{ inputs.artifact-id }}
 
       # Pull down dependencies with Gradle and put them in the right places.
       - name: Gather dependencies using Gradle

--- a/.github/workflows/pr-cli.yaml
+++ b/.github/workflows/pr-cli.yaml
@@ -81,32 +81,32 @@ jobs:
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
 
-      # - name: Download platform from last successful workflow
-      #   if: ${{ steps.download-platform.outcome == 'failure' }}
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: platform
-      #     path: modules/artifacts
-      #     github-token: ${{ github.token }}
-      #     run-id: ${{ inputs.artifact-id }}
+      - name: Download platform from last successful workflow
+        if: ${{ steps.download-platform.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.artifact-id }}
 
-      # - name: Download framework artifacts from last successful workflow
-      #   if: ${{ steps.download-framework.outcome == 'failure' }}
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #       name: framework
-      #       path: modules/artifacts
-      #       github-token: ${{ github.token }}
-      #       run-id: ${{ inputs.artifact-id }}
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: framework
+            path: modules/artifacts
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.artifact-id }}
 
-      # - name: Download obr artifacts from last successful workflow
-      #   if: ${{ steps.download-obr.outcome == 'failure' }}
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #       name: obr
-      #       path: modules/artifacts
-      #       github-token: ${{ github.token }}
-      #       run-id: ${{ inputs.artifact-id }}
+      - name: Download obr artifacts from last successful workflow
+        if: ${{ steps.download-obr.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: obr
+            path: modules/artifacts
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.artifact-id }}
 
       # Pull down dependencies with Gradle and put them in the right places.
       - name: Gather dependencies using Gradle

--- a/.github/workflows/pr-cli.yaml
+++ b/.github/workflows/pr-cli.yaml
@@ -62,6 +62,17 @@ jobs:
           name: platform
           path: modules/artifacts
 
+      # For any modules that weren't changed in this PR,
+      # download artifacts from the last successful workflow.
+      - name: Download platform from last successful workflow
+        if: ${{ steps.download-platform.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: platform
+          path: modules/artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.artifact-id }}
+
       - name: Download framework artifacts from this workflow
         id: download-framework
         continue-on-error: true
@@ -69,6 +80,17 @@ jobs:
         with:
           name: framework
           path: modules/artifacts
+
+      # For any modules that weren't changed in this PR,
+      # download artifacts from the last successful workflow.
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: framework
+            path: modules/artifacts
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.artifact-id }}
 
       - name: Download obr artifacts from this workflow
         id: download-obr
@@ -80,25 +102,6 @@ jobs:
 
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
-
-      - name: Download platform from last successful workflow
-        if: ${{ steps.download-platform.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: modules/artifacts
-          github-token: ${{ github.token }}
-          run-id: ${{ inputs.artifact-id }}
-
-      - name: Download framework artifacts from last successful workflow
-        if: ${{ steps.download-framework.outcome == 'failure' }}
-        uses: actions/download-artifact@v4
-        with:
-            name: framework
-            path: modules/artifacts
-            github-token: ${{ github.token }}
-            run-id: ${{ inputs.artifact-id }}
-
       - name: Download obr artifacts from last successful workflow
         if: ${{ steps.download-obr.outcome == 'failure' }}
         uses: actions/download-artifact@v4

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1503,7 +1503,7 @@
         "hashed_secret": "c042bdfc4bc5516ec716afe9e85c173b614ff9f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 830,
+        "line_number": 842,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/modules/cli/.gitignore
+++ b/modules/cli/.gitignore
@@ -43,3 +43,5 @@ pkg/galasaapi/
 
 # Don't check-in certificates
 *.der
+
+temp/

--- a/modules/cli/build.gradle
+++ b/modules/cli/build.gradle
@@ -20,9 +20,9 @@ def galasaVersion = '0.41.0'
 repositories {
     gradlePluginPortal()
     mavenLocal()
-    maven {
-        url "https://development.galasa.dev/main/maven-repo/obr/"
-    }
+    // maven {
+    //     url "https://development.galasa.dev/main/maven-repo/obr/"
+    // }
     mavenCentral()
 }
 apply plugin: 'java'

--- a/modules/cli/build.gradle
+++ b/modules/cli/build.gradle
@@ -21,7 +21,7 @@ repositories {
     gradlePluginPortal()
     mavenLocal()
     maven {
-        url "https://development.galasa.dev/main/maven-repo/obr/"
+        url = "$sourceMaven"
     }
     mavenCentral()
 }

--- a/modules/cli/build.gradle
+++ b/modules/cli/build.gradle
@@ -20,9 +20,9 @@ def galasaVersion = '0.41.0'
 repositories {
     gradlePluginPortal()
     mavenLocal()
-    // maven {
-    //     url "https://development.galasa.dev/main/maven-repo/obr/"
-    // }
+    maven {
+        url "https://development.galasa.dev/main/maven-repo/obr/"
+    }
     mavenCentral()
 }
 apply plugin: 'java'

--- a/modules/cli/docs/generated/galasactl_runs_submit.md
+++ b/modules/cli/docs/generated/galasactl_runs_submit.md
@@ -32,7 +32,7 @@ galasactl runs submit [flags]
       --requesttype string         the type of request, used to allocate a run name. Defaults to CLI. (default "CLI")
   -s, --stream string              test stream to extract the tests from
       --tag strings                tags of which tests will be selected from, tags are selected if the name contains this string, or if --regex is specified then matches the regex
-      --tags strings               tagging metadata to be associated with the submitted runs. This can be specified as a comma-separated list of tag strings, or by repeating the --tag parameter, or both.
+      --tags strings               tagging metadata to be associated with the submitted runs. This can be specified as a comma-separated list of tag strings, or by repeating the --tags parameter, or both.
       --test strings               test names which will be selected if the name contains this string, or if --regex is specified then matches the regex
       --throttle int               how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 3)
       --throttlefile string        a file where the current throttle is stored. Periodically the throttle value is read from the file used. Someone with edit access to the file can change it which dynamically takes effect. Long-running large portfolios can be throttled back to nothing (paused) using this mechanism (if throttle is set to 0). And they can be resumed (un-paused) if the value is set back. This facility can allow the tests to not show a failure when the system under test is taken out of service for maintainence.Optional. If not specified, no throttle file is used.

--- a/modules/cli/docs/generated/galasactl_runs_submit.md
+++ b/modules/cli/docs/generated/galasactl_runs_submit.md
@@ -32,6 +32,7 @@ galasactl runs submit [flags]
       --requesttype string         the type of request, used to allocate a run name. Defaults to CLI. (default "CLI")
   -s, --stream string              test stream to extract the tests from
       --tag strings                tags of which tests will be selected from, tags are selected if the name contains this string, or if --regex is specified then matches the regex
+      --tags strings               tagging metadata to be associated with the submitted runs. This can be specified as a comma-separated list of tag strings, or by repeating the --tag parameter, or both.
       --test strings               test names which will be selected if the name contains this string, or if --regex is specified then matches the regex
       --throttle int               how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 3)
       --throttlefile string        a file where the current throttle is stored. Periodically the throttle value is read from the file used. Someone with edit access to the file can change it which dynamically takes effect. Long-running large portfolios can be throttled back to nothing (paused) using this mechanism (if throttle is set to 0). And they can be resumed (un-paused) if the value is set back. This facility can allow the tests to not show a failure when the system under test is taken out of service for maintainence.Optional. If not specified, no throttle file is used.

--- a/modules/cli/docs/generated/galasactl_runs_submit_local.md
+++ b/modules/cli/docs/generated/galasactl_runs_submit_local.md
@@ -43,6 +43,7 @@ galasactl runs submit local [flags]
       --reportjunit string                    junit xml file to record the final results in
       --reportyaml string                     yaml file to record the final results in
       --requesttype string                    the type of request, used to allocate a run name. Defaults to CLI. (default "CLI")
+      --tags strings                          tagging metadata to be associated with the submitted runs. This can be specified as a comma-separated list of tag strings, or by repeating the --tag parameter, or both.
       --throttle int                          how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 3)
       --throttlefile string                   a file where the current throttle is stored. Periodically the throttle value is read from the file used. Someone with edit access to the file can change it which dynamically takes effect. Long-running large portfolios can be throttled back to nothing (paused) using this mechanism (if throttle is set to 0). And they can be resumed (un-paused) if the value is set back. This facility can allow the tests to not show a failure when the system under test is taken out of service for maintainence.Optional. If not specified, no throttle file is used.
       --trace                                 Trace to be enabled on the test runs

--- a/modules/cli/pkg/cmd/runsSubmit.go
+++ b/modules/cli/pkg/cmd/runsSubmit.go
@@ -92,6 +92,11 @@ func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 	runsSubmitCmd.PersistentFlags().StringVarP(&cmd.values.GroupName, "group", "g", "", "the group name to assign the test runs to, if not provided, a psuedo unique id will be generated")
 	runsSubmitCmd.PersistentFlags().StringVar(&cmd.values.RequestType, "requesttype", "CLI", "the type of request, used to allocate a run name. Defaults to CLI.")
 
+	runsSubmitCmd.PersistentFlags().StringSliceVar(&cmd.values.Tags, "tags", []string{},
+		"tagging metadata to be associated with the submitted runs. "+
+			"This can be specified as a comma-separated list of tag strings, or by repeating the --tag parameter, or both.",
+	)
+
 	runsSubmitCmd.PersistentFlags().StringVar(&cmd.values.ThrottleFileName, "throttlefile", "",
 		"a file where the current throttle is stored. Periodically the throttle value is read from the file used. "+
 			"Someone with edit access to the file can change it which dynamically takes effect. "+

--- a/modules/cli/pkg/cmd/runsSubmit.go
+++ b/modules/cli/pkg/cmd/runsSubmit.go
@@ -94,7 +94,7 @@ func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 
 	runsSubmitCmd.PersistentFlags().StringSliceVar(&cmd.values.Tags, "tags", []string{},
 		"tagging metadata to be associated with the submitted runs. "+
-			"This can be specified as a comma-separated list of tag strings, or by repeating the --tag parameter, or both.",
+			"This can be specified as a comma-separated list of tag strings, or by repeating the --tags parameter, or both.",
 	)
 
 	runsSubmitCmd.PersistentFlags().StringVar(&cmd.values.ThrottleFileName, "throttlefile", "",

--- a/modules/cli/pkg/cmd/runsSubmitLocal.go
+++ b/modules/cli/pkg/cmd/runsSubmitLocal.go
@@ -166,17 +166,17 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 	err = utils.CaptureLog(fileSystem, commsFlagSetValues.logFileName)
 	if err == nil {
 		commsFlagSetValues.isCapturingLogs = true
-	
+
 		log.Println("Galasa CLI - Submit tests (Local)")
-	
+
 		// Get the ability to query environment variables.
 		env := factory.GetEnvironment()
-	
+
 		// Work out where galasa home is, only once.
 		var galasaHome spi.GalasaHome
 		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 		if err == nil {
-	
+
 			var commsClient api.APICommsClient
 			commsClient, err = api.NewAPICommsClient(
 				commsFlagSetValues.bootstrap,
@@ -185,25 +185,25 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 				factory,
 				galasaHome,
 			)
-	
+
 			if err == nil {
-	
+
 				timeService := utils.NewRealTimeService()
 				timedSleeper := utils.NewRealTimedSleeper()
-	
+
 				// the submit is targetting a local JVM
 				embeddedFileSystem := embedded.GetReadOnlyFileSystem()
-	
+
 				// Something which can kick off new operating system processes
 				processFactory := launcher.NewRealProcessFactory()
-	
+
 				// Validate the test selection parameters.
 				validator := runs.NewObrBasedValidator()
 				err = validator.Validate(cmd.values.submitLocalSelectionFlags)
 				if err == nil {
-	
+
 					bootstrapData := commsClient.GetBootstrapData()
-	
+
 					// A launcher is needed to launch anythihng
 					var launcherInstance launcher.Launcher
 					launcherInstance, err = launcher.NewJVMLauncher(
@@ -211,13 +211,13 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 						bootstrapData.Properties, embeddedFileSystem,
 						cmd.values.runsSubmitLocalCmdParams,
 						processFactory, galasaHome, timedSleeper)
-	
+
 					if err == nil {
 						var console = factory.GetStdOutConsole()
-	
+
 						renderer := images.NewImageRenderer(embeddedFileSystem)
 						expander := images.NewImageExpander(fileSystem, renderer, true)
-	
+
 						// Do the launching of the tests.
 						submitter := runs.NewSubmitter(
 							galasaHome,
@@ -229,12 +229,12 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 							console,
 							expander,
 						)
-	
+
 						err = submitter.ExecuteSubmitRuns(
 							runsSubmitCmdValues,
 							cmd.values.submitLocalSelectionFlags,
 						)
-	
+
 						if err == nil {
 							reportOnExpandedImages(expander)
 						}

--- a/modules/cli/pkg/launcher/jvmLauncher.go
+++ b/modules/cli/pkg/launcher/jvmLauncher.go
@@ -196,6 +196,7 @@ func (launcher *JvmLauncher) SubmitTestRun(
 	gherkinURL string,
 	GherkinFeature string,
 	overrides map[string]interface{},
+	tags []string,
 ) (*galasaapi.TestRuns, error) {
 
 	if gherkinURL != "" {

--- a/modules/cli/pkg/launcher/jvmLauncher_test.go
+++ b/modules/cli/pkg/launcher/jvmLauncher_test.go
@@ -231,6 +231,8 @@ func TestCanLaunchLocalJvmTest(t *testing.T) {
 	isTraceEnabled := true
 	var overrides map[string]interface{} = make(map[string]interface{})
 
+	var tags []string
+
 	// When...
 	testRuns, err := launcher.SubmitTestRun(
 		"myGroup",
@@ -243,6 +245,7 @@ func TestCanLaunchLocalJvmTest(t *testing.T) {
 		"", // No Gherkin URL supplied
 		"", // No Gherkin Feature supplied
 		overrides,
+		tags,
 	)
 	if err != nil {
 		assert.Fail(t, "Launcher should have launched command OK")
@@ -290,6 +293,8 @@ func TestCanGetRunGroupStatus(t *testing.T) {
 	isTraceEnabled := true
 	var overrides map[string]interface{} = make(map[string]interface{})
 
+	var tags []string
+
 	launcher.SubmitTestRun(
 		"myGroup",
 		"galasa.dev.example.banking.account/galasa.dev.example.banking.account.TestAccount",
@@ -301,6 +306,7 @@ func TestCanGetRunGroupStatus(t *testing.T) {
 		"", // No Gherkin URL supplied
 		"", // No Gherkin Feature supplied
 		overrides,
+		tags,
 	)
 
 	// Wait for the child process to complete...
@@ -435,6 +441,8 @@ func TestBadlyFormedObrFromProfileInfoCausesError(t *testing.T) {
 	isTraceEnabled := true
 	var overrides map[string]interface{} = make(map[string]interface{})
 
+	var tags []string
+
 	// When...
 	var err error
 	_, err = launcher.SubmitTestRun(
@@ -448,6 +456,7 @@ func TestBadlyFormedObrFromProfileInfoCausesError(t *testing.T) {
 		"", // No Gherkin URL supplied
 		"", // No Gherkin Feature supplied
 		overrides,
+		tags,
 	)
 
 	assert.NotNil(t, err)
@@ -479,6 +488,8 @@ func TestNoObrsFromParameterOrProfileCausesError(t *testing.T) {
 	// Empty list of obrs from the command-line.
 	jvmLaunchParams.Obrs = make([]string, 0)
 
+	var tags []string
+
 	// When...
 	var err error
 	_, err = launcher.SubmitTestRun(
@@ -492,6 +503,7 @@ func TestNoObrsFromParameterOrProfileCausesError(t *testing.T) {
 		"", // No Gherkin URL supplied
 		"", // No Gherkin Feature supplied
 		overrides,
+		tags,
 	)
 
 	assert.NotNil(t, err)
@@ -1397,6 +1409,8 @@ func TestCanLaunchLocalJvmGherkinTest(t *testing.T) {
 	isTraceEnabled := true
 	var overrides map[string]interface{} = make(map[string]interface{})
 
+	var tags []string
+
 	// When...
 	testRuns, err := launcher.SubmitTestRun(
 		"myGroup",
@@ -1409,6 +1423,7 @@ func TestCanLaunchLocalJvmGherkinTest(t *testing.T) {
 		"file:///dev.galasa.simbank.tests/src/main/java/dev/galasa/simbank/tests/GherkinLog.feature",
 		"GherkinLog",
 		overrides,
+		tags,
 	)
 	if err != nil {
 		assert.Fail(t, "Launcher should have launched command OK")
@@ -1443,6 +1458,7 @@ func TestBadGherkinURLSuffixReturnsError(t *testing.T) {
 
 	isTraceEnabled := true
 	var overrides map[string]interface{} = make(map[string]interface{})
+	var tags []string
 
 	// When...
 	_, err = launcher.SubmitTestRun(
@@ -1456,6 +1472,7 @@ func TestBadGherkinURLSuffixReturnsError(t *testing.T) {
 		"file:///dev.galasa.simbank.tests/src/main/java/dev/galasa/simbank/tests/GherkinLog.future",
 		"GherkinLog",
 		overrides,
+		tags,
 	)
 
 	assert.NotNil(t, err)
@@ -1486,7 +1503,7 @@ func TestBadGherkinURLPrefixReutrnsError(t *testing.T) {
 
 	isTraceEnabled := true
 	var overrides map[string]interface{} = make(map[string]interface{})
-
+	var tags []string
 	// When...
 	_, err = launcher.SubmitTestRun(
 		"myGroup",
@@ -1499,6 +1516,7 @@ func TestBadGherkinURLPrefixReutrnsError(t *testing.T) {
 		"https://dev.galasa.simbank.tests/src/main/java/dev/galasa/simbank/tests/GherkinLog.feature",
 		"GherkinLog",
 		overrides,
+		tags,
 	)
 
 	assert.NotNil(t, err)
@@ -1677,7 +1695,7 @@ func TestGetRunsByIdReturnsOk(t *testing.T) {
 
 	isTraceEnabled := true
 	var overrides map[string]interface{} = make(map[string]interface{})
-
+	var tags []string
 	launcher.SubmitTestRun(
 		"myGroup",
 		"galasa.dev.examples.banking.account/galasa.dev.examples.banking.account.TestAccount",
@@ -1689,6 +1707,7 @@ func TestGetRunsByIdReturnsOk(t *testing.T) {
 		"", // No Gherkin URL supplied
 		"", // No Gherkin Feature supplied
 		overrides,
+		tags,
 	)
 
 	// Wait for the child process to complete...

--- a/modules/cli/pkg/launcher/launcher.go
+++ b/modules/cli/pkg/launcher/launcher.go
@@ -30,6 +30,7 @@ type Launcher interface {
 		gherkinURL string,
 		GherkinFeature string,
 		overrides map[string]interface{},
+		tags []string,
 	) (*galasaapi.TestRuns, error)
 
 	// GetRunsById gets the Run information for the run with a specific run identifier

--- a/modules/cli/pkg/launcher/launcherMock.go
+++ b/modules/cli/pkg/launcher/launcherMock.go
@@ -77,6 +77,7 @@ func (launcher *MockLauncher) SubmitTestRun(
 	GherkinURL string,
 	GherkinFeature string,
 	overrides map[string]interface{},
+	tags []string,
 ) (*galasaapi.TestRuns, error) {
 
 	launchRecord := LaunchParameters{

--- a/modules/cli/pkg/launcher/remoteLauncher.go
+++ b/modules/cli/pkg/launcher/remoteLauncher.go
@@ -76,6 +76,7 @@ func (launcher *RemoteLauncher) SubmitTestRun(
 	GherkinURL string,
 	GherkinFeature string,
 	overrides map[string]interface{},
+	tags []string,
 ) (*galasaapi.TestRuns, error) {
 
 	classNames := make([]string, 1)
@@ -88,6 +89,7 @@ func (launcher *RemoteLauncher) SubmitTestRun(
 	testRunRequest.SetTestStream(stream)
 	testRunRequest.SetTrace(isTraceEnabled)
 	testRunRequest.SetOverrides(overrides)
+	testRunRequest.SetTags(tags)
 
 	log.Printf("RemoteLauncher.SubmitTestRuns : using requestor %s\n", requestor)
 

--- a/modules/cli/pkg/runs/runTypes.go
+++ b/modules/cli/pkg/runs/runTypes.go
@@ -22,6 +22,7 @@ type TestRun struct {
 	Group          string            `yaml:"group" json:"group"`
 	SubmissionId   string            `yaml:"submissionId" json:"submissionId"`
 	RunId          string            `yaml:"runId,omitempty" json:"runId,omitempty"`
+	Tags           []string          `yaml:"tags,omitempty" json:"tags,omitempty"`
 }
 
 type TestMethod struct {

--- a/modules/cli/pkg/runs/runsConverter.go
+++ b/modules/cli/pkg/runs/runsConverter.go
@@ -118,6 +118,7 @@ func getTestStructureData(run galasaapi.Run, apiServerUrl string) runsformatter.
 	newFormattableTest.Bundle = run.TestStructure.GetBundle()
 	newFormattableTest.Methods = run.TestStructure.GetMethods()
 	newFormattableTest.Group = run.TestStructure.GetGroup()
+	newFormattableTest.Tags = run.TestStructure.GetTags()
 
 	return newFormattableTest
 }

--- a/modules/cli/pkg/runs/runsConverter.go
+++ b/modules/cli/pkg/runs/runsConverter.go
@@ -118,7 +118,11 @@ func getTestStructureData(run galasaapi.Run, apiServerUrl string) runsformatter.
 	newFormattableTest.Bundle = run.TestStructure.GetBundle()
 	newFormattableTest.Methods = run.TestStructure.GetMethods()
 	newFormattableTest.Group = run.TestStructure.GetGroup()
+
+	// Get the tags, and sort them alphabetically. Order shouldn't matter, but the output will be more
+	// consistent across runs this way.
 	newFormattableTest.Tags = run.TestStructure.GetTags()
+	sort.Strings(newFormattableTest.Tags)
 
 	return newFormattableTest
 }

--- a/modules/cli/pkg/runs/runsConverter_test.go
+++ b/modules/cli/pkg/runs/runsConverter_test.go
@@ -128,6 +128,41 @@ func TestRunConvertsTags(t *testing.T) {
 	assert.Equal(t, 0, len(output[1].Tags))
 }
 
+func TestRunConvertsTagsOutOfOrderGetSorted(t *testing.T) {
+	//Given
+	tags := make([]string, 2)
+	tags[0] = "tag2"
+	tags[1] = "tag1"
+
+	methods := make([]galasaapi.TestMethod, 0)
+
+	runs := make([]galasaapi.Run, 0)
+	//runName, testName, requestor, status, result, queued, methods
+	run1 := createRunForConverter("LongRunName", "TestName", "requestor", "LongStatus", "Passed", "2023-05-04T10:45:29.545323Z", methods)
+
+	// run1 has tags
+	run1.TestStructure.Tags = tags
+
+	run2 := createRunForConverter("U456", "MyTestName", "myRequestorString", "Status", "Failed", "2023-05-04T10:55:29.545323Z", methods)
+	// run2 does not have any tags
+
+	runs = append(runs, run1, run2)
+	apiServerUrl := ""
+
+	//When
+	var output []runsformatter.FormattableTest
+	output = FormattableTestFromGalasaApi(runs, apiServerUrl)
+
+	assert.NotNil(t, output[0])
+	// Check that the tag1 comes first, as they should be sorted in the galasactl output.
+	assert.Contains(t, output[0].Tags, "tag1")
+	assert.Contains(t, output[0].Tags, "tag2")
+	assert.Equal(t, 2, len(output[0].Tags))
+
+	assert.NotNil(t, output[1])
+	assert.Equal(t, 0, len(output[1].Tags))
+}
+
 func TestGalasaapiRunHasRecordsReturnsSameAmountOfRecordsWithMethods(t *testing.T) {
 	//Given
 	methods := make([]galasaapi.TestMethod, 0)

--- a/modules/cli/pkg/runs/runsConverter_test.go
+++ b/modules/cli/pkg/runs/runsConverter_test.go
@@ -94,6 +94,40 @@ func TestGalasaapiRunHasRecordsReturnsSameAmountOfRecordsWithNoMethods(t *testin
 	assert.Equal(t, len(runs), len(output), "The input record has a length of %v whilst the output has length of %v", len(runs), len(output))
 }
 
+func TestRunConvertsTags(t *testing.T) {
+	//Given
+	tags := make([]string, 2)
+	tags[0] = "tag1"
+	tags[1] = "tag2"
+
+	methods := make([]galasaapi.TestMethod, 0)
+
+	runs := make([]galasaapi.Run, 0)
+	//runName, testName, requestor, status, result, queued, methods
+	run1 := createRunForConverter("LongRunName", "TestName", "requestor", "LongStatus", "Passed", "2023-05-04T10:45:29.545323Z", methods)
+
+	// run1 has tags
+	run1.TestStructure.Tags = tags
+
+	run2 := createRunForConverter("U456", "MyTestName", "myRequestorString", "Status", "Failed", "2023-05-04T10:55:29.545323Z", methods)
+	// run2 does not have any tags
+
+	runs = append(runs, run1, run2)
+	apiServerUrl := ""
+
+	//When
+	var output []runsformatter.FormattableTest
+	output = FormattableTestFromGalasaApi(runs, apiServerUrl)
+
+	assert.NotNil(t, output[0])
+	assert.Contains(t, output[0].Tags, "tag1")
+	assert.Contains(t, output[0].Tags, "tag2")
+	assert.Equal(t, 2, len(output[0].Tags))
+
+	assert.NotNil(t, output[1])
+	assert.Equal(t, 0, len(output[1].Tags))
+}
+
 func TestGalasaapiRunHasRecordsReturnsSameAmountOfRecordsWithMethods(t *testing.T) {
 	//Given
 	methods := make([]galasaapi.TestMethod, 0)

--- a/modules/cli/pkg/runs/runsGet_test.go
+++ b/modules/cli/pkg/runs/runsGet_test.go
@@ -259,7 +259,7 @@ func TestRunsGetOfRunNameWhichExistsProducesExpectedSummary(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -272,8 +272,8 @@ func TestRunsGetOfRunNameWhichExistsProducesExpectedSummary(t *testing.T) {
 		textGotBack := mockConsole.ReadText()
 		assert.Contains(t, textGotBack, runName)
 		want :=
-			"submitted-time(UTC) name requestor   status   result test-name                group\n" +
-				"2023-05-10 06:00:13 U456 unitTesting Finished Passed myTestPackage.MyTestName dummyGroup\n" +
+			"submitted-time(UTC) name requestor   status   result test-name                group      tags\n" +
+				"2023-05-10 06:00:13 U456 unitTesting Finished Passed myTestPackage.MyTestName dummyGroup \n" +
 				"\n" +
 				"Total:1 Passed:1\n"
 		assert.Equal(t, want, textGotBack)
@@ -301,7 +301,7 @@ func TestRunsGetOfRunNameWhichDoesNotExistProducesError(t *testing.T) {
 	outputFormat := "summary"
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -336,7 +336,7 @@ func TestRunsGetWhereRunNameExistsTwiceProducesTwoRunResultLines(t *testing.T) {
 	outputFormat := "summary"
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -349,12 +349,12 @@ func TestRunsGetWhereRunNameExistsTwiceProducesTwoRunResultLines(t *testing.T) {
 		textGotBack := mockConsole.ReadText()
 		assert.Contains(t, textGotBack, runName)
 		want :=
-			"submitted-time(UTC) name requestor     status   result           test-name                group\n" +
-				"2023-05-10 06:00:13 U456 unitTesting   Finished Passed           myTestPackage.MyTestName dummyGroup\n" +
-				"2023-05-10 06:00:13 U456 unitTesting22 Finished LongResultString myTestPackage.MyTest2    \n" +
+			"submitted-time(UTC) name requestor     status   result           test-name                group      tags\n" +
+				"2023-05-10 06:00:13 U456 unitTesting   Finished Passed           myTestPackage.MyTestName dummyGroup \n" +
+				"2023-05-10 06:00:13 U456 unitTesting22 Finished LongResultString myTestPackage.MyTest2               \n" +
 				"\n" +
 				"Total:2 Passed:1\n"
-		assert.Equal(t, textGotBack, want)
+		assert.Equal(t, want, textGotBack)
 	}
 }
 
@@ -377,7 +377,7 @@ func TestFailingGetRunsRequestReturnsError(t *testing.T) {
 	outputFormat := "summary"
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -417,7 +417,7 @@ func TestRunsGetOfRunNameWhichExistsProducesExpectedDetails(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -441,6 +441,7 @@ func TestRunsGetOfRunNameWhichExistsProducesExpectedDetails(t *testing.T) {
 				"requestor           : unitTesting\n" +
 				"bundle              : myBundleId\n" +
 				"group               : dummyGroup\n" +
+				"tags                : \n" +
 				"run-log             : " + apiServerUrl + "/ras/runs/xxx876xxx/runlog\n" +
 				"\n" +
 				"method           type status result  start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -483,7 +484,7 @@ func TestAPIInternalErrorIsHandledOk(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -517,7 +518,7 @@ func TestRunsGetOfRunNameWhichExistsProducesExpectedRaw(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -527,7 +528,7 @@ func TestRunsGetOfRunNameWhichExistsProducesExpectedRaw(t *testing.T) {
 	assert.Nil(t, err)
 	textGotBack := mockConsole.ReadText()
 	assert.Contains(t, textGotBack, runName)
-	want := "U456|Finished|Passed|2023-05-10T06:00:13.043037Z|2023-05-10T06:00:36.159003Z|2023-05-10T06:02:53.823338Z|137664|myTestPackage.MyTestName|unitTesting|myBundleId|dummyGroup|" + apiServerUrl + "/ras/runs/xxx876xxx/runlog\n"
+	want := "U456|Finished|Passed|2023-05-10T06:00:13.043037Z|2023-05-10T06:00:36.159003Z|2023-05-10T06:02:53.823338Z|137664|myTestPackage.MyTestName|unitTesting|myBundleId|dummyGroup|" + apiServerUrl + "/ras/runs/xxx876xxx/runlog|\n"
 	assert.Equal(t, textGotBack, want)
 }
 
@@ -653,7 +654,7 @@ func TestRunsGetURLQueryWithFromAndToDate(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -687,7 +688,7 @@ func TestRunsGetURLQueryJustFromAge(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -721,7 +722,7 @@ func TestRunsGetURLQueryWithNoRunNameAndNoFromAgeReturnsError(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -756,7 +757,7 @@ func TestRunsGetURLQueryWithOlderToAgeThanFromAgeReturnsError(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -791,7 +792,7 @@ func TestRunsGetURLQueryWithBadlyFormedFromAndToParameterReturnsError(t *testing
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -981,7 +982,7 @@ func TestRunsGetURLQueryWithRequestorNotSuppliedReturnsOK(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1017,7 +1018,7 @@ func TestRunsGetURLQueryWithRequestorSuppliedReturnsOK(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1053,7 +1054,7 @@ func TestRunsGetURLQueryWithNumericRequestorSuppliedReturnsOK(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1089,7 +1090,7 @@ func TestRunsGetURLQueryWithDashInRequestorSuppliedReturnsOK(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1125,7 +1126,7 @@ func TestRunsGetURLQueryWithAmpersandRequestorSuppliedReturnsOK(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1162,7 +1163,7 @@ func TestRunsGetURLQueryWithSpecialCharactersRequestorSuppliedReturnsOK(t *testi
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1192,7 +1193,7 @@ func TestRunsGetURLQueryWithResultSuppliedReturnsOK(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1224,7 +1225,7 @@ func TestRunsGetURLQueryWithMultipleResultSuppliedReturnsOK(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 
@@ -1257,7 +1258,7 @@ func TestRunsGetURLQueryWithResultNotSuppliedReturnsOK(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1287,7 +1288,7 @@ func TestRunsGetURLQueryWithInvalidResultSuppliedReturnsError(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1319,7 +1320,7 @@ func TestActiveAndResultAreMutuallyExclusiveShouldReturnError(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1350,7 +1351,7 @@ func TestActiveParameterReturnsOk(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1389,7 +1390,7 @@ func TestRunsGetActiveRunsBuildsQueryCorrectly(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1423,7 +1424,7 @@ func TestRunsGetWithNextCursorGetsNextPageOfRuns(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1433,7 +1434,7 @@ func TestRunsGetWithNextCursorGetsNextPageOfRuns(t *testing.T) {
 	runsReturned := mockConsole.ReadText()
 	assert.Contains(t, runsReturned, runName)
 
-	run := "U456|Finished|Passed|2023-05-10T06:00:13.043037Z|2023-05-10T06:00:36.159003Z|2023-05-10T06:02:53.823338Z|137664|myTestPackage.MyTestName|unitTesting|myBundleId|dummyGroup|" + apiServerUrl + "/ras/runs/xxx876xxx/runlog\n"
+	run := "U456|Finished|Passed|2023-05-10T06:00:13.043037Z|2023-05-10T06:00:36.159003Z|2023-05-10T06:02:53.823338Z|137664|myTestPackage.MyTestName|unitTesting|myBundleId|dummyGroup|" + apiServerUrl + "/ras/runs/xxx876xxx/runlog|\n"
 	expectedResults := run + run
 	assert.Equal(t, runsReturned, expectedResults)
 }
@@ -1460,7 +1461,7 @@ func TestRunsGetOfGroupWhichExistsProducesExpectedRaw(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
@@ -1470,7 +1471,7 @@ func TestRunsGetOfGroupWhichExistsProducesExpectedRaw(t *testing.T) {
 	assert.Nil(t, err)
 	textGotBack := mockConsole.ReadText()
 	assert.Contains(t, textGotBack, runName)
-	want := "U456|Finished|Passed|2023-05-10T06:00:13.043037Z|2023-05-10T06:00:36.159003Z|2023-05-10T06:02:53.823338Z|137664|myTestPackage.MyTestName|unitTesting|myBundleId|dummyGroup|" + apiServerUrl + "/ras/runs/xxx876xxx/runlog\n"
+	want := "U456|Finished|Passed|2023-05-10T06:00:13.043037Z|2023-05-10T06:00:36.159003Z|2023-05-10T06:02:53.823338Z|137664|myTestPackage.MyTestName|unitTesting|myBundleId|dummyGroup|" + apiServerUrl + "/ras/runs/xxx876xxx/runlog|\n"
 	assert.Equal(t, textGotBack, want)
 }
 
@@ -1479,7 +1480,7 @@ func TestRunsGetWithBadGroupNameThrowsError(t *testing.T) {
 	// Given ...
 	pages := make(map[string][]string, 0)
 	pages[""] = []string{}
-	nextPageCursors := []string{ "" }
+	nextPageCursors := []string{""}
 
 	runName := "U457"
 	age := ""
@@ -1498,7 +1499,7 @@ func TestRunsGetWithBadGroupNameThrowsError(t *testing.T) {
 
 	apiServerUrl := server.URL
 	mockTimeService := utils.NewMockTimeService()
-    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)

--- a/modules/cli/pkg/runs/submitter.go
+++ b/modules/cli/pkg/runs/submitter.go
@@ -176,7 +176,7 @@ func (submitter *Submitter) executeSubmitRuns(
 		for len(submittedRuns) < throttle && len(readyRuns) > 0 {
 
 			readyRuns, err = submitter.submitRun(params.GroupName, readyRuns, submittedRuns,
-				lostRuns, &runOverrides, params.Trace, currentUser, params.RequestType)
+				lostRuns, &runOverrides, params.Trace, currentUser, params.RequestType, params.Tags)
 
 			if err != nil {
 				// Ignore the error and continue to process the list of available runs.
@@ -314,6 +314,7 @@ func (submitter *Submitter) submitRun(
 	trace bool,
 	requestor string,
 	requestType string,
+	tags []string,
 ) ([]TestRun, error) {
 
 	var err error
@@ -333,7 +334,7 @@ func (submitter *Submitter) submitRun(
 		var resultGroup *galasaapi.TestRuns
 		log.Printf("submitRun - %s, %s", className, requestType)
 		resultGroup, err = submitter.launcher.SubmitTestRun(groupName, className, requestType, requestor,
-			nextRun.Stream, nextRun.Obr, trace, nextRun.GherkinUrl, nextRun.GherkinFeature, submitOverrides)
+			nextRun.Stream, nextRun.Obr, trace, nextRun.GherkinUrl, nextRun.GherkinFeature, submitOverrides, tags)
 		if err != nil {
 			log.Printf("Failed to submit test %v/%v - %v\n", nextRun.Bundle, nextRun.Class, err)
 			lostRuns[className] = &nextRun
@@ -699,6 +700,10 @@ func (submitter *Submitter) validateAndCorrectParams(
 	}
 
 	submitter.tildaExpandAllPaths(params)
+
+	if err == nil {
+		params.Tags, err = utils.CombineAllCommaSeparatedLists(params.Tags)
+	}
 
 	return err
 }

--- a/modules/cli/pkg/runs/submitter_test.go
+++ b/modules/cli/pkg/runs/submitter_test.go
@@ -519,8 +519,9 @@ func TestSubmitRunwithGherkinFile(t *testing.T) {
 	trace := false
 	requestor := "user"
 	requestType := ""
+	tags := []string{}
 
-	run, err := submitter.submitRun(groupName, readyRuns, submittedRuns, lostRuns, runOverrides, trace, requestor, requestType)
+	run, err := submitter.submitRun(groupName, readyRuns, submittedRuns, lostRuns, runOverrides, trace, requestor, requestType, tags)
 	assert.Nil(t, err)
 	assert.Empty(t, run)
 	assert.Contains(t, submittedRuns["M100"].GherkinUrl, "gherkin.feature")

--- a/modules/cli/pkg/runs/yamlReporter_test.go
+++ b/modules/cli/pkg/runs/yamlReporter_test.go
@@ -18,6 +18,10 @@ func TestYamlReportWorks(t *testing.T) {
 	// Given...
 	mockFileSystem := files.NewMockFileSystem()
 
+	tags := []string{}
+	tags = append(tags, "a")
+	tags = append(tags, "b")
+
 	finishedRuns := TestRun{
 		Name:           "myTestRun",
 		Bundle:         "myBundle",
@@ -33,6 +37,7 @@ func TestYamlReportWorks(t *testing.T) {
 		GherkinUrl:     "file:///my.feature",
 		GherkinFeature: "my",
 		SubmissionId:   "123",
+		Tags:           tags,
 	}
 
 	finishedRunsMap := make(map[string]*TestRun, 1)
@@ -76,7 +81,10 @@ func TestYamlReportWorks(t *testing.T) {
 	  gherkin: file:///my.feature
 	  feature: my
 	  group:""
-	  submissionId:"123"`
+	  submissionId:"123"
+	  tags:
+	  - a
+	  - b`
 
 	actualContents, err := mockFileSystem.ReadTextFile("myReportYamlFilename")
 	if err != nil {

--- a/modules/cli/pkg/runsformatter/detailsFormatter.go
+++ b/modules/cli/pkg/runsformatter/detailsFormatter.go
@@ -105,6 +105,7 @@ func tabulateCoreRunDetails(run FormattableTest) [][]string {
 		{HEADER_REQUESTOR, ": " + run.Requestor},
 		{HEADER_BUNDLE, ": " + run.Bundle},
 		{HEADER_GROUP, ": " + run.Group},
+		{HEADER_TAGS, ": " + strings.Join(run.Tags[:], ",")},
 		{HEADER_RUN_LOG, ": " + run.ApiServerUrl + RAS_RUNS_URL + run.RunId + "/runlog"},
 	}
 	return table

--- a/modules/cli/pkg/runsformatter/detailsFormatter_test.go
+++ b/modules/cli/pkg/runsformatter/detailsFormatter_test.go
@@ -107,6 +107,7 @@ func TestDetailsFormatterReturnsExpectedFormat(t *testing.T) {
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-123/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -146,6 +147,7 @@ func TestDetailsFormatterWithMultipleRunsReturnsSeparatedWithDashes(t *testing.T
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-123/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -164,6 +166,7 @@ func TestDetailsFormatterWithMultipleRunsReturnsSeparatedWithDashes(t *testing.T
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-456/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -182,6 +185,7 @@ func TestDetailsFormatterWithMultipleRunsReturnsSeparatedWithDashes(t *testing.T
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-789/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -219,6 +223,7 @@ func TestDetailsNoRunEndtimeReturnsBlankEndtimeFieldAndNoDuration(t *testing.T) 
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-123/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -256,6 +261,7 @@ func TestMethodTableRendersOkIfNoEndtime(t *testing.T) {
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-123/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC) duration(ms)\n" +
@@ -301,6 +307,7 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-123/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -319,6 +326,7 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-456/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -337,6 +345,7 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-789/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -355,6 +364,7 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-12345/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -373,6 +383,7 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-67890/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -391,6 +402,7 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-98765/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -409,6 +421,7 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-543210/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -427,6 +440,7 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-222/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -445,6 +459,7 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-333/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -490,6 +505,7 @@ func TestDetailsFormatterMultipleRunsDoesNotDisplayLostRunsAndProducesExpectedTo
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-456/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -508,6 +524,7 @@ func TestDetailsFormatterMultipleRunsDoesNotDisplayLostRunsAndProducesExpectedTo
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-12345/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -526,6 +543,7 @@ func TestDetailsFormatterMultipleRunsDoesNotDisplayLostRunsAndProducesExpectedTo
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-98765/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -544,6 +562,7 @@ func TestDetailsFormatterMultipleRunsDoesNotDisplayLostRunsAndProducesExpectedTo
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-543210/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
@@ -562,6 +581,7 @@ func TestDetailsFormatterMultipleRunsDoesNotDisplayLostRunsAndProducesExpectedTo
 			"requestor           : galasa\n" +
 			"bundle              : dev.galasa\n" +
 			"group               : none\n" +
+			"tags                : \n" +
 			"run-log             : https://127.0.0.1/ras/runs/cbd-333/runlog\n" +
 			"\n" +
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +

--- a/modules/cli/pkg/runsformatter/rawFormatter.go
+++ b/modules/cli/pkg/runsformatter/rawFormatter.go
@@ -28,7 +28,7 @@ func (*RawFormatter) IsNeedingMethodDetails() bool {
 	return false
 }
 
-func (*RawFormatter) FormatRuns(runs []FormattableTest) (string, error) {
+func (formatter *RawFormatter) FormatRuns(runs []FormattableTest) (string, error) {
 	var result string = ""
 	var err error
 	buff := strings.Builder{}
@@ -45,19 +45,33 @@ func (*RawFormatter) FormatRuns(runs []FormattableTest) (string, error) {
 
 		runLog := run.ApiServerUrl + RAS_RUNS_URL + run.RunId + "/runlog"
 
-		buff.WriteString(run.Name + "|" +
-			run.Status + "|" +
-			run.Result + "|" +
-			run.QueuedTimeUTC + "|" +
-			startTimeStringRaw + "|" +
-			endTimeStringRaw + "|" +
-			duration + "|" +
-			run.TestName + "|" +
-			run.Requestor + "|" +
-			run.Bundle + "|" +
-			run.Group + "|" +
-			runLog,
-		)
+		tags := strings.Join(run.Tags[:], ",")
+
+		buff.WriteString(run.Name)
+		buff.WriteString("|")
+		buff.WriteString(run.Status)
+		buff.WriteString("|")
+		buff.WriteString(run.Result)
+		buff.WriteString("|")
+		buff.WriteString(run.QueuedTimeUTC)
+		buff.WriteString("|")
+		buff.WriteString(startTimeStringRaw)
+		buff.WriteString("|")
+		buff.WriteString(endTimeStringRaw)
+		buff.WriteString("|")
+		buff.WriteString(duration)
+		buff.WriteString("|")
+		buff.WriteString(run.TestName)
+		buff.WriteString("|")
+		buff.WriteString(run.Requestor)
+		buff.WriteString("|")
+		buff.WriteString(run.Bundle)
+		buff.WriteString("|")
+		buff.WriteString(run.Group)
+		buff.WriteString("|")
+		buff.WriteString(runLog)
+		buff.WriteString("|")
+		buff.WriteString(tags)
 
 		buff.WriteString("\n")
 

--- a/modules/cli/pkg/runsformatter/rawFormatter_test.go
+++ b/modules/cli/pkg/runsformatter/rawFormatter_test.go
@@ -24,6 +24,7 @@ func createFormattableTestForRaw(runId string,
 	apiServerUrl string,
 	isLost bool,
 	group string,
+	tags []string,
 ) FormattableTest {
 	formattableTest := FormattableTest{
 		RunId:         runId,
@@ -39,6 +40,7 @@ func createFormattableTestForRaw(runId string,
 		ApiServerUrl:  apiServerUrl,
 		Group:         group,
 		Lost:          isLost,
+		Tags:          tags,
 	}
 	return formattableTest
 }
@@ -60,15 +62,16 @@ func TestRawFormatterNoDataReturnsNothing(t *testing.T) {
 func TestRawFormatterReturnsExpectedFormat(t *testing.T) {
 	formatter := NewRawFormatter()
 
+	tags := []string{}
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForRaw("cbd-123", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none")
+	formattableTest1 := createFormattableTestForRaw("cbd-123", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1)
 
 	// When...
 	actualFormattedOutput, err := formatter.FormatRuns(formattableTest)
 
 	assert.Nil(t, err)
-	expectedFormattedOutput := "U456|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-123/runlog\n"
+	expectedFormattedOutput := "U456|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-123/runlog|\n"
 
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
 }
@@ -76,10 +79,11 @@ func TestRawFormatterReturnsExpectedFormat(t *testing.T) {
 func TestRawFormatterWithMultipleFormattableTestsSeparatesWithNewLine(t *testing.T) {
 	formatter := NewRawFormatter()
 
+	tags := []string{}
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForRaw("cbd-123", "U123", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none")
-	formattableTest2 := createFormattableTestForRaw("cbd-456", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none")
-	formattableTest3 := createFormattableTestForRaw("cbd-789", "U789", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none")
+	formattableTest1 := createFormattableTestForRaw("cbd-123", "U123", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none", tags)
+	formattableTest2 := createFormattableTestForRaw("cbd-456", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none", tags)
+	formattableTest3 := createFormattableTestForRaw("cbd-789", "U789", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3)
 
 	// When...
@@ -87,24 +91,25 @@ func TestRawFormatterWithMultipleFormattableTestsSeparatesWithNewLine(t *testing
 
 	assert.Nil(t, err)
 	expectedFormattedOutput :=
-		"U123|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-123/runlog\n" +
-			"U456|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-456/runlog\n" +
-			"U789|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-789/runlog\n"
+		"U123|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-123/runlog|\n" +
+			"U456|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-456/runlog|\n" +
+			"U789|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-789/runlog|\n"
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
 }
 
 func TestRawFormatterNoRunEndtimeReturnsBlankEndtimeFieldAndNoDuration(t *testing.T) {
 	formatter := NewRawFormatter()
 
+	tags := []string{}
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForRaw("cbd-123", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", false, "none")
+	formattableTest1 := createFormattableTestForRaw("cbd-123", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", false, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1)
 
 	// When...
 	actualFormattedOutput, err := formatter.FormatRuns(formattableTest)
 
 	assert.Nil(t, err)
-	expectedFormattedOutput := "U456|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|||dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-123/runlog\n"
+	expectedFormattedOutput := "U456|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|||dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-123/runlog|\n"
 
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
 }
@@ -112,9 +117,10 @@ func TestRawFormatterNoRunEndtimeReturnsBlankEndtimeFieldAndNoDuration(t *testin
 func TestRawFormatterOnlyLostRunReturnsEmpty(t *testing.T) {
 	formatter := NewRawFormatter()
 
+	tags := []string{}
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForRaw("cbd-123", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", true, "none")
-	formattableTest2 := createFormattableTestForRaw("cbd-456", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", true, "none")
+	formattableTest1 := createFormattableTestForRaw("cbd-123", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", true, "none", tags)
+	formattableTest2 := createFormattableTestForRaw("cbd-456", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", true, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1, formattableTest2)
 
 	// When...
@@ -131,20 +137,22 @@ func TestRawFormatterMultipleRunsPrintsOnlyFinishedRuns(t *testing.T) {
 	formatter := NewRawFormatter()
 
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForRaw("cbd-123", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", true, "none")
-	formattableTest2 := createFormattableTestForRaw("cbd-123", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", false, "none")
-	formattableTest3 := createFormattableTestForRaw("cbd-456", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", true, "none")
-	formattableTest4 := createFormattableTestForRaw("cbd-456", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none")
-	formattableTest5 := createFormattableTestForRaw("cbd-789", "U789", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none")
+	tags := []string{}
+
+	formattableTest1 := createFormattableTestForRaw("cbd-123", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", true, "none", tags)
+	formattableTest2 := createFormattableTestForRaw("cbd-123", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", false, "none", tags)
+	formattableTest3 := createFormattableTestForRaw("cbd-456", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", true, "none", tags)
+	formattableTest4 := createFormattableTestForRaw("cbd-456", "U456", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none", tags)
+	formattableTest5 := createFormattableTestForRaw("cbd-789", "U789", "Finished", "Passed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", false, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5)
 
 	// When...
 	actualFormattedOutput, err := formatter.FormatRuns(formattableTest)
 
 	assert.Nil(t, err)
-	expectedFormattedOutput := "U456|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|||dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-123/runlog\n" +
-		"U456|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-456/runlog\n" +
-		"U789|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-789/runlog\n"
+	expectedFormattedOutput := "U456|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|||dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-123/runlog|\n" +
+		"U456|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-456/runlog|\n" +
+		"U789|Finished|Passed|2023-05-04T10:55:29.545323Z|2023-05-05T06:00:14.496953Z|2023-05-05T06:00:15.654565Z|1157|dev.galasa.Zos3270LocalJava11Ubuntu|galasa|dev.galasa|none|https://127.0.0.1/ras/runs/cbd-789/runlog|\n"
 
 	assert.Equal(t, len(formattableTest), 5)
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)

--- a/modules/cli/pkg/runsformatter/runsFormatter.go
+++ b/modules/cli/pkg/runsformatter/runsFormatter.go
@@ -45,6 +45,7 @@ const (
 	HEADER_METHOD_NAME    = "method"
 	HEADER_METHOD_TYPE    = "type"
 	HEADER_GROUP          = "group"
+	HEADER_TAGS           = "tags"
 
 	RAS_RUNS_URL = "/ras/runs/"
 )
@@ -66,6 +67,7 @@ type FormattableTest struct {
 	Group         string
 	Methods       []galasaapi.TestMethod
 	Lost          bool
+	Tags          []string
 }
 
 func NewFormattableTest() FormattableTest {

--- a/modules/cli/pkg/runsformatter/summaryFormatter.go
+++ b/modules/cli/pkg/runsformatter/summaryFormatter.go
@@ -45,7 +45,7 @@ func (*SummaryFormatter) FormatRuns(testResultsData []FormattableTest) (string, 
 	if totalResults > 0 {
 		var table [][]string
 
-		var headers = []string{HEADER_SUBMITTED_TIME, HEADER_RUNNAME, HEADER_REQUESTOR, HEADER_STATUS, HEADER_RESULT, HEADER_TEST_NAME, HEADER_GROUP}
+		var headers = []string{HEADER_SUBMITTED_TIME, HEADER_RUNNAME, HEADER_REQUESTOR, HEADER_STATUS, HEADER_RESULT, HEADER_TEST_NAME, HEADER_GROUP, HEADER_TAGS}
 
 		table = append(table, headers)
 		for _, run := range testResultsData {
@@ -58,7 +58,8 @@ func (*SummaryFormatter) FormatRuns(testResultsData []FormattableTest) (string, 
 
 				accumulateResults(resultCountsMap, run)
 
-				line = append(line, submittedTimeReadable, run.Name, run.Requestor, run.Status, run.Result, run.TestName, run.Group)
+				tagsList := strings.Join(run.Tags[:], ",")
+				line = append(line, submittedTimeReadable, run.Name, run.Requestor, run.Status, run.Result, run.TestName, run.Group, tagsList)
 				table = append(table, line)
 			}
 		}

--- a/modules/cli/pkg/runsformatter/summaryFormatter_test.go
+++ b/modules/cli/pkg/runsformatter/summaryFormatter_test.go
@@ -34,16 +34,18 @@ func createFormattableTestForSummary(
 	requestor string,
 	isLost bool,
 	group string,
+	tags []string,
 ) FormattableTest {
 	formattableTest := FormattableTest{
-		Name: name,
+		Name:          name,
 		TestName:      testName,
 		Requestor:     requestor,
 		Status:        status,
 		Result:        result,
 		QueuedTimeUTC: queuedTimeUTC,
 		Group:         group,
-		Lost: isLost,
+		Lost:          isLost,
+		Tags:          tags,
 	}
 	return formattableTest
 }
@@ -51,8 +53,9 @@ func createFormattableTestForSummary(
 func TestSummaryFormatterLongResultStringReturnsExpectedFormat(t *testing.T) {
 	formatter := NewSummaryFormatter()
 
+	tags := []string{}
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName", "Finished", "MyLongResultString", "myUserId1", false, "none")
+	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName", "Finished", "MyLongResultString", "myUserId1", false, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1)
 
 	// When...
@@ -60,8 +63,8 @@ func TestSummaryFormatterLongResultStringReturnsExpectedFormat(t *testing.T) {
 
 	assert.Nil(t, err)
 	expectedFormattedOutput :=
-		"submitted-time(UTC) name requestor status   result             test-name  group\n" +
-			"2023-05-04 10:55:29 U456 myUserId1 Finished MyLongResultString MyTestName none\n" +
+		"submitted-time(UTC) name requestor status   result             test-name  group tags\n" +
+			"2023-05-04 10:55:29 U456 myUserId1 Finished MyLongResultString MyTestName none  \n" +
 			"\n" +
 			"Total:1\n"
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
@@ -71,7 +74,8 @@ func TestSummaryFormatterShortResultStringReturnsExpectedFormat(t *testing.T) {
 	formatter := NewSummaryFormatter()
 
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName", "Finished", "Short", "myUserId1", false, "none")
+	tags := []string{}
+	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName", "Finished", "Short", "myUserId1", false, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1)
 
 	// When...
@@ -79,8 +83,8 @@ func TestSummaryFormatterShortResultStringReturnsExpectedFormat(t *testing.T) {
 
 	assert.Nil(t, err)
 	expectedFormattedOutput :=
-		"submitted-time(UTC) name requestor status   result test-name  group\n" +
-			"2023-05-04 10:55:29 U456 myUserId1 Finished Short  MyTestName none\n" +
+		"submitted-time(UTC) name requestor status   result test-name  group tags\n" +
+			"2023-05-04 10:55:29 U456 myUserId1 Finished Short  MyTestName none  \n" +
 			"\n" +
 			"Total:1\n"
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
@@ -90,8 +94,9 @@ func TestSummaryFormatterShortAndLongStatusReturnsExpectedFormat(t *testing.T) {
 	formatter := NewSummaryFormatter()
 
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:45:29.545323Z", "LongRunName", "TestName", "LongStatus", "Short", "myUserId1", false, "none")
-	formattableTest2 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName", "short", "MyLongResultString", "myUserId1", false, "none")
+	tags := []string{}
+	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:45:29.545323Z", "LongRunName", "TestName", "LongStatus", "Short", "myUserId1", false, "none", tags)
+	formattableTest2 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName", "short", "MyLongResultString", "myUserId1", false, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1, formattableTest2)
 
 	// When...
@@ -99,9 +104,9 @@ func TestSummaryFormatterShortAndLongStatusReturnsExpectedFormat(t *testing.T) {
 
 	assert.Nil(t, err)
 	expectedFormattedOutput :=
-		"submitted-time(UTC) name        requestor status     result             test-name  group\n" +
-			"2023-05-04 10:45:29 LongRunName myUserId1 LongStatus Short              TestName   none\n" +
-			"2023-05-04 10:55:29 U456        myUserId1 short      MyLongResultString MyTestName none\n" +
+		"submitted-time(UTC) name        requestor status     result             test-name  group tags\n" +
+			"2023-05-04 10:45:29 LongRunName myUserId1 LongStatus Short              TestName   none  \n" +
+			"2023-05-04 10:55:29 U456        myUserId1 short      MyLongResultString MyTestName none  \n" +
 			"\n" +
 			"Total:2\n"
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
@@ -111,15 +116,16 @@ func TestSummaryFormatterWithMultipleRunsPrintsOnlyFinishedRuns(t *testing.T) {
 	formatter := NewSummaryFormatter()
 
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:45:29.545323Z", "U123", "TestName", "Finished", "Passed", "myUserId1", false, "none")
-	formattableTest2 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName1", "Finished", "Failed", "myUserId2", false, "none")
-	formattableTest3 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U789", "MyTestName2", "Finished", "EnvFail", "myUserId1", false, "none")
-	formattableTest4 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L123", "MyTestName3", "UNKNOWN", "", "myUserId2", false, "none")
-	formattableTest5 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L456", "MyTestName4", "Building", "EnvFail", "myUserId1", false, "none")
-	formattableTest6 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L789", "MyTestName5", "Finished", "Passed With Defects", "myUserId2", false, "none")
-	formattableTest7 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C111", "MyTestName6", "Finished", "Failed", "myUserId1", false, "none")
-	formattableTest8 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C222", "MyTestName7", "Finished", "UNKNOWN", "myUserId2", false, "none")
-	formattableTest9 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C333", "MyTestName8", "Finished", "Ignored", "myUserId1", false, "none")
+	tags := []string{}
+	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:45:29.545323Z", "U123", "TestName", "Finished", "Passed", "myUserId1", false, "none", tags)
+	formattableTest2 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName1", "Finished", "Failed", "myUserId2", false, "none", tags)
+	formattableTest3 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U789", "MyTestName2", "Finished", "EnvFail", "myUserId1", false, "none", tags)
+	formattableTest4 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L123", "MyTestName3", "UNKNOWN", "", "myUserId2", false, "none", tags)
+	formattableTest5 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L456", "MyTestName4", "Building", "EnvFail", "myUserId1", false, "none", tags)
+	formattableTest6 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L789", "MyTestName5", "Finished", "Passed With Defects", "myUserId2", false, "none", tags)
+	formattableTest7 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C111", "MyTestName6", "Finished", "Failed", "myUserId1", false, "none", tags)
+	formattableTest8 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C222", "MyTestName7", "Finished", "UNKNOWN", "myUserId2", false, "none", tags)
+	formattableTest9 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C333", "MyTestName8", "Finished", "Ignored", "myUserId1", false, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9)
 
 	// When...
@@ -127,16 +133,16 @@ func TestSummaryFormatterWithMultipleRunsPrintsOnlyFinishedRuns(t *testing.T) {
 
 	assert.Nil(t, err)
 	expectedFormattedOutput :=
-		"submitted-time(UTC) name requestor status   result              test-name   group\n" +
-			"2023-05-04 10:45:29 U123 myUserId1 Finished Passed              TestName    none\n" +
-			"2023-05-04 10:55:29 U456 myUserId2 Finished Failed              MyTestName1 none\n" +
-			"2023-05-04 10:55:29 U789 myUserId1 Finished EnvFail             MyTestName2 none\n" +
-			"2023-05-04 10:55:29 L123 myUserId2 UNKNOWN                      MyTestName3 none\n" +
-			"2023-05-04 10:55:29 L456 myUserId1 Building EnvFail             MyTestName4 none\n" +
-			"2023-05-04 10:55:29 L789 myUserId2 Finished Passed With Defects MyTestName5 none\n" +
-			"2023-05-04 10:55:29 C111 myUserId1 Finished Failed              MyTestName6 none\n" +
-			"2023-05-04 10:55:29 C222 myUserId2 Finished UNKNOWN             MyTestName7 none\n" +
-			"2023-05-04 10:55:29 C333 myUserId1 Finished Ignored             MyTestName8 none\n" +
+		"submitted-time(UTC) name requestor status   result              test-name   group tags\n" +
+			"2023-05-04 10:45:29 U123 myUserId1 Finished Passed              TestName    none  \n" +
+			"2023-05-04 10:55:29 U456 myUserId2 Finished Failed              MyTestName1 none  \n" +
+			"2023-05-04 10:55:29 U789 myUserId1 Finished EnvFail             MyTestName2 none  \n" +
+			"2023-05-04 10:55:29 L123 myUserId2 UNKNOWN                      MyTestName3 none  \n" +
+			"2023-05-04 10:55:29 L456 myUserId1 Building EnvFail             MyTestName4 none  \n" +
+			"2023-05-04 10:55:29 L789 myUserId2 Finished Passed With Defects MyTestName5 none  \n" +
+			"2023-05-04 10:55:29 C111 myUserId1 Finished Failed              MyTestName6 none  \n" +
+			"2023-05-04 10:55:29 C222 myUserId2 Finished UNKNOWN             MyTestName7 none  \n" +
+			"2023-05-04 10:55:29 C333 myUserId1 Finished Ignored             MyTestName8 none  \n" +
 			"\n" +
 			"Total:9 Passed:1 PassedWithDefects:1 Failed:2 EnvFail:2 UNKNOWN:1 Active:1 Ignored:1\n"
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
@@ -146,15 +152,16 @@ func TestSummaryFormatterMultipleRunsWithLostRunsDoesNotDisplayLostRunsAndCounts
 	formatter := NewSummaryFormatter()
 
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:45:29.545323Z", "U123", "TestName", "Finished", "Passed", "myUserId1", false, "none")
-	formattableTest2 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName1", "Finished", "Failed", "myUserId2", true, "none")
-	formattableTest3 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U789", "MyTestName2", "Finished", "EnvFail", "myUserId1", true, "none")
-	formattableTest4 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L123", "MyTestName3", "UNKNOWN", "", "myUserId2", false, "none")
-	formattableTest5 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L456", "MyTestName4", "Building", "EnvFail", "myUserId1", false, "none")
-	formattableTest6 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L789", "MyTestName5", "Finished", "Passed With Defects", "myUserId2", false, "none")
-	formattableTest7 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C111", "MyTestName6", "Finished", "Failed", "myUserId1", false, "none")
-	formattableTest8 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C222", "MyTestName7", "Finished", "UNKNOWN", "myUserId2", false, "none")
-	formattableTest9 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C333", "MyTestName8", "Finished", "Ignored", "myUserId1", true, "none")
+	tags := []string{}
+	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:45:29.545323Z", "U123", "TestName", "Finished", "Passed", "myUserId1", false, "none", tags)
+	formattableTest2 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName1", "Finished", "Failed", "myUserId2", true, "none", tags)
+	formattableTest3 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U789", "MyTestName2", "Finished", "EnvFail", "myUserId1", true, "none", tags)
+	formattableTest4 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L123", "MyTestName3", "UNKNOWN", "", "myUserId2", false, "none", tags)
+	formattableTest5 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L456", "MyTestName4", "Building", "EnvFail", "myUserId1", false, "none", tags)
+	formattableTest6 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L789", "MyTestName5", "Finished", "Passed With Defects", "myUserId2", false, "none", tags)
+	formattableTest7 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C111", "MyTestName6", "Finished", "Failed", "myUserId1", false, "none", tags)
+	formattableTest8 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C222", "MyTestName7", "Finished", "UNKNOWN", "myUserId2", false, "none", tags)
+	formattableTest9 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C333", "MyTestName8", "Finished", "Ignored", "myUserId1", true, "none", tags)
 	//formattableTest10 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L321", "MyTestName9", "UNKNOWN", "", "myUserId2", true)
 	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9)
 
@@ -163,13 +170,13 @@ func TestSummaryFormatterMultipleRunsWithLostRunsDoesNotDisplayLostRunsAndCounts
 
 	assert.Nil(t, err)
 	expectedFormattedOutput :=
-		"submitted-time(UTC) name requestor status   result              test-name   group\n" +
-			"2023-05-04 10:45:29 U123 myUserId1 Finished Passed              TestName    none\n" +
-			"2023-05-04 10:55:29 L123 myUserId2 UNKNOWN                      MyTestName3 none\n" +
-			"2023-05-04 10:55:29 L456 myUserId1 Building EnvFail             MyTestName4 none\n" +
-			"2023-05-04 10:55:29 L789 myUserId2 Finished Passed With Defects MyTestName5 none\n" +
-			"2023-05-04 10:55:29 C111 myUserId1 Finished Failed              MyTestName6 none\n" +
-			"2023-05-04 10:55:29 C222 myUserId2 Finished UNKNOWN             MyTestName7 none\n" +
+		"submitted-time(UTC) name requestor status   result              test-name   group tags\n" +
+			"2023-05-04 10:45:29 U123 myUserId1 Finished Passed              TestName    none  \n" +
+			"2023-05-04 10:55:29 L123 myUserId2 UNKNOWN                      MyTestName3 none  \n" +
+			"2023-05-04 10:55:29 L456 myUserId1 Building EnvFail             MyTestName4 none  \n" +
+			"2023-05-04 10:55:29 L789 myUserId2 Finished Passed With Defects MyTestName5 none  \n" +
+			"2023-05-04 10:55:29 C111 myUserId1 Finished Failed              MyTestName6 none  \n" +
+			"2023-05-04 10:55:29 C222 myUserId2 Finished UNKNOWN             MyTestName7 none  \n" +
 			"\n" +
 			"Total:9 Passed:1 PassedWithDefects:1 Failed:1 Lost:3 EnvFail:1 UNKNOWN:1 Active:1\n"
 
@@ -180,16 +187,17 @@ func TestSummaryFormatterMultipleRunsWithUnknownStatusOfLostRunsDoesNotDisplayLo
 	formatter := NewSummaryFormatter()
 
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:45:29.545323Z", "U123", "TestName", "Finished", "Passed", "myUserId1", false, "none")
-	formattableTest2 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName1", "Finished", "Failed", "myUserId2", true, "none")
-	formattableTest3 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U789", "MyTestName2", "Finished", "EnvFail", "myUserId1", true, "none")
-	formattableTest4 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L123", "MyTestName3", "UNKNOWN", "", "myUserId2", false, "none")
-	formattableTest5 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L456", "MyTestName4", "Building", "EnvFail", "myUserId1", false, "none")
-	formattableTest6 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L789", "MyTestName5", "Finished", "Passed With Defects", "myUserId2", false, "none")
-	formattableTest7 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C111", "MyTestName6", "Finished", "Failed", "myUserId1", false, "none")
-	formattableTest8 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C222", "MyTestName7", "Finished", "UNKNOWN", "myUserId2", false, "none")
-	formattableTest9 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C333", "MyTestName8", "Finished", "Ignored", "myUserId1", true, "none")
-	formattableTest10 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L321", "MyTestName9", "UNKNOWN", "", "myUserId2", true, "none")
+	tags := []string{}
+	formattableTest1 := createFormattableTestForSummary("2023-05-04T10:45:29.545323Z", "U123", "TestName", "Finished", "Passed", "myUserId1", false, "none", tags)
+	formattableTest2 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U456", "MyTestName1", "Finished", "Failed", "myUserId2", true, "none", tags)
+	formattableTest3 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "U789", "MyTestName2", "Finished", "EnvFail", "myUserId1", true, "none", tags)
+	formattableTest4 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L123", "MyTestName3", "UNKNOWN", "", "myUserId2", false, "none", tags)
+	formattableTest5 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L456", "MyTestName4", "Building", "EnvFail", "myUserId1", false, "none", tags)
+	formattableTest6 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L789", "MyTestName5", "Finished", "Passed With Defects", "myUserId2", false, "none", tags)
+	formattableTest7 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C111", "MyTestName6", "Finished", "Failed", "myUserId1", false, "none", tags)
+	formattableTest8 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C222", "MyTestName7", "Finished", "UNKNOWN", "myUserId2", false, "none", tags)
+	formattableTest9 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C333", "MyTestName8", "Finished", "Ignored", "myUserId1", true, "none", tags)
+	formattableTest10 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L321", "MyTestName9", "UNKNOWN", "", "myUserId2", true, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9, formattableTest10)
 
 	// When...
@@ -197,13 +205,13 @@ func TestSummaryFormatterMultipleRunsWithUnknownStatusOfLostRunsDoesNotDisplayLo
 
 	assert.Nil(t, err)
 	expectedFormattedOutput :=
-		"submitted-time(UTC) name requestor status   result              test-name   group\n" +
-			"2023-05-04 10:45:29 U123 myUserId1 Finished Passed              TestName    none\n" +
-			"2023-05-04 10:55:29 L123 myUserId2 UNKNOWN                      MyTestName3 none\n" +
-			"2023-05-04 10:55:29 L456 myUserId1 Building EnvFail             MyTestName4 none\n" +
-			"2023-05-04 10:55:29 L789 myUserId2 Finished Passed With Defects MyTestName5 none\n" +
-			"2023-05-04 10:55:29 C111 myUserId1 Finished Failed              MyTestName6 none\n" +
-			"2023-05-04 10:55:29 C222 myUserId2 Finished UNKNOWN             MyTestName7 none\n" +
+		"submitted-time(UTC) name requestor status   result              test-name   group tags\n" +
+			"2023-05-04 10:45:29 U123 myUserId1 Finished Passed              TestName    none  \n" +
+			"2023-05-04 10:55:29 L123 myUserId2 UNKNOWN                      MyTestName3 none  \n" +
+			"2023-05-04 10:55:29 L456 myUserId1 Building EnvFail             MyTestName4 none  \n" +
+			"2023-05-04 10:55:29 L789 myUserId2 Finished Passed With Defects MyTestName5 none  \n" +
+			"2023-05-04 10:55:29 C111 myUserId1 Finished Failed              MyTestName6 none  \n" +
+			"2023-05-04 10:55:29 C222 myUserId2 Finished UNKNOWN             MyTestName7 none  \n" +
 			"\n" +
 			"Total:10 Passed:1 PassedWithDefects:1 Failed:1 Lost:4 EnvFail:1 UNKNOWN:1 Active:1\n"
 
@@ -214,7 +222,8 @@ func TestSummaryFormatterHasTestWithoutTimeStamps(t *testing.T) {
 	formatter := NewSummaryFormatter()
 
 	formattableTest := make([]FormattableTest, 0)
-	formattableTest1 := createFormattableTestForSummary("", "U123", "TestName", "Finished", "Passed", "myUserId1", false, "none")
+	tags := []string{}
+	formattableTest1 := createFormattableTestForSummary("", "U123", "TestName", "Finished", "Passed", "myUserId1", false, "none", tags)
 	formattableTest = append(formattableTest, formattableTest1)
 
 	// When...
@@ -222,8 +231,31 @@ func TestSummaryFormatterHasTestWithoutTimeStamps(t *testing.T) {
 
 	assert.Nil(t, err)
 	expectedFormattedOutput :=
-		"submitted-time(UTC) name requestor status   result test-name group\n" +
-			"                    U123 myUserId1 Finished Passed TestName  none\n" +
+		"submitted-time(UTC) name requestor status   result test-name group tags\n" +
+			"                    U123 myUserId1 Finished Passed TestName  none  \n" +
+			"\n" +
+			"Total:1 Passed:1\n"
+
+	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
+}
+
+func TestSummaryFormatterHasTestWithTags(t *testing.T) {
+	formatter := NewSummaryFormatter()
+
+	formattableTest := make([]FormattableTest, 0)
+	tags := []string{}
+	tags = append(tags, "a")
+	tags = append(tags, "b")
+	formattableTest1 := createFormattableTestForSummary("", "U123", "TestName", "Finished", "Passed", "myUserId1", false, "none", tags)
+	formattableTest = append(formattableTest, formattableTest1)
+
+	// When...
+	actualFormattedOutput, err := formatter.FormatRuns(formattableTest)
+
+	assert.Nil(t, err)
+	expectedFormattedOutput :=
+		"submitted-time(UTC) name requestor status   result test-name group tags\n" +
+			"                    U123 myUserId1 Finished Passed TestName  none  a,b\n" +
 			"\n" +
 			"Total:1 Passed:1\n"
 

--- a/modules/cli/pkg/utils/runSubmitCmdValues.go
+++ b/modules/cli/pkg/utils/runSubmitCmdValues.go
@@ -24,5 +24,6 @@ type RunsSubmitCmdValues struct {
 	ThrottleFileName              string
 	PortfolioFileName             string
 	OverrideFilePaths             []string
+	Tags                          []string
 	TestSelectionFlagValues       *TestSelectionFlagValues
 }

--- a/modules/cli/pkg/utils/stringLists.go
+++ b/modules/cli/pkg/utils/stringLists.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package utils
+
+import "strings"
+
+// The input is a slice containing strings, each of which could contain a single tag, or multiple tags in a
+// comma-separated list.
+// Here we mutate them into a single slice of tag strings, so they are all separate.
+// We can also remove duplicates.
+func CombineAllCommaSeparatedLists(stringListInputs []string) ([]string, error) {
+	var err error
+
+	collectedStrings := []string{}
+
+	for _, commaSeparatedList := range stringListInputs {
+		parts := strings.Split(commaSeparatedList, ",")
+
+		for _, part := range parts {
+			collectedStrings = append(collectedStrings, strings.TrimSpace(part))
+		}
+	}
+
+	return collectedStrings, err
+}

--- a/modules/cli/pkg/utils/stringLists_test.go
+++ b/modules/cli/pkg/utils/stringLists_test.go
@@ -1,0 +1,167 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoTagsInAreGatheredOk(t *testing.T) {
+
+	inputTagParameters := []string{}
+
+	cmdValues := RunsSubmitCmdValues{
+		Tags: inputTagParameters,
+	}
+
+	tagsOut, err := CombineAllCommaSeparatedLists(cmdValues.Tags)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, tagsOut)
+	assert.Len(t, tagsOut, 0)
+}
+
+func TestNilTagsInAreGatheredOk(t *testing.T) {
+
+	cmdValues := RunsSubmitCmdValues{
+		Tags: nil,
+	}
+
+	tagsOut, err := CombineAllCommaSeparatedLists(cmdValues.Tags)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, tagsOut)
+	assert.Len(t, tagsOut, 0)
+}
+
+func TestOneTagInIsGatheredOk(t *testing.T) {
+
+	inputTagParameters := []string{}
+	inputTagParameters = append(inputTagParameters, "tag1")
+
+	cmdValues := RunsSubmitCmdValues{
+		Tags: inputTagParameters,
+	}
+
+	tagsOut, err := CombineAllCommaSeparatedLists(cmdValues.Tags)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, tagsOut)
+	assert.Len(t, tagsOut, 1)
+	assert.EqualValues(t, tagsOut[0], "tag1")
+}
+
+func TestOneTagWithSpacesInIsGatheredOk(t *testing.T) {
+
+	inputTagParameters := []string{}
+	inputTagParameters = append(inputTagParameters, "   tag1   ")
+
+	cmdValues := RunsSubmitCmdValues{
+		Tags: inputTagParameters,
+	}
+
+	tagsOut, err := CombineAllCommaSeparatedLists(cmdValues.Tags)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, tagsOut)
+	assert.Len(t, tagsOut, 1)
+	assert.EqualValues(t, tagsOut[0], "tag1")
+}
+
+func TestTwoTagsInIsGatheredOk(t *testing.T) {
+
+	inputTagParameters := []string{}
+	inputTagParameters = append(inputTagParameters, "tag1")
+	inputTagParameters = append(inputTagParameters, "tag2")
+
+	cmdValues := RunsSubmitCmdValues{
+		Tags: inputTagParameters,
+	}
+
+	tagsOut, err := CombineAllCommaSeparatedLists(cmdValues.Tags)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, tagsOut)
+	assert.Len(t, tagsOut, 2)
+	assert.EqualValues(t, tagsOut[0], "tag1")
+	assert.EqualValues(t, tagsOut[1], "tag2")
+}
+
+func TestTwoTagsInAListIsGatheredOk(t *testing.T) {
+
+	inputTagParameters := []string{}
+	inputTagParameters = append(inputTagParameters, "tag1,tag2")
+
+	cmdValues := RunsSubmitCmdValues{
+		Tags: inputTagParameters,
+	}
+
+	tagsOut, err := CombineAllCommaSeparatedLists(cmdValues.Tags)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, tagsOut)
+	assert.Len(t, tagsOut, 2)
+	assert.EqualValues(t, tagsOut[0], "tag1")
+	assert.EqualValues(t, tagsOut[1], "tag2")
+}
+
+func TestTwoTagsInAListWithSpacesIsGatheredOk(t *testing.T) {
+
+	inputTagParameters := []string{}
+	inputTagParameters = append(inputTagParameters, "  tag1  , tag2     ")
+
+	cmdValues := RunsSubmitCmdValues{
+		Tags: inputTagParameters,
+	}
+
+	tagsOut, err := CombineAllCommaSeparatedLists(cmdValues.Tags)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, tagsOut)
+	assert.Len(t, tagsOut, 2)
+	assert.EqualValues(t, tagsOut[0], "tag1")
+	assert.EqualValues(t, tagsOut[1], "tag2")
+}
+
+func TestTwoTagsInAListWithSpacesAndTabsIsGatheredOk(t *testing.T) {
+
+	inputTagParameters := []string{}
+	inputTagParameters = append(inputTagParameters, "  tag1 \t , tag2    \t ")
+
+	cmdValues := RunsSubmitCmdValues{
+		Tags: inputTagParameters,
+	}
+
+	tagsOut, err := CombineAllCommaSeparatedLists(cmdValues.Tags)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, tagsOut)
+	assert.Len(t, tagsOut, 2)
+	assert.EqualValues(t, tagsOut[0], "tag1")
+	assert.EqualValues(t, tagsOut[1], "tag2")
+}
+
+func TestAMixOfTagListsAndSingleTagsAreGatheredOk(t *testing.T) {
+
+	inputTagParameters := []string{}
+	inputTagParameters = append(inputTagParameters, "tag1,tag2")
+	inputTagParameters = append(inputTagParameters, "tag3")
+
+	cmdValues := RunsSubmitCmdValues{
+		Tags: inputTagParameters,
+	}
+
+	tagsOut, err := CombineAllCommaSeparatedLists(cmdValues.Tags)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, tagsOut)
+	assert.Len(t, tagsOut, 3)
+	assert.EqualValues(t, tagsOut[0], "tag1")
+	assert.EqualValues(t, tagsOut[1], "tag2")
+	assert.EqualValues(t, tagsOut[2], "tag3")
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasStore.java
@@ -267,6 +267,13 @@ public class CouchdbRasStore extends CouchdbStore implements IResultArchiveStore
 
         String jsonStructure = gson.toJson(testStructure);
 
+        // logger.info("Storing this json structure into couchdb:"+jsonStructure);
+        // try {
+        //     throw new Exception("This is just to get the stack trace while developing");
+        // } catch( Exception ex ) {
+        //     logger.info("stack trace is ",ex);
+        // }
+
         HttpEntityEnclosingRequestBase request;
         if (runDocumentId == null) {
             request = httpRequestFactory.getHttpPostRequest(this.storeUri + "/"+RUNS_DB);

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasStore.java
@@ -267,13 +267,6 @@ public class CouchdbRasStore extends CouchdbStore implements IResultArchiveStore
 
         String jsonStructure = gson.toJson(testStructure);
 
-        // logger.info("Storing this json structure into couchdb:"+jsonStructure);
-        // try {
-        //     throw new Exception("This is just to get the stack trace while developing");
-        // } catch( Exception ex ) {
-        //     logger.info("stack trace is ",ex);
-        // }
-
         HttpEntityEnclosingRequestBase request;
         if (runDocumentId == null) {
             request = httpRequestFactory.getHttpPostRequest(this.storeUri + "/"+RUNS_DB);

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
@@ -7,6 +7,7 @@ package dev.galasa.ras.couchdb.internal.mocks;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 import dev.galasa.api.run.Run;
 import dev.galasa.framework.spi.IRun;
@@ -143,5 +144,9 @@ public class MockIRun implements IRun {
     @Override
     public List<RunRasAction> getRasActions() {
         throw new UnsupportedOperationException("Unimplemented method 'getRasActions'");
+    }
+
+    public Set<String> getTags() {
+        throw new UnsupportedOperationException("Unimplemented method 'getTags'");
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
@@ -64,13 +64,13 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
 
     @Override
     public @NotNull IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
-            String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
+            String mavenRepository, String obr, String stream, boolean local, boolean trace, Set<String> tags, Properties overrides,
             SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId)
             throws FrameworkException {
             if (stream.equals("null")){
                 throw new FrameworkException(language);
             }
-        return new MockIRun("runname"+testName, type, requestor, testName, sharedEnvironmentRunName, bundleName, language, groupName, this.mockSubmissionId);
+        return new MockIRun("runname"+testName, type, requestor, testName, sharedEnvironmentRunName, bundleName, language, groupName, this.mockSubmissionId, tags);
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
@@ -7,6 +7,8 @@ package dev.galasa.framework.api.common.mocks;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import dev.galasa.api.run.Run;
 import dev.galasa.framework.spi.IRun;
@@ -31,7 +33,7 @@ public class MockIRun implements IRun{
     private String repo;
     private String obr;
     private String result = "Passed";
-
+    private Set<String> tags ;
     
     public MockIRun(
         String runName,
@@ -42,7 +44,8 @@ public class MockIRun implements IRun{
         String bundle,
         String testClass,
         String groupName,
-        String submissionId
+        String submissionId,
+        Set<String> tags
     ) {
         this.runName = runName;
         this.runType = runType;
@@ -53,6 +56,10 @@ public class MockIRun implements IRun{
         this.testClass = testClass;
         this.groupName = groupName;
         this.submissionId = submissionId;
+        this.tags = new HashSet<String>();
+        if( tags != null) {
+            this.tags.addAll(tags);
+        }
     }
 
     @Override
@@ -143,7 +150,7 @@ public class MockIRun implements IRun{
     @Override
     public Run getSerializedRun() {
         return new Run(runName, heartbeat, runType, groupName, testClass, bundle, test, runStatus, result, queued,
-                finished, waitUntil, requestor, stream, repo, obr, false, false, "cdb-"+runName, submissionId);
+                finished, waitUntil, requestor, stream, repo, obr, false, false, "cdb-"+runName, submissionId, tags);
     }
 
     @Override
@@ -180,4 +187,10 @@ public class MockIRun implements IRun{
     public List<RunRasAction> getRasActions() {
         throw new UnsupportedOperationException("Unimplemented method 'getRasActions'");
     }
+    public Set<String> getTags() {
+        Set<String> tagsToReturn = new HashSet<String>();
+        tagsToReturn.addAll(this.tags);
+        return tagsToReturn;
+    }
+    
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -2851,6 +2851,10 @@ components:
           type: boolean
         rasRunId:
           type: string
+        tags:
+          type: array
+          items:
+            type: string
     TestRunRequest:
       type: object
       properties:
@@ -2884,6 +2888,16 @@ components:
           type: object
         trace:
           type: boolean
+        tags:
+          description: |-
+            A set of tag strings which are associated with this test run in the future.
+            These might include details which help categorise test results for charting for example.
+            Duplicate tags are ignored.
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+
     UpdateGalasaMonitorRequest:
       type: object
       properties:
@@ -3057,6 +3071,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TestMethod'
+        tags: 
+          type: array
+          items: 
+            type: string
     TestMethod:
       type: object
       properties:

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RunResultUtility.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RunResultUtility.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
@@ -67,8 +68,9 @@ public class RunResultUtility {
 	   String group = struc.getGroup();
 	   String submissionId = struc.getSubmissionId();
 	   List<RasTestMethod> rasMethods = convertMethods(methods);
+	   Set<String> tags = struc.getTags();
 	   
-	   return new RasTestStructure(runName, bundle, testName, testShortName, requestor, status, result, queued, startTime, endTime, rasMethods, group, submissionId);
+	   return new RasTestStructure(runName, bundle, testName, testShortName, requestor, status, result, queued, startTime, endTime, rasMethods, group, submissionId, tags);
 	}
 	
 	private static List<RasTestMethod> convertMethods(List<TestMethod> methods){

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
@@ -45,7 +45,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 
     public String generateExpectedJson (String runId, String runName, String submissionId) {
 
-		RasTestStructure testStructure = new RasTestStructure(runName, null, null, null, "galasa", null, "Passed", null, null, null, Collections.emptyList(), "none", submissionId);
+		RasTestStructure testStructure = new RasTestStructure(runName, null, null, null, "galasa", null, "Passed", null, null, null, Collections.emptyList(), "none", submissionId, new HashSet<String>());
 		RasRunResult rasRunResult = new RasRunResult(runId, Collections.emptyList(), testStructure);
 
 		testStructure.setRunName(runName);
@@ -404,7 +404,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
+		Set<String> tags = new HashSet<>();
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1", tags));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
@@ -440,7 +441,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT",headerMap);
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
+		Set<String> tags = new HashSet<>();
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1",tags));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
@@ -474,7 +476,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
+		Set<String> tags = new HashSet<>();
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1",tags));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
@@ -515,7 +518,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
+		Set<String> tags = new HashSet<>();
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1",tags));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
@@ -556,7 +560,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
+		Set<String> tags = new HashSet<>();
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1",tags));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
@@ -592,7 +597,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
+		Set<String> tags = new HashSet<>();
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1",tags));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs) {
 			@Override
     		public boolean reset(String runname) throws DynamicStatusStoreException {
@@ -633,7 +639,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
+		Set<String> tags = new HashSet<>();
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1",tags));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs) {
 			@Override
 			public boolean markRunCancelled(String runname) throws DynamicStatusStoreException {
@@ -674,7 +681,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
+		Set<String> tags = new HashSet<>();
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1",tags));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs) {
 			@Override
     		public boolean reset(String runname) throws DynamicStatusStoreException {
@@ -715,7 +723,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
+		Set<String> tags = new HashSet<>();
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1",tags));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs) {
 			@Override
 			public boolean markRunCancelled(String runname) throws DynamicStatusStoreException {
@@ -756,7 +765,8 @@ public class TestRunDetailsRoute extends RasServletTest {
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT");
 		
 		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1"));
+		Set<String> tags = new HashSet<>();
+		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1", "submission1",tags));
 		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
 		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
 		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunQuery.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunQuery.java
@@ -185,6 +185,7 @@ public class TestRunQuery extends RasServletTest {
         jsonResult.addProperty("amountOfRuns", mockInputRunResults.size());
         jsonResult.addProperty("nextCursor", nextCursor);
         jsonResult.add("runs", runsJson);
+
 		return gson.toJson(jsonResult);
 	}
 
@@ -2224,9 +2225,13 @@ public class TestRunQuery extends RasServletTest {
 		servlet.doGet(req,resp);
 
 		// Then...
+		String payloadGotBack = outStream.toString();
+		// System.out.println("Got back: "+payloadGotBack);
 		String expectedJson = generateExpectedJson(mockInputRunResults, nextCursor, pageSize);
+
+		// System.out.println("Expected: "+expectedJson);
 		assertThat(resp.getStatus()).isEqualTo(200);
-		assertThat(outStream.toString()).isEqualTo(expectedJson);
+		assertThat(payloadGotBack).isEqualTo(expectedJson);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
 	}
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
@@ -120,6 +120,7 @@ public class GroupRuns extends ProtectedRoute {
                     request.getTestStream(),
                     false,
                     request.isTrace(),
+                    request.getTags(),
                     request.getOverrides(), 
                     senvPhase, 
                     request.getSharedEnvironmentRunName(),

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/RunsServletTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/RunsServletTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -92,8 +93,8 @@ public class RunsServletTest extends BaseServletTest {
 	    return this.resp;
 	}
 
-    protected void addRun(String runName, String runType, String requestor, String test, String runStatus, String bundle, String testClass, String groupName, String submissionId){
-		this.runs.add(new MockIRun( runName, runType, requestor, test, runStatus, bundle, testClass, groupName, submissionId));
+    protected void addRun(String runName, String runType, String requestor, String test, String runStatus, String bundle, String testClass, String groupName, String submissionId, Set<String> tags){
+		this.runs.add(new MockIRun( runName, runType, requestor, test, runStatus, bundle, testClass, groupName, submissionId, tags));
     }
 
 	protected String generateExpectedJson(List<IRun> runs, boolean complete) {
@@ -128,6 +129,12 @@ public class RunsServletTest extends BaseServletTest {
             runJson.addProperty("isTraceEnabled", false);
             runJson.addProperty("rasRunId", "cdb-" + run.getName());
 
+            JsonArray tagsArray = new JsonArray();
+            for( String tag : run.getTags() ) {
+                tagsArray.add(tag);
+            }
+            runJson.add("tags", tagsArray);
+
             runsJsonArray.add(runJson);
         }
 
@@ -137,13 +144,13 @@ public class RunsServletTest extends BaseServletTest {
         return expectedJson;
     }
 
-    protected String generatePayload(String[] classNames, String requestorType, String requestor, String testStream, String groupName, String overrideExpectedRequestor, String submissionId) {
+    protected String generatePayload(String[] classNames, String requestorType, String requestor, String testStream, String groupName, String overrideExpectedRequestor, String submissionId, Set<String>tags) {
         String classes ="";
         if (overrideExpectedRequestor !=null){
             requestor = overrideExpectedRequestor;
         }
         for (String className : classNames){
-            addRun( "runnamename", requestorType, requestor, "name", "submitted", className.split("/")[0], "java", groupName, submissionId);
+            addRun( "runnamename", requestorType, requestor, "name", "submitted", className.split("/")[0], "java", groupName, submissionId, tags);
             classes += "\""+className+"\",";
         }
         classes = classes.substring(0, classes.length()-1);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -7,6 +7,8 @@ package dev.galasa.framework.api.runs.routes;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import javax.servlet.ServletOutputStream;
@@ -218,7 +220,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "framework";
         String submissionId = "submission1";
-        addRun("name1", "type1", "requestor1", "test1", "FINISHED","bundle1", "testClass1", groupName, submissionId);
+        Set<String> tags = new HashSet<>();
+        addRun("name1", "type1", "requestor1", "test1", "FINISHED","bundle1", "testClass1", groupName, submissionId,tags);
         setServlet("/"+groupName, groupName, this.runs);
 		MockRunsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
@@ -240,8 +243,9 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "framework";
         String submissionId = "submission1";
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId);
+        Set<String> tags = new HashSet<>();
+        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags);
+        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags);
         setServlet("/"+groupName, groupName, this.runs);
 		MockRunsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
@@ -263,16 +267,17 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "framework";
         String submissionId = "submission1";
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId);
-        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId);
-        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId);
-        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId);
-        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId);
-        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId);
-        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId);
-        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId);
-        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId);
+        Set<String> tags = new HashSet<>();
+        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags);
+        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags);
+        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId,tags);
+        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId,tags);
+        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId,tags);
+        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId,tags);
+        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId,tags);
+        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId,tags);
+        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId,tags);
+        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId,tags);
         setServlet("/"+groupName, groupName, this.runs);
 		MockRunsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
@@ -294,16 +299,17 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
         String submissionId = "submission1";
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId);
-        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId);
-        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId);
-        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId);
-        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId);
-        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId);
-        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId);
-        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId);
-        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId);
+        Set<String> tags = new HashSet<>();
+        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags);
+        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags);
+        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId,tags);
+        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId,tags);
+        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId,tags);
+        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId,tags);
+        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId,tags);
+        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId,tags);
+        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId,tags);
+        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId,tags);
         setServlet("/"+groupName, groupName, this.runs);
 		MockRunsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
@@ -490,8 +496,9 @@ public class TestGroupRunsRoute extends RunsServletTest{
         "\"sharedEnvironmentRunTime\": \"envRunTime\"," +
         "\"overrides\": {}," +
         "\"trace\": true }";
+        Set<String> tags = new HashSet<>();
         addRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted",
-               "Class", "java", groupName, submissionId);
+               "Class", "java", groupName, submissionId,tags);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -516,7 +523,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "valid";
         String[] classes = new String[]{"Class/name"};
         String submissionId = "submission1";
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId);
+        Set<String> tags = new HashSet<>();
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId,tags);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -540,7 +548,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "valid";
         String[] classes = new String[]{"Class/name"};
         String submissionId = "submission1";
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, null, groupName, null, submissionId);
+        Set<String> tags = new HashSet<>();
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, null, groupName, null, submissionId,tags);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -566,7 +575,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "valid";
         String[] classes = new String[]{"Class1/name", "Class2/name"};
         String submissionId = "submission1";
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId);
+        Set<String> tags = new HashSet<>();
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId,tags);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -590,7 +600,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
         String[] classes = new String[]{"Class1/name", "Class2/name"};
         String submissionId = "submission1";
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId);
+        Set<String> tags = new HashSet<>();
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId, tags);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -628,8 +639,9 @@ public class TestGroupRunsRoute extends RunsServletTest{
         "\"overrides\": {}," +
         "\"trace\": true }";
 
+        Set<String> tags = new HashSet<>();
         addRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted",
-               "Class", "java", groupName, submissionId);
+               "Class", "java", groupName, submissionId,tags);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -654,7 +666,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "valid";
         String[] classes = new String[]{"Class/name"};
         String submissionId = "submission1";
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId);
+        Set<String> tags = new HashSet<>();
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId, tags);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -678,7 +691,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "valid";
         String submissionId = "submission1";
         String[] classes = new String[]{"Class1/name", "Class2/name"};
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId);
+        Set<String> tags = new HashSet<>();
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId,tags);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();
@@ -702,7 +716,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
         String[] classes = new String[]{"Class1/name", "Class2/name"};
         String submissionId = "submission1";
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId);
+        Set<String> tags = new HashSet<>();
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId,tags);
 
         setServlet("/"+groupName, groupName, payload, "POST");
 		MockRunsServlet servlet = getServlet();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -185,6 +185,11 @@ public class BaseTestRunner {
         }
     }
 
+    /**
+     * Create a new test structure, and populate it with as much information as we can from the DSS.
+     * @param run The run structure. It has data loaded already from the DSS
+     * @return A TestStructure which is written into the RAS eventually.
+     */
     protected TestStructure createNewTestStructure(IRun run) {
         TestStructure testStructure = new TestStructure();
 
@@ -200,6 +205,11 @@ public class BaseTestRunner {
         testStructure.setRequestor(requestor);
         testStructure.setGroup(group);
         testStructure.setSubmissionId(submissionId);
+        
+        for( String tag : run.getTags()) {
+            testStructure.addTag(tag);
+        }
+
         return testStructure;
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -186,7 +186,7 @@ public class FrameworkRuns implements IFrameworkRuns {
     @NotNull
     public @NotNull IRun submitRun(String runType, String requestor, String bundleName,
             @NotNull String testName, String groupName, String mavenRepository, String obr, String stream,
-            boolean local, boolean trace, Properties overrides, SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName,
+            boolean local, boolean trace, Set<String> tags, Properties overrides, SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName,
             String language, String submissionId) throws FrameworkException {
         SubmitRunRequest runRequest = new SubmitRunRequest(
             runType,
@@ -200,6 +200,7 @@ public class FrameworkRuns implements IFrameworkRuns {
             stream,
             local,
             trace,
+            tags,
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
@@ -224,6 +225,7 @@ public class FrameworkRuns implements IFrameworkRuns {
         Properties overrides = runRequest.getOverrides();
         boolean local = runRequest.isLocalRun();
         boolean trace = runRequest.isTraceEnabled();
+        Set<String> tags = runRequest.getTags();
 
         String runPropertyPrefix = RUN_PREFIX + runName;
 
@@ -254,6 +256,12 @@ public class FrameworkRuns implements IFrameworkRuns {
         }
 
         otherRunProperties.put(runPropertyPrefix + ".submissionId", submissionId);
+
+        if (tags != null) {
+            String tagsAsString = gson.toJson(tags);
+            otherRunProperties.put(runPropertyPrefix + ".tags",tagsAsString);
+        }
+
         otherRunProperties.put(runPropertyPrefix + ".requestor", requestor);
 
         if (sharedEnvironmentPhase != null) {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
@@ -145,6 +145,8 @@ public class RunImpl implements IRun {
             if (tagsAsString!= null && !tagsAsString.trim().isEmpty()) {
                 HashSet<?> tagSetOfObj = gson.fromJson(tagsAsString, HashSet.class);
                 for( Object entry : tagSetOfObj) {
+                    // Tags are always going to be strings, so we can safely cast as a string,
+                    // but do an instanceof check to keep the compiler happy.
                     if( entry instanceof String) {
                         tags.add((String)entry);
                     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ValidateEcosystem.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ValidateEcosystem.java
@@ -7,6 +7,7 @@ package dev.galasa.framework;
 
 import java.time.Instant;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 
 import org.apache.commons.logging.Log;
@@ -24,6 +25,8 @@ public class ValidateEcosystem {
     private Log             logger  =  LogFactory.getLog(this.getClass());
     
     private IFramework framework;
+
+    private static final Set<String> NULL_TAGS = null ;
     
     /**
      * <p>Validate the Ecosystem will work for remote access</p>
@@ -68,7 +71,8 @@ public class ValidateEcosystem {
                     null, 
                     null, 
                     false, 
-                    true, 
+                    true,
+                    NULL_TAGS, 
                     null, 
                     null, 
                     null, 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/SubmitRunRequest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/SubmitRunRequest.java
@@ -5,7 +5,9 @@
  */
 package dev.galasa.framework.beans;
 
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IFrameworkRuns.SharedEnvironmentPhase;
@@ -26,6 +28,7 @@ public class SubmitRunRequest {
     private String stream;
     private boolean isLocalRun;
     private boolean isTraceEnabled = false;
+    private Set<String> tags = new HashSet<>();
     private Properties overrides = new Properties();
     private SharedEnvironmentPhase sharedEnvironmentPhase;
     private String sharedEnvironmentRunName;
@@ -45,6 +48,7 @@ public class SubmitRunRequest {
         String stream,
         boolean isLocalRun,
         boolean isTraceEnabled,
+        Set<String> tags,
         Properties overrides,
         SharedEnvironmentPhase sharedEnvironmentPhase,
         String sharedEnvironmentRunName,
@@ -62,6 +66,9 @@ public class SubmitRunRequest {
         this.stream = stream;
         this.isLocalRun = isLocalRun;
         this.isTraceEnabled = isTraceEnabled;
+        if (tags!=null) {
+            this.tags.addAll(tags);
+        }
         this.overrides = overrides;
         this.sharedEnvironmentPhase = sharedEnvironmentPhase;
         this.sharedEnvironmentRunName = sharedEnvironmentRunName;
@@ -205,5 +212,13 @@ public class SubmitRunRequest {
 
     public void setSubmissionId(String submissionId) {
         this.submissionId = submissionId;
+    }
+
+    public void setTags(Set<String> newTags) {
+        this.tags = newTags ;
+    }
+
+    public Set<String> getTags() {
+        return this.tags ;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/TestRunInitStrategy.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/init/TestRunInitStrategy.java
@@ -6,6 +6,7 @@
 package dev.galasa.framework.internal.init;
 
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 
 import org.apache.commons.logging.Log;
@@ -28,6 +29,8 @@ public class TestRunInitStrategy implements IFrameworkInitialisationStrategy {
 
     private final static Log logger = LogFactory.getLog(Framework.class);
     private static final GalasaGson gson = new GalasaGson();
+
+    private static final Set<String> NULL_TAGS = null;
 
     @Override
     public void startLoggingCapture(Framework framework) {
@@ -63,7 +66,7 @@ public class TestRunInitStrategy implements IFrameworkInitialisationStrategy {
         return runName;
     }
 
-        /**
+    /**
      * Submit the run and return the run name.
      * 
      * @param runBundleClass
@@ -81,10 +84,10 @@ public class TestRunInitStrategy implements IFrameworkInitialisationStrategy {
                 String split[] = runBundleClass.split("/");
                 String bundle = split[0];
                 String test = split[1];
-                run = frameworkRuns.submitRun("local", null, bundle, test, null, null, null, null, true, false, null, null, null, language, submissionId);
+                run = frameworkRuns.submitRun("local", null, bundle, test, null, null, null, null, true, false, NULL_TAGS, null, null, null, language, submissionId);
                 break;
             case "gherkin":
-                run = frameworkRuns.submitRun("local", null, null, runBundleClass, null, null, null, null, true, false, null, null, null, language, submissionId);
+                run = frameworkRuns.submitRun("local", null, null, runBundleClass, null, null, null, null, true, false, NULL_TAGS, null, null, null, language, submissionId);
                 break;
             default:
                 throw new FrameworkException("Unknown language to create run");

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
@@ -36,7 +36,7 @@ public interface IFrameworkRuns {
 
     @NotNull
     IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
-            String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
+            String mavenRepository, String obr, String stream, boolean local, boolean trace, Set<String> tags, Properties overrides,
             SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId) throws FrameworkException;
 
     boolean delete(String runname) throws DynamicStatusStoreException;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
@@ -7,6 +7,7 @@ package dev.galasa.framework.spi;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 import dev.galasa.api.run.Run;
 
@@ -61,4 +62,5 @@ public interface IRun {
     String getRasRunId();
 
     List<RunRasAction> getRasActions();
+    public Set<String> getTags();
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/teststructure/TestStructure.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/teststructure/TestStructure.java
@@ -44,9 +44,15 @@ public class TestStructure {
 
     private List<String>     artifactRecordIds;
 
+    private Set<String>     tags = new HashSet<String>();
+
     public TestStructure() {
     }
 
+    /**
+     * Deep clone the source Test stucture.
+     * @param source
+     */
     public TestStructure( TestStructure source ) {
         if (source!=null) {
             this.runName = source.runName;
@@ -75,7 +81,27 @@ public class TestStructure {
                 this.artifactRecordIds = new ArrayList<String>();
                 this.artifactRecordIds.addAll(source.artifactRecordIds);
             }
+            if (source.tags != null ) {
+                this.tags = new HashSet<String>();
+                this.tags.addAll(source.tags);
+            }
         }
+    }
+
+    /**
+     * @return a deep clone of the tags set associated with this test structure.
+     * If you wish to manipulate the test structure directly, use the {@link #addTag() addTag} and {@link #removeTag() void} calls.
+     */
+    public Set<String> getTags() {
+        Set<String> tagsToReturn = new HashSet<String>();
+        tagsToReturn.addAll(tags);
+        return tagsToReturn;
+    }
+    public void addTag(String additionalTag) {
+        this.tags.add(additionalTag);
+    }
+    public void removeTag(String tagToRemove) {
+        this.tags.remove(tagToRemove);
     }
 
     public String getSubmissionId() {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/teststructure/TestStructure.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/teststructure/TestStructure.java
@@ -90,7 +90,7 @@ public class TestStructure {
 
     /**
      * @return a deep clone of the tags set associated with this test structure.
-     * If you wish to manipulate the test structure directly, use the {@link #addTag() addTag} and {@link #removeTag() void} calls.
+     * If you wish to manipulate the test structure directly, use the {@link #addTag(java.lang.String) Set<String>} and {@link #removeTag(java.lang.String) void} calls.
      */
     public Set<String> getTags() {
         Set<String> tagsToReturn = new HashSet<String>();
@@ -293,6 +293,10 @@ public class TestStructure {
 
         if (this.queued == null) {
             this.queued = this.startTime;
+        }
+
+        if (this.tags == null) {
+            this.tags = new HashSet<String>();
         }
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
@@ -13,6 +13,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.Map.Entry;
 
 import org.junit.BeforeClass;
@@ -73,6 +74,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
         String override1Key = "override1";
@@ -98,6 +100,7 @@ public class FrameworkRunsTest {
             stream,
             local,
             trace,
+            tags,
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
@@ -150,6 +153,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
         String override1Key = "override1";
@@ -175,6 +179,7 @@ public class FrameworkRunsTest {
             stream,
             local,
             trace,
+            tags,
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
@@ -229,6 +234,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
         String override1Key = "override1";
@@ -255,6 +261,7 @@ public class FrameworkRunsTest {
                 stream,
                 local,
                 trace,
+                tags,
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
@@ -289,6 +296,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
 
@@ -309,6 +317,7 @@ public class FrameworkRunsTest {
                 stream,
                 local,
                 trace,
+                tags,
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
@@ -343,6 +352,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
 
@@ -363,6 +373,7 @@ public class FrameworkRunsTest {
                 stream,
                 local,
                 trace,
+                tags,
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
@@ -398,6 +409,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
 
@@ -416,6 +428,7 @@ public class FrameworkRunsTest {
             stream,
             local,
             trace,
+            tags,
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
@@ -451,6 +464,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
 
@@ -469,6 +483,7 @@ public class FrameworkRunsTest {
             stream,
             local,
             trace,
+            tags,
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
@@ -504,6 +519,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
 
@@ -522,6 +538,7 @@ public class FrameworkRunsTest {
             stream,
             local,
             trace,
+            tags,
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
@@ -575,6 +592,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
 
@@ -590,6 +608,7 @@ public class FrameworkRunsTest {
             stream,
             local,
             trace,
+            tags,
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
@@ -644,6 +663,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
 
@@ -660,6 +680,7 @@ public class FrameworkRunsTest {
                 stream,
                 local,
                 trace,
+                tags,
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
@@ -701,6 +722,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
 
@@ -716,6 +738,7 @@ public class FrameworkRunsTest {
             stream,
             local,
             trace,
+            tags,
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
@@ -762,6 +785,7 @@ public class FrameworkRunsTest {
         String stream = "a-test-stream";
         boolean local = true;
         boolean trace = true;
+        Set<String> tags = null ;
 
         Properties overrides = new Properties();
 
@@ -778,6 +802,7 @@ public class FrameworkRunsTest {
                 stream,
                 local,
                 trace,
+                tags,
                 overrides,
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestRunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestRunImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
+import java.util.*;
+
+import org.assertj.core.api.ByteArrayAssert;
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.*;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.utils.GalasaGson;
+
+public class TestRunImpl {
+
+    @Test
+    public void testCanCreateARunImplWithNothingInDss() throws Exception  {
+        String name = "U1234";
+        Map<String,String> properties = new HashMap<String,String>();
+        IDynamicStatusStoreService dss = new MockDSSStore(properties);
+        new RunImpl(name,dss);
+    }
+
+    @Test
+    public void testCanCreateARunImplWithARunInDss() throws Exception  {
+        String name = "U1234";
+        Map<String,String> dssProps = new HashMap<String,String>();
+
+        Set<String> tagsValueGoingIn = new HashSet<String>();
+        tagsValueGoingIn.add("tag1");
+        tagsValueGoingIn.add("tag2");
+        GalasaGson gson = new GalasaGson();
+        String tagsAsJsonString = gson.toJson(tagsValueGoingIn);
+        dssProps.put("run.U1234"+".tags", tagsAsJsonString);
+        IDynamicStatusStoreService dss = new MockDSSStore(dssProps);
+
+        RunImpl run = new RunImpl(name,dss);
+        Set<String> tagsGotBack = run.getTags();
+
+        assertThat( tagsGotBack).containsExactly("tag1","tag2");
+    }
+
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestRunner.java
@@ -44,6 +44,12 @@ public class TestTestRunner {
         String TEST_REQUESTOR_NAME = "daffyduck";
         boolean TEST_IS_LOCAL_RUN_TRUE = true;
         boolean IGNORE_TEST_CLASS_FALSE = false;
+        String TEST_GHERKIN_URL = "http://my.gherkin.url";
+        String TEST_GROUP = "myGroup";
+        String TEST_SUBMISSION_ID = "mySubmissionId";
+        Set<String> testTagsInput = new HashSet<String>();
+        testTagsInput.add("tag1");
+        testTagsInput.add("tag2");
 
         MockFileSystem mockFileSystem = new MockFileSystem();
         Properties overrideProps = new Properties();
@@ -59,7 +65,11 @@ public class TestTestRunner {
             TEST_STREAM_OBR , 
             TEST_STREAM_REPO_URL,
             TEST_REQUESTOR_NAME,
-            TEST_IS_LOCAL_RUN_TRUE
+            TEST_IS_LOCAL_RUN_TRUE,
+            TEST_GHERKIN_URL,
+            TEST_GROUP,
+            TEST_SUBMISSION_ID,
+            testTagsInput
         );
 
 
@@ -167,6 +177,9 @@ public class TestTestRunner {
         // initial setup.
         assertThat(rasHistory.get(0)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
             .containsExactly("myTestRun",null,null, null, "daffyduck", null,null);
+
+        // Check that the RAS structure is populated with tags from the outset.
+        assertThat(rasHistory.get(0).getTags()).containsOnly("tag1","tag2");
 
         // status = started
         assertThat(rasHistory.get(1)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
@@ -7,6 +7,7 @@ package dev.galasa.framework.spi.language.gherkin;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 import dev.galasa.api.run.Run;
 import dev.galasa.framework.spi.IRun;
@@ -143,5 +144,9 @@ public class MockRun implements IRun {
     @Override
     public List<RunRasAction> getRasActions() {
         throw new UnsupportedOperationException("Unimplemented method 'getRasActions'");
+    }
+    
+    public Set<String> getTags() {
+        throw new UnsupportedOperationException("Unimplemented method 'getTags'");
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/teststructure/TestTestStructure.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/teststructure/TestTestStructure.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.teststructure; 
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
+
+
+public class TestTestStructure {
+
+    @Test
+    public void testCanCreateTestStructureFromNothingWithDefaults() throws Exception {
+        TestStructure t = new TestStructure();
+        assertThat(t.getTags()).isNotNull().isEmpty();
+        assertThat(t.getSubmissionId()).isNull();
+        assertThat(t.getTestName()).isNull();
+        assertThat(t.getTestShortName()).isNull();
+        assertThat(t.getResult()).isNull();
+    }
+
+    private TestStructure getPopulatedTestStructure() throws Exception {
+        TestStructure t = new TestStructure();
+        t.setBundle("myBundle");
+        t.addTag("tag1");
+        t.addTag("tag2");
+        t.setSubmissionId("mySubmissionId");
+        t.setTestName("myTestName");
+        t.setTestShortName("myShortName");
+        t.setResult("myResult");
+        return t ;
+    }
+
+    private void assertTestStructureIsPopulated(TestStructure t) throws Exception {
+        assertThat(t.getBundle()).isEqualTo("myBundle");
+        assertThat(t.getTags()).containsExactlyInAnyOrder("tag1","tag2");
+        assertThat(t.getSubmissionId()).isEqualTo("mySubmissionId");
+        assertThat(t.getTestName()).isEqualTo("myTestName");
+        assertThat(t.getTestShortName()).isEqualTo("myShortName");
+        assertThat(t.getResult()).isEqualTo("myResult");
+    }
+
+    @Test
+    public void testCanCreateFilledInTestStructure() throws Exception {
+
+        TestStructure t = getPopulatedTestStructure();
+        assertTestStructureIsPopulated(t);
+    }
+
+    @Test
+    public void testCanCloneTestStructureFromAnother() throws Exception {
+        TestStructure t1 = getPopulatedTestStructure();
+        TestStructure t2 = new TestStructure(t1);
+        assertTestStructureIsPopulated(t2);
+    }
+
+    @Test
+    public void testCanRemoveTag() throws Exception {
+        TestStructure t = getPopulatedTestStructure();
+        t.removeTag("tag1");
+        assertThat(t.getTags()).containsExactlyInAnyOrder("tag2");
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
@@ -78,7 +78,7 @@ public class MockFrameworkRuns implements IFrameworkRuns{
 
     @Override
     public @NotNull IRun submitRun(String type, String requestor, String bundleName, String testName, String groupName,
-            String mavenRepository, String obr, String stream, boolean local, boolean trace, Properties overrides,
+            String mavenRepository, String obr, String stream, boolean local, boolean trace, Set<String> tags,Properties overrides,
             SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId)
             throws FrameworkException {
             if (stream.equals("null")){

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
@@ -7,6 +7,8 @@ package dev.galasa.framework.mocks;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import dev.galasa.api.run.Run;
@@ -31,6 +33,7 @@ public class MockRun implements IRun {
     private String result;
     private String runId;
     private List<RunRasAction> rasActions;
+    private Set<String> tags = new HashSet<String>();
 
     public MockRun(
         String testBundleName, 
@@ -43,14 +46,15 @@ public class MockRun implements IRun {
             testClassName, testRunName , 
             testStream, testStreamOBR, 
             testStreamRepoUrl, requestorName, 
-            isRunLocal ,null, null, UUID.randomUUID().toString());
+            isRunLocal ,null, null, UUID.randomUUID().toString(), new HashSet<String>());
     }
     public MockRun(
         String testBundleName, 
         String testClassName, String testRunName , 
         String testStream, String testStreamOBR, 
         String testStreamRepoUrl, String requestorName, 
-        boolean isRunLocal , String gherkinUrl, String group, String submissionId
+        boolean isRunLocal , 
+        String gherkinUrl, String group, String submissionId, Set<String>tags
     ) {
         this.testBundleName = testBundleName;
         this.testClassName = testClassName ;
@@ -62,6 +66,7 @@ public class MockRun implements IRun {
         this.isRunLocal = isRunLocal;
         this.gherkinUrl = gherkinUrl;
         this.submissionId = submissionId;
+        this.tags = tags;
     }
 
     // Shared environment not used very often so not adding
@@ -187,6 +192,10 @@ public class MockRun implements IRun {
     public void setRasActions(List<RunRasAction> rasActions) {
         this.rasActions = rasActions;
     }
+    
+    public Set<String> getTags() {
+        return this.tags;
+    }
 
     // ------------- un-implemented methods follow ----------------
 
@@ -219,4 +228,5 @@ public class MockRun implements IRun {
     public Run getSerializedRun() {
         throw new UnsupportedOperationException("Unimplemented method 'getSerializedRun'");
     }
+
 }

--- a/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/api/ras/RasTestStructure.java
+++ b/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/api/ras/RasTestStructure.java
@@ -7,6 +7,7 @@ package dev.galasa.api.ras;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 
 public class RasTestStructure {
@@ -24,10 +25,11 @@ public class RasTestStructure {
    private Instant startTime;
    private Instant endTime;
    private List<RasTestMethod> methods;
+   private Set<String> tags;
    
    public RasTestStructure(String runName, String bundle, String testName, String testShortName, String requestor,
          String status, String result, Instant queued, Instant startTime, Instant endTime, List<RasTestMethod> methods,
-         String group, String submissionId
+         String group, String submissionId, Set<String> tags
    ) {
       this.runName = runName;
       this.bundle = bundle;
@@ -42,6 +44,7 @@ public class RasTestStructure {
       this.methods = methods;
       this.group = group;
       this.submissionId = submissionId;
+      this.tags = tags;
    }
 
    public String getRunName() {
@@ -148,5 +151,12 @@ public class RasTestStructure {
       this.methods = methods;
    }
    
+   public Set<String> getTags() {
+      return this.tags;
+   }
+
+   public void setTags(Set<String> newTags) {
+      this.tags = newTags;
+   }
    
 }

--- a/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/api/run/Run.java
+++ b/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/api/run/Run.java
@@ -6,6 +6,8 @@
 package dev.galasa.api.run;
 
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 
 public class Run {
     private String  name;
@@ -28,12 +30,13 @@ public class Run {
     private boolean isLocal;
     private boolean isTraceEnabled;
     private String  rasRunId;
+    private Set<String> tags;
 
 
     public Run(String name, Instant heartbeat, String type, String group, String test, String bundleName,
             String testName, String status, String result, Instant queued, Instant finished, Instant waitUntil,
             String requestor, String stream, String repo, String obr, boolean isLocal, boolean isTraceEnabled,
-            String rasRunId, String submissionId
+            String rasRunId, String submissionId, Set<String> tags
     ) {
         this.name = name;
         this.heartbeat = heartbeat;
@@ -55,6 +58,11 @@ public class Run {
         this.isLocal = isLocal;
         this.isTraceEnabled = isTraceEnabled;
         this.rasRunId = rasRunId;
+
+        this.tags = new HashSet<String>();
+        if( tags != null) {
+            this.tags.addAll(tags);
+        }
     }
 
     public String getName() {
@@ -163,6 +171,10 @@ public class Run {
     
     public String getRasRunId() {
         return rasRunId;
+    }
+
+    public Set<String> getTags() {
+        return this.tags; 
     }
 
 }

--- a/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/api/runs/ScheduleRequest.java
+++ b/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/api/runs/ScheduleRequest.java
@@ -8,6 +8,7 @@ package dev.galasa.api.runs;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 public class ScheduleRequest implements Serializable {
     private static final long       serialVersionUID = 1L;
@@ -22,6 +23,7 @@ public class ScheduleRequest implements Serializable {
     private String                  sharedEnvironmentPhase;
     private String                  sharedEnvironmentRunName;
     private Properties              overrides;
+    private Set<String>             tags;
 
     public static long getSerialversionuid() {
         return serialVersionUID;
@@ -110,5 +112,12 @@ public class ScheduleRequest implements Serializable {
     }
     
     
+    public void setTags(Set<String> newTags) {
+        this.tags = newTags;
+    }
+
+    public Set<String> getTags() {
+        return this.tags;
+    }
 
 }


### PR DESCRIPTION
# Why ?

See issue [Add test tags to the JSON test report produced by Galasactl #1974](https://github.com/galasa-dev/projectmanagement/issues/1974)

- [x] CLI accepts tags on the command syntax when launching a remote test
- [x] REST submit test accepts a list of test tags
- [x] test tags stored in DSS
- [x] test tags stored in RAS
- [x] test tags returned with test structure on "galasactl runs get --age 1d"
- [x] CLI formats test tags in the summary and details view
- [x] CLI build process gets an old version of the openapi.yaml from main?
- [ ] codeql stage of build is not happy if you change the openapi.yaml and generate code with it in the same PR

