### PR TITLE
Add 'tags' query parameter to /ras/runs endpoint and add '--tags' flag to 'galasactl runs get' to query runs by tags

### DIFF
--- a/modules/cli/docs/generated/galasactl_runs_get.md
+++ b/modules/cli/docs/generated/galasactl_runs_get.md
@@ -21,6 +21,7 @@ galasactl runs get [flags]
       --name string        the name of the test run we want information about. Cannot be used in conjunction with --requestor, --result or --active flags
       --requestor string   the requestor of the test run we want information about. Cannot be used in conjunction with --name flag.
       --result string      A filter on the test runs we want information about. Optional. Default is to display test runs with any result. Case insensitive. Value can be a single value or a comma-separated list. For example "--result Failed,Ignored,EnvFail". Cannot be used in conjunction with --name or --active flag.
+      --tags strings       the tags associated with test runs to be retrieved. Tags can be supplied in a comma-separated list (e.g. --tags tag1,tag2,tag3) or as separate '--tags' flags (e.g. --tags tag1 --tags tag2).
 ```
 
 ### Options inherited from parent commands

--- a/modules/cli/pkg/cmd/runsGet.go
+++ b/modules/cli/pkg/cmd/runsGet.go
@@ -28,6 +28,7 @@ type RunsGetCmdValues struct {
 	result             string
 	isActiveRuns       bool
 	group              string
+	tags               []string
 }
 
 type RunsGetCommand struct {
@@ -103,6 +104,8 @@ func (cmd *RunsGetCommand) createCobraCommand(
 		" Cannot be used in conjunction with --name or --active flag.")
 	runsGetCobraCmd.PersistentFlags().BoolVar(&cmd.values.isActiveRuns, "active", false, "parameter to retrieve runs that have not finished yet."+
 		" Cannot be used in conjunction with --name or --result flag.")
+	runsGetCobraCmd.PersistentFlags().StringSliceVar(&cmd.values.tags, "tags", make([]string, 0), "the tags associated with test runs to be retrieved."+
+		" Tags can be supplied in a comma-separated list (e.g. --tags tag1,tag2,tag3) or as separate '--tags' flags (e.g. --tags tag1 --tags tag2).")
 
 	runsGetCobraCmd.MarkFlagsMutuallyExclusive("name", "requestor")
 	runsGetCobraCmd.MarkFlagsMutuallyExclusive("name", "result")
@@ -161,6 +164,7 @@ func (cmd *RunsGetCommand) executeRunsGet(
 					cmd.values.isActiveRuns,
 					cmd.values.outputFormatString,
 					cmd.values.group,
+					cmd.values.tags,
 					timeService,
 					console,
 					commsClient,

--- a/modules/cli/pkg/cmd/runsGet_test.go
+++ b/modules/cli/pkg/cmd/runsGet_test.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/galasa-dev/cli/pkg/utils"
@@ -332,4 +333,75 @@ func TestRunsGetGroupRunNameMutuallyExclusive(t *testing.T) {
 
 	// Check what the user saw is reasonable.
 	checkOutput("", "Error: if any flags in the group [group name] are set none of the others can be; [group name] were all set", factory, t)
+}
+
+func TestRunsGetWithOneTagsFlagReturnsOk(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, cmd := setupTestCommandCollection(COMMAND_NAME_RUNS_GET, factory, t)
+
+	tag := "my-test-tag"
+
+	var args []string = []string{"runs", "get", "--age", "1d", "--tags", tag}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw was reasonable
+	checkOutput("", "", factory, t)
+
+	assert.Contains(t, cmd.Values().(*RunsGetCmdValues).tags, tag)
+}
+
+func TestRunsGetWithMultipleTagsFlagReturnsOk(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, cmd := setupTestCommandCollection(COMMAND_NAME_RUNS_GET, factory, t)
+
+	tag1 := "my-test-tag-1"
+	tag2 := "my-test-tag-2"
+
+	var args []string = []string{"runs", "get", "--age", "1d", "--tags", tag1, "--tags", tag2}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw was reasonable
+	checkOutput("", "", factory, t)
+
+	tags := cmd.Values().(*RunsGetCmdValues).tags
+	assert.Contains(t, tags, tag1)
+	assert.Contains(t, tags, tag2)
+}
+
+func TestRunsGetWithCommaSeparatedTagsFlagReturnsOk(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, cmd := setupTestCommandCollection(COMMAND_NAME_RUNS_GET, factory, t)
+
+	tag1 := "my-test-tag-1"
+	tag2 := "my-test-tag-2"
+	tags := []string{ tag1, tag2 }
+	commaSeparatedTags := strings.Join(tags, ",")
+
+	var args []string = []string{"runs", "get", "--age", "1d", "--tags", commaSeparatedTags}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw was reasonable
+	checkOutput("", "", factory, t)
+
+	actualTags := cmd.Values().(*RunsGetCmdValues).tags
+	assert.Contains(t, actualTags, tag1)
+	assert.Contains(t, actualTags, tag2)
 }

--- a/modules/cli/pkg/runs/runs.go
+++ b/modules/cli/pkg/runs/runs.go
@@ -31,10 +31,23 @@ func getRunIdFromRunName(runName string,
 	toAgeHours := 0
 	shouldGetActive := true
 	isNeedingMethodDetails := false
+	tags := make([]string, 0)
 
-	runsQuery := NewRunsQuery(runName, requestorParameter, resultParameter, group, fromAgeHours, toAgeHours, shouldGetActive, timeService.Now(), isNeedingMethodDetails)
 
-	runs, err = GetRunsFromRestApi(runsQuery, commsClient);
+	runsQuery := NewRunsQuery(
+		runName,
+		requestorParameter,
+		resultParameter,
+		group,
+		fromAgeHours,
+		toAgeHours,
+		shouldGetActive,
+		isNeedingMethodDetails,
+		tags,
+		timeService.Now(),
+	)
+
+	runs, err = GetRunsFromRestApi(runsQuery, commsClient)
 
 	if err == nil {
 

--- a/modules/cli/pkg/runs/runsDelete.go
+++ b/modules/cli/pkg/runs/runsDelete.go
@@ -45,11 +45,23 @@ func RunsDelete(
 		toAgeHours := 0
 		group := ""
 		shouldGetActive := false
+		tags := make([]string, 0)
 		isNeedingMethodDetails := false
+
+		runsQuery := NewRunsQuery(
+			runName,
+			requestorParameter,
+			resultParameter,
+			group,
+			fromAgeHours,
+			toAgeHours,
+			shouldGetActive,
+			isNeedingMethodDetails,
+			tags,
+			timeService.Now(),
+		)
+
 		var runs []galasaapi.Run
-
-		runsQuery := NewRunsQuery(runName, requestorParameter, resultParameter, group, fromAgeHours, toAgeHours, shouldGetActive, timeService.Now(), isNeedingMethodDetails)
-
 		runs, err = GetRunsFromRestApi(runsQuery, commsClient)
 
 		if err == nil {

--- a/modules/cli/pkg/runs/runsDownload.go
+++ b/modules/cli/pkg/runs/runsDownload.go
@@ -51,8 +51,20 @@ func DownloadArtifacts(
 		toAgeHours := 0
 		shouldGetActive := false
 		isNeedingMethodDetails := false
+		tags := make([]string, 0)
 
-		runsQuery := NewRunsQuery(runName, requestorParameter, resultParameter, group, fromAgeHours, toAgeHours, shouldGetActive, timeService.Now(), isNeedingMethodDetails)
+		runsQuery := NewRunsQuery(
+			runName,
+			requestorParameter,
+			resultParameter,
+			group,
+			fromAgeHours,
+			toAgeHours,
+			shouldGetActive,
+			isNeedingMethodDetails,
+			tags,
+			timeService.Now(),
+		)
 
 		runs, err = GetRunsFromRestApi(runsQuery, commsClient)
 		if err == nil {

--- a/modules/cli/pkg/runs/runsGet.go
+++ b/modules/cli/pkg/runs/runsGet.go
@@ -48,6 +48,7 @@ func GetRuns(
 	shouldGetActive bool,
 	outputFormatString string,
 	group string,
+	tags []string,
 	timeService spi.TimeService,
 	console spi.Console,
 	commsClient api.APICommsClient,
@@ -91,9 +92,19 @@ func GetRuns(
 			var runJson []galasaapi.Run
 			isNeedingMethodDetails := chosenFormatter.IsNeedingMethodDetails()
 
-			runsQuery := NewRunsQuery(runName, requestorParameter, resultParameter, group, fromAge, toAge, shouldGetActive, timeService.Now(), isNeedingMethodDetails)
+			runsQuery := NewRunsQuery(
+				runName,
+				requestorParameter,
+				resultParameter,
+				group,
+				fromAge,
+				toAge,
+				shouldGetActive,
+				isNeedingMethodDetails,
+				tags,
+				timeService.Now(),
+			)
 			runJson, err = GetRunsFromRestApi(runsQuery, commsClient)
-
 			if err == nil {
 				var outputText string
 

--- a/modules/cli/pkg/runs/runsGet_test.go
+++ b/modules/cli/pkg/runs/runsGet_test.go
@@ -77,7 +77,11 @@ const (
 				 "runLogStart":null,
 				 "runLogEnd":null,
 				 "befores":[]
-			 }]
+			 }],
+			 "tags": [
+			 	"core",
+				"anothertag"
+			 ]
 		 },
 		 "artifacts": [{
 			 "artifactPath": "myPathToArtifact1",
@@ -91,125 +95,12 @@ const (
 			"amountOfRuns": 0,
 			"runs":[]
 		}`
