### PR TITLE
Server certificate verification for z/OS 3270 terminals

### DIFF
--- a/docs/content/docs/managers/zos-managers/zos-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-manager.md
@@ -213,6 +213,42 @@ The following properties are used to configure the z/OS Manager.
 | Examples: | `zos.image.SYSA.iphostid=sysa.example.com`<br> |
 
 
+### Telnet port number of the z/OS Image
+
+| Property: | Telnet port number of the zOS Image |
+| --------------------------------------- | :------------------------------------- |
+| Name: | zos.image.[imageId].telnet.port |
+| Description: | The port number for telnet 3270 access to the z/OS Image for the supplied tag. |
+| Required:  | No |
+| Default value: | 23 |
+| Valid values: | A valid TCP/IP port number |
+| Examples: | `zos.image.SYSA.telnet.port=992`<br> |
+
+
+### TLS for telnet on the z/OS Image
+
+| Property: | TLS for telnet on the zOS Image |
+| --------------------------------------- | :------------------------------------- |
+| Name: | zos.image.[imageId].telnet.tls |
+| Description: | Set this to true if Transport Layer Security (TLS) is used on the telnet 3270 port of the z/OS Image for the supplied tag. |
+| Required:  | No |
+| Default value: | false |
+| Valid values: | `true` or `false` |
+| Examples: | `zos.image.SYSA.telnet.tls=true`<br> |
+
+
+### Server certificate verification for telnet on the z/OS Image
+
+| Property: | Server certificate verification for telnet on the zOS Image |
+| --------------------------------------- | :------------------------------------- |
+| Name: | zos.image.[imageId].telnet.verify |
+| Description: | Set this to true to request verification of the certificate provided by the z/OS Image for the supplied tag when connecting to the telnet 3270 port.<br> This property is ignored if Transport Layer Security (TLS) is not in use.<br> By default, the trust store containing certificate authorities used for verification is `$JAVA_HOME/lib/security/cacerts`. To use a different trust store, you can specify a different path on a `-Djavax.net.ssl.trustStore` option for the `galasactl.jvm.local.launch.options` property in bootstrap.properties. |
+| Required:  | No |
+| Default value: | false |
+| Valid values: | `true` or `false` |
+| Examples: | `zos.image.SYSA.telnet.verify=true`<br> |
+
+
 ### The z/OS Image
 
 | Property: | The zOS Image |

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/spi/CicsTerminalImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/spi/CicsTerminalImpl.java
@@ -35,9 +35,9 @@ public class CicsTerminalImpl extends Zos3270TerminalImpl implements ICicsTermin
     public final boolean connectAtStartup;
     public final String loginCredentialsTag;
 
