### PR TITLE
Strip off leading slashes from artifact paths passed to download files

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
@@ -85,6 +85,8 @@ public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
         matcher.matches();
         String runId = matcher.group(1);
         String artifactPath = matcher.group(2);
+
+        artifactPath = stripLeadingSlashesFromArtifactPath(artifactPath);
         return downloadArtifact(runId, artifactPath, response);
     }
 
@@ -162,5 +164,15 @@ public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
         outStream.write(content);
         outStream.close();
         return res;
+    }
+
+    private String stripLeadingSlashesFromArtifactPath(String path) {
+        int index = 0;
+        for (index = 0; index < path.length(); index++) {
+            if (path.charAt(index) != '/') {
+                break;
+            }
+        }
+        return path.substring(index);
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsDownloadServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsDownloadServlet.java
@@ -598,4 +598,97 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
 		assertThat(resp.getHeader("Content-Disposition")).isEqualTo("attachment");
 	}
+
+    @Test
+    public void testGoodRunIdAndArtifactWithTooManyLeadingSlashesFindsArtifact() throws Exception {
+		//Given..
+		String runId = "12345";
+		String runName = "testA";
+        MockPath artifactPath = new MockPath("/term002.gz", mockFileSystem);
+		String artifactPathStr = "////artifacts" + artifactPath.toString();
+		String fileContent = "dummy content";
+        List<IRunResult> mockInputRunResults = generateTestData(runId, runName, null);
+		mockFileSystem.createFile(artifactPath);
+		mockFileSystem.setFileContents(artifactPath, fileContent);
+
+		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs/" + runId + "/files" + artifactPathStr);
+		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest, mockFileSystem);
+
+		RasServlet servlet = mockServletEnvironment.getServlet();
+		HttpServletRequest req = mockServletEnvironment.getRequest();
+		HttpServletResponse resp = mockServletEnvironment.getResponse();
+		ServletOutputStream outStream = resp.getOutputStream();
+
+		//When...
+		servlet.init();
+		servlet.doGet(req,resp);
+
+		// Then...
+		// Expecting:
+		assertThat(resp.getStatus()).isEqualTo(200);
+        assertThat(outStream.toString()).isEqualTo(fileContent);
+		assertThat(resp.getContentType()).isEqualTo("application/x-gzip");
+		assertThat(resp.getHeader("Content-Disposition")).isEqualTo("attachment");
+	}
+
+    @Test
+    public void testGoodRunIdAndRunLogWithLeadingSlashReturnsOKAndFile() throws Exception {
+		//Given..
+		String runId = "12345";
+		String runName = "testA";
+        String artifactPath = "/run.log";
+        String runlog = "very detailed run log";
+        List<IRunResult> mockInputRunResults = generateTestData(runId, runName, runlog);
+
+		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs/" + runId + "/files/" + artifactPath);
+		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest, mockFileSystem);
+
+		RasServlet servlet = mockServletEnvironment.getServlet();
+		HttpServletRequest req = mockServletEnvironment.getRequest();
+		HttpServletResponse resp = mockServletEnvironment.getResponse();
+		ServletOutputStream outStream = resp.getOutputStream();
+
+		//When...
+		servlet.init();
+		servlet.doGet(req,resp);
+
+		// Then...
+		// Expecting:
+		assertThat(resp.getStatus()).isEqualTo(200);
+        assertThat(outStream.toString()).isEqualTo(runlog);
+		assertThat(resp.getContentType()).isEqualTo("text/plain");
+		assertThat(resp.getHeader("Content-Disposition")).isEqualTo("attachment");
+	}
+
+    @Test
+    public void testGoodRunIdAndSlashPathReturnsNotFound() throws Exception {
+		//Given..
+		String runId = "12345";
+		String runName = "testA";
+        String artifactPath = "/";
+        String runlog = "You have a terminal image to access.";
+        List<IRunResult> mockInputRunResults = generateTestData(runId, runName, runlog);
+
+		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs/" + runId + "/files/" + artifactPath);
+		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest, mockFileSystem);
+
+		RasServlet servlet = mockServletEnvironment.getServlet();
+		HttpServletRequest req = mockServletEnvironment.getRequest();
+		HttpServletResponse resp = mockServletEnvironment.getResponse();
+		ServletOutputStream outStream = resp.getOutputStream();
+
+		//When...
+		servlet.init();
+		servlet.doGet(req,resp);
+
+		// Then...
+		// Expecting:
+		assertThat(resp.getStatus()).isEqualTo(404);
+		checkErrorStructure(outStream.toString(), 5008, "GAL5008E", "", runName);
+
+		assertThat( resp.getContentType()).isEqualTo("application/json");
+	}
 }


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2223

## Changes
- Updated the `/ras/runs/{run-id}/files/{artifact-path}` endpoint to strip off any leading slashes `/` from artifact paths passed into it to prevent artifacts from not being found due to a leading `/`
  - Ideally files would be downloaded by some sort of ID instead of paths, but that can be discussed at a later time