### PR TITLE
Hide toc on website landing page

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -3,7 +3,7 @@ title: Home
 icon: material/home
 hide:
   - navigation
-#   - toc
+  - toc
 ---
 
 <div class="galasa-intro" markdown>


### PR DESCRIPTION
There's nothing in the toc so there's just a large gap down the side of the main page, which looks odd