### PR TITLE
When push to main, publish docs to the preview repo

### DIFF
--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -211,3 +211,9 @@ jobs:
     needs: [build-obr]
     uses: ./.github/workflows/cli.yaml
     secrets: inherit
+
+  build-docs:
+    name: Build the Galasa documentation 
+    needs: [build-cli]
+    uses: ./.github/workflows/docs.yaml
+    secrets: inherit


### PR DESCRIPTION
# Why ?

When something pushes to main branch, re-build and publish the docs preview to the galasa-docs-preview repository so that github pages can serve it up.