### PR TITLE
mkdocs meta plugin needs installing

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
-mkdocs
-mkdocs-material
+mkdocs==1.6.1
+mkdocs-get-deps==0.2.0
+mkdocs-material==9.6.14
+mkdocs-material-extensions==1.3.1


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
- The mkdocs build uses plugins with no versioning, so the latest was always being used.
This could lead to unstable builds eventually.
- The meta plugin was missing, which is not available on down-level versions so we need to upgrade the version everyone uses locally.
- Alter the mkdocs plugins to do the above.