### PR TITLE
Treat an unrecognised MF order as a blank space and log a trace message instead of throwing an exception

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2111,15 +2111,7 @@
         "hashed_secret": "dd2b42dd745ece79948e1e7b317c085802221cc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "21905cc274a685c51e8bc018b2b02321cdaddf84",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 148,
+        "line_number": 152,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2111,7 +2111,7 @@
         "hashed_secret": "dd2b42dd745ece79948e1e7b317c085802221cc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 146,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -2119,7 +2119,7 @@
         "hashed_secret": "21905cc274a685c51e8bc018b2b02321cdaddf84",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 143,
+        "line_number": 148,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,7 +91,7 @@
         "hashed_secret": "9b73324114b10c7b4a1b05b2c322a292db5ba7f8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 83,
+        "line_number": 84,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2103,6 +2103,24 @@
         "is_verified": false,
         "line_number": 114,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/datastream/InboundTest.java": [
+      {
+        "hashed_secret": "dd2b42dd745ece79948e1e7b317c085802221cc6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 142,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "21905cc274a685c51e8bc018b2b02321cdaddf84",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ]

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/comms/NetworkThread.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/comms/NetworkThread.java
@@ -933,7 +933,12 @@ public class NetworkThread extends Thread {
                         order = new OrderSetAttribute(buffer);
                         break;
                     case OrderModifyField.ID:
-                        order = new OrderModifyField(buffer);
+                        try {
+                            order = new OrderModifyField(buffer);
+                        } catch (DatastreamException e) {
+                            logger.trace("Failed to process MF order, processing as blank text instead", e);
+                            order = new OrderText(" ", codePage);
+                        }
                         break;
                     case OrderInsertCursor.ID:
                         order = new OrderInsertCursor();

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/datastream/InboundTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/datastream/InboundTest.java
@@ -141,14 +141,23 @@ public class InboundTest {
         String inbound3270Header = "0000000000";
 
         // Create a bad modify field order with invalid attributes
-        // This one says it has 81 attribute type/value pairs, but there are only three
-        // and all three are not known attribute types
+        // Modify field orders take the following format:
+        // <order ID><number of attribute type/value pairs><attribute type><attribute value>
+        //
+        // In this case:
+        // <order ID> is 2c
+        // <number of attribute type/value pairs> is 51 (decodes to 81 in decimal)
+        // <attribute type><attribute value> covers every two bytes/four hex characters in 'db301106e813'
+        // (there’s only 3 attribute pairs, none of which contain a recognised attribute type)
         String badModifyField = "2c51db301106e813";
 
-        String inboundMessage = "f1c11106c98396958489a38996957ee77df0f1f77d404d2c51db301106e813";
+        String mockScreenText = "WELCOME TO SIMBANK";
+        String ebcdicScreen = Hex.encodeHexString(mockScreenText.getBytes(codePage));
+
+        String commandCode = "f1c11106c9";
         String iacEorTrailer = Hex.encodeHexString(new byte[]{ NetworkThread.IAC, NetworkThread.EOR });
 
-        String inboundDataStream = inbound3270Header + inboundMessage + badModifyField + iacEorTrailer;
+        String inboundDataStream = inbound3270Header + commandCode + ebcdicScreen + badModifyField + iacEorTrailer;
         byte[] inboundAsBytes = Hex.decodeHex(inboundDataStream);
 
         Network network = new Network("here", 1, "a");
@@ -165,6 +174,7 @@ public class InboundTest {
         String screenStr = screen.printScreenTextWithCursor();
 
         // Then...
-        assertThat(screenStr).contains("condition=");
+        // Check that the screen text rendered OK
+        assertThat(screenStr).contains(mockScreenText);
     }
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/datastream/InboundTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/datastream/InboundTest.java
@@ -163,7 +163,6 @@ public class InboundTest {
         // When...
         networkThread.processMessage(inputStream);
         String screenStr = screen.printScreenTextWithCursor();
-        System.out.println(screenStr);
 
         // Then...
         assertThat(screenStr).contains("condition=");


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2026

## Changes
- When the 3270 manager encounters an unrecognised attribute in a modify field order, instead of throwing an exception, the manager will catch the thrown exception, log a trace message, and treat the bad modify field order as a blank space before continuing to process the 3270 message as normal