### PR TITLE
Stop throwing a validation error if no 3270 device name is provided in CPS

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/properties/TerminalDeviceName.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/properties/TerminalDeviceName.java
@@ -31,7 +31,7 @@ public class TerminalDeviceName extends CpsProperties {
 
     private static boolean isDeviceNameValid(String deviceName) {
         boolean isValid = false;
-        if (deviceName != null && !deviceName.isBlank()) {
+        if (!deviceName.isBlank()) {
             isValid = deviceName.length() <= MAX_DEVICE_NAME_LENGTH && US_ASCII_ENCODER.canEncode(deviceName);
         }
         return isValid;
@@ -40,8 +40,8 @@ public class TerminalDeviceName extends CpsProperties {
     public static String get(IZosImage image) throws Zos3270ManagerException {
         try {
             String deviceName = getStringNulled(Zos3270PropertiesSingleton.cps(), "image", "device.name", image.getImageID());
-            if (!isDeviceNameValid(deviceName)) {
-                throw new Zos3270ManagerException("Empty or invalid device name provided. Device name must not exceed 8 characters and must only include 7-bit US ASCII characters.");
+            if (deviceName != null && !isDeviceNameValid(deviceName)) {
+                throw new Zos3270ManagerException("Invalid device name provided. Device name must not exceed 8 characters and must only include 7-bit US ASCII characters.");
             }
             return deviceName;
         } catch (ConfigurationPropertyStoreException e) {

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/internal/properties/TerminalDeviceNameTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/internal/properties/TerminalDeviceNameTest.java
@@ -46,7 +46,7 @@ public class TerminalDeviceNameTest {
     }
 
     @Test
-    public void testGetDeviceNameEmptyThrowsError() throws Exception {
+    public void testGetDeviceNameEmptyDoesNotThrowError() throws Exception {
         // Given...
         String imageId = "MYZOSIMAGE";
         String deviceNameInCps = "    ";
@@ -64,13 +64,31 @@ public class TerminalDeviceNameTest {
         Zos3270PropertiesSingleton.setCps(mockCps);
 
         // When...
-        Zos3270ManagerException thrown = catchThrowableOfType(() -> {
-            TerminalDeviceName.get(zosImage);
-        }, Zos3270ManagerException.class);
+        String deviceNameGotBack = TerminalDeviceName.get(zosImage);
 
         // Then...
-        assertThat(thrown).isNotNull();
-        assertThat(thrown).hasMessageContaining("Empty or invalid device name provided");
+        assertThat(deviceNameGotBack).isNull();
+    }
+
+    @Test
+    public void testGetDeviceNameNotSetDoesNotThrowError() throws Exception {
+        // Given...
+        String imageId = "MYZOSIMAGE";
+
+        IZosImage zosImage = new MockZosImage(imageId);
+
+        Map<String, String> cpsProps = new HashMap<>();
+
+        IConfigurationPropertyStoreService mockCps = new MockConfigurationPropertyStoreService(cpsProps);
+        Zos3270PropertiesSingleton singletonInstance = new Zos3270PropertiesSingleton();
+        singletonInstance.activate();
+        Zos3270PropertiesSingleton.setCps(mockCps);
+
+        // When...
+        String deviceNameGotBack = TerminalDeviceName.get(zosImage);
+
+        // Then...
+        assertThat(deviceNameGotBack).isNull();
     }
 
     @Test
@@ -98,7 +116,7 @@ public class TerminalDeviceNameTest {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown).hasMessageContaining("Empty or invalid device name provided");
+        assertThat(thrown).hasMessageContaining("Invalid device name provided");
     }
 
     @Test
@@ -131,7 +149,7 @@ public class TerminalDeviceNameTest {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown).hasMessageContaining("Empty or invalid device name provided");
+        assertThat(thrown).hasMessageContaining("Invalid device name provided");
     }
 
     @Test


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/galasa/pull/338

## Changes
- Fixed the device name validation logic to stop throwing an error if no device name is provided in the CPS (since it should be an optional property)
- Added unit test to make sure the error is only thrown if the CPS property is provided with a blank string