-    public CicsTerminalImpl(ICicstsManagerSpi cicstsManager, IFramework framework, ICicsRegionProvisioned cicsRegion, String host, int port, boolean ssl, boolean connectAtStartup, ITextScannerManagerSpi textScanner, String loginCredentialsTag)
+    public CicsTerminalImpl(ICicstsManagerSpi cicstsManager, IFramework framework, ICicsRegionProvisioned cicsRegion, String host, int port, boolean ssl, boolean verifyServer, boolean connectAtStartup, ITextScannerManagerSpi textScanner, String loginCredentialsTag)
             throws TerminalInterruptedException, Zos3270ManagerException, ZosManagerException {
-        super(cicsRegion.getNextTerminalId(), host, port, ssl, framework, false, cicsRegion.getZosImage(), new TerminalSize(80, 24), new TerminalSize(0, 0), textScanner);
+        super(cicsRegion.getNextTerminalId(), host, port, ssl, verifyServer, framework, false, cicsRegion.getZosImage(), new TerminalSize(80, 24), new TerminalSize(0, 0), textScanner);
 
         this.cicsRegion = cicsRegion;
         this.cicstsManager = cicstsManager;
@@ -49,7 +49,7 @@ public class CicsTerminalImpl extends Zos3270TerminalImpl implements ICicsTermin
 
     public CicsTerminalImpl(ICicstsManagerSpi cicstsManager, IFramework framework, ICicsRegionProvisioned cicsRegion, IIpHost ipHost, boolean connectAtStartup, ITextScannerManagerSpi textScanner, String loginCredentialsTag)
             throws TerminalInterruptedException, IpNetworkManagerException, Zos3270ManagerException, ZosManagerException {
-        this(cicstsManager, framework, cicsRegion, ipHost.getHostname(), ipHost.getTelnetPort(), ipHost.isTelnetPortTls(), connectAtStartup, textScanner, loginCredentialsTag);
+        this(cicstsManager, framework, cicsRegion, ipHost.getHostname(), ipHost.getTelnetPort(), ipHost.isTelnetPortTls(), ipHost.shouldVerifyTelnetServer(), connectAtStartup, textScanner, loginCredentialsTag);
     }
 
     public CicsTerminalImpl(ICicstsManagerSpi cicstsManager, IFramework framework, ICicsRegionProvisioned cicsRegion, boolean connectAtStartup, ITextScannerManagerSpi textScanner, String loginCredentialsTag) throws TerminalInterruptedException, IpNetworkManagerException,

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackIpHost.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackIpHost.java
@@ -47,6 +47,11 @@ public class OpenstackIpHost implements IIpHost {
     }
 
     @Override
+    public boolean shouldVerifyTelnetServer() throws IpNetworkManagerException {
+        return false;
+    }
+
+    @Override
     public int getFtpPort() throws IpNetworkManagerException {
         return 21;
     }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/src/main/java/dev/galasa/ipnetwork/IIpHost.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/src/main/java/dev/galasa/ipnetwork/IIpHost.java
@@ -56,6 +56,14 @@ public interface IIpHost {
     boolean isTelnetPortTls() throws IpNetworkManagerException;
 
     /**
+     * Should the Telnet server's certificate be verified, default false
+     * 
+     * @return verify?
+     * @throws IpNetworkManagerException if there is a problem accessing the CPS
+     */
+    boolean shouldVerifyTelnetServer() throws IpNetworkManagerException;
+
+    /**
      * Get the FTP port, defaults to 21
      * 
      * @return FTP port

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/src/main/java/dev/galasa/ipnetwork/spi/AbstractGenericIpHost.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/src/main/java/dev/galasa/ipnetwork/spi/AbstractGenericIpHost.java
@@ -95,6 +95,16 @@ public abstract class AbstractGenericIpHost implements IIpHostSpi {
     }
 
     @Override
+    public boolean shouldVerifyTelnetServer() throws IpNetworkManagerException {
+        try {
+            return Boolean
+                    .parseBoolean(AbstractManager.nulled(this.cps.getProperty(this.prefix, "telnet.tls.verify", this.hostid)));
+        } catch (Exception e) {
+            throw new IpNetworkManagerException("Unable to retrieve telnet tls property for host " + this.hostid, e);
+        }
+    }
+
+    @Override
     public int getFtpPort() throws IpNetworkManagerException {
         try {
             String temp = AbstractManager.nulled(this.cps.getProperty(this.prefix, "ftp.port", this.hostid));

--- a/modules/managers/galasa-managers-parent/galasa-managers-imstm-parent/dev.galasa.imstm.manager/src/main/java/dev/galasa/imstm/spi/ImsTerminalImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-imstm-parent/dev.galasa.imstm.manager/src/main/java/dev/galasa/imstm/spi/ImsTerminalImpl.java
@@ -31,9 +31,9 @@ public class ImsTerminalImpl extends Zos3270TerminalImpl implements IImsTerminal
     public final boolean connectAtStartup;
     public final String loginCredentialsTag;
 
-    public ImsTerminalImpl(IImstmManagerSpi imstmManager, IFramework framework, IImsSystem imsSystem, String host, int port, boolean ssl, boolean connectAtStartup, ITextScannerManagerSpi textScanner, String loginCredentialsTag)
+    public ImsTerminalImpl(IImstmManagerSpi imstmManager, IFramework framework, IImsSystem imsSystem, String host, int port, boolean ssl, boolean verifyServer, boolean connectAtStartup, ITextScannerManagerSpi textScanner, String loginCredentialsTag)
             throws TerminalInterruptedException, Zos3270ManagerException, ZosManagerException {
-        super(imstmManager.getNextTerminalId(imsSystem), host, port, ssl, framework, false, imsSystem.getZosImage(), new TerminalSize(80, 24), new TerminalSize(0, 0), textScanner);
+        super(imstmManager.getNextTerminalId(imsSystem), host, port, ssl, verifyServer, framework, false, imsSystem.getZosImage(), new TerminalSize(80, 24), new TerminalSize(0, 0), textScanner);
 
         this.imsSystem = imsSystem;
         this.imstmManager = imstmManager;
@@ -45,7 +45,7 @@ public class ImsTerminalImpl extends Zos3270TerminalImpl implements IImsTerminal
 
     public ImsTerminalImpl(IImstmManagerSpi imstmManager, IFramework framework, IImsSystem imsSystem, IIpHost ipHost, boolean connectAtStartup, ITextScannerManagerSpi textScanner, String loginCredentialsTag)
             throws TerminalInterruptedException, IpNetworkManagerException, Zos3270ManagerException, ZosManagerException {
-        this(imstmManager, framework, imsSystem, ipHost.getHostname(), ipHost.getTelnetPort(), ipHost.isTelnetPortTls(), connectAtStartup, textScanner, loginCredentialsTag);
+        this(imstmManager, framework, imsSystem, ipHost.getHostname(), ipHost.getTelnetPort(), ipHost.isTelnetPortTls(), ipHost.shouldVerifyTelnetServer(), connectAtStartup, textScanner, loginCredentialsTag);
     }
 
     public ImsTerminalImpl(IImstmManagerSpi imstmManager, IFramework framework, IImsSystem imsSystem, boolean connectAtStartup, ITextScannerManagerSpi textScanner, String loginCredentialsTag) throws TerminalInterruptedException, IpNetworkManagerException,

--- a/modules/managers/galasa-managers-parent/galasa-managers-imstm-parent/dev.galasa.imstm.manager/src/test/java/dev/galasa/imstm/spi/TestImsTerminalImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-imstm-parent/dev.galasa.imstm.manager/src/test/java/dev/galasa/imstm/spi/TestImsTerminalImpl.java
@@ -60,6 +60,7 @@ public class TestImsTerminalImpl {
     private static final String HOST = "my.test.host";
     private static final int PORT = 12345;
     private static final boolean SSL = true;
+    private static final boolean VERIFY = true;
     private static final boolean AUTOCONNECT = true;
     private static final String CREDENTIALS_TAG = "TEST_CREDENTIALS";
 
@@ -71,6 +72,7 @@ public class TestImsTerminalImpl {
         Mockito.when(ipHost.getHostname()).thenReturn(HOST);
         Mockito.when(ipHost.getTelnetPort()).thenReturn(PORT);
         Mockito.when(ipHost.isTelnetPortTls()).thenReturn(SSL);
+        Mockito.when(ipHost.shouldVerifyTelnetServer()).thenReturn(VERIFY);
         Mockito.when(zosImage.getIpHost()).thenReturn(ipHost);
         logonProviders = new ArrayList<IImsSystemLogonProvider>();
         logonProviders.add(logonProvider);
@@ -85,6 +87,7 @@ public class TestImsTerminalImpl {
             Assert.assertEquals("Wrong host name passed to Zos3270TerminalImpl constructor",HOST, (String) arguments.get(0));
             Assert.assertEquals("Wrong port passed to Zos3270TerminalImpl constructor",PORT, (int) arguments.get(1));
             Assert.assertEquals("Wrong SSL flag passed to Zos3270TerminalImpl constructor",SSL, (boolean) arguments.get(2));
+            Assert.assertEquals("Wrong Verify Server flag passed to Zos3270TerminalImpl constructor",VERIFY, (boolean) arguments.get(3));
             // Set up an exception so that a network call (that we will trigger later in this test)
             // fails quickly.
             Mockito.when(mock.connectClient()).thenThrow(new NetworkException());
@@ -103,7 +106,7 @@ public class TestImsTerminalImpl {
         MockedStatic<TerminalDeviceTypes> deviceTypes = Mockito.mockStatic(TerminalDeviceTypes.class);
         MockedStatic<TerminalDeviceName> deviceName = Mockito.mockStatic(TerminalDeviceName.class);
         MockedStatic<LogConsoleTerminals> consoles = Mockito.mockStatic(LogConsoleTerminals.class)) {
-            terminal = new ImsTerminalImpl(imsManager, framework, system, HOST, PORT, SSL, AUTOCONNECT, textScanManager, CREDENTIALS_TAG);
+            terminal = new ImsTerminalImpl(imsManager, framework, system, HOST, PORT, SSL, VERIFY, AUTOCONNECT, textScanManager, CREDENTIALS_TAG);
             verifyConstructorActions(networks.constructed(), deviceTypes, deviceName, screens.constructed());
             Assert.assertEquals("Wrong login credentials tag was saved", CREDENTIALS_TAG, terminal.getLoginCredentialsTag());
         }
@@ -116,6 +119,7 @@ public class TestImsTerminalImpl {
             Assert.assertEquals("Wrong host name passed to Zos3270TerminalImpl constructor",HOST, (String) arguments.get(0));
             Assert.assertEquals("Wrong port passed to Zos3270TerminalImpl constructor",PORT, (int) arguments.get(1));
             Assert.assertEquals("Wrong SSL flag passed to Zos3270TerminalImpl constructor",SSL, (boolean) arguments.get(2));
+            Assert.assertEquals("Wrong Verify Server flag passed to Zos3270TerminalImpl constructor",VERIFY, (boolean) arguments.get(3));
             // Set up an exception so that a network call (that we will trigger later in this test)
             // fails quickly.
             Mockito.when(mock.connectClient()).thenThrow(new NetworkException());
@@ -147,6 +151,7 @@ public class TestImsTerminalImpl {
             Assert.assertEquals("Wrong host name passed to Zos3270TerminalImpl constructor",HOST, (String) arguments.get(0));
             Assert.assertEquals("Wrong port passed to Zos3270TerminalImpl constructor",PORT, (int) arguments.get(1));
             Assert.assertEquals("Wrong SSL flag passed to Zos3270TerminalImpl constructor",SSL, (boolean) arguments.get(2));
+            Assert.assertEquals("Wrong Verify Server flag passed to Zos3270TerminalImpl constructor",VERIFY, (boolean) arguments.get(3));
             // Set up an exception so that a network call (that we will trigger later in this test)
             // fails quickly.
             Mockito.when(mock.connectClient()).thenThrow(new NetworkException());
@@ -178,6 +183,7 @@ public class TestImsTerminalImpl {
             Assert.assertEquals("Wrong host name passed to Zos3270TerminalImpl constructor",HOST, (String) arguments.get(0));
             Assert.assertEquals("Wrong port passed to Zos3270TerminalImpl constructor",PORT, (int) arguments.get(1));
             Assert.assertEquals("Wrong SSL flag passed to Zos3270TerminalImpl constructor",SSL, (boolean) arguments.get(2));
+            Assert.assertEquals("Wrong Verify Server flag passed to Zos3270TerminalImpl constructor",VERIFY, (boolean) arguments.get(3));
             // Set up an exception so that a network call (that we will trigger later in this test)
             // fails quickly.
             Mockito.when(mock.connectClient()).thenThrow(new NetworkException());

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/Zos3270ManagerImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/Zos3270ManagerImpl.java
@@ -195,7 +195,7 @@ public class Zos3270ManagerImpl extends AbstractGherkinManager implements IZos32
             String terminaId = "term" + (terminalCount);
 
             Zos3270TerminalImpl terminal = new Zos3270TerminalImpl(terminaId, host.getHostname(), host.getTelnetPort(),
-                    host.isTelnetPortTls(), getFramework(), autoConnect, image, primarySize, alternateSize, textScannerManager);
+                    host.isTelnetPortTls(), host.shouldVerifyTelnetServer(), getFramework(), autoConnect, image, primarySize, alternateSize, textScannerManager);
             
             this.terminals.add(terminal);
             logger.info("Generated a terminal for zOS Image tagged " + imageTag);

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
@@ -73,15 +73,15 @@ public class Terminal implements ITerminal {
      */
     @Deprecated(since = "0.28.0", forRemoval = true)
     public Terminal(String id, String host, int port, boolean ssl, int primaryColumns, int primaryRows, int alternateColumns, int alternateRows, ITextScannerManagerSpi textScan) throws TerminalInterruptedException {
-        network = new Network(host, port, ssl, id);
+        network = new Network(host, port, ssl, false, id);
         screen = new Screen(primaryColumns, primaryRows, alternateColumns, alternateRows, this.network);
         this.id = id;
         this.textScan = textScan;
     }
 
 
-    public Terminal(String id, String host, int port, boolean ssl, TerminalSize primarySize, TerminalSize alternateSize, ITextScannerManagerSpi textScan, Charset codePage) throws TerminalInterruptedException {
-        network = new Network(host, port, ssl, id);
+    public Terminal(String id, String host, int port, boolean ssl, boolean verifyServer, TerminalSize primarySize, TerminalSize alternateSize, ITextScannerManagerSpi textScan, Charset codePage) throws TerminalInterruptedException {
+        network = new Network(host, port, ssl, verifyServer, id);
         screen = new Screen(primarySize, alternateSize, this.network, codePage);
         this.id = id;
         this.textScan = textScan;

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Zos3270TerminalImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Zos3270TerminalImpl.java
@@ -137,10 +137,10 @@ public class Zos3270TerminalImpl extends Terminal implements IScreenUpdateListen
     }
 
 
-    public Zos3270TerminalImpl(String id, String host, int port, boolean tls, IFramework framework, boolean autoConnect,
+    public Zos3270TerminalImpl(String id, String host, int port, boolean tls, boolean verifyServer, IFramework framework, boolean autoConnect,
             IZosImage image, TerminalSize primarySize, TerminalSize alternateSize, ITextScannerManagerSpi textScanner)
             throws Zos3270ManagerException, TerminalInterruptedException, ZosManagerException {
-        super(id, host, port, tls, primarySize, alternateSize, textScanner, image.getCodePage());
+        super(id, host, port, tls, verifyServer, primarySize, alternateSize, textScanner, image.getCodePage());
         this.terminalId = id;
         this.runId = framework.getTestRunName();
         this.autoConnect = autoConnect;

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/network/Network3270Test.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/network/Network3270Test.java
@@ -234,7 +234,7 @@ public class Network3270Test extends Zos3270TestBase {
         Screen mockScreen = CreateTestScreen();
         TerminalSize primarySize = new TerminalSize(mockScreen.getPrimaryColumns(), mockScreen.getPrimaryRows());
         TerminalSize alternateSize = new TerminalSize(mockScreen.getAlternateColumns(), mockScreen.getAlternateRows());
-        Terminal terminal = new Terminal("terminal1", "host", 0, false, primarySize, alternateSize, null, ebcdic);
+        Terminal terminal = new Terminal("terminal1", "host", 0, false, false, primarySize, alternateSize, null, ebcdic);
         terminal.setRequestedDeviceName(mockDeviceName);
 
         NetworkThread networkThread = new NetworkThread(terminal, mockScreen, network, inputStream, mockDeviceTypes);

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/util/Zos3270TestBase.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/util/Zos3270TestBase.java
@@ -41,7 +41,7 @@ public class Zos3270TestBase {
 				return logScanner;
 			}
 		};
-		return new Terminal("test", "", 0, false, terminalSize, alternateTerminalSize, mockTextScannerManager, ebcdic);
+		return new Terminal("test", "", 0, false, false, terminalSize, alternateTerminalSize, mockTextScannerManager, ebcdic);
 	}
 
     protected Screen CreateTestScreen() throws TerminalInterruptedException {


### PR DESCRIPTION
PR for issue https://github.com/galasa-dev/projectmanagement/issues/2296

The key to making this work is in Network.createSocket() where the TrustManagerFactory is initialized with a null KeyStore. This is the magic incantation that tells the TrustManager to respect the javax.net.ssl.* properties and fall back to the $JAVA_HOME/lib/security/cacerts trust store.