### PR TITLE
mcobbett null pointer ex in 3270 cleanup 2271

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1972,6 +1972,16 @@
         "verified_result": null
       }
     ],
+    "modules/cli/test-scripts/run-3270-test-locally.sh": [
+      {
+        "hashed_secret": "bb18df36fd72c81a1c5180cace0be6d5d7cdf947",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 83,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3CredentialsStoreTest.java": [
       {
         "hashed_secret": "1beb7496ebbe82c61151be093956d83dac625c13",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,18 @@ Welcome to Galasa! To learn more about contributing to this repository, please r
 
 ## How to make a contribution?
 
+### Sign your commits
+
+Make sure you are able to sign commits with your personal GPG key. See https://git-scm.com/book/ms/v2/Git-Tools-Signing-Your-Work
+
+Whenever you commit, please sign commits with `-s -S` flags to sign the commit.
+This allows us to prove who made each change to the codebase.
+
+Each PR build has "Developer Certificate of Origin" [DCO](./CONTRIBUTIONS.md) checking turned on, so nothing will get
+delivered without signed commits.
+
+If you forgot to sign one or all of your commits, you can squash your PR changes and force-push your branch.
+
 ### Set up a fork of a repository
 
 1. On GitHub, navigate to the repository.

--- a/modules/cli/test-scripts/run-3270-test-locally.sh
+++ b/modules/cli/test-scripts/run-3270-test-locally.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+echo "Running script $0"
+
+# This script can be ran locally or executed in a pipeline to test the various built binaries of galasactl
+# This script tests the 'galasactl project create' and 'galasactl runs submit local' commands
+# Pre-requesite: the CLI must have been built first so the binaries are present in the ./bin directory
+
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+export ORIGINAL_DIR=$(pwd)
+cd "${BASEDIR}"
+
+
+#--------------------------------------------------------------------------
+#
+# Set Colors
+#
+#--------------------------------------------------------------------------
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#--------------------------------------------------------------------------
+#
+# Headers and Logging
+#
+#--------------------------------------------------------------------------
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ;}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ;}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ;}
+debug() { printf "${white}%s${reset}\n" "$@" ;}
+info() { printf "${white}➜ %s${reset}\n" "$@" ;}
+success() { printf "${green}✔ %s${reset}\n" "$@" ;}
+error() { printf "${red}✖ %s${reset}\n" "$@" ;}
+warn() { printf "${tan}➜ %s${reset}\n" "$@" ;}
+bold() { printf "${bold}%s${reset}\n" "$@" ;}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
+
+rm -fr "${BASEDIR}/../temp/home"
+mkdir -p "${BASEDIR}/../temp/home"
+cd "${BASEDIR}/../temp/home"
+export GALASA_HOME=$(pwd)
+cd "$BASEDIR"
+
+
+
+galasactl local init --development --galasahome "$GALASA_HOME"
+rc=$? ; if [[ "$rc" != "0" ]]; then error "Failed to create galasa home folder" ; exit 1 ; fi
+
+
+overrides_file=$BASEDIR/../temp/overrides-for-3270-test.properties
+
+if [[ "${ZOS_HOSTNAME}" == "" ]]; then 
+    error "Env variable ZOS_HOSTNAME is not set. Set it and re-try" 
+    exit 1
+fi
+
+
+cat << EOF >> "$overrides_file"
+
+zos.dse.tag.PRIMARY.clusterid=PLEX2
+zos.dse.tag.PRIMARY.imageid=MV26
+zos.cluster.PLEX2.images=MV26
+
+zos.image.MV26.sysplex=PLEX2
+zos.image.MV26.default.hostname=${ZOS_HOSTNAME}
+zos.image.MV26.ipv4.hostname=${ZOS_HOSTNAME}
+zos.image.MV26.telnet.port=992
+zos.image.MV26.telnet.tls=true
+zos.image.MV26.credentials=PLEX2
+EOF
+
+
+credentials_file=$GALASA_HOME/credentials.properties
+cat << EOF >> "$credentials_file"
+
+secure.credentials.PLEX2.username=${ZOS_TEST_USERNAME}
+secure.credentials.PLEX2.password=${ZOS_TEST_PASSWORD}
+EOF
+
+galasa_version=$(cat "$BASEDIR/../VERSION")
+
+galasactl runs submit local \
+--obr "mvn:dev.galasa/dev.galasa.ivts.obr/${galasa_version}/obr" \
+--class dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos3270.Zos3270IVT \
+--overridefile "$overrides_file" \
+--log - \
+--tags 3270 \
+--trace
+

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
@@ -33,18 +33,22 @@ import dev.galasa.zos3270.internal.comms.NetworkThread;
 
 public class Terminal implements ITerminal {
 
+    // The max amount of time this thread will wait around for the network thread to finish after
+    // we have closed the network. Units are milliseconds. 
+    public static final long MAX_MILLISECS_TO_WAIT_FOR_NETWORK_THREAD_TO_FINISH = 20 * 1000 ; // 20 seconds
+
 	public ITextScannerManagerSpi textScan;
     private final Screen  screen;
     private final Network network;
     private final String  id;
-    private NetworkThread networkThread;
-    private boolean connected = false;
+    private volatile NetworkThread networkThread;
+    private volatile boolean connected = false;
 
     private int           defaultWaitTime = 120_000;
 
     private Log           logger          = LogFactory.getLog(getClass());
     
-    private boolean       autoReconnect   = false;
+    private volatile boolean       autoReconnect   = false;
     
     private List<String>  deviceTypes;
     private String        requestedDeviceName;
@@ -81,7 +85,14 @@ public class Terminal implements ITerminal {
 
 
     public Terminal(String id, String host, int port, boolean ssl, boolean verifyServer, TerminalSize primarySize, TerminalSize alternateSize, ITextScannerManagerSpi textScan, Charset codePage) throws TerminalInterruptedException {
-        network = new Network(host, port, ssl, verifyServer, id);
+        this(id, host, port, ssl, verifyServer, primarySize, alternateSize, textScan, codePage, new Network(host, port, ssl, verifyServer, id));
+    }
+
+    /** 
+     * A constructor which passes-in the network object, so unit tests can use this one.
+     */
+    protected Terminal(String id, String host, int port, boolean ssl, boolean verifyServer, TerminalSize primarySize, TerminalSize alternateSize, ITextScannerManagerSpi textScan, Charset codePage, Network network) throws TerminalInterruptedException {
+        this.network = network;
         screen = new Screen(primarySize, alternateSize, this.network, codePage);
         this.id = id;
         this.textScan = textScan;
@@ -143,6 +154,7 @@ public class Terminal implements ITerminal {
         logger.trace("connect() exiting");
     }
 
+
     @Override
     public void disconnect() throws TerminalInterruptedException {
         logger.trace("disconnect() entered");
@@ -158,7 +170,7 @@ public class Terminal implements ITerminal {
         if (networkThread != null) {
             try {
                 logger.trace("Waiting for network thread to end...");
-                networkThread.join();
+                networkThread.join(MAX_MILLISECS_TO_WAIT_FOR_NETWORK_THREAD_TO_FINISH);
                 logger.trace("Network thread ended OK");
             } catch (InterruptedException e) {
                 logger.warn("Interrupted while waiting for network thread to end. Network thread might still be active.");
@@ -172,14 +184,23 @@ public class Terminal implements ITerminal {
         logger.trace("disconnect() exiting");
     }
     
+    /**
+     * The network thread has closed the network connection.
+     * After this point, it will immediately exit.
+     */
     public void networkClosed() {
         logger.trace("networkClosed() entered");
         connected = false;
         if (network != null) {
             network.close();
         }
-        networkThread = null;
-        
+
+        // Do NOT null-out the networkThread variable. Doing so will potentially cause a race condition
+        // in the disconnect code.
+        // But nulling-out the connection will mean we potentially have an inactive thread which won't get cleaned
+        // up so quickly... until either the disconnect() or connect() calls are made, or this terminal is freed-up
+        // by garbage collection.
+        // Of both of these, avoiding the race is the best option.
         if (autoReconnect) {
             logger.trace("Auto reconnecting...");
             try {

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/spi/TerminalTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/spi/TerminalTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.zos3270.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import dev.galasa.textscan.spi.ITextScannerManagerSpi;
+import dev.galasa.zos3270.TerminalInterruptedException;
+import dev.galasa.zos3270.common.screens.TerminalSize;
+import dev.galasa.zos3270.mocks.MockNetwork;
+
+public class TerminalTest {
+
+    @Test
+    public void testCanCreateTerminal() throws Exception {
+
+        String terminalId = "abcdef";
+        String host = "myHost";
+        int port = 1234;
+        boolean isSSL = false;
+        boolean isVerifyServer = false;
+        TerminalSize primarySize = new TerminalSize(80,24);
+        TerminalSize alternateSize = new TerminalSize(80,24);
+        ITextScannerManagerSpi textScan = null ;
+        Charset codePage = Charset.availableCharsets().get("1024");
+
+        ByteArrayOutputStream networkOut = new ByteArrayOutputStream();
+
+        MockNetwork network = new MockNetwork(networkOut) {
+            public boolean connectClient() throws NetworkException {
+                return true;
+            }
+        };
+
+        new Terminal(terminalId, host, port, isSSL, isVerifyServer, primarySize, alternateSize,
+        textScan, codePage, network);
+
+    }
+    
+}


### PR DESCRIPTION
# Why ?
See [Started seeing irregular NullPointerException's in zos3270 manager disconnect() #2271](https://github.com/galasa-dev/projectmanagement/issues/2271)

I think there is a race condition which gets hit occasionally, causing a NPE.

Trying to add a lock to prevent this race condition from occurring.

- Added a section in the CONTRIBUTING.md to tell contributors to sign their commits
- Terminal should protect against race condition with networkThread variable being nulled-out.
