### PR TITLE
Release notes for 0.42.0 added

### DIFF
--- a/docs/content/docs/cli-command-reference/installing-cli-tool.md
+++ b/docs/content/docs/cli-command-reference/installing-cli-tool.md
@@ -31,8 +31,8 @@ On Mac:
 3. Then you have a choice. Either install the latest version fo the `galasactl` tool, or install a specific version.
     1. To install the latest version of `galasactl`: 
     `brew install --no-quarantine galasactl`
-    2. To install a specific version of `galasactl` (version 0.41.0 for example): 
-    `brew install --no-quarantine galasactl@0.41.0`
+    2. To install a specific version of `galasactl` (version 0.42.0 for example): 
+    `brew install --no-quarantine galasactl@0.42.0`
     Note: You can check to see what versions are available using this:
     `brew tap-info galasa-dev/tap --json` and look in the `"cask_tokens"` part of the json file.
 

--- a/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
+++ b/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
@@ -256,14 +256,14 @@ Once you have successfully installed the Ecosystem, you can then deploy your Gal
 
 ## Upgrading the Galasa Ecosystem
 
-Get the latest version of the Ecosystem chart and upgrade the Galasa Ecosystem to use the newer version of Galasa - for example version 0.41.0 - by running the following command:
+Get the latest version of the Ecosystem chart and upgrade the Galasa Ecosystem to use the newer version of Galasa - for example version 0.42.0 - by running the following command:
 
 On Mac or Unix:
 
 ```shell
 helm repo update \
 helm upgrade <release-name> galasa/ecosystem --reuse-values \
---set galasaVersion=0.41.0 --wait
+--set galasaVersion=0.42.0 --wait
 ```
 
 On Windows (Powershell):
@@ -271,7 +271,7 @@ On Windows (Powershell):
 ```powershell
 helm repo update `
 helm upgrade <release-name> galasa/ecosystem --reuse-values `
---set galasaVersion=0.41.0 --wait
+--set galasaVersion=0.42.0 --wait
 ```
 
 where:

--- a/docs/content/docs/ecosystem/ecosystem-role-based-access.md
+++ b/docs/content/docs/ecosystem/ecosystem-role-based-access.md
@@ -85,7 +85,7 @@ The system also has some constraints on how these resources can be set up and us
 
 ## Upgrading to a version of Galasa which supports RBAC
 
-When upgrading your Galasa service to a version 0.41.0 or later, any existing users will be assigned the role of `admin` without any extra action being required.
+When upgrading your Galasa service to a version 0.42.0 or later, any existing users will be assigned the role of `admin` without any extra action being required.
 
 Under such circumstances you may wish to assign the role of `tester` to anyone who now should not have administration rights.
 

--- a/docs/content/docs/managers/ecosystem-managers/galasa-ecosystem-manager.md
+++ b/docs/content/docs/managers/ecosystem-managers/galasa-ecosystem-manager.md
@@ -144,7 +144,7 @@ The following are properties used to configure the Galasa Ecosystem Manager.
 | Required:  | No |
 | Default value: | None |
 | Valid values: | Valid URL |
-| Examples: | `galasaecosystem.isolated.mvp.zip=https://github.com/galasa-dev/isolated/releases/download/v0.41.0/galasa-isolated-mvp-0.41.0.zip` |
+| Examples: | `galasaecosystem.isolated.mvp.zip=https://github.com/galasa-dev/isolated/releases/download/v0.42.0/galasa-isolated-mvp-0.42.0.zip` |
 
 
 ### Kubernetes Ecosystem Tag Shared Environment

--- a/docs/content/docs/running-simbank-tests/running-simbank-tests-cli-offline.md
+++ b/docs/content/docs/running-simbank-tests/running-simbank-tests-cli-offline.md
@@ -48,7 +48,7 @@ In order to run the Galasa SimBanks tests you need to add some configuration inf
 
 ## Running the SimBank IVT test class by using the CLI
 