+
+	RESULT_NAMES_RESPONSE = `
+		{
+			"resultnames":["UNKNOWN","Passed","Failed","EnvFail"]
+		}`
 )
-
-func NewRunsGetServletMock(t *testing.T, status int, nextPageCursors []string, pages map[string][]string, pageSize int, runName string, runResultStrings ...string) *httptest.Server {
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		clientVersion := r.Header.Get("ClientApiVersion")
-		assert.NotEmpty(t, clientVersion, "Client version header not set.")
-		if strings.Contains(r.URL.Path, "/ras/runs/") {
-			ConfigureServerForDetailsEndpoint(t, w, r, status, runResultStrings...)
-		} else if strings.Contains(r.URL.Path, "/ras/resultnames") {
-			ConfigureServerForResultNamesEndpoint(t, w, r, status)
-		} else {
-			nextCursor := ""
-			if len(nextPageCursors) > 0 {
-				// Advance the expected page cursors by one
-				nextCursor = nextPageCursors[0]
-				nextPageCursors = nextPageCursors[1:]
-			}
-			ConfigureServerForRasRunsEndpoint(t, w, r, pages, nextCursor, runName, pageSize, status)
-		}
-	}))
-	return server
-}
-
-func ConfigureServerForDetailsEndpoint(t *testing.T, w http.ResponseWriter, r *http.Request, status int, runResultStrings ...string) {
-	if r.Header.Get("Accept") != "application/json" {
-		t.Errorf("Expected Accept: application/json header, got: %s", r.Header.Get("Accept"))
-	}
-	urlParts := strings.Split(r.URL.Path, "/")
-	runid := urlParts[3]
-	for _, runResult := range runResultStrings {
-		assert.Contains(t, runResult, runid)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	combinedRunResultStrings := ""
-	for index, runResult := range runResultStrings {
-		if index > 0 {
-			combinedRunResultStrings += ","
-		}
-		combinedRunResultStrings += runResult
-	}
-
-	w.Write([]byte(fmt.Sprintf(`
-			%s
-		`, combinedRunResultStrings)))
-}
-
-func ConfigureServerForRasRunsEndpoint(
-	t *testing.T,
-	w http.ResponseWriter,
-	r *http.Request,
-	pages map[string][]string,
-	nextPageCursor string,
-	runName string,
-	pageSize int,
-	status int,
-) {
-	if r.URL.Path != "/ras/runs" {
-		t.Errorf("Expected to request '/ras/runs', got: %s", r.URL.Path)
-	}
-	if r.Header.Get("Accept") != "application/json" {
-		t.Errorf("Expected Accept: application/json header, got: %s", r.Header.Get("Accept"))
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-
-	values := r.URL.Query()
-	runNameQueryParameter := values.Get("runname")
-
-	var pageRunsJson []string
-	var keyExists bool
-	cursorQueryParameter := values.Get("cursor")
-
-	// Keys of the pages map correspond to page cursors, including
-	// an empty string key for the first request to /ras/runs
-	pageRunsJson, keyExists = pages[cursorQueryParameter]
-	assert.True(t, keyExists)
-
-	// Subsequent requests shouldn't be made to the same page,
-	// so delete the page since we've visited it
-	delete(pages, cursorQueryParameter)
-
-	assert.Equal(t, runNameQueryParameter, runName)
-	combinedRunResultStrings := ""
-	for index, runResult := range pageRunsJson {
-		if index > 0 {
-			combinedRunResultStrings += ","
-		}
-		combinedRunResultStrings += runResult
-	}
-
-	w.Write([]byte(fmt.Sprintf(`
-		 {
-			 "nextCursor": "%s",
-			 "pageSize": %d,
-			 "amountOfRuns": %d,
-			 "runs":[ %s ]
-		 }`, nextPageCursor, pageSize, len(pageRunsJson), combinedRunResultStrings)))
-}
-
-func ConfigureServerForResultNamesEndpoint(t *testing.T, w http.ResponseWriter, r *http.Request, status int) {
-	if r.URL.Path != "/ras/resultnames" {
-		t.Errorf("Expected to request '/ras/resultnames', got: %s", r.URL.Path)
-	}
-	if r.Header.Get("Accept") != "application/json" {
-		t.Errorf("Expected Accept: application/json header, got: %s", r.Header.Get("Accept"))
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-
-	w.Write([]byte(`
-			{
-				"resultnames":["UNKNOWN","Passed","Failed","EnvFail"]
-			}
-	`))
-
-}
 
 // ------------------------------------------------------------------
 // Testing that the output format string passed by the user on the command-line
@@ -239,30 +130,48 @@ func TestOutputFormatGarbageStringValidationGivesError(t *testing.T) {
 func TestRunsGetOfRunNameWhichExistsProducesExpectedSummary(t *testing.T) {
 
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
-
 	runName := "U456"
 	age := "2d:24h"
 	requestor := ""
 	result := ""
-	pageSize := 100
 	group := ""
-
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
+	tags := make([]string, 0)
 	shouldGetActive := false
-	defer server.Close()
+
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "",
+				"pageSize": 100,
+				"amountOfRuns": 1,
+				"runs":[ %s ]
+			}`, RUN_U456)))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then...
 	// We expect
@@ -284,27 +193,26 @@ func TestRunsGetOfRunNameWhichDoesNotExistProducesError(t *testing.T) {
 	// Given ...
 	age := "2d:24h"
 	runName := "garbage"
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	requestor := ""
 	result := ""
 	shouldGetActive := false
 	group := ""
-	pageSize := 100
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+    interactions := []utils.HttpInteraction{}
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	mockConsole := utils.NewMockConsole()
 
 	outputFormat := "summary"
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then...
 	// We expect
@@ -318,28 +226,49 @@ func TestRunsGetOfRunNameWhichDoesNotExistProducesError(t *testing.T) {
 
 func TestRunsGetWhereRunNameExistsTwiceProducesTwoRunResultLines(t *testing.T) {
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456, RUN_U456_v2}
-	nextPageCursors := []string{""}
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := ""
 	shouldGetActive := false
-	pageSize := 100
 	group := ""
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		runsToReturn := []string{RUN_U456, RUN_U456_v2}
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "",
+				"pageSize": 100,
+				"amountOfRuns": 2,
+				"runs":[ %s ]
+			}`, strings.Join(runsToReturn, ","))))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	mockConsole := utils.NewMockConsole()
 	outputFormat := "summary"
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then...
 	// We expect
@@ -351,7 +280,7 @@ func TestRunsGetWhereRunNameExistsTwiceProducesTwoRunResultLines(t *testing.T) {
 		want :=
 			"submitted-time(UTC) name requestor     status   result           test-name                group      tags\n" +
 				"2023-05-10 06:00:13 U456 unitTesting   Finished Passed           myTestPackage.MyTestName dummyGroup \n" +
-				"2023-05-10 06:00:13 U456 unitTesting22 Finished LongResultString myTestPackage.MyTest2               \n" +
+				"2023-05-10 06:00:13 U456 unitTesting22 Finished LongResultString myTestPackage.MyTest2               anothertag,core\n" +
 				"\n" +
 				"Total:2 Passed:1\n"
 		assert.Equal(t, want, textGotBack)
@@ -372,6 +301,7 @@ func TestFailingGetRunsRequestReturnsError(t *testing.T) {
 	requestor := ""
 	result := ""
 	shouldGetActive := false
+	tags := make([]string, 0)
 
 	mockConsole := utils.NewMockConsole()
 	outputFormat := "summary"
@@ -380,7 +310,7 @@ func TestFailingGetRunsRequestReturnsError(t *testing.T) {
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then...
 	assert.Contains(t, err.Error(), "GAL1075")
@@ -398,29 +328,57 @@ func TestOutputFormatDetailsValidatesOk(t *testing.T) {
 func TestRunsGetOfRunNameWhichExistsProducesExpectedDetails(t *testing.T) {
 
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := ""
 	shouldGetActive := false
 	group := ""
-	pageSize := 100
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName, RUN_U456)
-	defer server.Close()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "",
+				"pageSize": 100,
+				"amountOfRuns": 1,
+				"runs":[ %s ]
+			}`, RUN_U456)))
+    }
+
+	getRunsDetailsInteraction := utils.NewHttpInteraction("/ras/runs/xxx876xxx", http.MethodGet)
+    getRunsDetailsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+
+		writer.Write([]byte(RUN_U456))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+		getRunsDetailsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "details"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then...
 	// We expect
@@ -465,29 +423,36 @@ func TestGetFormatterNamesStringMultipleFormattersFormatsOk(t *testing.T) {
 
 func TestAPIInternalErrorIsHandledOk(t *testing.T) {
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	group := ""
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := ""
 	shouldGetActive := false
-	pageSize := 100
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusInternalServerError, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusInternalServerError)
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "details"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then...
 	// We expect
@@ -499,29 +464,48 @@ func TestAPIInternalErrorIsHandledOk(t *testing.T) {
 func TestRunsGetOfRunNameWhichExistsProducesExpectedRaw(t *testing.T) {
 
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := ""
 	shouldGetActive := false
-	pageSize := 100
 	group := ""
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "",
+				"pageSize": 100,
+				"amountOfRuns": 1,
+				"runs":[ %s ]
+			}`, RUN_U456)))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "raw"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then...
 	// We expect
@@ -636,28 +620,36 @@ func TestRunsGetURLQueryWithFromAndToDate(t *testing.T) {
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.NotNil(t, query.Get("from"))
 		assert.NotEqualValues(t, query.Get("from"), "")
 		assert.NotNil(t, query.Get("to"))
 		assert.NotEqualValues(t, query.Get("to"), "")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -671,27 +663,35 @@ func TestRunsGetURLQueryJustFromAge(t *testing.T) {
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.NotNil(t, query.Get("from"))
 		assert.NotEqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -705,27 +705,35 @@ func TestRunsGetURLQueryWithNoRunNameAndNoFromAgeReturnsError(t *testing.T) {
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
-		assert.EqualValues(t, query.Get("from"), "")
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
+		assert.NotNil(t, query.Get("from"))
+		assert.NotEqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
-		assert.EqualValues(t, query.Get("runname"), "")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.NotNil(t, err)
@@ -740,27 +748,35 @@ func TestRunsGetURLQueryWithOlderToAgeThanFromAgeReturnsError(t *testing.T) {
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.EqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
 		assert.EqualValues(t, query.Get("runname"), "U456")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.NotNil(t, err)
@@ -775,27 +791,35 @@ func TestRunsGetURLQueryWithBadlyFormedFromAndToParameterReturnsError(t *testing
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.EqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
 		assert.EqualValues(t, query.Get("runname"), "U456")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.NotNil(t, err)
@@ -961,31 +985,39 @@ func TestRunsGetURLQueryWithRequestorNotSuppliedReturnsOK(t *testing.T) {
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.EqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
 		assert.EqualValues(t, query.Get("runname"), runName)
 
 		// The request should not have the requestor parameter
-		assert.NotContains(t, r.URL.RawQuery, "requestor")
+		assert.NotContains(t, req.URL.RawQuery, "requestor")
 
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -999,29 +1031,37 @@ func TestRunsGetURLQueryWithRequestorSuppliedReturnsOK(t *testing.T) {
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.EqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
 		assert.EqualValues(t, query.Get("runname"), runName)
-		assert.Contains(t, r.URL.RawQuery, "requestor="+url.QueryEscape(requestor))
+		assert.Contains(t, req.URL.RawQuery, "requestor="+url.QueryEscape(requestor))
 		assert.EqualValues(t, query.Get("requestor"), requestor)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -1035,29 +1075,37 @@ func TestRunsGetURLQueryWithNumericRequestorSuppliedReturnsOK(t *testing.T) {
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.EqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
 		assert.EqualValues(t, query.Get("runname"), runName)
 		assert.EqualValues(t, query.Get("requestor"), requestor)
-		assert.Contains(t, r.URL.RawQuery, "requestor="+url.QueryEscape(requestor))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		assert.Contains(t, req.URL.RawQuery, "requestor="+url.QueryEscape(requestor))
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -1071,29 +1119,37 @@ func TestRunsGetURLQueryWithDashInRequestorSuppliedReturnsOK(t *testing.T) {
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.EqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
 		assert.EqualValues(t, query.Get("runname"), runName)
 		assert.EqualValues(t, query.Get("requestor"), requestor)
-		assert.Contains(t, r.URL.RawQuery, "requestor="+url.QueryEscape(requestor))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		assert.Contains(t, req.URL.RawQuery, "requestor="+url.QueryEscape(requestor))
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -1107,29 +1163,37 @@ func TestRunsGetURLQueryWithAmpersandRequestorSuppliedReturnsOK(t *testing.T) {
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.EqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
 		assert.EqualValues(t, query.Get("runname"), runName)
+		assert.Contains(t, req.URL.RawQuery, "requestor="+url.QueryEscape(requestor))
 		assert.EqualValues(t, query.Get("requestor"), requestor)
-		assert.Contains(t, r.URL.RawQuery, "requestor="+url.QueryEscape(requestor))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -1143,30 +1207,38 @@ func TestRunsGetURLQueryWithSpecialCharactersRequestorSuppliedReturnsOK(t *testi
 	result := ""
 	shouldGetActive := false
 	group := ""
+	tags := make([]string, 0)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.EqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
 		assert.EqualValues(t, query.Get("runname"), runName)
 		assert.EqualValues(t, query.Get("requestor"), requestor)
-		assert.Contains(t, r.URL.RawQuery, "requestor="+url.QueryEscape(requestor))
+		assert.Contains(t, req.URL.RawQuery, "requestor="+url.QueryEscape(requestor))
 
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -1174,29 +1246,56 @@ func TestRunsGetURLQueryWithSpecialCharactersRequestorSuppliedReturnsOK(t *testi
 
 func TestRunsGetURLQueryWithResultSuppliedReturnsOK(t *testing.T) {
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := "Passed"
 	shouldGetActive := false
-	pageSize := 100
 	group := ""
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+	resultNamesInteraction := utils.NewHttpInteraction("/ras/resultnames", http.MethodGet)
+    resultNamesInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(RESULT_NAMES_RESPONSE))
+    }
+
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "",
+				"pageSize": 100,
+				"amountOfRuns": 1,
+				"runs":[ %s ]
+			}`, RUN_U456)))
+    }
+
+    interactions := []utils.HttpInteraction{
+		resultNamesInteraction,
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -1206,30 +1305,57 @@ func TestRunsGetURLQueryWithResultSuppliedReturnsOK(t *testing.T) {
 
 func TestRunsGetURLQueryWithMultipleResultSuppliedReturnsOK(t *testing.T) {
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := "Passed,envfail"
 	shouldGetActive := false
-	pageSize := 100
 	group := ""
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+	resultNamesInteraction := utils.NewHttpInteraction("/ras/resultnames", http.MethodGet)
+    resultNamesInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(RESULT_NAMES_RESPONSE))
+    }
+
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "",
+				"pageSize": 100,
+				"amountOfRuns": 1,
+				"runs":[ %s ]
+			}`, RUN_U456)))
+    }
+
+    interactions := []utils.HttpInteraction{
+		resultNamesInteraction,
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
 
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -1239,29 +1365,48 @@ func TestRunsGetURLQueryWithMultipleResultSuppliedReturnsOK(t *testing.T) {
 
 func TestRunsGetURLQueryWithResultNotSuppliedReturnsOK(t *testing.T) {
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := ""
 	shouldGetActive := false
 	group := ""
-	pageSize := 100
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "",
+				"pageSize": 100,
+				"amountOfRuns": 1,
+				"runs":[ %s ]
+			}`, RUN_U456)))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -1269,29 +1414,37 @@ func TestRunsGetURLQueryWithResultNotSuppliedReturnsOK(t *testing.T) {
 
 func TestRunsGetURLQueryWithInvalidResultSuppliedReturnsError(t *testing.T) {
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := "garbage"
 	shouldGetActive := false
-	pageSize := 100
 	group := ""
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+	resultNamesInteraction := utils.NewHttpInteraction("/ras/resultnames", http.MethodGet)
+    resultNamesInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(RESULT_NAMES_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+		resultNamesInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Error(t, err)
@@ -1301,29 +1454,28 @@ func TestRunsGetURLQueryWithInvalidResultSuppliedReturnsError(t *testing.T) {
 
 func TestActiveAndResultAreMutuallyExclusiveShouldReturnError(t *testing.T) {
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := "Passed"
 	shouldGetActive := true
-	pageSize := 100
 	group := ""
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+    interactions := []utils.HttpInteraction{}
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Error(t, err)
@@ -1332,29 +1484,48 @@ func TestActiveAndResultAreMutuallyExclusiveShouldReturnError(t *testing.T) {
 
 func TestActiveParameterReturnsOk(t *testing.T) {
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := ""
 	shouldGetActive := true
-	pageSize := 100
 	group := ""
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "",
+				"pageSize": 100,
+				"amountOfRuns": 1,
+				"runs":[ %s ]
+			}`, RUN_U456)))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -1368,32 +1539,40 @@ func TestRunsGetActiveRunsBuildsQueryCorrectly(t *testing.T) {
 	result := ""
 	shouldGetActive := true
 	group := ""
+	tags := make([]string, 0)
 
 	mockEnv := utils.NewMockEnv()
 	mockEnv.SetUserName(requestor)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		query := req.URL.Query()
 		assert.EqualValues(t, query.Get("from"), "")
 		assert.EqualValues(t, query.Get("to"), "")
 		assert.EqualValues(t, query.Get("runname"), runName)
 		assert.EqualValues(t, query.Get("requestor"), requestor)
-		assert.NotContains(t, r.URL.RawQuery, "status="+url.QueryEscape("finished"))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(EMPTY_RUNS_RESPONSE))
-	}))
-	defer server.Close()
+		assert.NotContains(t, req.URL.RawQuery, "status="+url.QueryEscape("finished"))
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(200)
+		writer.Write([]byte(EMPTY_RUNS_RESPONSE))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "summary"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then ...
 	assert.Nil(t, err)
@@ -1402,32 +1581,89 @@ func TestRunsGetActiveRunsBuildsQueryCorrectly(t *testing.T) {
 func TestRunsGetWithNextCursorGetsNextPageOfRuns(t *testing.T) {
 
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	pages["page2"] = []string{RUN_U456}
-	pages["page3"] = []string{}
-	nextPageCursors := []string{"page2", "page3"}
+	page2Cursor := "page2"
+	page3Cursor := "page3"
 
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := ""
 	shouldGetActive := false
-	pageSize := 1
 	group := ""
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+	getRunsInteraction1 := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction1.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "%s",
+				"pageSize": 1,
+				"amountOfRuns": 1,
+				"runs":[ %s ]
+			}`, page2Cursor, RUN_U456)))
+    }
+
+	getRunsInteraction2 := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction2.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "%s",
+				"pageSize": 1,
+				"amountOfRuns": 1,
+				"runs":[ %s ]
+			}`, page3Cursor, RUN_U456)))
+    }
+
+	getRunsInteraction3 := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction3.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "%s",
+				"pageSize": 1,
+				"amountOfRuns": 0,
+				"runs":[]
+			}`, page3Cursor)))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction1,
+        getRunsInteraction2,
+        getRunsInteraction3,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "raw"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then...
 	assert.Nil(t, err)
@@ -1442,29 +1678,48 @@ func TestRunsGetWithNextCursorGetsNextPageOfRuns(t *testing.T) {
 func TestRunsGetOfGroupWhichExistsProducesExpectedRaw(t *testing.T) {
 
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{RUN_U456}
-	nextPageCursors := []string{""}
 	age := ""
 	runName := "U456"
 	requestor := ""
 	result := ""
 	shouldGetActive := false
-	pageSize := 100
 	group := "dummyGroup"
+	tags := make([]string, 0)
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		runNameQueryParameter := values.Get("runname")
+		assert.Equal(t, runNameQueryParameter, runName)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			{
+				"nextCursor": "",
+				"pageSize": 100,
+				"amountOfRuns": 1,
+				"runs":[ %s ]
+			}`, RUN_U456)))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	outputFormat := "raw"
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then...
 	// We expect
