### PR TITLE
Iss2214 - Set `runLogStart` and `runLogEnd` in test structure for methods in a test class

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
@@ -60,7 +60,10 @@ public class GenericMethodWrapper {
      * @param testMethod the test method if the execution method is @Before or @After 
      * @throws TestRunException The failure thrown by the test run
      */
-    public void invoke(@NotNull ITestRunManagers managers, Object testClassObject, GenericMethodWrapper testMethod) throws TestRunException {
+    public void invoke(@NotNull ITestRunManagers managers, Object testClassObject, GenericMethodWrapper testMethod, TestClassWrapper testClassWrapper) throws TestRunException {
+
+        int runLogStart = testClassWrapper.getRunLogLines();
+        
         try {
             // Associate the wrapped method with a test method if a test method has been passed in
             Method testExecutionMethod = null;
@@ -131,6 +134,19 @@ public class GenericMethodWrapper {
         } catch (FrameworkException e) {
             throw new TestRunException("There was a problem with the framework, please check stacktrace", e);
         }
+
+        int runLogEnd = testClassWrapper.getRunLogLines();
+
+        // Compare the run log start and run log end to see if this method produced any output.
+        // If it did then set the runLogStart and runLogEnd in the test structure.
+        // If it didn't, runLogStart and runLogEnd will stay as default of 0.
+        if (runLogStart != runLogEnd) {
+            // The runLogStart value will be what is in the run log
+            // so far, so + 1 of that is where this method starts.
+            setRunLogStart(runLogStart + 1);
+            setRunLogEnd(runLogEnd);
+        }
+
         return;
     }
 
@@ -148,6 +164,14 @@ public class GenericMethodWrapper {
         if (this.testStructureMethod != null) {
             this.testStructureMethod.setResult(result.getName());
         }
+    }
+
+    public void setRunLogStart(int runLogStart) {
+        this.testStructureMethod.setRunLogStart(runLogStart);
+    }
+
+    public void setRunLogEnd(int runLogEnd) {
+        this.testStructureMethod.setRunLogEnd(runLogEnd);
     }
 
     public TestMethod getStructure() {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
@@ -62,7 +62,7 @@ public class GenericMethodWrapper {
      */
     public void invoke(@NotNull ITestRunManagers managers, Object testClassObject, GenericMethodWrapper testMethod, TestClassWrapper testClassWrapper) throws TestRunException {
 
-        int runLogStart = testClassWrapper.getRunLogLines();
+        int runLogStart = testClassWrapper.getRunLogLineCount();
         
         try {
             // Associate the wrapped method with a test method if a test method has been passed in
@@ -135,7 +135,7 @@ public class GenericMethodWrapper {
             throw new TestRunException("There was a problem with the framework, please check stacktrace", e);
         }
 
-        int runLogEnd = testClassWrapper.getRunLogLines();
+        int runLogEnd = testClassWrapper.getRunLogLineCount();
 
         // Compare the run log start and run log end to see if this method produced any output.
         // If it did then set the runLogStart and runLogEnd in the test structure.

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -27,6 +27,8 @@ import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.IFramework;
+import dev.galasa.framework.spi.IResultArchiveStore;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.teststructure.TestMethod;
 import dev.galasa.framework.spi.teststructure.TestStructure;
@@ -229,7 +231,7 @@ public class TestClassWrapper {
      */
     private void runGenericMethods(@NotNull ITestRunManagers managers, ArrayList<GenericMethodWrapper> genericMethods) throws TestRunException {
         for (GenericMethodWrapper genericMethod : genericMethods) {
-            genericMethod.invoke(managers, this.testClassObject, null);
+            genericMethod.invoke(managers, this.testClassObject, null, this);
             // Set the result so far after every generic method
             Result beforeClassMethodResult = genericMethod.getResult();
             setResult(beforeClassMethodResult, managers);
@@ -409,6 +411,25 @@ public class TestClassWrapper {
             isContinueOnTestFailureSet = this.testRunner.getContinueOnTestFailureFromCPS();
         }
         return isContinueOnTestFailureSet;
+    }
+    
+    protected IFramework getFramework() {
+        return this.testRunner.getFramework();
+    }
+
+    protected int getRunLogLines() {
+        int runLogLines;
+
+        IResultArchiveStore ras = getFramework().getResultArchiveStore();
+
+        String logSoFar = ras.retrieveLog();
+        if (logSoFar.isEmpty()) {
+            runLogLines = 0;
+        } else {
+            String[] lines = logSoFar.split("\n");
+            runLogLines = lines.length;
+        }
+        return runLogLines;
     }
 
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -417,7 +417,7 @@ public class TestClassWrapper {
         return this.testRunner.getFramework();
     }
 
-    protected int getRunLogLines() {
+    protected int getRunLogLineCount() {
         int runLogLines;
 
         IResultArchiveStore ras = getFramework().getResultArchiveStore();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
@@ -65,7 +65,7 @@ public class TestMethodWrapper {
             } else {
                 // run all the @Befores before the test method
                 for (GenericMethodWrapper before : this.befores) {
-                    before.invoke(managers, testClassObject, testMethod);
+                    before.invoke(managers, testClassObject, testMethod, testClassWrapper);
                     testClassWrapper.setResult(before.getResult(), managers);
                     if (before.getResult().isFullStop()) {
                         this.fullStop = true;
@@ -75,7 +75,7 @@ public class TestMethodWrapper {
                 }
 
                 if (this.result == null) {
-                    testMethod.invoke(managers, testClassObject, null);
+                    testMethod.invoke(managers, testClassObject, null, testClassWrapper);
                     testClassWrapper.setResult(testMethod.getResult(), managers);
                     if (this.testMethod.fullStop()) {
                         if (continueOnTestFailure) {
@@ -91,7 +91,7 @@ public class TestMethodWrapper {
                 // run all the @Afters after the test method
                 Result afterResult = null;
                 for (GenericMethodWrapper after : this.afters) {
-                    after.invoke(managers, testClassObject, testMethod);
+                    after.invoke(managers, testClassObject, testMethod, testClassWrapper);
                     testClassWrapper.setResult(after.getResult(), managers);
                     if (after.fullStop()) {
                         this.fullStop = true;
@@ -120,7 +120,20 @@ public class TestMethodWrapper {
     public String getName() {
         return this.testMethod.getName();
     }
-    
+
+    /**
+     * This returns the test structure for this @Test method.
+     * @return the existing TestMethod structure for a @Test method.
+     */
+    public TestMethod getTestStructureMethod() {
+        return testMethod.getTestStructureMethod();
+    }
+
+    /**
+     * This creates a new test structure for this @Test method, priming
+     * it with the @Before and @After methods that belong to it.
+     * @return a new TestMethod structure for a @Test method.
+     */
     public TestMethod getStructure() {
         TestMethod methodStructure = testMethod.getStructure();
         ArrayList<TestMethod> structureBefores = new ArrayList<>();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryResultArchiveStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryResultArchiveStoreService.java
@@ -50,9 +50,11 @@ public class DirectoryResultArchiveStoreService implements IResultArchiveStoreSe
     private Path                           testStructureFile;
     private Path                           runLog;
 
-    private final GalasaGson                     gson     = new GalasaGson();
+    private final GalasaGson               gson     = new GalasaGson();
 
     private DirectoryRASFileSystemProvider provider;
+
+    private String                         message;
 
     public DirectoryResultArchiveStoreService(IFramework framework, URI rasUri) throws ResultArchiveStoreException {
         this.framework = framework;
@@ -155,6 +157,9 @@ public class DirectoryResultArchiveStoreService implements IResultArchiveStoreSe
         } catch (final Exception e) {
             throw new ResultArchiveStoreException("Unable to write message to run log", e);
         }
+
+        updateRunLogSoFar();
+
     }
 
     /*
@@ -171,6 +176,19 @@ public class DirectoryResultArchiveStoreService implements IResultArchiveStoreSe
             } catch(final Exception e){
                 throw new ResultArchiveStoreException("Unable to write messages to run log", e);
             }
+        }
+    }
+
+    /**
+     * Update the run log so far into a global variable of this class.
+     * Then it can be retrieved through the Framework from the RAS so
+     * methods in a test class can calculate their start and end line.
+     */
+    private void updateRunLogSoFar() throws ResultArchiveStoreException {
+        try {
+            this.message = Files.readString(this.runLog);
+        } catch (final Exception e) {
+            throw new ResultArchiveStoreException("Unable to read the run log", e);
         }
     }
 
@@ -238,6 +256,11 @@ public class DirectoryResultArchiveStoreService implements IResultArchiveStoreSe
     public void updateTestStructure(@NotNull String runId, @NotNull TestStructure testStructure)
             throws ResultArchiveStoreException {
         throw new UnsupportedOperationException("Unimplemented method 'updateTestStructure'");
+    }
+
+    @Override
+    public String retrieveLog() {
+        return this.message;
     }
 
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryResultArchiveStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryResultArchiveStoreService.java
@@ -54,7 +54,7 @@ public class DirectoryResultArchiveStoreService implements IResultArchiveStoreSe
 
     private DirectoryRASFileSystemProvider provider;
 
-    private String                         message;
+    private String                         runLogContent;
 
     public DirectoryResultArchiveStoreService(IFramework framework, URI rasUri) throws ResultArchiveStoreException {
         this.framework = framework;
@@ -186,7 +186,7 @@ public class DirectoryResultArchiveStoreService implements IResultArchiveStoreSe
      */
     private void updateRunLogSoFar() throws ResultArchiveStoreException {
         try {
-            this.message = Files.readString(this.runLog);
+            this.runLogContent = Files.readString(this.runLog);
         } catch (final Exception e) {
             throw new ResultArchiveStoreException("Unable to read the run log", e);
         }
@@ -260,7 +260,7 @@ public class DirectoryResultArchiveStoreService implements IResultArchiveStoreSe
 
     @Override
     public String retrieveLog() {
-        return this.message;
+        return this.runLogContent;
     }
 
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStore.java
@@ -56,6 +56,14 @@ public interface IResultArchiveStore {
     void writeLog(@NotNull List<String> messages) throws ResultArchiveStoreException;
 
     /**
+     * Retrieves the log so far from the RAS as a String so we can
+     * work out the start and end line numbers of the run log for 
+     * each method in a test class.
+     * @return the run log as a String at any given time in a test.
+     */
+    default String retrieveLog() { return ""; };
+
+    /**
      * Update the Test Structure object in the RASs with the current status
      * 
      * @param testStructure - The Test Structure

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestMethodWrapperTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestMethodWrapperTest.java
@@ -16,8 +16,10 @@ import javax.validation.constraints.NotNull;
 import org.junit.Test;
 
 import dev.galasa.framework.GenericMethodWrapper.Type;
+import dev.galasa.framework.mocks.MockFramework;
 import dev.galasa.framework.mocks.MockIConfigurationPropertyStoreService;
 import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
+import dev.galasa.framework.mocks.MockRASStoreService;
 import dev.galasa.framework.mocks.MockRun;
 import dev.galasa.framework.mocks.MockTestRunManagers;
 import dev.galasa.framework.mocks.MockTestRunnerDataProvider;
@@ -29,20 +31,33 @@ import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class TestMethodWrapperTest {
 
+    private MockRASStoreService ras = new MockRASStoreService(null);
+
     class MockTestClass {
         public int beforeMethodCallCount = 0;
         public int testMethodCallCount = 0;
         public int afterMethodCallCount = 0;
 
-        public void MockBeforeMethod() {
+        String testMethodRunLog = "";
+
+        MockTestClass(List<String> runLogLines) {
+            for (String runLogLine : runLogLines) {
+                this.testMethodRunLog += runLogLine + "\n";
+            }
+        }
+
+        public void MockBeforeMethod() throws Exception {
+            ras.writeLog("This is the before method\n");
             beforeMethodCallCount++;
         }
 
-        public void MockTestMethod() {
+        public void MockTestMethod() throws Exception {
+            ras.writeLog(testMethodRunLog);
             testMethodCallCount++;
         }
 
-        public void MockAfterMethod() {
+        public void MockAfterMethod() throws Exception {
+            ras.writeLog("This is the after method\n");
             afterMethodCallCount++;
         }
     }
@@ -67,7 +82,7 @@ public class TestMethodWrapperTest {
 
     }
 
-    private TestClassWrapper creatTestClassWrapper() throws Exception {
+    private TestClassWrapper createTestClassWrapper() throws Exception {
         TestRunner testRunner = new TestRunner();
 
         IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
@@ -77,6 +92,11 @@ public class TestMethodWrapperTest {
         mockDataProvider.setCps(cps);
         mockDataProvider.setDss(dss);
         mockDataProvider.setRun(new MockRun(null, null, null, null, null, null, null, false));
+
+        MockFramework mockFramework = new MockFramework();
+        mockFramework.setMockRas(ras);
+
+        mockDataProvider.setFramework(mockFramework);
 
         testRunner.init(mockDataProvider);
 
@@ -105,7 +125,7 @@ public class TestMethodWrapperTest {
         afterMethods.add(afterMethodWrapper);
 
         TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, MockTestClass.class, beforeMethods, afterMethods);
-        TestClassWrapper testClassWrapper = creatTestClassWrapper();
+        TestClassWrapper testClassWrapper = createTestClassWrapper();
 
         boolean continueOnTestFailure = false;
         boolean ignoreTestClass = false;
@@ -113,7 +133,7 @@ public class TestMethodWrapperTest {
 
         MockTestRunManagersExtended mockTestRunManagers = new MockTestRunManagersExtended(ignoreTestClass, resultToReturn);
 
-        MockTestClass mockTestClass = new MockTestClass();
+        MockTestClass mockTestClass = new MockTestClass(new ArrayList<String>());
 
         // When...
         testMethodWrapper.getStructure();
@@ -147,7 +167,7 @@ public class TestMethodWrapperTest {
         afterMethods.add(afterMethodWrapper);
 
         TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, MockTestClass.class, beforeMethods, afterMethods);
-        TestClassWrapper testClassWrapper = creatTestClassWrapper();
+        TestClassWrapper testClassWrapper = createTestClassWrapper();
 
         boolean continueOnTestFailure = false;
         boolean ignoreTestClass = false;
@@ -157,7 +177,7 @@ public class TestMethodWrapperTest {
         MockTestRunManagersExtended mockTestRunManagers = new MockTestRunManagersExtended(ignoreTestClass, ignoredResult);
         mockTestRunManagers.setTestMethodResultToReturn(passedResult);
 
-        MockTestClass mockTestClass = new MockTestClass();
+        MockTestClass mockTestClass = new MockTestClass(new ArrayList<String>());
 
         // When...
         testMethodWrapper.getStructure();
@@ -192,7 +212,7 @@ public class TestMethodWrapperTest {
         afterMethods.add(afterMethodWrapper);
 
         TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, MockTestClass.class, beforeMethods, afterMethods);
-        TestClassWrapper testClassWrapper = creatTestClassWrapper();
+        TestClassWrapper testClassWrapper = createTestClassWrapper();
 
         boolean continueOnTestFailure = false;
         boolean ignoreTestClass = false;
@@ -202,7 +222,7 @@ public class TestMethodWrapperTest {
 
         // When...
         testMethodWrapper.getStructure();
-        testMethodWrapper.invoke(mockTestRunManagers, new MockTestClass(), continueOnTestFailure, testClassWrapper);
+        testMethodWrapper.invoke(mockTestRunManagers, new MockTestClass(new ArrayList<String>()), continueOnTestFailure, testClassWrapper);
 
         // Then...
         List<GalasaMethod> galasaMethods = mockTestRunManagers.getGalasaMethodsReceived();
@@ -212,4 +232,183 @@ public class TestMethodWrapperTest {
         assertThat(galasaMethods.get(0).getJavaExecutionMethod()).isEqualTo(testMethod);
         assertThat(galasaMethods.get(0).getJavaTestMethod()).isNull();
     }
+
+    @Test
+    public void testInvokeSetsCorrectRunLogStartAndEndLines1TestMethodWithSingleLine() throws Exception {
+        // Given...
+        Class<?> mockClass = MockTestClass.class;
+
+        List<String> runLogLinesForTestMethod = new ArrayList<>();
+        runLogLinesForTestMethod.add("This is the test method");
+
+        MockTestClass mockClassInstance = new MockTestClass(runLogLinesForTestMethod);
+        Method testMethod = mockClass.getMethod("MockTestMethod");
+
+        ArrayList<GenericMethodWrapper> beforeMethods = new ArrayList<>();
+
+        ArrayList<GenericMethodWrapper> afterMethods = new ArrayList<>();
+
+        TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, mockClass, beforeMethods, afterMethods);
+        testMethodWrapper.getStructure();
+
+        ITestRunManagers mockTestRunManagers = new MockTestRunManagers(false, null);
+
+        TestClassWrapper testClassWrapper = createTestClassWrapper();
+
+        // When...
+        testMethodWrapper.invoke(mockTestRunManagers, mockClassInstance, false, testClassWrapper);
+
+        // Then...
+        assertThat(testMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(1);
+        assertThat(testMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(1);
+    }
+
+    @Test
+    public void testInvokeSetsCorrectRunLogStartAndEndLines1TestMethodWithMultiLine() throws Exception {
+        // Given...
+        Class<?> mockClass = MockTestClass.class;
+
+        List<String> runLogLinesForTestMethod = new ArrayList<>();
+        runLogLinesForTestMethod.add("This is the test method");
+        runLogLinesForTestMethod.add("It's run log has multiple lines");
+        runLogLinesForTestMethod.add("They need to be counted");
+
+        MockTestClass mockClassInstance = new MockTestClass(runLogLinesForTestMethod);
+        Method testMethod = mockClass.getMethod("MockTestMethod");
+
+        ArrayList<GenericMethodWrapper> beforeMethods = new ArrayList<>();
+
+        ArrayList<GenericMethodWrapper> afterMethods = new ArrayList<>();
+
+        TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, mockClass, beforeMethods, afterMethods);
+        testMethodWrapper.getStructure();
+
+        ITestRunManagers mockTestRunManagers = new MockTestRunManagers(false, null);
+
+        TestClassWrapper testClassWrapper = createTestClassWrapper();
+
+        // When...
+        testMethodWrapper.invoke(mockTestRunManagers, mockClassInstance, false, testClassWrapper);
+
+        // Then...
+        assertThat(testMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(1);
+        assertThat(testMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(3);
+    }
+
+    @Test
+    public void testInvokeSetsCorrectRunLogStartAndEndLines1TestMethodWithNoLines() throws Exception {
+        // Given...
+        Class<?> mockClass = MockTestClass.class;
+
+        List<String> runLogLinesForTestMethod = new ArrayList<>();
+
+        MockTestClass mockClassInstance = new MockTestClass(runLogLinesForTestMethod);
+        Method testMethod = mockClass.getMethod("MockTestMethod");
+
+        ArrayList<GenericMethodWrapper> beforeMethods = new ArrayList<>();
+
+        ArrayList<GenericMethodWrapper> afterMethods = new ArrayList<>();
+
+        TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, mockClass, beforeMethods, afterMethods);
+        testMethodWrapper.getStructure();
+
+        ITestRunManagers mockTestRunManagers = new MockTestRunManagers(false, null);
+
+        TestClassWrapper testClassWrapper = createTestClassWrapper();
+
+        // When...
+        testMethodWrapper.invoke(mockTestRunManagers, mockClassInstance, false, testClassWrapper);
+
+        // Then...
+        assertThat(testMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(0);
+        assertThat(testMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(0);
+    }
+
+    @Test
+    public void testInvokeSetsCorrectRunLogStartAndEndLinesBeforeTestAndAfterMethod() throws Exception {
+        // Given...
+        Class<?> mockClass = MockTestClass.class;
+
+        List<String> runLogLinesForTestMethod = new ArrayList<>();
+        runLogLinesForTestMethod.add("This is a test method");
+
+        MockTestClass mockClassInstance = new MockTestClass(runLogLinesForTestMethod);
+        Method beforeMethod = mockClass.getMethod("MockBeforeMethod");
+        Method testMethod = mockClass.getMethod("MockTestMethod");
+        Method afterMethod = mockClass.getMethod("MockAfterMethod");
+
+        ArrayList<GenericMethodWrapper> beforeMethods = new ArrayList<>();
+        GenericMethodWrapper beforeMethodWrapper = new GenericMethodWrapper(beforeMethod, mockClass, Type.Before);
+        beforeMethodWrapper.getStructure();
+        beforeMethods.add(beforeMethodWrapper);
+
+        ArrayList<GenericMethodWrapper> afterMethods = new ArrayList<>();
+        GenericMethodWrapper afterMethodWrapper = new GenericMethodWrapper(afterMethod, mockClass, Type.After);
+        afterMethodWrapper.getStructure();
+        afterMethods.add(afterMethodWrapper);
+
+        TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, mockClass, beforeMethods, afterMethods);
+        testMethodWrapper.getStructure();
+
+        ITestRunManagers mockTestRunManagers = new MockTestRunManagers(false, null);
+
+        TestClassWrapper testClassWrapper = createTestClassWrapper();
+
+        // When...
+        testMethodWrapper.invoke(mockTestRunManagers, mockClassInstance, false, testClassWrapper);
+
+        // Then...
+        assertThat(beforeMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(1);
+        assertThat(beforeMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(1);
+
+        assertThat(testMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(2);
+        assertThat(testMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(2);
+
+        assertThat(afterMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(3);
+        assertThat(afterMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(3);
+    }
+
+    @Test
+    public void testInvokeSetsCorrectRunLogStartAndEndLinesBeforeTestAndAfterMethodTestMethodHasNoRunLog() throws Exception {
+        // Given...
+        Class<?> mockClass = MockTestClass.class;
+
+        List<String> runLogLinesForTestMethod = new ArrayList<>();
+
+        MockTestClass mockClassInstance = new MockTestClass(runLogLinesForTestMethod);
+        Method beforeMethod = mockClass.getMethod("MockBeforeMethod");
+        Method testMethod = mockClass.getMethod("MockTestMethod");
+        Method afterMethod = mockClass.getMethod("MockAfterMethod");
+
+        ArrayList<GenericMethodWrapper> beforeMethods = new ArrayList<>();
+        GenericMethodWrapper beforeMethodWrapper = new GenericMethodWrapper(beforeMethod, mockClass, Type.Before);
+        beforeMethodWrapper.getStructure();
+        beforeMethods.add(beforeMethodWrapper);
+
+        ArrayList<GenericMethodWrapper> afterMethods = new ArrayList<>();
+        GenericMethodWrapper afterMethodWrapper = new GenericMethodWrapper(afterMethod, mockClass, Type.After);
+        afterMethodWrapper.getStructure();
+        afterMethods.add(afterMethodWrapper);
+
+        TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, mockClass, beforeMethods, afterMethods);
+        testMethodWrapper.getStructure();
+
+        ITestRunManagers mockTestRunManagers = new MockTestRunManagers(false, null);
+
+        TestClassWrapper testClassWrapper = createTestClassWrapper();
+
+        // When...
+        testMethodWrapper.invoke(mockTestRunManagers, mockClassInstance, false, testClassWrapper);
+
+        // Then...
+        assertThat(beforeMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(1);
+        assertThat(beforeMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(1);
+
+        assertThat(testMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(0);
+        assertThat(testMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(0);
+
+        assertThat(afterMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(2);
+        assertThat(afterMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(2);
+    }
+
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFramework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFramework.java
@@ -13,6 +13,7 @@ import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.IResultArchiveStore;
 
 import java.io.File;
 import java.util.Properties;
@@ -26,6 +27,7 @@ public class MockFramework extends Framework {
 
     private MockDSSStore mockDss;
     private MockCPSStore mockCps;
+    private MockRASStoreService mockRas;
 
     private String runName ;
 
@@ -42,6 +44,11 @@ public class MockFramework extends Framework {
 
     public MockFramework(File cpsFile) {
         this.cpsFile = cpsFile;
+    }
+
+    @Override
+    public @NotNull IResultArchiveStore getResultArchiveStore() {
+        return this.mockRas;
     }
 
     @Override
@@ -77,6 +84,10 @@ public class MockFramework extends Framework {
 
     public void setMockDss(MockDSSStore mockDss) {
         this.mockDss = mockDss;
+    }
+
+    public void setMockRas(MockRASStoreService mockRas) {
+        this.mockRas = mockRas;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRASStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRASStoreService.java
@@ -20,6 +20,8 @@ public class MockRASStoreService implements IResultArchiveStoreService{
     Map<String,String> properties ;
     Path rasRootPath;
 
+    private String log = "";
+
 
     public MockRASStoreService( Map<String,String> properties ) {
         this(properties, null);
@@ -34,12 +36,17 @@ public class MockRASStoreService implements IResultArchiveStoreService{
         return rasRootPath;
     }
 
-    // un-implemented methods are below.
-
     @Override
     public void writeLog(@NotNull String message) throws ResultArchiveStoreException {
-        throw new UnsupportedOperationException("Unimplemented method 'writeLog'");
+        this.log += message;
     }
+
+    @Override
+    public String retrieveLog() {
+        return this.log;
+    }
+
+    // un-implemented methods are below.
 
     @Override
     public void writeLog(@NotNull List<String> messages) throws ResultArchiveStoreException {


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2214

Set runLogStart and runLogEnd in test structure for methods in a test class allowing users to easily find the log output relating to a specific method, either manually or in future, from the Galasa UI.

**Note:** the `runLogStart` and `runLogEnd` for `@Before` and `@After` methods are not being set and are still 0, apart from for the last `@Test` method. This is due to a general defect in which the `@Before` and `@After` methods apart from the last ones are not being updated at all in the test structure. A defect has been raised for this [here](https://github.com/galasa-dev/projectmanagement/issues/2291).