### PR TITLE
Update the message for `galasabld slackpost tests`

### DIFF
--- a/modules/buildutils/pkg/cmd/slackpostTests.go
+++ b/modules/buildutils/pkg/cmd/slackpostTests.go
@@ -87,7 +87,7 @@ func slackpostTestsExecute(cmd *cobra.Command, args []string) {
 		total++
 	}
 
-	content := fmt.Sprintf("Galasa Regression Testing - Failure Report\nTest Suite: %s\n%s\nTotal: %v\nPassed: %v, Failed: %v, Failed With Defects: %v, Passed With Defects: %v, Other: %v\n", testSuiteName, testSuiteDesc, total, passed, failed, fwd, pwd, other)
+	content := fmt.Sprintf("Galasa Regression Testing - Status Report\nTest Suite: %s (%s)\nTotal: %v\nPassed: %v, Failed: %v, Failed With Defects: %v, Passed With Defects: %v, Other: %v\n", testSuiteName, testSuiteDesc, total, passed, failed, fwd, pwd, other)
 	for _, f := range failingTests {
 		content += f
 	}


### PR DESCRIPTION
## Why?

Update the message posted into Slack by galasabld for the regression test status report.

Too many new lines makes the message to long and where there are multiple test suites with multiple of these messages, it crowds the channel.