@@ -1478,34 +1733,151 @@ func TestRunsGetOfGroupWhichExistsProducesExpectedRaw(t *testing.T) {
 func TestRunsGetWithBadGroupNameThrowsError(t *testing.T) {
 
 	// Given ...
-	pages := make(map[string][]string, 0)
-	pages[""] = []string{}
-	nextPageCursors := []string{""}
-
 	runName := "U457"
 	age := ""
 	requestor := ""
 	result := ""
 	shouldGetActive := false
-	pageSize := 100
 	outputFormat := "raw"
+	tags := make([]string, 0)
 
 	group := string(rune(300)) + "NONLATIN1"
 
-	server := NewRunsGetServletMock(t, http.StatusOK, nextPageCursors, pages, pageSize, runName)
-	defer server.Close()
+    interactions := []utils.HttpInteraction{}
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	mockConsole := utils.NewMockConsole()
 
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	mockTimeService := utils.NewMockTimeService()
 	commsClient := api.NewMockAPICommsClient(apiServerUrl)
 
 	// When...
-	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, mockTimeService, mockConsole, commsClient)
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
 
 	// Then...
 	assert.NotNil(t, err, "A non-Latin-1 group name should throw an error")
 	assert.ErrorContains(t, err, "GAL1105E")
 	assert.ErrorContains(t, err, "Invalid group name provided")
+}
+
+func TestRunsGetWithOneTagSendsRequestWithCorrectTagsQuery(t *testing.T) {
+
+	// Given ...
+	runName := "U456"
+	age := "2d:24h"
+	requestor := ""
+	result := ""
+	group := ""
+	tag := "core"
+	tags := []string{ tag }
+	shouldGetActive := false
+
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		tagsQueryParameter := values.Get("tags")
+		assert.Equal(t, tagsQueryParameter, tag)
+
+		writer.Write([]byte(fmt.Sprintf(`
+			 {
+				 "nextCursor": "",
+				 "pageSize": 100,
+				 "amountOfRuns": 1,
+				 "runs":[ %s ]
+			 }`, RUN_U456_v2)))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	outputFormat := "summary"
+	mockConsole := utils.NewMockConsole()
+
+	apiServerUrl := server.Server.URL
+	mockTimeService := utils.NewMockTimeService()
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
+
+	// When...
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
+
+	// Then...
+	assert.Nil(t, err, "Failed with an error when we expected it to pass")
+	textGotBack := mockConsole.ReadText()
+	assert.Contains(t, textGotBack, runName)
+	want :=
+		"submitted-time(UTC) name requestor     status   result           test-name             group tags\n" +
+			"2023-05-10 06:00:13 U456 unitTesting22 Finished LongResultString myTestPackage.MyTest2       anothertag,core\n" +
+			"\n" +
+			"Total:1\n"
+	assert.Equal(t, want, textGotBack)
+}
+
+func TestRunsGetWithMultipleTagsSendsRequestWithCorrectTagsQuery(t *testing.T) {
+
+	// Given ...
+	runName := "U456"
+	age := "2d:24h"
+	requestor := ""
+	result := ""
+	group := ""
+	tag1 := "core"
+	tag2 := "anothertag"
+	tags := []string{ tag1, tag2 }
+	shouldGetActive := false
+
+	getRunsInteraction := utils.NewHttpInteraction("/ras/runs", http.MethodGet)
+    getRunsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+	
+		values := req.URL.Query()
+		tagsQueryParameter := values.Get("tags")
+		assert.Equal(t, tagsQueryParameter, strings.Join(tags, ","))
+
+		writer.Write([]byte(fmt.Sprintf(`
+			 {
+				 "nextCursor": "",
+				 "pageSize": 100,
+				 "amountOfRuns": 1,
+				 "runs":[ %s ]
+			 }`, RUN_U456_v2)))
+    }
+
+    interactions := []utils.HttpInteraction{
+        getRunsInteraction,
+    }
+
+    server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	outputFormat := "summary"
+	mockConsole := utils.NewMockConsole()
+
+	apiServerUrl := server.Server.URL
+	mockTimeService := utils.NewMockTimeService()
+	commsClient := api.NewMockAPICommsClient(apiServerUrl)
+
+	// When...
+	err := GetRuns(runName, age, requestor, result, shouldGetActive, outputFormat, group, tags, mockTimeService, mockConsole, commsClient)
+
+	// Then...
+	assert.Nil(t, err, "Failed with an error when we expected it to pass")
+	textGotBack := mockConsole.ReadText()
+	assert.Contains(t, textGotBack, runName)
+	want :=
+		"submitted-time(UTC) name requestor     status   result           test-name             group tags\n" +
+			"2023-05-10 06:00:13 U456 unitTesting22 Finished LongResultString myTestPackage.MyTest2       anothertag,core\n" +
+			"\n" +
+			"Total:1\n"
+	assert.Equal(t, want, textGotBack)
 }

