### PR TITLE
mcobbett fix builds

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -50,7 +50,7 @@ jobs:
         id: download-javadoc
         uses: actions/download-artifact@v4
         with:
-          name: docs
+          name: javadoc
           path: /home/runner/.m2/repository
 
       # - name: Download rest-api artifacts from this workflow


### PR DESCRIPTION
- **docs build - if docs pr didn't rebuild javadoc then don't fail, but download it from a previous build**
- **main build of obr javadoc should deploy to temporary location instead of installing**
- **typo in the main build docs yaml**