-The SimBank tests are located in the `maven` directory of the `isolated.zip` downloadable file. Complete the following steps to run the SimBankIVT test that is provided with Galasa. The following example uses SimBank OBR version `0.41.0`.
+The SimBank tests are located in the `maven` directory of the `isolated.zip` downloadable file. Complete the following steps to run the SimBankIVT test that is provided with Galasa. The following example uses SimBank OBR version `0.42.0`.
 
 Remember to initialise your local environment by running the `galasactl local init` command and to start the SimPlatform server by running the `run-simplatform.sh` script, as described in the [Running Galasa SimBank using the CLI offline](./simbank-cli-offline.md) documentation.
 
@@ -60,7 +60,7 @@ You are now ready to run a local Galasa test offline with just the contents of t
 
     ```shell
     galasactl runs submit local --log - \
-    --obr mvn:dev.galasa/dev.galasa.simbank.obr/0.41.0/obr \
+    --obr mvn:dev.galasa/dev.galasa.simbank.obr/0.42.0/obr \
     --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT \
     --localMaven file:////Users/youruserid/Downloads/isolated/maven
     ```
@@ -69,7 +69,7 @@ You are now ready to run a local Galasa test offline with just the contents of t
 
     ```powershell
     galasactl runs submit local --log - `
-    --obr mvn:dev.galasa/dev.galasa.simbank.obr/0.41.0/obr `
+    --obr mvn:dev.galasa/dev.galasa.simbank.obr/0.42.0/obr `
     --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT `
     --localMaven file:////Users/youruserid/Downloads/isolated/maven
     ```
@@ -87,7 +87,7 @@ On Mac or Unix:
 
 ```shell
 galasactl runs submit local --log - \
---obr mvn:dev.galasa/dev.galasa.simbank.obr/0.41.0/obr \
+--obr mvn:dev.galasa/dev.galasa.simbank.obr/0.42.0/obr \
 --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BasicAccountCreditTest \
 --localMaven file:////Users/youruserid/Downloads/isolated/maven
 ```
@@ -96,7 +96,7 @@ On Windows (Powershell):
 
 ```powershell
 galasactl runs submit local --log - `
---obr mvn:dev.galasa/dev.galasa.simbank.obr/0.41.0/obr `
+--obr mvn:dev.galasa/dev.galasa.simbank.obr/0.42.0/obr `
 --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BasicAccountCreditTest `
 --localMaven file:////Users/youruserid/Downloads/isolated/maven
 ```

