### PR TITLE
mcobbett tags harvested from tests

### DIFF
--- a/modules/cli/docs/generated/galasactl_runs_submit_local.md
+++ b/modules/cli/docs/generated/galasactl_runs_submit_local.md
@@ -43,7 +43,7 @@ galasactl runs submit local [flags]
       --reportjunit string                    junit xml file to record the final results in
       --reportyaml string                     yaml file to record the final results in
       --requesttype string                    the type of request, used to allocate a run name. Defaults to CLI. (default "CLI")
-      --tags strings                          tagging metadata to be associated with the submitted runs. This can be specified as a comma-separated list of tag strings, or by repeating the --tag parameter, or both.
+      --tags strings                          tagging metadata to be associated with the submitted runs. This can be specified as a comma-separated list of tag strings, or by repeating the --tags parameter, or both.
       --throttle int                          how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 3)
       --throttlefile string                   a file where the current throttle is stored. Periodically the throttle value is read from the file used. Someone with edit access to the file can change it which dynamically takes effect. Long-running large portfolios can be throttled back to nothing (paused) using this mechanism (if throttle is set to 0). And they can be resumed (un-paused) if the value is set back. This facility can allow the tests to not show a failure when the system under test is taken out of service for maintainence.Optional. If not specified, no throttle file is used.
       --trace                                 Trace to be enabled on the test runs

--- a/modules/cli/how-to-annotate-test-runs-with-a-tag-cloud.md
+++ b/modules/cli/how-to-annotate-test-runs-with-a-tag-cloud.md
@@ -20,7 +20,7 @@ There are 2 ways of annotating a test run with tags:
 1. Send a collection of tags to the Galasa Service when the test is launched
 2. Add fixed tags to the test source code using an annotation
 
-We will discuss each of these methods in separate secctions.
+We will discuss each of these methods in separate sections.
 
 ### Inject tags when a test is submitted to the Galasa Service
 When you launch a test using the REST inteface, or with the `galasactl` command-line tool, you can specify a collection of tags using the `--tags` flag.
@@ -35,7 +35,7 @@ So, consider the command-line to launch a single test:
 --tags tag1,tag2,tag3
 ```
 
-Alternatively, one or more tags can be specified using multiple occurrances of the same `--tags` option:
+Alternatively, one or more tags can be specified using multiple occurrences of the same `--tags` option:
 
 ```shell
 >galasactl runs submit \

--- a/modules/cli/how-to-annotate-test-runs-with-a-tag-cloud.md
+++ b/modules/cli/how-to-annotate-test-runs-with-a-tag-cloud.md
@@ -1,0 +1,81 @@
+# How to annotate test runs with a tag cloud
+
+## What are tags ?
+A tag is a piece of metadata which can be attached to a test, or a test run when it is launched, such that when a test result is made available, 
+the result also has those tags.
+
+Each tag is a string, which is free-form, and can contain any characters.
+
+Tags are organised into un-ordered sets, so order is unimportant, and duplicates are ignored.
+
+Tags can be useful to categorise test results when charting, it can help define which areas of solution code were tested by a passing or failing test, 
+and can help to group tests together.
+
+You can select a group of tests to run based on many factors like test class name, test package name, bundle name. You can also select a group of tests
+from a test portfolio file based on the tags associated with tests. So, for example, you could choose to launch all the tests which have a certain tag.
+
+## How to inject tags into your test results
+
+There are 2 ways of annotating a test run with tags:
+1. Send a collection of tags to the Galasa Service when the test is launched
+2. Add fixed tags to the test source code using an annotation
+
+We will discuss each of these methods in separate secctions.
+
+### Inject tags when a test is submitted to the Galasa Service
+When you launch a test using the REST inteface, or with the `galasactl` command-line tool, you can specify a collection of tags using the `--tags` flag.
+
+So, consider the command-line to launch a single test:
+
+```shell
+>galasactl runs submit \
+--class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
+--stream ivts \
+--group myGroup \
+--tags tag1,tag2,tag3
+```
+
+Alternatively, one or more tags can be specified using multiple occurrances of the same `--tags` option:
+
+```shell
+>galasactl runs submit \
+--class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
+--stream ivts \
+--group myGroup \
+--tags tag1 \
+--tags tag2,tag3
+```
+
+When that test passes, and you query the test back from the Galasa service, you can see the list of tags in the output of the test run.
+
+```shell
+>galasactl runs get --age 1d
+submitted-time(UTC) name requestor  status   result test-name                           group          tags
+2025-04-28 09:47:46 U69  techcobweb finished Passed dev.galasa.ivts.core.CoreManagerIVT mcobbett-14988 tag1,tag2,tag3
+
+Total:3 Passed:3
+```
+
+### Inject tags into the test code using the annotation
+
+To inject tags into your java source code, you must 
+- import the `Tags` annotation.
+  ```java
+  import dev.galasa.Tags;
+  ```
+- use the `@Tags` annotation immediately above your test class definition. For example: 
+  ```java
+  @Tags({"tag1","tag2","tag3"})
+  public class myTest {
+    ...
+  }
+  ```
+
+If you then run the test, you will see `tag1`,`tag2` and `tag3` are tags on that test run.
+
+Only one such annotation is allowed per test class.
+
+All sources of tags for a test run are combined when the test runs. Duplicates are ignored.
+
+
+

