### PR TITLE
Fix NullPointerException when interrupting runs that have no RAS record

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/InterruptedRunEventProcessor.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/InterruptedRunEventProcessor.java
@@ -62,7 +62,9 @@ public class InterruptedRunEventProcessor implements Runnable {
                 } else {
                     String runName = interruptEvent.getRunName();
                     List<RunRasAction> rasActions = interruptEvent.getRasActions();
-                    rasActionProcessor.processRasActions(runName, rasActions);
+                    if (rasActions != null && !rasActions.isEmpty()) {
+                        rasActionProcessor.processRasActions(runName, rasActions);
+                    }
                     
                     String interruptReason = interruptEvent.getInterruptReason();
                     switch (interruptReason) {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -338,15 +338,19 @@ public class FrameworkRuns implements IFrameworkRuns {
     private void interruptRun(IRun run, String interruptReason) throws DynamicStatusStoreException {
         String runName = run.getName();
 
-        // Add a RAS action to the run's existing RAS actions so that the RAS records for any re-runs can be updated correctly
-        List<RunRasAction> rasActions = new ArrayList<>(run.getRasActions());
-        RunRasAction rasActionToAdd = new RunRasAction(run.getRasRunId(), TestRunLifecycleStatus.FINISHED.toString(), interruptReason);
-        rasActions.add(rasActionToAdd);
-
-        String encodedRasActions = encodeRasActionsToBase64(rasActions);
-
         Map<String, String> propertiesToSet = new HashMap<>();
-        propertiesToSet.put(getSuffixedRunDssKey(runName, "rasActions"), encodedRasActions);
+
+        String runId = run.getRasRunId();
+        if (runId != null) {
+            // Add a RAS action to the run's existing RAS actions so that the RAS records for any re-runs can be updated correctly
+            List<RunRasAction> rasActions = new ArrayList<>(run.getRasActions());
+            RunRasAction rasActionToAdd = new RunRasAction(runId, TestRunLifecycleStatus.FINISHED.toString(), interruptReason);
+            rasActions.add(rasActionToAdd);
+            String encodedRasActions = encodeRasActionsToBase64(rasActions);
+
+            propertiesToSet.put(getSuffixedRunDssKey(runName, "rasActions"), encodedRasActions);
+        }
+
         propertiesToSet.put(getSuffixedRunDssKey(runName, "interruptReason"), interruptReason);
 
         this.dss.put(propertiesToSet);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunRasActionProcessor.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunRasActionProcessor.java
@@ -38,19 +38,21 @@ public class RunRasActionProcessor implements IRunRasActionProcessor {
         for (RunRasAction rasAction : rasActions) {
             try {
                 String runId = rasAction.getRunId();
-                TestStructure testStructure = getRunTestStructure(runId);
-                if (testStructure != null) {
-    
-                    // Set the status and result for the run if it doesn't already have the desired status
-                    String runStatus = testStructure.getStatus();
-                    String desiredRunStatus = rasAction.getDesiredRunStatus();
-                    if (!desiredRunStatus.equals(runStatus)) {
-                        testStructure.setStatus(desiredRunStatus);
-                        testStructure.setResult(rasAction.getDesiredRunResult());
-    
-                        rasStore.updateTestStructure(runId, testStructure);
-                    } else {
-                        logger.info("Run already has status '" + desiredRunStatus + "', will not update its RAS record");
+                if (runId != null) {
+                    TestStructure testStructure = getRunTestStructure(runId);
+                    if (testStructure != null) {
+        
+                        // Set the status and result for the run if it doesn't already have the desired status
+                        String runStatus = testStructure.getStatus();
+                        String desiredRunStatus = rasAction.getDesiredRunStatus();
+                        if (!desiredRunStatus.equals(runStatus)) {
+                            testStructure.setStatus(desiredRunStatus);
+                            testStructure.setResult(rasAction.getDesiredRunResult());
+        
+                            rasStore.updateTestStructure(runId, testStructure);
+                        } else {
+                            logger.info("Run already has status '" + desiredRunStatus + "', will not update its RAS record");
+                        }
                     }
                 }
             } catch (ResultArchiveStoreException ex) {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
@@ -851,6 +851,32 @@ public class FrameworkRunsTest {
     }
 
     @Test
+    public void testCancelRunWithoutRunIdSetsInterruptReasonOnly() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        String runName = "mytestrun1";
+        String status = "allocated";
+
+        // Put a run-related property into the DSS to show that the run with the given name exists in the DSS
+        mockDss.put("run." + runName + ".status", status);
+
+        // When...
+        boolean isRunMarkedCancelled = frameworkRuns.markRunInterrupted(runName, Result.CANCELLED);
+
+        // Then...
+        assertThat(isRunMarkedCancelled).isTrue();
+        assertThat(mockDss.get("run." + runName + ".interruptReason")).isEqualTo(Result.CANCELLED);
+
+        // We expect the 'rasActions' property to be empty
+        assertThat(mockDss.get("run." + runName + ".rasActions")).isNull();
+    }
+
+    @Test
     public void testCancelNonExistantRunReturnsFalse() throws Exception {
         // Given...
         MockDSSStore mockDss = new MockDSSStore(new HashMap<>());


### PR DESCRIPTION
## Why?
Likely related to https://github.com/galasa-dev/projectmanagement/issues/2231

Runs that are in the `allocated` state have no RAS record yet, and when these runs fail to start after a given period of time, the dead heartbeat monitor times them out and tries to mark them as "Hung", which causes a null pointer exception as the engine controller attempts to update the runs' non-existent RAS records.

This PR adds a guard against null run IDs when setting and processing a run's RAS actions.

## Changes
- Guard against null run IDs when processing a run's RAS actions
- When a run is marked as interrupted and the run has no RAS run ID, no RAS actions will be set for the run in the DSS - only an interrupt reason will be set