### PR TITLE
Add init containers to test pods so that they wait for the RAS and etcd pods to be ready before starting

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -25,11 +25,13 @@ public class Settings implements Runnable {
 
     private final K8sController controller;
 
+    private String            galasaServiceName;
     private String            namespace;
     private String            podname;
     private String            configMapName;
     private String            engineLabel                 = "none";
     private String            engineImage                 = "none";
+    private String            kubectlImage                = "none";
     private int               engineMemoryHeapSizeMi      = 150;
     private int               engineMemoryRequestMi       = 150;
     private int               engineMemoryLimitMi         = 200;
@@ -181,9 +183,11 @@ public class Settings implements Runnable {
 
     protected void updateConfigMapProperties(Map<String,String> configMapData) throws K8sControllerException { 
 
+        this.galasaServiceName = updateProperty(configMapData, "galasa_service_name", "", this.galasaServiceName);
         this.maxEngines = updateProperty(configMapData, "max_engines", 1, this.maxEngines);
         this.engineLabel = updateProperty(configMapData, "engine_label", "k8s-standard-engine", this.engineLabel);
         this.engineImage = updateProperty(configMapData, "engine_image", "ghcr.io/galasa-dev/galasa-boot-embedded-amd64", this.engineImage);
+        this.kubectlImage = updateProperty(configMapData, "kubectl_image", kubectlImage, this.kubectlImage);
         this.kubeLaunchIntervalMillisecs = updateProperty(configMapData, "kube_launch_interval_milliseconds", kubeLaunchIntervalMillisecs, this.kubeLaunchIntervalMillisecs);
 
         this.engineMemoryRequestMi = updateProperty(configMapData, "engine_memory_request", engineMemoryRequestMi, this.engineMemoryRequestMi);
@@ -385,5 +389,13 @@ public class Settings implements Runnable {
 
     public long getKubeLaunchIntervalMillisecs() {
         return this.kubeLaunchIntervalMillisecs;
+    }
+
+    public String getKubectlImage() {
+        return this.kubectlImage;
+    }
+
+    public String getGalasaServiceName() {
+        return this.galasaServiceName;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -25,7 +25,7 @@ public class Settings implements Runnable {
 
     private final K8sController controller;
 
-    private String            galasaServiceName;
+    private String            galasaServiceInstallName;
     private String            namespace;
     private String            podname;
     private String            configMapName;
@@ -183,7 +183,7 @@ public class Settings implements Runnable {
 
     protected void updateConfigMapProperties(Map<String,String> configMapData) throws K8sControllerException { 
 
-        this.galasaServiceName = updateProperty(configMapData, "galasa_service_name", "", this.galasaServiceName);
+        this.galasaServiceInstallName = updateProperty(configMapData, "galasa_install_name", "", this.galasaServiceInstallName);
         this.maxEngines = updateProperty(configMapData, "max_engines", 1, this.maxEngines);
         this.engineLabel = updateProperty(configMapData, "engine_label", "k8s-standard-engine", this.engineLabel);
         this.engineImage = updateProperty(configMapData, "engine_image", "ghcr.io/galasa-dev/galasa-boot-embedded-amd64", this.engineImage);
@@ -395,7 +395,7 @@ public class Settings implements Runnable {
         return this.kubectlImage;
     }
 
-    public String getGalasaServiceName() {
-        return this.galasaServiceName;
+    public String getGalasaServiceInstallName() {
+        return this.galasaServiceInstallName;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -251,9 +251,15 @@ public class TestPodScheduler implements Runnable {
         podSpec.setOverhead(null);
         podSpec.setRestartPolicy("Never");
 
+        // Only add the init containers to wait for the RAS and etcd pods if a service
+        // account name to be assigned to the pod definition could be found
         String testPodServiceAccountName = env.getenv(TEST_POD_SERVICE_ACCOUNT_NAME_ENV_VAR);
         if (testPodServiceAccountName != null && !testPodServiceAccountName.isBlank()) {
             podSpec.setServiceAccountName(testPodServiceAccountName);
+            podSpec.setInitContainers(createTestPodInitContainers());
+        } else {
+            logger.warn("No service account could be assigned to the pod definition for run " + runName +
+                ". The test pod will not wait for the Galasa service's RAS or etcd pods before launching.");
         }
 
         String nodeArch = this.settings.getNodeArch();
@@ -300,7 +306,6 @@ public class TestPodScheduler implements Runnable {
 
         podSpec.setVolumes(createTestPodVolumes());
         podSpec.addContainersItem(createTestContainer(runName, engineName, isTraceEnabled));
-        podSpec.setInitContainers(createTestPodInitContainers());
         return newPod;
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -330,8 +330,8 @@ public class TestPodScheduler implements Runnable {
     }
 
     private List<V1Container> createTestPodInitContainers() {
-        String rasPodSelector = "app=" + this.settings.getGalasaServiceName() + "-ras";
-        String etcdPodSelector = "app=" + this.settings.getGalasaServiceName() + "-etcd";
+        String rasPodSelector = "app=" + this.settings.getGalasaServiceInstallName() + "-ras";
+        String etcdPodSelector = "app=" + this.settings.getGalasaServiceInstallName() + "-etcd";
 
         List<V1Container> initContainers = new ArrayList<>();
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
@@ -116,10 +116,10 @@ public class SettingsTest {
         Map<String,String> configMap = new HashMap<String,String>();
 
         String mockServiceName = "my-galasa-service";
-        configMap.put("galasa_service_name", mockServiceName);
+        configMap.put("galasa_install_name", mockServiceName);
         settings.updateConfigMapProperties(configMap);
 
-        String serviceNameGotBack = settings.getGalasaServiceName();
+        String serviceNameGotBack = settings.getGalasaServiceInstallName();
 
         assertThat(serviceNameGotBack).isEqualTo(mockServiceName);
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
@@ -91,4 +91,36 @@ public class SettingsTest {
 
         assertThat(intervalGotBack).isEqualTo(1000);
     }
+
+    @Test
+    public void testCanReadKubectlImageFromConfigMap() throws Exception {
+        K8sController controller = new K8sController();
+        CoreV1Api api = new CoreV1Api();
+        Settings settings = new Settings(controller, api);
+        Map<String,String> configMap = new HashMap<String,String>();
+
+        String mockKubectlImage = "registry/kubectl:12345";
+        configMap.put("kubectl_image", mockKubectlImage);
+        settings.updateConfigMapProperties(configMap);
+
+        String kubectlImageGotBack = settings.getKubectlImage();
+
+        assertThat(kubectlImageGotBack).isEqualTo(mockKubectlImage);
+    }
+
+    @Test
+    public void testCanReadGalasaServiceNameFromConfigMap() throws Exception {
+        K8sController controller = new K8sController();
+        CoreV1Api api = new CoreV1Api();
+        Settings settings = new Settings(controller, api);
+        Map<String,String> configMap = new HashMap<String,String>();
+
+        String mockServiceName = "my-galasa-service";
+        configMap.put("galasa_service_name", mockServiceName);
+        settings.updateConfigMapProperties(configMap);
+
+        String serviceNameGotBack = settings.getGalasaServiceName();
+
+        assertThat(serviceNameGotBack).isEqualTo(mockServiceName);
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -177,8 +177,8 @@ public class TestPodSchedulerTest {
         // We expect two init containers: one to wait for the RAS and another to wait for etcd
         assertThat(actualInitContainers).hasSize(2);
 
-        String expectedRasPodSelector = "app=" + settings.getGalasaServiceName() + "-ras";
-        String expectedEtcdPodSelector = "app=" + settings.getGalasaServiceName() + "-etcd";
+        String expectedRasPodSelector = "app=" + settings.getGalasaServiceInstallName() + "-ras";
+        String expectedEtcdPodSelector = "app=" + settings.getGalasaServiceInstallName() + "-etcd";
 
         V1Container waitForRasContainer = actualInitContainers.get(0);
         V1Container waitForEtcdContainer = actualInitContainers.get(1);


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2235

## Changes
- Added two init containers to test pod definitions so that test pods wait for the Galasa service's RAS and etcd pods to be ready before launching the test container.
- Added `galasa_service_name` and `kubectl_image` values to the engine controller settings, and set a service account name into test pod definitions so that test pods can run a `kubectl wait pods` command using a service account with the relevant permissions
- If no service account name is found in the engine controller's environment, test pods will fall back to not waiting for the RAS and etcd to be up (behaving like it does today)