### PR TITLE
Move anyReasonTestMethodShouldBeIgnored check to only check against the test method

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
@@ -69,17 +69,6 @@ public class GenericMethodWrapper {
             }
 
             String methodType = ",type=" + type.toString();
-            Result ignored = managers.anyReasonTestMethodShouldBeIgnored(new GalasaMethod(this.executionMethod, testExecutionMethod));
-            if (ignored != null) {
-            	logger.info(TestClassWrapper.LOG_STARTING + TestClassWrapper.LOG_START_LINE + TestClassWrapper.LOG_ASTERS
-                        + TestClassWrapper.LOG_START_LINE + "*** Ignoring test method " + testClass.getName() + "#"
-                        + executionMethod.getName() + methodType + TestClassWrapper.LOG_START_LINE
-                        + TestClassWrapper.LOG_ASTERS);
-                logger.info("Ignoring " + executionMethod.getName() + " due to "+ ignored.getReason());
-                this.result = ignored;
-                this.testStructureMethod.setResult(this.result.getName());
-                return;
-            }
             managers.fillAnnotatedFields(testClassObject);
             managers.startOfTestMethod(new GalasaMethod(this.executionMethod, testExecutionMethod));
 
@@ -153,6 +142,14 @@ public class GenericMethodWrapper {
         return this.result;
     }
 