--- a/modules/cli/pkg/embedded/templates/projectCreate/parent-project/test-project/src/main/java/TestExtended.java.template
+++ b/modules/cli/pkg/embedded/templates/projectCreate/parent-project/test-project/src/main/java/TestExtended.java.template
@@ -14,6 +14,7 @@ import org.apache.commons.logging.Log;
 import dev.galasa.artifact.*;
 import dev.galasa.core.manager.*;
 import dev.galasa.Test;
+import dev.galasa.Tags;
 
 import java.nio.file.*;
 
@@ -21,6 +22,7 @@ import java.nio.file.*;
  * A sample galasa test class, which does slightly more than the simple test class
  */
 @Test
+@Tags({"generated"})
 public class {{.ClassName}} {
 
 	//obtain a reference to the logger

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -64,7 +64,7 @@ public class BaseTestRunner {
 
     protected Properties overrideProperties;
 
-    private static final GalasaGson gson = new GalasaGson();
+    protected static final GalasaGson gson = new GalasaGson();
 
     protected void init(ITestRunnerDataProvider dataProvider) throws TestRunException {
         this.run = dataProvider.getRun() ;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -24,6 +24,7 @@ import dev.galasa.framework.internal.runner.FelixRepoAdminOBRAdder;
 import dev.galasa.framework.internal.runner.MavenRepositoryListBuilder;
 import dev.galasa.framework.internal.runner.RunType;
 import dev.galasa.framework.internal.runner.RunTypeDetails;
+import dev.galasa.framework.internal.runner.TagHarvester;
 import dev.galasa.framework.internal.runner.TestRunnerDataProvider;
 import dev.galasa.framework.maven.repository.spi.IMavenRepository;
 import dev.galasa.framework.spi.AbstractManager;
@@ -42,7 +43,7 @@ import dev.galasa.framework.spi.teststructure.TestStructure;
 @Component(service = { TestRunner.class })
 public class TestRunner extends BaseTestRunner {
 
-    private Log logger = LogFactory.getLog(TestRunner.class);
+    Log logger = LogFactory.getLog(TestRunner.class);
 
     // Field is protected so unit tests can inject a value here.
     @Reference(cardinality = ReferenceCardinality.OPTIONAL)
@@ -102,6 +103,8 @@ public class TestRunner extends BaseTestRunner {
                 throw new TestRunException(ex.getMessage(),ex);
             }
 
+            TagHarvester harvester = new TagHarvester(this.dss, this.ras, this.testStructure, gson);
+            harvester.harvestTagsFromTestClass(testClass, this.run.getName());
 
             RunTypeDetails runTypeDetails = new RunTypeDetails(dataProvider.getAnnotationExtractor(), testClass, testBundleName, testClassName , framework);
             this.runType = runTypeDetails.getDetectedRunType();
@@ -547,5 +550,4 @@ public class TestRunner extends BaseTestRunner {
             throw new TestRunException("Unable to load the test bundle " + testBundleName, e);
         }
     }
-
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TagHarvester.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/TagHarvester.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.runner;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.google.gson.JsonArray;
+
+import dev.galasa.Tags;
+import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.IResultArchiveStore;
+import dev.galasa.framework.spi.ResultArchiveStoreException;
+import dev.galasa.framework.spi.teststructure.TestStructure;
+import dev.galasa.framework.spi.utils.GalasaGson;
+
+/**
+ * Allows a test runner to harvest tags from a java class.
+ */
+public class TagHarvester {
+
+    Log logger = LogFactory.getLog(TagHarvester.class);
+
+    private IDynamicStatusStoreService dss;
+    private IResultArchiveStore ras;
+    private TestStructure testStructure;
+    private GalasaGson gson ;
+    public TagHarvester(IDynamicStatusStoreService dss, IResultArchiveStore ras, TestStructure testStructure, GalasaGson gson) {
+        this.dss = dss ;
+        this.ras = ras ;
+        this.testStructure = testStructure;
+        this.gson = gson;
+    }
+
+    /**
+     * We have a test class with possible annotations inside. 
+     * Harvest these and add them to the collection of tags we have from when the test was submitted.
+     * Then update the dss and ras accordingly.
+     * 
+     * @param testClass
+     */
+    public void harvestTagsFromTestClass( Class<?> testClass, String runName) {
+        Set<String> classAnnotationTags = extractTagsFromClass(testClass);
+        if( ! classAnnotationTags.isEmpty() ) {
+            // There were test class annotations which added tags.
+            updateTestStructureWithTags(classAnnotationTags);
+            updateTagsInDss(runName);
+            updateTagsInRas();
+        }
+    }
+
+    private Set<String> extractTagsFromClass(Class<?> clazz) {
+        HashSet<String> tags = new HashSet<String>();
+
+        Tags[] annotations = clazz.getAnnotationsByType(Tags.class);
+        if( annotations != null) {
+            for( Tags annotation : annotations ){
+                String[] values = annotation.value();
+                if( values != null) {
+                    for( String value : values) {
+                        if( value != null) {
+                            String trimmedValue = value.trim();
+                            if(!trimmedValue.isBlank() ){
+                                tags.add(trimmedValue);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return tags;
+    }
+
+    private void updateTestStructureWithTags(Set<String> tagsToAdd) {
+        // Update the test structure with tags.
+        for(String tag: tagsToAdd ) {
+            this.testStructure.addTag(tag);
+        }
+    }
+
+    private void updateTagsInDss(String runName) {
+
+        // Update the dss with the tags we have collected in the test structure.
+        Set<String> tags = this.testStructure.getTags();
+        String key = "run." + runName + "." + "tags" ;
+
+        // The tags are stored as a json array of strings... so 
+        // turn the tags into json.
+        JsonArray tagsJsonArray = new JsonArray();
+        for( String tag: tags) {
+            tagsJsonArray.add(tag);
+        }
+        String tagsJson = gson.toJson(tagsJsonArray);
+
+        try {
+            this.dss.put(key, tagsJson);
+        } catch (DynamicStatusStoreException ex) {
+            logger.error("Failed to write tags to dss. Ignoring and running the test anyway.",ex);
+        }
+    }
+
+    private void updateTagsInRas() {
+        try {
+            this.ras.updateTestStructure(testStructure);
+        } catch( ResultArchiveStoreException rasEx) {
+            logger.error("Failed to update the tags in test structure in the RAS. Ignoring and running the test anyway.",rasEx);
+        }
+    }
+
+
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/runner/TestTagHarvester.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/runner/TestTagHarvester.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.runner;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.Test;
+
+import dev.galasa.Tags;
+import dev.galasa.framework.mocks.*;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.IResultArchiveStore;
+import dev.galasa.framework.spi.teststructure.TestStructure;
+import dev.galasa.framework.spi.utils.GalasaGson;
+
+public class TestTagHarvester {
+
+    @Test
+    public void testCanCreateAHarvester() {
+        IDynamicStatusStoreService dss = null;
+        IResultArchiveStore ras = null ;
+        TestStructure testStructure = null ;
+        GalasaGson gson = null;
+        new TagHarvester(dss,ras,testStructure,gson);
+    }
+
+    @Test
+    public void testCanHarvestTagsFromAClassWhichHasSomeTagsButLaunchDidntSupplyAny() {
+        IDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        MockFileSystem fileSystem = new MockFileSystem();
+        IResultArchiveStore ras = new MockIResultArchiveStore("U1234", fileSystem);
+        TestStructure testStructure = new TestStructure() ;
+        GalasaGson gson = new GalasaGson();
+        TagHarvester harvester = new TagHarvester(dss,ras,testStructure,gson);
+
+        @Tags({"hello","world"})
+        class TestClass {
+        }
+
+        TestClass testClassInstance = new TestClass();
+        Class<?> testClass = testClassInstance.getClass();
+
+        harvester.harvestTagsFromTestClass(testClass, "U1234");
+
+        assertThat(testStructure.getTags()).hasSize(2);
+        assertThat(testStructure.getTags()).contains("hello");
+        assertThat(testStructure.getTags()).contains("world");
+    }
+
+    @Test
+    public void testCanHarvestTagsFromEmptyTagAnnotation() {
+        IDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        MockFileSystem fileSystem = new MockFileSystem();
+        IResultArchiveStore ras = new MockIResultArchiveStore("U1234", fileSystem);
+        TestStructure testStructure = new TestStructure() ;
+        GalasaGson gson = new GalasaGson();
+        TagHarvester harvester = new TagHarvester(dss,ras,testStructure,gson);
+
+        @Tags({})
+        class TestClass {
+        }
+
+        TestClass testClassInstance = new TestClass();
+        Class<?> testClass = testClassInstance.getClass();
+
+        harvester.harvestTagsFromTestClass(testClass, "U1234");
+
+        assertThat(testStructure.getTags()).hasSize(0);
+    }
+
+    @Test
+    public void testCanHarvestTagsFromSpacesOnlyTagAnnotation() {
+        IDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        MockFileSystem fileSystem = new MockFileSystem();
+        IResultArchiveStore ras = new MockIResultArchiveStore("U1234", fileSystem);
+        TestStructure testStructure = new TestStructure() ;
+        GalasaGson gson = new GalasaGson();
+        TagHarvester harvester = new TagHarvester(dss,ras,testStructure,gson);
+
+        @Tags({"   "})
+        class TestClass {
+        }
+
+        TestClass testClassInstance = new TestClass();
+        Class<?> testClass = testClassInstance.getClass();
+
+        harvester.harvestTagsFromTestClass(testClass, "U1234");
+
+        assertThat(testStructure.getTags()).hasSize(0);
+    }
+
+    @Test
+    public void testCanHarvestTagsFromAClassWhichHasSomeTagsButLaunchSuupliedSomeAlso() {
+        IDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        MockFileSystem fileSystem = new MockFileSystem();
+        IResultArchiveStore ras = new MockIResultArchiveStore("U1234", fileSystem);
+
+        // Simulate tags being available because they were supplied in the test structure before we
+        // harvest tags from the class code.
+        TestStructure testStructure = new TestStructure() ;
+        testStructure.addTag("one");
+        testStructure.addTag("two");
+
+        GalasaGson gson = new GalasaGson();
+        TagHarvester harvester = new TagHarvester(dss,ras,testStructure,gson);
+
+        @Tags({"hello","world"})
+        class TestClass {
+        }
+
+        TestClass testClassInstance = new TestClass();
+        Class<?> testClass = testClassInstance.getClass();
+
+        harvester.harvestTagsFromTestClass(testClass, "U1234");
+
+        assertThat(testStructure.getTags()).hasSize(4).contains("hello","world","one","two");
+    }
+
+    @Test
+    public void testCanHarvestTagsFromAClassWhichAreDuplicatedByLaunchTags() {
+        IDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        MockFileSystem fileSystem = new MockFileSystem();
+        IResultArchiveStore ras = new MockIResultArchiveStore("U1234", fileSystem);
+
+        // Simulate tags being available because they were supplied in the test structure before we
+        // harvest tags from the class code.
+        TestStructure testStructure = new TestStructure() ;
+        testStructure.addTag("one");
+        testStructure.addTag("two");
+
+        GalasaGson gson = new GalasaGson();
+        TagHarvester harvester = new TagHarvester(dss,ras,testStructure,gson);
+
+        @Tags({"one","world"})
+        class TestClass {
+        }
+
+        TestClass testClassInstance = new TestClass();
+        Class<?> testClass = testClassInstance.getClass();
+
+        harvester.harvestTagsFromTestClass(testClass, "U1234");
+
+        assertThat(testStructure.getTags()).hasSize(3).contains("world","one","two");
+    }
+
+
+    @Test
+    public void testCanHarvestTagsIntoDss() throws Exception {
+        IDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        MockFileSystem fileSystem = new MockFileSystem();
+        IResultArchiveStore ras = new MockIResultArchiveStore("U1234", fileSystem);
+        TestStructure testStructure = new TestStructure() ;
+        GalasaGson gson = new GalasaGson();
+        TagHarvester harvester = new TagHarvester(dss,ras,testStructure,gson);
+
+        @Tags({"hello"})
+        class TestClass {
+        }
+
+        TestClass testClassInstance = new TestClass();
+        Class<?> testClass = testClassInstance.getClass();
+
+        harvester.harvestTagsFromTestClass(testClass, "U1234");
+
+        // Then ...
+        String tagsAsString = dss.get("run.U1234.tags");
+
+        assertThat(tagsAsString).isNotNull().isNotEmpty().isNotBlank();
+
+        HashSet<?> tagSetOfObj = gson.fromJson(tagsAsString, HashSet.class);
+        HashSet<String> tags = new HashSet<String>();
+        for( Object entry : tagSetOfObj) {
+            // Tags are always going to be strings, so we can safely cast as a string,
+            // but do an instanceof check to keep the compiler happy.
+            if( entry instanceof String) {
+                tags.add((String)entry);
+            }
+        }
+
+        assertThat(tags).hasSize(1).contains("hello");
+    }
+
+    @Test
+    public void testCanHarvestTagsAndAddToExistingDssTagsOverwritingWhatsAlreadyThere() throws Exception {
+
+        String dssKey = "run.U1234.tags";
+        IDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        dss.put(dssKey,"{\"world\"}");
+
+        MockFileSystem fileSystem = new MockFileSystem();
+        IResultArchiveStore ras = new MockIResultArchiveStore("U1234", fileSystem);
+        TestStructure testStructure = new TestStructure() ;
+
+        GalasaGson gson = new GalasaGson();
+        TagHarvester harvester = new TagHarvester(dss,ras,testStructure,gson);
+
+        @Tags({"hello"})
+        class TestClass {
+        }
+
+        TestClass testClassInstance = new TestClass();
+        Class<?> testClass = testClassInstance.getClass();
+
+        harvester.harvestTagsFromTestClass(testClass, "U1234");
+
+        // Then ...
+        String tagsAsString = dss.get(dssKey);
+
+        assertThat(tagsAsString).isNotNull().isNotEmpty().isNotBlank();
+
+        HashSet<?> tagSetOfObj = gson.fromJson(tagsAsString, HashSet.class);
+        HashSet<String> tags = new HashSet<String>();
+        for( Object entry : tagSetOfObj) {
+            // Tags are always going to be strings, so we can safely cast as a string,
+            // but do an instanceof check to keep the compiler happy.
+            if( entry instanceof String) {
+                tags.add((String)entry);
+            }
+        }
+
+        assertThat(tags).hasSize(1).contains("hello");
+    }
+
+    @Test
+    public void testCanHarvestTagsIntoRas() throws Exception {
+        IDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
+        MockFileSystem rasFileSystem = new MockFileSystem();
+        MockIResultArchiveStore ras = new MockIResultArchiveStore("U1234", rasFileSystem);
+        TestStructure testStructure = new TestStructure() ;
+        GalasaGson gson = new GalasaGson();
+        TagHarvester harvester = new TagHarvester(dss,ras,testStructure,gson);
+
+        @Tags({"hello"})
+        class TestClass {
+        }
+
+        TestClass testClassInstance = new TestClass();
+        Class<?> testClass = testClassInstance.getClass();
+
+        harvester.harvestTagsFromTestClass(testClass, "U1234");
+
+        // Then ...
+        List<TestStructure> testStructuresSaved = ras.getTestStructureHistory();
+        assertThat(testStructuresSaved).isNotNull().hasSize(1);
+        TestStructure testStructureSaved = testStructuresSaved.get(0);
+        assertThat(testStructureSaved.getTags()).hasSize(1).contains("hello");
+    }
+}

--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/CoreManagerIVT.java
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/CoreManagerIVT.java
@@ -8,6 +8,7 @@ package dev.galasa.ivts.core;
 import org.apache.commons.logging.Log;
 
 import dev.galasa.Summary;
+import dev.galasa.Tags;
 import dev.galasa.Test;
 import dev.galasa.core.manager.CoreManager;
 import dev.galasa.core.manager.ICoreManager;
@@ -16,6 +17,7 @@ import dev.galasa.core.manager.RunName;
 
 @Test
 @Summary("Ensure the basic functions are working in the Core Manager")
+@Tags({"core","ivt"})
 public class CoreManagerIVT {
     
     @Logger


### PR DESCRIPTION
# Why ?

See issue [Add test tags to the JSON test report produced by Galasactl #1974](https://github.com/galasa-dev/projectmanagement/issues/1974)

- **test runner harvests testcase tags at runtime**
- **generated extended test on project create from CLI now adds a @Tags example.**
