### PR TITLE
build-locally.sh script should also build the documentation

### DIFF
--- a/tools/build-locally.sh
+++ b/tools/build-locally.sh
@@ -94,6 +94,7 @@ module_names=(\
     "obr" \
     "ivts" \
     "cli" \
+    "docs" \
 )
 
 function check_module_name_is_supported() {
@@ -304,6 +305,18 @@ function build_module() {
         h2 "Building $module"
         cd ${PROJECT_DIR}/modules/$module
         ${PROJECT_DIR}/modules/$module/build-locally.sh --clean --detectsecrets false 
+        rc=$? ;  if [[ "${rc}" != "0" ]]; then error "Failed to build module $module. rc=$rc" ; exit 1 ; fi
+        success "Built module $module OK"
+        if [[ "$chain" == "true" ]]; then 
+            module="docs"
+        fi
+    fi
+
+    # docs
+    if [[ "$module" == "docs" ]]; then
+        h2 "Building $module"
+        cd ${PROJECT_DIR}/$module
+        ${PROJECT_DIR}/$module/build-locally.sh
         rc=$? ;  if [[ "${rc}" != "0" ]]; then error "Failed to build module $module. rc=$rc" ; exit 1 ; fi
         success "Built module $module OK"
     fi


### PR DESCRIPTION
Signed-off-by: testcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
When we build the code locally, we should build the documentation also. That means the built documentation gets checked for secrets too prior to check-in.