### PR TITLE
k8s controller waits for etcd and RAS to be ready before scheduling new runs

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/ISettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/ISettings.java
@@ -5,19 +5,7 @@
  */
 package dev.galasa.framework.k8s.controller;
 
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
-import dev.galasa.framework.k8s.controller.api.KubernetesEngineFacade;
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.V1ConfigMap;
-import io.kubernetes.client.openapi.models.V1ObjectMeta;
 
 /**
  * A collection of settings obtained from a config map.

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -15,7 +15,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.k8s.controller.api.KubernetesEngineFacade;
-import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunInterruptMonitorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunInterruptMonitorTest.java
@@ -22,7 +22,6 @@ import dev.galasa.framework.mocks.MockFrameworkRuns;
 import dev.galasa.framework.mocks.MockRun;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.RunRasAction;
-import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 
@@ -33,6 +32,7 @@ public class RunInterruptMonitorTest {
 
         V1ObjectMeta podMetadata = new V1ObjectMeta();
         podMetadata.putLabelsItem(TestPodScheduler.GALASA_RUN_POD_LABEL, runName);
+        podMetadata.putLabelsItem(KubernetesEngineFacade.ENGINE_CONTROLLER_LABEL_KEY, "none");
         podMetadata.setName(runName);
 
         mockPod.setMetadata(podMetadata);
@@ -88,10 +88,10 @@ public class RunInterruptMonitorTest {
         MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
         MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
 
-        KubernetesEngineFacade kube = new KubernetesEngineFacade(mockApiClient, "myNamespace");
+        KubernetesEngineFacade kube = new KubernetesEngineFacade(mockApiClient, "myNamespace", "myGalasaService");
         Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
 
-        MockSettings settings = new MockSettings(null, null, kube, "myPodName" , "myConfigMapName");
+        MockSettings settings = new MockSettings(null, kube, "myPodName" , "myConfigMapName");
         RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings);
 
         // When...
@@ -143,10 +143,10 @@ public class RunInterruptMonitorTest {
         MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
 
 
-        KubernetesEngineFacade kube = new KubernetesEngineFacade(mockApiClient, "myNamespace");
+        KubernetesEngineFacade kube = new KubernetesEngineFacade(mockApiClient, "myNamespace", "myGalasaService");
         Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
 
-        MockSettings settings = new MockSettings(null, null, kube, "myPodName" , "myConfigMapName");
+        MockSettings settings = new MockSettings(null, kube, "myPodName" , "myConfigMapName");
         RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings);
 
         // When...
@@ -190,10 +190,10 @@ public class RunInterruptMonitorTest {
         MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
         MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
 
-        KubernetesEngineFacade kube = new KubernetesEngineFacade(mockApiClient, "myNamespace");
+        KubernetesEngineFacade kube = new KubernetesEngineFacade(mockApiClient, "myNamespace", "myGalasaService");
         Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
 
-        MockSettings settings = new MockSettings(null, null, kube, "myPodName" , "myConfigMapName");
+        MockSettings settings = new MockSettings(null, kube, "myPodName" , "myConfigMapName");
         RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings);
 
         // When...

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunPodCleanupTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunPodCleanupTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.k8s.controller.api.KubernetesEngineFacade;
 import dev.galasa.framework.k8s.controller.mocks.MockKubernetesApiClient;
-import dev.galasa.framework.k8s.controller.mocks.MockSettings;
 import dev.galasa.framework.mocks.MockFrameworkRuns;
 import dev.galasa.framework.mocks.MockRun;
 import dev.galasa.framework.spi.IRun;
@@ -78,7 +77,7 @@ public class RunPodCleanupTest {
         MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
         MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
 
-        KubernetesEngineFacade kubeEngineFacade = new KubernetesEngineFacade(mockApiClient, "myNameSpace");
+        KubernetesEngineFacade kubeEngineFacade = new KubernetesEngineFacade(mockApiClient, "myNamespace", "myGalasaService");
 
         Settings settings = new Settings(null,kubeEngineFacade , "myPodName" , "myConfigMapName");
         RunPodCleanup runPodCleanup = new RunPodCleanup(settings, kubeEngineFacade, mockFrameworkRuns);
@@ -115,7 +114,7 @@ public class RunPodCleanupTest {
         MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
         MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
 
-        KubernetesEngineFacade kubeEngineFacade = new KubernetesEngineFacade(mockApiClient, "myNameSpace");
+        KubernetesEngineFacade kubeEngineFacade = new KubernetesEngineFacade(mockApiClient, "myNamespace", "myGalasaService");
 
         Settings settings = new Settings(null,kubeEngineFacade , "myPodName" , "myConfigMapName");
         RunPodCleanup runPodCleanup = new RunPodCleanup(settings, kubeEngineFacade, mockFrameworkRuns);
@@ -143,7 +142,7 @@ public class RunPodCleanupTest {
         MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
         MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
 
-        KubernetesEngineFacade kubeEngineFacade = new KubernetesEngineFacade(mockApiClient, "myNameSpace");
+        KubernetesEngineFacade kubeEngineFacade = new KubernetesEngineFacade(mockApiClient, "myNamespace", "myGalasaService");
 
         Settings settings = new Settings(null,kubeEngineFacade , "myPodName" , "myConfigMapName");
         RunPodCleanup runPodCleanup = new RunPodCleanup(settings, kubeEngineFacade, mockFrameworkRuns);

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.Test;
 
 import dev.galasa.framework.k8s.controller.api.KubernetesEngineFacade;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
 
 
 public class SettingsTest {

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockKubernetesApiClient.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockKubernetesApiClient.java
@@ -51,7 +51,21 @@ public class MockKubernetesApiClient implements IKubernetesApiClient {
 
     @Override
     public List<V1Pod> getPods(String namespace, String labelSelector) throws ApiException {
-        return this.mockPods;
+        List<V1Pod> matchingPods = new ArrayList<>();
+
+        // Label selectors are in the form <key>=<value>
+        String[] labelSelectorParts = labelSelector.split("=");
+        String labelSelectorKey = labelSelectorParts[0];
+        String labelSelectorValue = labelSelectorParts[1];
+
+        for (V1Pod pod : mockPods) {
+            Map<String, String> podLabels = pod.getMetadata().getLabels();
+            String podLabelValue = podLabels.get(labelSelectorKey);
+            if (podLabelValue != null && podLabelValue.equals(labelSelectorValue)) {
+                matchingPods.add(pod);
+            }
+        }
+        return matchingPods;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockSettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockSettings.java
@@ -9,16 +9,11 @@ import dev.galasa.framework.k8s.controller.K8sController;
 import dev.galasa.framework.k8s.controller.K8sControllerException;
 import dev.galasa.framework.k8s.controller.Settings;
 import dev.galasa.framework.k8s.controller.api.KubernetesEngineFacade;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.models.V1ConfigMap;
 
 public class MockSettings extends Settings {
 
-    private V1ConfigMap mockConfigMap;
-
-    public MockSettings(V1ConfigMap configMap, K8sController controller, KubernetesEngineFacade kube, String podName , String engineName) throws K8sControllerException {
+    public MockSettings(K8sController controller, KubernetesEngineFacade kube, String podName , String engineName) throws K8sControllerException {
         super(controller, kube, podName , engineName);
-        this.mockConfigMap = configMap;
     }
 
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
@@ -5,6 +5,7 @@
  */
 package dev.galasa.framework.mocks;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -59,7 +60,14 @@ public class MockFrameworkRuns implements IFrameworkRuns{
 
     @Override
     public @NotNull List<IRun> getQueuedRuns() throws FrameworkException {
-        throw new UnsupportedOperationException("Unimplemented method 'getQueuedRuns'");
+        List<IRun> queuedRuns = new ArrayList<>();
+        for (IRun run : this.runs) {
+            String runStatus = run.getStatus();
+            if (runStatus != null && runStatus.equals(TestRunLifecycleStatus.QUEUED.toString())) {
+                queuedRuns.add(run);
+            }
+        }
+        return queuedRuns;
     }
 
     @Override


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2235

## Changes
- The k8s controller now checks that the etcd and RAS pods are in the "Ready" state before proceeding to schedule test runs
- Passed in the Galasa installation name provided when installing the Helm chart into the k8s controller via a `GALASA_INSTALL_NAME` environment variable, so that the k8s controller can query for pods with the `app=<name>-etcd` and `app=<name>-ras` labels
- Removed unused imports