### PR TITLE
docs publishing to avoid using long commit messages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -138,8 +138,7 @@ jobs:
         run: |
           git add .
           git commit -m "Automated update from the galasa-dev/galasa repo." \
-                     -m "Source branch ${{ env.BRANCH }} git head commit id: ${{ github.event.head_commit.id }}" \
-                     -m "Change: ${{ github.event.head_commit.message }}"
+                     -m "Source branch ${{ env.BRANCH }} git head commit id: ${{ github.event.head_commit.id }}" 
           git push origin main
 
   report-failure:


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
publishing docs to the preview repo fails if the commit message is long.

- Remove the commit message from the flow. We were trying to use the same message to push the changes to the preview repo, but we have the commit id so that will have to do for now.