+    public void setResult(Result result) {
+        this.result = result;
+
+        if (this.testStructureMethod != null) {
+            this.testStructureMethod.setResult(result.getName());
+        }
+    }
+
     public TestMethod getStructure() {
         this.testStructureMethod = new TestMethod(testClass);
         this.testStructureMethod.setMethodName(executionMethod.getName());
@@ -167,5 +164,13 @@ public class GenericMethodWrapper {
 
     public Type getType() {
         return this.type;
+    }
+
+    public Method getExecutionMethod() {
+        return executionMethod;
+    }
+
+    public TestMethod getTestStructureMethod() {
+        return testStructureMethod;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
@@ -14,7 +14,9 @@ import javax.validation.constraints.NotNull;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.Result;
+import dev.galasa.framework.spi.language.GalasaMethod;
 import dev.galasa.framework.spi.teststructure.TestMethod;
 
 public class TestMethodWrapper {
@@ -47,45 +49,63 @@ public class TestMethodWrapper {
     }
 
     public void invoke(@NotNull ITestRunManagers managers, Object testClassObject, boolean continueOnTestFailure, TestClassWrapper testClassWrapper) throws TestRunException {
-        // run all the @Befores before the test method
-        for (GenericMethodWrapper before : this.befores) {
-            before.invoke(managers, testClassObject, testMethod);
-            testClassWrapper.setResult(before.getResult(), managers);
-            if (before.getResult().isFullStop()) {
-                this.fullStop = true;
-                this.result = Result.failed("Before method failed");
-                break;
-            }
-        }
+        try {
+            // Check if the test method should be ignored, and if so, mark it as ignored along
+            // with any @Before and @After methods associated with the test method
+            Method executionMethod = testMethod.getExecutionMethod();
+            Result ignoredResult = managers.anyReasonTestMethodShouldBeIgnored(new GalasaMethod(executionMethod, null));
+            if (ignoredResult != null) {
+                logger.info(TestClassWrapper.LOG_STARTING + TestClassWrapper.LOG_START_LINE + TestClassWrapper.LOG_ASTERS
+                        + TestClassWrapper.LOG_START_LINE + "*** Ignoring test method " + testClassObject.getClass().getName() + "#"
+                        + testMethod.getName() + ",type=" + testMethod.getType().toString() + TestClassWrapper.LOG_START_LINE
+                        + TestClassWrapper.LOG_ASTERS);
+                logger.info("Ignoring " + executionMethod.getName() + " due to " + ignoredResult.getReason());
 
-        if (this.result == null) {
-            testMethod.invoke(managers, testClassObject, null);
-            testClassWrapper.setResult(testMethod.getResult(), managers);
-            if (this.testMethod.fullStop()) {
-                if (continueOnTestFailure) {
-                    logger.warn("Test method failed, however, continue on test failure was requested, so carrying on");
-                } else {
-                    this.fullStop = this.testMethod.fullStop();
+                markTestAndLinkedMethodsIgnored(ignoredResult, testClassWrapper, managers);
+            } else {
+                // run all the @Befores before the test method
+                for (GenericMethodWrapper before : this.befores) {
+                    before.invoke(managers, testClassObject, testMethod);
+                    testClassWrapper.setResult(before.getResult(), managers);
+                    if (before.getResult().isFullStop()) {
+                        this.fullStop = true;
+                        this.result = Result.failed("Before method failed");
+                        break;
+                    }
                 }
-            }
-            
-            this.result = this.testMethod.getResult();
-        }
 
-        // run all the @Afters after the test method
-        Result afterResult = null;
-        for (GenericMethodWrapper after : this.afters) {
-            after.invoke(managers, testClassObject, testMethod);
-            testClassWrapper.setResult(after.getResult(), managers);
-            if (after.fullStop()) {
-                this.fullStop = true;
-                if (afterResult == null) {
-                    afterResult = Result.failed("After method failed");
-                    if (this.result == null || this.result.isPassed()) {
-                        this.result = afterResult;
+                if (this.result == null) {
+                    testMethod.invoke(managers, testClassObject, null);
+                    testClassWrapper.setResult(testMethod.getResult(), managers);
+                    if (this.testMethod.fullStop()) {
+                        if (continueOnTestFailure) {
+                            logger.warn("Test method failed, however, continue on test failure was requested, so carrying on");
+                        } else {
+                            this.fullStop = this.testMethod.fullStop();
+                        }
+                    }
+                    
+                    this.result = this.testMethod.getResult();
+                }
+
+                // run all the @Afters after the test method
+                Result afterResult = null;
+                for (GenericMethodWrapper after : this.afters) {
+                    after.invoke(managers, testClassObject, testMethod);
+                    testClassWrapper.setResult(after.getResult(), managers);
+                    if (after.fullStop()) {
+                        this.fullStop = true;
+                        if (afterResult == null) {
+                            afterResult = Result.failed("After method failed");
+                            if (this.result == null || this.result.isPassed()) {
+                                this.result = afterResult;
+                            }
+                        }
                     }
                 }
             }
+        } catch (FrameworkException ex) {
+            throw new TestRunException("Failure occurred when invoking methods in the given test class", ex);
         }
     }
 
@@ -120,4 +140,22 @@ public class TestMethodWrapper {
         return methodStructure;
     }
 
+    private void markTestAndLinkedMethodsIgnored(Result ignoredResult, TestClassWrapper testClassWrapper, ITestRunManagers managers) {
+        // Mark test method as ignored
+        testMethod.setResult(ignoredResult);
+        testClassWrapper.setResult(testMethod.getResult(), managers);
+        this.result = ignoredResult;
+
+        // Mark any before methods associated with the test method as ignored
+        for (GenericMethodWrapper before : this.befores) {
+            before.setResult(ignoredResult);
+            testClassWrapper.setResult(before.getResult(), managers);
+        }
+
+        // Mark any after methods associated with the test method as ignored
+        for (GenericMethodWrapper after : this.afters) {
+            after.setResult(ignoredResult);
+            testClassWrapper.setResult(after.getResult(), managers);
+        }
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestMethodWrapperTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestMethodWrapperTest.java
@@ -175,7 +175,7 @@ public class TestMethodWrapperTest {
     }
 
     @Test
-    public void testBeforeAndAfterMethodsAreAssociatedWithTestMethod() throws Exception {
+    public void testCheckForReasonToIgnoreTestMethodOnlyRunsOnce() throws Exception {
         // Given...
         Class<?> mockClass = MockTestClass.class;
         Method beforeMethod = mockClass.getMethod("MockBeforeMethod");
@@ -206,18 +206,10 @@ public class TestMethodWrapperTest {
 
         // Then...
         List<GalasaMethod> galasaMethods = mockTestRunManagers.getGalasaMethodsReceived();
-        assertThat(galasaMethods).hasSize(3);
+        assertThat(galasaMethods).hasSize(1);
 
-        // The before should have an execution method and a test method associated with it
-        assertThat(galasaMethods.get(0).getJavaExecutionMethod()).isEqualTo(beforeMethod);
-        assertThat(galasaMethods.get(0).getJavaTestMethod()).isEqualTo(testMethod);
-
-        // The test method should only have an execution method
-        assertThat(galasaMethods.get(1).getJavaExecutionMethod()).isEqualTo(testMethod);
-        assertThat(galasaMethods.get(1).getJavaTestMethod()).isNull();
-
-        // The before should have an execution method and a test method associated with it
-        assertThat(galasaMethods.get(2).getJavaExecutionMethod()).isEqualTo(afterMethod);
-        assertThat(galasaMethods.get(2).getJavaTestMethod()).isEqualTo(testMethod);
+        // Only the test method should have been passed in when checking whether to ignore it
+        assertThat(galasaMethods.get(0).getJavaExecutionMethod()).isEqualTo(testMethod);
+        assertThat(galasaMethods.get(0).getJavaTestMethod()).isNull();
     }
 }


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2187

## Changes
- Lifted up the anyReasonTestMethodShouldBeIgnored check to determine if a test method should be ignored out from the GenericMethodWrapper to reduce the number of times the check is made
  - This check is now performed once for each test method, rather than performing it for all `@Before` and `@After` methods associated with each test method