### PR TITLE
Fix Pull Request Build Orchestrator call to codeql-java and codeql-go

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -339,16 +339,16 @@ jobs:
   codeql-java:
     name: CodeQL scans the Java code
     if: ${{ 
-      needs.get-changed-modules.outputs.platform_changed || 
-      needs.get-changed-modules.outputs.wrapping_changed ||
-      needs.get-changed-modules.outputs.gradle_changed ||
-      needs.get-changed-modules.outputs.maven_changed ||
-      needs.get-changed-modules.outputs.framework_changed ||
-      needs.get-changed-modules.outputs.extensions_changed ||
-      needs.get-changed-modules.outputs.managers_changed ||
-      needs.get-changed-modules.outputs.obr_changed ||
-      needs.get-changed-modules.outputs.ivts_changed
-      }}
+        needs.get-changed-modules.outputs.platform_changed == 'true' || 
+        needs.get-changed-modules.outputs.wrapping_changed == 'true' ||
+        needs.get-changed-modules.outputs.gradle_changed == 'true' ||
+        needs.get-changed-modules.outputs.maven_changed == 'true' ||
+        needs.get-changed-modules.outputs.framework_changed == 'true' ||
+        needs.get-changed-modules.outputs.extensions_changed == 'true' ||
+        needs.get-changed-modules.outputs.managers_changed == 'true' ||
+        needs.get-changed-modules.outputs.obr_changed == 'true' ||
+        needs.get-changed-modules.outputs.ivts_changed == 'true' 
+        }}
     needs: [get-changed-modules, download-artifacts-for-codeql]
     uses: ./.github/workflows/codeql-java.yml
     secrets: inherit
@@ -360,7 +360,10 @@ jobs:
 
   codeql-go:
     name: CodeQL scans the Golang code
-    if: ${{ needs.get-changed-modules.outputs.buildutils_changed || needs.get-changed-modules.outputs.cli_changed }}
+    if: ${{ 
+        needs.get-changed-modules.outputs.buildutils_changed == 'true' || 
+        needs.get-changed-modules.outputs.cli_changed == 'true' 
+        }}
     needs: [get-changed-modules, download-artifacts-for-codeql]
     uses: ./.github/workflows/codeql-go.yml
     secrets: inherit


### PR DESCRIPTION
## Why?

The jobs `codeql-java` and `codeql-go` were always being called, regardless of which modules had changed, because the `if` condition that selects if the job should run or not was incorrect. The values it is testing are strings not booleans, so were missing `== 'true'` to actually check the value properly.