--- a/docs/content/docs/running-simbank-tests/running-simbank-tests-cli.md
+++ b/docs/content/docs/running-simbank-tests/running-simbank-tests-cli.md
@@ -50,7 +50,7 @@ In order to run the Galasa SimBanks tests you need to add some configuration inf
 
 The SimBank tests are held in the [Galasa simplatform repository](https://github.com/galasa-dev/simplatform){target="_blank"} in GitHub. To start running the tests you need to clone the repository, if you have not already done so. To find out how to clone the cli repository, follow the instruction in the [Running Galasa SimBank online](../running-simbank-tests/simbank-cli.md) documentation.
 
-After cloning the repository, complete the following steps to run the SimBankIVT test that is provided with Galasa. The following example uses SimBank OBR version `0.41.0` and Galasa uber OBR version `0.41.0`.
+After cloning the repository, complete the following steps to run the SimBankIVT test that is provided with Galasa. The following example uses SimBank OBR version `0.42.0` and Galasa uber OBR version `0.42.0`.
 
 You can find the version of the `dev.galasa.simbank.obr` that you are using by looking in the `pom.xml` file in the `dev.galasa.simbank.obr` folder. The `dev.galasa.uber.obr` is the OBR that contains all the bundles that are needed for Galasa to work including Managers, any required dependencies, the framework, etc. The version of the `dev.galasa.uber.obr` depends on which version of Galasa you have installed.
 
@@ -87,7 +87,7 @@ Remember to initialise your local environment by running the `galasactl local in
 
     ```shell
     galasactl runs submit local --log - \
-    --obr mvn:dev.galasa/dev.galasa.simbank.obr/0.41.0/obr \
+    --obr mvn:dev.galasa/dev.galasa.simbank.obr/0.42.0/obr \
     --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT 
     ```
 
@@ -95,7 +95,7 @@ Remember to initialise your local environment by running the `galasactl local in
 
     ```powershell
     galasactl runs submit local --log - `
-    --obr mvn:dev.galasa/dev.galasa.simbank.obr/0.41.0/obr `
+    --obr mvn:dev.galasa/dev.galasa.simbank.obr/0.42.0/obr `
     --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT
     ```
 
@@ -115,7 +115,7 @@ On Mac or Unix:
 
 ```shell
 galasactl runs submit local --log - \
---obr mvn:dev.galasa/dev.galasa.simbank.obr/0.41.0/obr \
+--obr mvn:dev.galasa/dev.galasa.simbank.obr/0.42.0/obr \
 --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BasicAccountCreditTest 
 ```
 
@@ -123,7 +123,7 @@ On Windows (Powershell):
 
 ```powershell
 galasactl runs submit local --log - `
---obr mvn:dev.galasa/dev.galasa.simbank.obr/0.41.0/obr `
+--obr mvn:dev.galasa/dev.galasa.simbank.obr/0.42.0/obr `
 --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BasicAccountCreditTest
 ```
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -14,7 +14,7 @@ Allowing you to test applications at scale regardless of platform — including 
 
 [Get started](./docs/index.md){ .md-button .md-button--primary }
 [Learn more](./about/index.md){ .md-button }
-[0.41.0 highlights](./releases/posts/20250506-v0.41.0.md){ .md-button }
+[0.42.0 highlights](./releases/posts/v0.42.0.md){ .md-button }
 
 </div>
 

--- a/docs/content/releases/posts/v0.42.0.md
+++ b/docs/content/releases/posts/v0.42.0.md
@@ -1,0 +1,38 @@
+---
+slug: v0.42.0
+date: 2025-06-10
+links:
+  - v0.42.0 GitHub release: https://github.com/galasa-dev/galasa/releases/tag/v0.42.0
+---
+
+# 0.42.0 - Release Highlights
+
+## Changes affecting the Galasa Service
+
+- Cancel a run group using the Group ID. See https://galasa.dev/docs/reference/cli-syntax/galasactl_runs_cancel/
+
+- For developers of Galasa: Easier development of the Web user interface
+    - A Personal Access Token can now be used to run a local instance of the web user interface, targetting an existing Galasa Service. 
+
+- Added a configuration setting `kubeLaunchIntervalMillisecs` in the Galasa Helm chart to control the time between launching of successive test runs, to space out launches more evenly so that Kubernetes is not as stressed.
+
+- Various defects, fixes, version uplifts
+
+## Changes affecting tests running locally or on the Galasa Service
+
+- IMS-TM Manager - Improvements to how the manager handles active conversations (See issue [#2250](https://github.com/galasa-dev/projectmanagement/issues/2250))
+
+## Other changes
+
+- Make contributing code easier:
+
+    - Code for the Galasa documentation has moved git repositories, to the [`galasa` repository](https://github.com/galasa-dev/galasa).
+      This simplifies the build process for the Galasa documentation and makes changes on a git fork easier to build and verify.
+      It also facilitates closer integration between the javadoc, REST interface, CLI syntax and the rest of the material.
+
+- New look for the Galasa web site:
+    
+    - The look and feel of the [Galasa website and documentation](../../index.md) has been improved.
+      The site now includes page-indexes on the right to navigate each page of the documentation.
+      The site also supports light and dark mode for easy-reading.
+      Command-line tool syntax is now more integrated with the documentation, and is searchable.


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
- Added release notes for v0.42.0
- Made 0.42.0 the release notes doc we link to from the homepage
- Changed all 0.41.0 references to 0.42.0 (as we don't have a set-version.sh script for the docs yet)
