### PR TITLE
Iss2165 - Update CONTRIBUTING guidelines for mono repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ The table below outlines which secrets/variables are required for the build of t
 | managers | Gradle | `GPG_KEY`, `GPG_KEYID`, `GPG_PASSPHRASE` |
 | obr | Maven | `GPG_KEY`, `GPG_KEYID`, `GPG_PASSPHRASE`, `WRITE_GITHUB_PACKAGES_USERNAME`, `WRITE_GITHUB_PACKAGES_TOKEN` |
 | ivts | Gradle | `GPG_KEY`, `GPG_KEYID`, `GPG_PASSPHRASE`, `WRITE_GITHUB_PACKAGES_USERNAME`, `WRITE_GITHUB_PACKAGES_TOKEN` |
+| cli | Go and Docker | `WRITE_GITHUB_PACKAGES_USERNAME`, `WRITE_GITHUB_PACKAGES_TOKEN` |
 
 #### How to set repository variables:
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2165

Contributing guidelines for forks now mentions the CLI now its been pulled into this repo as a module. The guidelines describe the CLI build's required secrets/variables.

Nothing else in the guidelines needs updating/adding. I've tested a full Main Build on my fork here: https://github.com/jadecarino/galasa/actions/runs/14775639829