### PR TITLE
Fix artifact not found response code from 500 to 404

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
@@ -112,7 +112,7 @@ public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
                 res = downloadStoredArtifact(res, run, artifactPath.substring(artifactsPrefix.length() - 1));
             } else {
                 ServletError error = new ServletError(GAL5008_ERROR_LOCATING_ARTIFACT, artifactPath, runName);
-                throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
             }
         } catch (ResultArchiveStoreException | IOException ex) {
             ServletError error = new ServletError(GAL5009_ERROR_RETRIEVING_ARTIFACT, artifactPath, runName);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsDownloadServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsDownloadServlet.java
@@ -276,7 +276,7 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 		//   "error_code" : 5008,
 		//   "error_message" : "GAL5008E: Error locating artifact '/bad/artifact/path' for run with identifier 'U123'."
 		// }
-		assertThat(resp.getStatus()).isEqualTo(500);
+		assertThat(resp.getStatus()).isEqualTo(404);
 		checkErrorStructure(outStream.toString(), 5008, "GAL5008E", artifactPath, runName);
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2288

## Changes
- Changed the HTTP response code when an artifact couldn't be found from 500 to 404
- Fixed incorrect unit test assertion