### PR TITLE
Add netty-codec-http2 to the dev.galasa.platform

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -129,7 +129,7 @@ dependencies {
         api 'io.netty:netty-codec:4.1.111.Final'
         api 'io.netty:netty-codec-dns:4.1.111.Final'
         api 'io.netty:netty-codec-http:4.1.111.Final'
-        api 'io.netty:netty-code-http2:4.1.111.Final'
+        api 'io.netty:netty-codec-http2:4.1.111.Final'
         api 'io.netty:netty-codec-socks:4.1.111.Final'
         api 'io.netty:netty-common:4.1.111.Final'
         api 'io.netty:netty-handler:4.1.111.Final'


### PR DESCRIPTION
## Why?

fix: fix typo in dev.galasa.platform that caused netty-codec-http2 version to not be found, which failed validation checks for dev.galasa.cps.etcd in the maven central portal