### PR TITLE
docs build - if docs pr didn't rebuild javadoc then don't fail, but download it from a previous build

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -497,7 +497,7 @@ jobs:
           set -o pipefail
           # Note: We install the built artifacts into a temporary location.
           mkdir -p ${{ github.workspace }}/modules/obr/javadocs/temp
-          mvn -f pom.xml install -X \
+          mvn -f pom.xml deploy -X \
           -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/javadocs/temp \

--- a/.github/workflows/pr-docs.yaml
+++ b/.github/workflows/pr-docs.yaml
@@ -95,6 +95,7 @@ jobs:
       - name: Download javadoc artifacts from this workflow
         id: download-javadoc
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: javadoc
           path: /home/runner/.m2/repository


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>