--- a/modules/cli/pkg/runs/runsGet_test.go
+++ b/modules/cli/pkg/runs/runsGet_test.go
@@ -354,17 +354,8 @@ func TestRunsGetOfRunNameWhichExistsProducesExpectedDetails(t *testing.T) {
 			}`, RUN_U456)))
     }
 
-	getRunsDetailsInteraction := utils.NewHttpInteraction("/ras/runs/xxx876xxx", http.MethodGet)
-    getRunsDetailsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
-		writer.Header().Set("Content-Type", "application/json")
-		writer.WriteHeader(http.StatusOK)
-
-		writer.Write([]byte(RUN_U456))
-    }
-
     interactions := []utils.HttpInteraction{
         getRunsInteraction,
-		getRunsDetailsInteraction,
     }
 
     server := utils.NewMockHttpServer(t, interactions)

--- a/modules/cli/pkg/runs/runsQuery.go
+++ b/modules/cli/pkg/runs/runsQuery.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/galasa-dev/cli/pkg/api"
@@ -18,38 +19,41 @@ import (
 )
 
 type RunsQuery struct {
-	pageCursor             string
-	runName                string
-	requestor              string
-	result                 string
-	group                  string
-	fromTime               time.Time
-	toTime                 time.Time
-	shouldGetActive        bool
+    pageCursor             string
+    runName                string
+    requestor              string
+    result                 string
+    group                  string
+    fromTime               time.Time
+    toTime                 time.Time
+    shouldGetActive        bool
 	isNeedingMethodDetails bool
+    tags                   []string
 }
 
 const METHOD_DETAIL_QUERY_PARAM = "methods"
 
 func NewRunsQuery(
-	runName string,
-	requestor string,
-	result string,
-	group string,
-	fromAgeMins int,
-	toAgeMins int,
-	shouldGetActive bool,
-	now time.Time,
+    runName string,
+    requestor string,
+    result string,
+    group string,
+    fromAgeMins int,
+    toAgeMins int,
+    shouldGetActive bool,
 	isNeedingMethodDetails bool,
+    tags []string,
+    now time.Time,
 ) *RunsQuery {
-	runsQuery := &RunsQuery{
-		runName:                runName,
-		requestor:              requestor,
-		result:                 result,
-		group:                  group,
-		shouldGetActive:        shouldGetActive,
+    runsQuery := &RunsQuery{
+        runName: runName,
+        requestor: requestor,
+        result: result,
+        group: group,
+        shouldGetActive: shouldGetActive,
 		isNeedingMethodDetails: isNeedingMethodDetails,
-	}
+        tags: tags,
+    }
 
 	if fromAgeMins != 0 {
 		runsQuery.fromTime = now.Add(-(time.Duration(fromAgeMins) * time.Minute)).UTC() // Add a minus, so subtract
@@ -73,64 +77,68 @@ func (query *RunsQuery) GetRunsPageFromRestApi(
 	var err error
 	var runData *galasaapi.RunResults
 
-	err = commsClient.RunAuthenticatedCommandWithRateLimitRetries(func(apiClient *galasaapi.APIClient) error {
-		var err error
-		var httpResponse *http.Response
-		var context context.Context = nil
-
-		apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion).IncludeCursor("true")
-		if !query.fromTime.IsZero() {
-			apicall = apicall.From(query.fromTime)
-		}
-		if !query.toTime.IsZero() {
-			apicall = apicall.To(query.toTime)
-		}
-		if query.runName != "" {
-			apicall = apicall.Runname(query.runName)
-		}
-		if query.requestor != "" {
-			apicall = apicall.Requestor(query.requestor)
-		}
-		if query.result != "" {
-			apicall = apicall.Result(query.result)
-		}
-		if query.shouldGetActive {
-			apicall = apicall.Status(activeStatusNames)
-		}
-		if query.pageCursor != "" {
-			apicall = apicall.Cursor(query.pageCursor)
-		}
-		if query.group != "" {
-			apicall = apicall.Group(query.group)
-		}
+    err = commsClient.RunAuthenticatedCommandWithRateLimitRetries(func(apiClient *galasaapi.APIClient) error {
+        var err error
+        var httpResponse *http.Response
+        var context context.Context = nil
+    
+        apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion).IncludeCursor("true")
+        if !query.fromTime.IsZero() {
+            apicall = apicall.From(query.fromTime)
+        }
+        if !query.toTime.IsZero() {
+            apicall = apicall.To(query.toTime)
+        }
+        if query.runName != "" {
+            apicall = apicall.Runname(query.runName)
+        }
+        if query.requestor != "" {
+            apicall = apicall.Requestor(query.requestor)
+        }
+        if query.result != "" {
+            apicall = apicall.Result(query.result)
+        }
+        if query.shouldGetActive {
+            apicall = apicall.Status(activeStatusNames)
+        }
+        if query.pageCursor != "" {
+            apicall = apicall.Cursor(query.pageCursor)
+        }
+        if query.group != "" {
+            apicall = apicall.Group(query.group)
+        }
 		if query.isNeedingMethodDetails {
 			apicall = apicall.Detail(METHOD_DETAIL_QUERY_PARAM)
 		}
-		apicall = apicall.Sort("from:desc")
-		runData, httpResponse, err = apicall.Execute()
+        if len(query.tags) > 0 {
+            apicall = apicall.Tags(strings.Join(query.tags, ","))
+        }
 
-		var statusCode int
-		if httpResponse != nil {
-			defer httpResponse.Body.Close()
-			statusCode = httpResponse.StatusCode
-		}
-
-		if err != nil {
-			err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_QUERY_RUNS_FAILED, err.Error())
-		} else {
-			if statusCode != http.StatusOK {
-				httpError := "\nhttp response status code: " + strconv.Itoa(statusCode)
-				errString := httpError
-				err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_QUERY_RUNS_FAILED, errString)
-			} else {
-
-				log.Printf("HTTP status was OK")
-
-				// Copy the results from this page into our bigger list of results.
-				log.Printf("runsOnThisPage: %v", len(runData.GetRuns()))
-			}
-		}
-		return err
-	})
-	return runData, err
+        apicall = apicall.Sort("from:desc")
+        runData, httpResponse, err = apicall.Execute()
+    
+        var statusCode int
+        if httpResponse != nil {
+            defer httpResponse.Body.Close()
+            statusCode = httpResponse.StatusCode
+        }
+    
+        if err != nil {
+            err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_QUERY_RUNS_FAILED, err.Error())
+        } else {
+            if statusCode != http.StatusOK {
+                httpError := "\nhttp response status code: " + strconv.Itoa(statusCode)
+                errString := httpError
+                err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_QUERY_RUNS_FAILED, errString)
+            } else {
+    
+                log.Printf("HTTP status was OK")
+    
+                // Copy the results from this page into our bigger list of results.
+                log.Printf("runsOnThisPage: %v", len(runData.GetRuns()))
+            }
+        }
+        return err
+    })
+    return runData, err
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasQueryBuilder.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasQueryBuilder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.ras.couchdb.internal;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import dev.galasa.framework.spi.ResultArchiveStoreException;
+import dev.galasa.framework.spi.ras.IRasSearchCriteria;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaQueuedFrom;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaQueuedTo;
+
+public class CouchdbRasQueryBuilder {
+
+    public JsonObject buildGetRunsQuery(IRasSearchCriteria... searchCriterias) throws ResultArchiveStoreException {
+        JsonObject selector = new JsonObject();
+        JsonArray and = new JsonArray();
+        selector.add("$and", and);
+
+        for (IRasSearchCriteria searchCriteria : searchCriterias) {
+            if (searchCriteria instanceof RasSearchCriteriaQueuedFrom) {
+                RasSearchCriteriaQueuedFrom sFrom = (RasSearchCriteriaQueuedFrom) searchCriteria;
+
+                JsonObject criteria = new JsonObject();
+                JsonObject jFrom = new JsonObject();
+                jFrom.addProperty("$gte", sFrom.getFrom().toString());
+                criteria.add("queued", jFrom);
+                and.add(criteria);
+            } else if (searchCriteria instanceof RasSearchCriteriaQueuedTo) {
+                RasSearchCriteriaQueuedTo sTo = (RasSearchCriteriaQueuedTo) searchCriteria;
+
+                JsonObject criteria = new JsonObject();
+                JsonObject jTo = new JsonObject();
+                jTo.addProperty("$lt", sTo.getTo().toString());
+                criteria.add("queued", jTo);
+                and.add(criteria);
+            } else {
+                addInArrayConditionToQuery(and, searchCriteria.getCriteriaName(), searchCriteria.getCriteriaContent());
+            }
+        }
+        return selector;
+    }
+
+    private void addInArrayConditionToQuery(JsonArray existingQuery, String field, String[] inArray) {
+        if (inArray != null && inArray.length > 0) {
+            JsonArray inArrayJson = new JsonArray();
+            for (String in : inArray) {
+                if (in != null && !in.isEmpty()) {
+                    inArrayJson.add(in);
+                }
+            }
+
+            if (!inArrayJson.isEmpty()) {
+                JsonObject inCondition = new JsonObject();
+                inCondition.add("$in", inArrayJson);
+        
+                JsonObject criteria = new JsonObject();
+                criteria.add(field, inCondition);
+        
+                existingQuery.add(criteria);
+            }
+        }
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImpl.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImpl.java
@@ -97,6 +97,7 @@ public class CouchdbValidatorImpl implements CouchdbValidator {
             checkIndex(httpClient, rasUri, 1, "galasa_run", "result", timeService);
             checkIndex(httpClient, rasUri, 1, "galasa_run", "group", timeService);
             checkIndex(httpClient, rasUri, 1, "galasa_run", "submissionId", timeService);
+            checkIndex(httpClient, rasUri, 1, "galasa_run", "tags", timeService);
 
             logger.debug("RAS CouchDB at " + rasUri.toString() + " validated");
         } catch (CouchdbException e) {

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryServiceTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryServiceTest.java
@@ -14,8 +14,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.validation.constraints.NotNull;
-
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpStatus;
@@ -32,7 +30,6 @@ import dev.galasa.extensions.common.mocks.MockCloseableHttpClient;
 import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
-import dev.galasa.framework.spi.ras.IRasSearchCriteria;
 import dev.galasa.framework.spi.ras.RasRunResultPage;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaBundle;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaQueuedFrom;
@@ -43,7 +40,6 @@ import dev.galasa.framework.spi.ras.RasSearchCriteriaRunName;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaStatus;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaTestName;
 import dev.galasa.framework.spi.ras.RasSortField;
-import dev.galasa.framework.spi.teststructure.TestStructure;
 import dev.galasa.ras.couchdb.internal.mocks.CouchdbTestFixtures;
 import dev.galasa.ras.couchdb.internal.mocks.MockLogFactory;
 import dev.galasa.ras.couchdb.internal.pojos.FoundRuns;
@@ -319,31 +315,6 @@ public class CouchdbDirectoryServiceTest extends BaseCouchdbOperationTest {
         assertThat(runs).hasSize(2);
         assertThat(runs.get(0).getTestStructure().getRunName()).isEqualTo(mockRun1.getRunName());
         assertThat(runs.get(1).getTestStructure().getRunName()).isEqualTo(mockRun2.getRunName());
-    }
-
-
-    @Test
-    public void testGetRunsWithInvalidCriteriaThrowsError() throws Exception {
-        // Given...
-        IRasSearchCriteria unknownCriteria = new IRasSearchCriteria() {
-            @Override
-            public boolean criteriaMatched(@NotNull TestStructure testStructure) {
-                return false;
-            }
-        };
-
-        List<HttpInteraction> interactions = new ArrayList<>();
-
-        MockLogFactory mockLogFactory = new MockLogFactory();
-        CouchdbRasStore mockRasStore = fixtures.createCouchdbRasStore(interactions, mockLogFactory);
-        CouchdbDirectoryService directoryService = new CouchdbDirectoryService(mockRasStore, mockLogFactory, new HttpRequestFactoryImpl());
-
-        // When...
-        ResultArchiveStoreException thrown = catchThrowableOfType(() -> directoryService.getRuns(unknownCriteria), ResultArchiveStoreException.class);
-
-        // Then...
-        assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("Unrecognised search criteria");
     }
 
     @Test

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
@@ -322,6 +322,8 @@ public class CouchdbValidatorImplTest {
         interactions.add( new CheckIndexPOSTInteraction("group"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
         interactions.add( new CheckIndexPOSTInteraction("submissionId"));
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("tags"));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1595,6 +1595,15 @@ paths:
           schema:
             type: string
           example: methods
+        - name: tags
+          in: query
+          description: |
+            One or more tags that may be associated with one or more existing test runs.
+            Multiple tags can be supplied as a comma-separated list, for example, 'tags=tag1,tag2,tag3'.
+            If multiple tags are supplied, test runs that have any of the supplied tags will be returned.
+          schema:
+            type: string
+          example: my-zos-tests
         
         # Temporary feature flag to enable cursor-based pagination
         - name: includeCursor

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
@@ -7,8 +7,10 @@ package dev.galasa.framework.api.ras.internal.common;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.time.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -144,8 +146,8 @@ public class RasQueryParameters {
         return generalQueryParams.getMultipleString("runId", new ArrayList<String>());
     }
 
-    public List<String> getTags() {
-        return generalQueryParams.getMultipleString("tags", new ArrayList<String>());
+    public Set<String> getTags() {
+        return new HashSet<>(generalQueryParams.getMultipleString("tags", new ArrayList<String>()));
     }
 
     public boolean isAtLeastOneMandatoryParameterPresent() throws InternalServletException {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
@@ -144,6 +144,10 @@ public class RasQueryParameters {
         return generalQueryParams.getMultipleString("runId", new ArrayList<String>());
     }
 
+    public List<String> getTags() {
+        return generalQueryParams.getMultipleString("tags", new ArrayList<String>());
+    }
+
     public boolean isAtLeastOneMandatoryParameterPresent() throws InternalServletException {
         return generalQueryParams.checkAtLeastOneQueryParameterPresent(
             RunQueryRoute.QUERY_PARAMETER_FROM,

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
@@ -37,6 +37,7 @@ import dev.galasa.framework.spi.ras.RasSearchCriteriaResult;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaRunName;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaStatus;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaSubmissionId;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaTags;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaTestName;
 import dev.galasa.framework.spi.ras.RasSortField;
 import dev.galasa.framework.spi.rbac.RBACException;
@@ -83,6 +84,7 @@ public class RunQueryRoute extends RunsRoute {
 	public static final String QUERY_PARAMETER_RUNNAME = "runname";
 	public static final String QUERY_PARAMETER_RUNID = "runid";
 	public static final String QUERY_PARAMETER_DETAIL = "detail";
+	public static final String QUERY_PARAMETER_TAGS = "tags";
 
     public static final SupportedQueryParameterNames SUPPORTED_QUERY_PARAMETER_NAMES = new SupportedQueryParameterNames(
 		QUERY_PARAMETER_SORT, QUERY_PARAMETER_RESULT, QUERY_PARAMETER_STATUS,
@@ -90,7 +92,7 @@ public class RunQueryRoute extends RunsRoute {
 		QUERY_PARAMETER_TO, QUERY_PARAMETER_TESTNAME, QUERY_PARAMETER_PAGE,
 		QUERY_PARAMETER_SIZE, QUERY_PARAMETER_GROUP, QUERY_PARAMETER_SUBMISSION_ID,
 		QUERY_PARAMETER_INCLUDECURSOR, QUERY_PARAMETER_CURSOR, QUERY_PARAMETER_RUNNAME,
-		QUERY_PARAMETER_RUNID
+		QUERY_PARAMETER_RUNID, QUERY_PARAMETER_TAGS
 	);
 
 
@@ -224,6 +226,7 @@ public class RunQueryRoute extends RunsRoute {
 		String group = queryParams.getGroup();
 		String submissionId = queryParams.getSubmissionId();
 		Instant to = queryParams.getToTime();
+		List<String> tags = queryParams.getTags();
 
 		Instant defaultFromTime = Instant.now().minus(24,ChronoUnit.HOURS);
 		// from will error if no runname is specified as it is a mandatory field
@@ -273,6 +276,10 @@ public class RunQueryRoute extends RunsRoute {
 		if (submissionId != null && !submissionId.isEmpty()) {
 			RasSearchCriteriaSubmissionId submissionIdCriteria = new RasSearchCriteriaSubmissionId(submissionId);
 			critList.add(submissionIdCriteria);
+		}
+		if (tags != null && !tags.isEmpty()) {
+			RasSearchCriteriaTags tagsCriteria = new RasSearchCriteriaTags(tags.toArray(new String[0]));
+			critList.add(tagsCriteria);
 		}
 
 		return critList;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
@@ -226,7 +226,7 @@ public class RunQueryRoute extends RunsRoute {
 		String group = queryParams.getGroup();
 		String submissionId = queryParams.getSubmissionId();
 		Instant to = queryParams.getToTime();
-		List<String> tags = queryParams.getTags();
+		Set<String> tags = queryParams.getTags();
 
 		Instant defaultFromTime = Instant.now().minus(24,ChronoUnit.HOURS);
 		// from will error if no runname is specified as it is a mandatory field

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/IRasSearchCriteria.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/IRasSearchCriteria.java
@@ -12,5 +12,7 @@ import dev.galasa.framework.spi.teststructure.TestStructure;
 public interface IRasSearchCriteria {
 	
 	boolean criteriaMatched(@NotNull TestStructure testStructure);
-	
+
+	String getCriteriaName();
+	String[] getCriteriaContent();
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaBundle.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaBundle.java
@@ -11,6 +11,7 @@ import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class RasSearchCriteriaBundle implements IRasSearchCriteria {
    
+   private static final String CRITERIA_NAME = "bundle";
    private final String[] bundles;
    
    public RasSearchCriteriaBundle(@NotNull String... bundles) {
@@ -38,6 +39,16 @@ public class RasSearchCriteriaBundle implements IRasSearchCriteria {
 
    public String[] getBundles() {
        return bundles;
+   }
+
+   @Override
+   public String getCriteriaName() {
+       return CRITERIA_NAME;
+   }
+
+   @Override
+   public String[] getCriteriaContent() {
+        return this.bundles;
    }
 
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaGroup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaGroup.java
@@ -11,10 +11,11 @@ import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class RasSearchCriteriaGroup implements IRasSearchCriteria {
 	
-	private final String[] group;
+	private static final String CRITERIA_NAME = "group";
+	private final String[] groups;
 
-	public RasSearchCriteriaGroup(@NotNull String... testNameCriteria) {
-		this.group = testNameCriteria;
+	public RasSearchCriteriaGroup(@NotNull String... groups) {
+		this.groups = groups;
 	}
 
 	@Override
@@ -24,8 +25,8 @@ public class RasSearchCriteriaGroup implements IRasSearchCriteria {
 			return Boolean.FALSE;	
 		}
 
-		if(group != null) {
-			for(String groupIn : group) {
+		if(groups != null) {
+			for(String groupIn : groups) {
 				if(groupIn.equals(structure.getGroup())) {
 					return Boolean.TRUE;
 				}
@@ -37,7 +38,17 @@ public class RasSearchCriteriaGroup implements IRasSearchCriteria {
 
 
     public String[] getGroups() {
-        return this.group;
+        return this.groups;
     }
+
+	@Override
+	public String getCriteriaName() {
+		return CRITERIA_NAME;
+	}
+
+	@Override
+	public String[] getCriteriaContent() {
+		return this.groups;
+	}
 }
 	

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaQueuedFrom.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaQueuedFrom.java
@@ -12,6 +12,7 @@ import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class RasSearchCriteriaQueuedFrom implements IRasSearchCriteria {
 	
+	private static final String CRITERIA_NAME = "queued";
 	private final Instant from;
 	
 	public RasSearchCriteriaQueuedFrom(@NotNull Instant fromCriteria) {
@@ -43,6 +44,16 @@ public class RasSearchCriteriaQueuedFrom implements IRasSearchCriteria {
     public Instant getFrom() {
         return this.from;
     }
+
+	@Override
+	public String getCriteriaName() {
+		return CRITERIA_NAME;
+	}
+
+	@Override
+	public String[] getCriteriaContent() {
+		return new String[]{ this.from.toString() };
+	}
 	
 }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaQueuedTo.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaQueuedTo.java
@@ -12,7 +12,8 @@ import javax.validation.constraints.NotNull;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class RasSearchCriteriaQueuedTo implements IRasSearchCriteria {
-	
+
+	private static final String CRITERIA_NAME = "queued";
 	private final Instant to;
 	
 	public RasSearchCriteriaQueuedTo(@NotNull Instant toCriteria) {
@@ -44,4 +45,14 @@ public class RasSearchCriteriaQueuedTo implements IRasSearchCriteria {
     public Instant getTo() {
         return this.to;
     }
+
+	@Override
+	public String getCriteriaName() {
+		return CRITERIA_NAME;
+	}
+
+	@Override
+	public String[] getCriteriaContent() {
+		return new String[]{ this.to.toString() };
+	}
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaRequestor.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaRequestor.java
@@ -9,8 +9,9 @@ import javax.validation.constraints.NotNull;
 
 import dev.galasa.framework.spi.teststructure.TestStructure;
 
-public class RasSearchCriteriaRequestor implements IRasSearchCriteria{
+public class RasSearchCriteriaRequestor implements IRasSearchCriteria {
 	
+	private static final String CRITERIA_NAME = "requestor";
 	private final String[] requestors;
 	
 	public RasSearchCriteriaRequestor(@NotNull String... requestorCriteria) {
@@ -38,4 +39,14 @@ public class RasSearchCriteriaRequestor implements IRasSearchCriteria{
     public String[] getRequestors() {
         return requestors;
     }
+
+	@Override
+	public String getCriteriaName() {
+		return CRITERIA_NAME;
+	}
+
+	@Override
+	public String[] getCriteriaContent() {
+		return this.requestors;
+	}
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaResult.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaResult.java
@@ -11,6 +11,7 @@ import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class RasSearchCriteriaResult implements IRasSearchCriteria {
    
+   private static final String CRITERIA_NAME = "result";
    private final String[] results;
    
    public RasSearchCriteriaResult(@NotNull String... results) {
@@ -40,6 +41,16 @@ public class RasSearchCriteriaResult implements IRasSearchCriteria {
 
    public String[] getResults() {
        return this.results;
+   }
+
+   @Override
+   public String getCriteriaName() {
+      return CRITERIA_NAME;
+   }
+
+   @Override
+   public String[] getCriteriaContent() {
+      return this.results;
    }
    
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaRunName.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaRunName.java
@@ -11,6 +11,7 @@ import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class RasSearchCriteriaRunName implements IRasSearchCriteria {
 	
+	private static final String CRITERIA_NAME = "runName";
 	private final String[] runNames;
 
 	public RasSearchCriteriaRunName(@NotNull String... testNameCriteria) {
@@ -39,5 +40,15 @@ public class RasSearchCriteriaRunName implements IRasSearchCriteria {
     public String[] getRunNames() {
         return this.runNames;
     }
+
+	@Override
+	public String getCriteriaName() {
+		return CRITERIA_NAME;
+	}
+
+	@Override
+	public String[] getCriteriaContent() {
+		return this.runNames;
+	}
 }
 	

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaStatus.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaStatus.java
@@ -15,6 +15,7 @@ import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class RasSearchCriteriaStatus implements IRasSearchCriteria {
    
+   private static final String CRITERIA_NAME = "status";
    private final List<TestRunLifecycleStatus> statuses;
    
    public RasSearchCriteriaStatus(@NotNull List<TestRunLifecycleStatus> statuses) {
@@ -42,5 +43,15 @@ public class RasSearchCriteriaStatus implements IRasSearchCriteria {
          statusesStrings.add(status.toString());
       }
       return statusesStrings.toArray(new String[0]);
+   }
+
+   @Override
+   public String getCriteriaName() {
+      return CRITERIA_NAME;
+   }
+
+   @Override
+   public String[] getCriteriaContent() {
+      return getStatusesAsStrings();
    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaTags.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaTags.java
@@ -5,26 +5,29 @@
  */
 package dev.galasa.framework.spi.ras;
 
+import java.util.Set;
+
 import javax.validation.constraints.NotNull;
 
 import dev.galasa.framework.spi.teststructure.TestStructure;
 
-public class RasSearchCriteriaSubmissionId implements IRasSearchCriteria {
+public class RasSearchCriteriaTags implements IRasSearchCriteria {
 
-	private static final String CRITERIA_NAME = "submissionId";
-	private final String[] submissionIds;
+	private static final String CRITERIA_NAME = "tags";
+	private final String[] tags;
 
-	public RasSearchCriteriaSubmissionId(@NotNull String... submissionIdCriteria) {
-		this.submissionIds = submissionIdCriteria;
+	public RasSearchCriteriaTags(@NotNull String... tags) {
+		this.tags = tags;
 	}
 
 	@Override
 	public boolean criteriaMatched(@NotNull TestStructure structure) {
 
 		boolean isMatched = false;
-		if (structure != null && submissionIds != null) {
-			for (String submissionId : submissionIds) {
-				if (submissionId.equals(structure.getSubmissionId())) {
+		if (structure != null && tags != null) {
+			Set<String> structureTags = structure.getTags();
+			for (String tag : tags) {
+				if (structureTags.contains(tag)) {
 					isMatched = true;
 					break;
 				}
@@ -34,8 +37,8 @@ public class RasSearchCriteriaSubmissionId implements IRasSearchCriteria {
 		return isMatched;
 	}
 
-    public String[] getSubmissionIds() {
-        return this.submissionIds;
+    public String[] getTags() {
+        return this.tags;
     }
 
 	@Override
@@ -45,6 +48,6 @@ public class RasSearchCriteriaSubmissionId implements IRasSearchCriteria {
 
 	@Override
 	public String[] getCriteriaContent() {
-		return this.submissionIds;
+		return this.tags;
 	}
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaTestName.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaTestName.java
@@ -10,7 +10,8 @@ import javax.validation.constraints.NotNull;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class RasSearchCriteriaTestName implements IRasSearchCriteria {
-	
+
+	private static final String CRITERIA_NAME = "testName";
 	private final String[] testNames;
 	
 	public RasSearchCriteriaTestName(@NotNull String... testNameCriteria) {
@@ -39,4 +40,14 @@ public class RasSearchCriteriaTestName implements IRasSearchCriteria {
     public String[] getTestNames() {
         return this.testNames;
     }
+
+	@Override
+	public String getCriteriaName() {
+		return CRITERIA_NAME;
+	}
+
+	@Override
+	public String[] getCriteriaContent() {
+		return this.testNames;
+	}
 }


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2216

## Changes
- Added a new 'tags' query parameter to the /ras/runs endpoint used to query the RAS for test runs, which provides REST API users with the ability to search for runs by test tags.
- Added a new `--tags` flag to galasactl's  `runs get` command to allow users to be able to provide one or more tags (either by supplying a comma-separated list of tags or by supplying multiple `--tags` flags)
- Minor refactoring to the `runs get` unit tests to use individual HTTP interactions instead of a shared mock server configuration (i.e. moved HTTP interactions closer to the individual tests)
- Minor refactoring to the code that converts RAS search criteria into CouchDB queries
  - Shortened the lengthy `instanceof` condition chain from 11 conditions down to 3