### PR TITLE
Stop scheduling queued runs that have been interrupted, create RAS records for queued runs before test pods are created

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
@@ -446,11 +446,9 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
 
     @Override
     public IRunResult getRunById(@NotNull String runId) throws ResultArchiveStoreException {
-        if (!runId.startsWith("cdb-")) {
-            return null;
+        if (runId.startsWith(COUCHDB_RUN_ID_PREFIX)) {
+            runId = runId.substring(COUCHDB_RUN_ID_PREFIX.length());
         }
-
-        runId = runId.substring(4);
 
         try {
             return fetchRun(runId);

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasStore.java
@@ -40,6 +40,7 @@ import dev.galasa.extensions.common.couchdb.CouchdbException;
 import dev.galasa.extensions.common.couchdb.CouchdbStore;
 import dev.galasa.extensions.common.couchdb.CouchdbValidator;
 import dev.galasa.extensions.common.couchdb.RetryableCouchdbUpdateOperationProcessor;
+import dev.galasa.extensions.common.couchdb.pojos.IdRev;
 import dev.galasa.extensions.common.couchdb.pojos.PutPostResponse;
 import dev.galasa.extensions.common.impl.HttpClientFactoryImpl;
 import dev.galasa.extensions.common.impl.HttpRequestFactoryImpl;
@@ -123,21 +124,35 @@ public class CouchdbRasStore extends CouchdbStore implements IResultArchiveStore
 
         this.run = this.framework.getTestRun();
 
-        // *** If this is a run, ensure we can create the run document
+        // *** If this is a run, ensure we can create/update the run document
         if (this.run != null) {
-            lastTestStructure = new TestStructure();
-            lastTestStructure.setRunName(this.run.getName());
-            try {
-                updateTestStructure(lastTestStructure);
-            } catch (ResultArchiveStoreException e) {
-                throw new CouchdbException("Validation failed - unable to create initial run document", e);
-            }
-
-            createArtifactDocument();
+            initialiseRunDocument();
         }
 
         ResultArchiveStoreFileStore fileStore = new ResultArchiveStoreFileStore();
         this.provider = new CouchdbRasFileSystemProvider(fileStore, this, this.logFactory);
+    }
+
+    private void initialiseRunDocument() throws CouchdbException {
+        lastTestStructure = new TestStructure();
+        lastTestStructure.setRunName(this.run.getName());
+
+        // If we already have a RAS run ID associated with the run, get the existing document and revision
+        String runId = this.run.getRasRunId();
+        if (runId != null) {
+            this.runDocumentId = getRasDocumentId(runId);
+
+            IdRev runDocIdRev = getDocumentFromDatabase(RUNS_DB, runDocumentId, IdRev.class);
+            this.runDocumentRevision = runDocIdRev._rev;
+        }
+
+        try {
+            updateTestStructure(lastTestStructure);
+        } catch (ResultArchiveStoreException e) {
+            throw new CouchdbException("Validation failed - unable to create initial run document", e);
+        }
+
+        createArtifactDocument();
     }
 
     // Protected so that we can create artifact documents from elsewhere.
@@ -243,10 +258,7 @@ public class CouchdbRasStore extends CouchdbStore implements IResultArchiveStore
 
         TestStructureCouchdb couchdbTestStructure = (TestStructureCouchdb) testStructure;
 
-        String documentId = runId;
-        if (runId.startsWith(COUCHDB_RUN_ID_PREFIX)) {
-            documentId = runId.substring(COUCHDB_RUN_ID_PREFIX.length());
-        }
+        String documentId = getRasDocumentId(runId);
 
         String revision = couchdbTestStructure._rev;
         if (revision == null) {
@@ -254,6 +266,14 @@ public class CouchdbRasStore extends CouchdbStore implements IResultArchiveStore
         }
 
         writeTestStructure(testStructure, documentId, revision);
+    }
+
+    private String getRasDocumentId(String runId) {
+        String documentId = runId;
+        if (runId.startsWith(COUCHDB_RUN_ID_PREFIX)) {
+            documentId = runId.substring(COUCHDB_RUN_ID_PREFIX.length());
+        }
+        return documentId;
     }
 
     private synchronized void writeTestStructure(TestStructure testStructure, String documentId, String revision)
@@ -288,10 +308,7 @@ public class CouchdbRasStore extends CouchdbStore implements IResultArchiveStore
     public synchronized void createTestStructure(@NotNull String runId, @NotNull TestStructure testStructure)
             throws ResultArchiveStoreException {
 
-        String documentId = runId;
-        if (runId.startsWith(COUCHDB_RUN_ID_PREFIX)) {
-            documentId = runId.substring(COUCHDB_RUN_ID_PREFIX.length());
-        }
+        String documentId = getRasDocumentId(runId);
 
         writeTestStructure(testStructure, documentId, null);
     }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/CouchdbTestFixtures.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/CouchdbTestFixtures.java
@@ -201,7 +201,6 @@ public class CouchdbTestFixtures {
         }
     }
 
-
     public CouchdbRasStore createCouchdbRasStore(Map<String,String> inputProps) throws Exception {
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         interactions.add( new CreateTestDocInteractionOK(rasUriStr, documentId1, "124") );

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import dev.galasa.api.run.Run;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.RunRasAction;
+import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class MockIRun implements IRun {
 
@@ -153,5 +154,10 @@ public class MockIRun implements IRun {
 
     public Set<String> getTags() {
         throw new UnsupportedOperationException("Unimplemented method 'getTags'");
+    }
+
+    @Override
+    public TestStructure toTestStructure() {
+        throw new UnsupportedOperationException("Unimplemented method 'toTestStructure'");
     }
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
@@ -15,7 +15,8 @@ import dev.galasa.framework.spi.RunRasAction;
 
 public class MockIRun implements IRun {
 
-    private String name ;
+    private String rasRunId;
+    private String name;
 
     public MockIRun(String name) {
         this.name = name ;
@@ -24,6 +25,15 @@ public class MockIRun implements IRun {
     @Override
     public String getName() {
         return this.name;
+    }
+
+    @Override
+    public String getRasRunId() {
+        return this.rasRunId;
+    }
+
+    public void setRasRunId(String rasRunId) {
+        this.rasRunId = rasRunId;
     }
 
     @Override
@@ -134,11 +144,6 @@ public class MockIRun implements IRun {
     @Override
     public String getInterruptReason() {
         throw new UnsupportedOperationException("Unimplemented method 'getInterruptReason'");
-    }
-
-    @Override
-    public String getRasRunId() {
-        throw new UnsupportedOperationException("Unimplemented method 'getRasRunId'");
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockFramework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockFramework.java
@@ -119,9 +119,17 @@ public class MockFramework implements IFramework {
         return archiveStore;
     }
 
+    public void setResultArchiveStore(IResultArchiveStore rasStore) {
+        this.archiveStore = rasStore;
+    }
+
     @Override
     public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
         return this.frameworkRuns;
+    }
+
+    public void setFrameworkRuns(IFrameworkRuns frameworkRuns) {
+        this.frameworkRuns = frameworkRuns;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
@@ -71,7 +71,7 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
             if (stream.equals("null")){
                 throw new FrameworkException(language);
             }
-        return new MockIRun("runname"+testName, type, requestor, testName, sharedEnvironmentRunName, bundleName, language, groupName, this.mockSubmissionId, tags);
+        return new MockIRun("runname", type, requestor, bundleName + "/" + testName, null, bundleName, testName, groupName, this.mockSubmissionId, tags);
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import dev.galasa.api.run.Run;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.RunRasAction;
+import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class MockIRun implements IRun{
 
@@ -170,6 +171,35 @@ public class MockIRun implements IRun{
     }
 
     @Override
+    public String getRasRunId() {
+        return UUID.randomUUID().toString();
+    }
+
+    public Set<String> getTags() {
+        Set<String> tagsToReturn = new HashSet<String>();
+        tagsToReturn.addAll(this.tags);
+        return tagsToReturn;
+    }
+
+    @Override
+    public TestStructure toTestStructure() {
+        TestStructure testStructure = new TestStructure();
+
+        testStructure.setBundle(bundle);
+        testStructure.setTestName(testClass);
+        testStructure.setRunName(runName);
+        testStructure.setRequestor(requestor);
+        testStructure.setSubmissionId(submissionId);
+        testStructure.setGroup(groupName);
+
+        for (String tag : tags) {
+            testStructure.addTag(tag);
+        }
+
+        return testStructure;
+    }
+
+    @Override
     public String getInterruptReason() {
         throw new UnsupportedOperationException("Unimplemented method 'getInterruptReason'");
     }
@@ -180,18 +210,7 @@ public class MockIRun implements IRun{
     }
 
     @Override
-    public String getRasRunId() {
-        return UUID.randomUUID().toString();
-    }
-
-    @Override
     public List<RunRasAction> getRasActions() {
         throw new UnsupportedOperationException("Unimplemented method 'getRasActions'");
     }
-    public Set<String> getTags() {
-        Set<String> tagsToReturn = new HashSet<String>();
-        tagsToReturn.addAll(this.tags);
-        return tagsToReturn;
-    }
-    
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 import dev.galasa.api.run.Run;
 import dev.galasa.framework.spi.IRun;
@@ -180,7 +181,7 @@ public class MockIRun implements IRun{
 
     @Override
     public String getRasRunId() {
-        throw new UnsupportedOperationException("Unimplemented method 'getRasRunId'");
+        return UUID.randomUUID().toString();
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockArchiveStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockArchiveStore.java
@@ -77,4 +77,10 @@ public class MockArchiveStore implements IResultArchiveStore {
     public long retrieveRunLogLineCount() {
         throw new UnsupportedOperationException("Unimplemented method 'retrieveRunLogLineCount'");
     }
+
+    @Override
+    public void createTestStructure(@NotNull String runId, @NotNull TestStructure testStructure)
+            throws ResultArchiveStoreException {
+        throw new UnsupportedOperationException("Unimplemented method 'createTestStructure'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
@@ -8,6 +8,7 @@ package dev.galasa.framework.api.runs.common;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -156,18 +157,24 @@ public class GroupRuns extends ProtectedRoute {
     private TestStructure createRunTestStructure(IRun run) {
         TestStructure testStructure = new TestStructure();
 
+        String bundleName = run.getTestBundleName();
+        String testName = run.getTestClassName();
         String runName = run.getName();
         String group = run.getGroup();
         String submissionId = run.getSubmissionId();
         Instant queuedAt = run.getQueued();
-        String requestor = AbstractManager.defaultString(run.getRequestor(), "unknown");         
+        String requestor = AbstractManager.defaultString(run.getRequestor(), "unknown");
 
+        testStructure.setBundle(bundleName);
+        testStructure.setTestName(testName);
         testStructure.setQueued(queuedAt);
-        testStructure.setStartTime(Instant.now());
         testStructure.setRunName(runName);
         testStructure.setRequestor(requestor);
         testStructure.setGroup(group);
         testStructure.setSubmissionId(submissionId);
+        testStructure.setLogRecordIds(new ArrayList<>());
+        testStructure.setArtifactRecordIds(new ArrayList<>());
+        testStructure.normalise();
 
         for (String tag : run.getTags()) {
             testStructure.addTag(tag);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
@@ -7,8 +7,6 @@ package dev.galasa.framework.api.runs.common;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -26,7 +24,6 @@ import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.ProtectedRoute;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
-import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
@@ -149,51 +146,8 @@ public class GroupRuns extends ProtectedRoute {
         return status;
     }
 
-    /**
-     * Create a new test structure, and populate it with as much information as we can from the DSS.
-     * @param run The run structure. It has data loaded already from the DSS
-     * @return A TestStructure which is written into the RAS eventually.
-     */
-    private TestStructure createRunTestStructure(IRun run) {
-        TestStructure testStructure = new TestStructure();
-
-        String bundleName = run.getTestBundleName();
-        String testName = run.getTestClassName();
-        String runName = run.getName();
-        String group = run.getGroup();
-        String submissionId = run.getSubmissionId();
-        Instant queuedAt = run.getQueued();
-        String requestor = AbstractManager.defaultString(run.getRequestor(), "unknown");
-
-        if (testName != null) {
-            // The test name is in the form "package.class", so get the class after the last "."
-            String trimmedTestName = testName.trim();
-            if (trimmedTestName.contains(".") && !trimmedTestName.endsWith(".")) {
-                String testShortName = testName.substring(testName.lastIndexOf(".") + 1);
-                testStructure.setTestShortName(testShortName);
-            }
-        }
-
-        testStructure.setBundle(bundleName);
-        testStructure.setTestName(testName);
-        testStructure.setQueued(queuedAt);
-        testStructure.setRunName(runName);
-        testStructure.setRequestor(requestor);
-        testStructure.setGroup(group);
-        testStructure.setSubmissionId(submissionId);
-        testStructure.setLogRecordIds(new ArrayList<>());
-        testStructure.setArtifactRecordIds(new ArrayList<>());
-        testStructure.normalise();
-
-        for (String tag : run.getTags()) {
-            testStructure.addTag(tag);
-        }
-
-        return testStructure;
-    }
-
     private void createRunRasRecord(IRun newRun) throws InternalServletException {
-        TestStructure newTestStructure = createRunTestStructure(newRun);
+        TestStructure newTestStructure = newRun.toTestStructure();
         String runId = newRun.getRasRunId();
 
         try {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
@@ -165,6 +165,15 @@ public class GroupRuns extends ProtectedRoute {
         Instant queuedAt = run.getQueued();
         String requestor = AbstractManager.defaultString(run.getRequestor(), "unknown");
 
+        if (testName != null) {
+            // The test name is in the form "package.class", so get the class after the last "."
+            String trimmedTestName = testName.trim();
+            if (trimmedTestName.contains(".") && !trimmedTestName.endsWith(".")) {
+                String testShortName = testName.substring(testName.lastIndexOf(".") + 1);
+                testStructure.setTestShortName(testShortName);
+            }
+        }
+
         testStructure.setBundle(bundleName);
         testStructure.setTestName(testName);
         testStructure.setQueued(queuedAt);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/RunsServletTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/RunsServletTest.java
@@ -5,103 +5,20 @@
  */
 package dev.galasa.framework.api.runs;
 
-
-import java.io.PrintWriter;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import dev.galasa.framework.api.common.BaseServletTest;
-import dev.galasa.framework.api.common.EnvironmentVariables;
-import dev.galasa.framework.api.common.ResponseBuilder;
-import dev.galasa.framework.api.common.mocks.MockEnvironment;
-import dev.galasa.framework.api.common.mocks.MockFramework;
-import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
-import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
-import dev.galasa.framework.api.common.mocks.MockIFrameworkRuns;
-import dev.galasa.framework.api.common.mocks.MockIRun;
-import dev.galasa.framework.api.common.mocks.MockServletOutputStream;
-import dev.galasa.framework.api.runs.mocks.MockRunsServlet;
-import dev.galasa.framework.spi.IFramework;
-import dev.galasa.framework.spi.IFrameworkRuns;
 import dev.galasa.framework.spi.IRun;
-import dev.galasa.framework.spi.utils.GalasaGson;
 
 public class RunsServletTest extends BaseServletTest {
 
     public static final Map<String, String> REQUIRED_HEADERS = new HashMap<>(Map.of("Authorization", "Bearer " + DUMMY_JWT));
-	static final GalasaGson gson = new GalasaGson();
-
-	MockRunsServlet servlet;
-	HttpServletRequest req;
-	HttpServletResponse resp;
-    protected List<IRun> runs = new ArrayList<IRun>();
-
-
-	protected void setServlet(String path, String groupName, List<IRun> runs){
-        MockEnvironment mockEnv = new MockEnvironment();
-        mockEnv.setenv(EnvironmentVariables.GALASA_USERNAME_CLAIMS, "preferred_username,name,sub");
-
-        this.servlet = new MockRunsServlet(mockEnv);
-        servlet.setResponseBuilder(new ResponseBuilder(mockEnv));
-
-        ServletOutputStream outStream = new MockServletOutputStream();
-        PrintWriter writer = new PrintWriter(outStream);
-        this.resp = new MockHttpServletResponse(writer, outStream);
-        this.req = new MockHttpServletRequest(path, REQUIRED_HEADERS);
-		if (groupName != null){
-            IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(groupName, runs);
-			IFramework framework = new MockFramework(frameworkRuns);
-			this.servlet.setFramework(framework);
-		}
-	}
-	
-	protected void setServlet(String path, String groupName, String value, String method){
-		setServlet(path, groupName, null);
-		this.req = new MockHttpServletRequest(path, value, method, REQUIRED_HEADERS);
-	}
-
-    protected void setServlet(String path, String groupName, String value, String method, List<IRun> runs){
-		setServlet(path, groupName, runs);
-		this.req = new MockHttpServletRequest(path, value, method, REQUIRED_HEADERS);
-	}
-
-    protected void setServlet(String path, String groupName, String value, String method, Map<String, String> headerMap){
-		setServlet(path, groupName, null);
-        headerMap.putAll(REQUIRED_HEADERS);
-		this.req = new MockHttpServletRequest(path, value, method, headerMap);
-	}
-
-    protected void setServlet(String path, String groupName, List<IRun> runs, String value, String method, Map<String, String> headerMap){
-		setServlet(path, groupName, runs);
-        headerMap.putAll(REQUIRED_HEADERS);
-		this.req = new MockHttpServletRequest(path, value, method, headerMap);
-	}
-
-	protected MockRunsServlet getServlet(){
-		return this.servlet;
-	}
-
-	protected HttpServletRequest getRequest(){
-		return this.req;
-	}
-
-	protected HttpServletResponse getResponse(){
-	    return this.resp;
-	}
-
-    protected void addRun(String runName, String runType, String requestor, String test, String runStatus, String bundle, String testClass, String groupName, String submissionId, Set<String> tags){
-		this.runs.add(new MockIRun( runName, runType, requestor, test, runStatus, bundle, testClass, groupName, submissionId, tags));
-    }
 
     protected String generateStatusUpdateJson(String result) {
 		return
@@ -163,7 +80,6 @@ public class RunsServletTest extends BaseServletTest {
             requestor = overrideExpectedRequestor;
         }
         for (String className : classNames){
-            addRun( "runnamename", requestorType, requestor, "name", "submitted", className.split("/")[0], "java", groupName, submissionId, tags);
             classes += "\""+className+"\",";
         }
         classes = classes.substring(0, classes.length()-1);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/mocks/MockRunsServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/mocks/MockRunsServlet.java
@@ -7,16 +7,17 @@ package dev.galasa.framework.api.runs.mocks;
 
 import dev.galasa.framework.IFileSystem;
 import dev.galasa.framework.api.common.Environment;
+import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.mocks.IServletUnderTest;
-import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.api.runs.RunsServlet;
 import dev.galasa.framework.spi.IFramework;
 
 public class MockRunsServlet extends RunsServlet implements IServletUnderTest {
 
-    public MockRunsServlet(Environment env) {
+    public MockRunsServlet(Environment env, IFramework framework) {
 		super(env);
-		super.framework = new MockFramework();
+		setResponseBuilder(new ResponseBuilder(env));
+		super.framework = framework;
     }
 
 	@Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -126,17 +126,6 @@ public class TestGroupRunsRoute extends BaseServletTest {
         payloadJson.addProperty("trace", true);
 
         return gson.toJson(payloadJson);
-        // String payload = "{\"classNames\": ["+classes+"]," +
-        //     "\"requestorType\": \""+requestorType+"\"," +
-        //     "\"requestor\": \""+requestor+"\"," +
-        //     "\"testStream\": \""+testStream+"\"," +
-        //     "\"obr\": \"this.obr\","+
-        //     "\"mavenRepository\": \"this.maven.repo\"," +
-        //     "\"sharedEnvironmentRunTime\": \"envRunTime\"," +
-        //     "\"overrides\": {}," +
-        //     "\"trace\": true }";
-            
-        // return payload;
     }
 
     /*

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -42,6 +42,7 @@ import dev.galasa.framework.mocks.MockIResultArchiveStore;
 import dev.galasa.framework.mocks.MockRBACService;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.rbac.Action;
+import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class TestGroupRunsRoute extends BaseServletTest {
 
@@ -658,8 +659,8 @@ public class TestGroupRunsRoute extends BaseServletTest {
         "\"trace\": true }";
         Set<String> tags = new HashSet<>();
         List<IRun> runs = new ArrayList<IRun>();
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted",
-               "Class", "java", groupName, submissionId,tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, "Class/name", "submitted",
+               "Class", "name", groupName, submissionId,tags));
 
         MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
         MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
@@ -689,13 +690,15 @@ public class TestGroupRunsRoute extends BaseServletTest {
     public void testPostRunsWithValidBodyReturnsOK() throws Exception {
         // Given...
 		String groupName = "valid";
-        String class1 = "Class/name";
+        String testName1 = "package.class";
+        String class1 = "bundle/" + testName1;
         String[] classes = new String[]{class1};
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
         List<IRun> runs = new ArrayList<IRun>();
 
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
+        MockIRun run = new MockIRun("runname", "requestorType", JWT_USERNAME, class1, "submitted", class1.split("/")[0], testName1, groupName, submissionId, tags);
+        runs.add(run);
 
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId,tags);
 
@@ -720,6 +723,18 @@ public class TestGroupRunsRoute extends BaseServletTest {
         String expectedJson = generateExpectedJson(runs, false);
         assertThat(resp.getStatus()).isEqualTo(201);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
+
+        List<TestStructure> testStructureHistory = mockRasStore.getTestStructureHistory();
+        assertThat(testStructureHistory).hasSize(1);
+
+        TestStructure testStructure = testStructureHistory.get(0);
+        assertThat(testStructure.getRunName()).isEqualTo(run.getName());
+        assertThat(testStructure.getBundle()).isEqualTo(run.getTestBundleName());
+        assertThat(testStructure.getTestName()).isEqualTo(run.getTestClassName());
+        assertThat(testStructure.getTestShortName()).isEqualTo("class");
+        assertThat(testStructure.getSubmissionId()).isEqualTo(run.getSubmissionId());
+        assertThat(testStructure.getRequestor()).isEqualTo(run.getRequestor());
+        assertThat(testStructure.getGroup()).isEqualTo(run.getGroup());
     }
 
     @Test
@@ -732,7 +747,7 @@ public class TestGroupRunsRoute extends BaseServletTest {
         Set<String> tags = new HashSet<>();
         List<IRun> runs = new ArrayList<IRun>();
 
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
 
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "null", groupName, null, submissionId,tags);
 
@@ -772,8 +787,8 @@ public class TestGroupRunsRoute extends BaseServletTest {
         Set<String> tags = new HashSet<>();
         List<IRun> runs = new ArrayList<IRun>();
 
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class2.split("/")[0], "java", groupName, submissionId, tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, class1, "submitted", class1.split("/")[0], "name", groupName, submissionId, tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, class2, "submitted", class2.split("/")[0], "name", groupName, submissionId, tags));
 
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId,tags);
 
@@ -811,8 +826,8 @@ public class TestGroupRunsRoute extends BaseServletTest {
         Set<String> tags = new HashSet<>();
         List<IRun> runs = new ArrayList<IRun>();
 
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class2.split("/")[0], "java", groupName, submissionId, tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, class1, "submitted", class1.split("/")[0], "name", groupName, submissionId, tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, class2, "submitted", class2.split("/")[0], "name", groupName, submissionId, tags));
 
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId, tags);
 
@@ -861,8 +876,8 @@ public class TestGroupRunsRoute extends BaseServletTest {
 
         Set<String> tags = new HashSet<>();
         List<IRun> runs = new ArrayList<IRun>();
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted",
-               "Class", "java", groupName, submissionId,tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, "Class/name", "submitted",
+               "Class", "name", groupName, submissionId,tags));
 
         MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
         MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
@@ -898,7 +913,7 @@ public class TestGroupRunsRoute extends BaseServletTest {
         Set<String> tags = new HashSet<>();
         List<IRun> runs = new ArrayList<IRun>();
 
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, class1, "submitted", class1.split("/")[0], "name", groupName, submissionId, tags));
 
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId, tags);
 
@@ -936,8 +951,8 @@ public class TestGroupRunsRoute extends BaseServletTest {
         Set<String> tags = new HashSet<>();
         List<IRun> runs = new ArrayList<IRun>();
 
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class2.split("/")[0], "java", groupName, submissionId, tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, class1, "submitted", class1.split("/")[0], "name", groupName, submissionId, tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, class2, "submitted", class2.split("/")[0], "name", groupName, submissionId, tags));
 
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId,tags);
 
@@ -975,8 +990,8 @@ public class TestGroupRunsRoute extends BaseServletTest {
         Set<String> tags = new HashSet<>();
         List<IRun> runs = new ArrayList<IRun>();
 
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
-        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class2.split("/")[0], "java", groupName, submissionId, tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, class1, "submitted", class1.split("/")[0], "name", groupName, submissionId, tags));
+        runs.add(new MockIRun("runname", "requestorType", JWT_USERNAME, class2, "submitted", class2.split("/")[0], "name", groupName, submissionId, tags));
 
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId,tags);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -731,7 +731,6 @@ public class TestGroupRunsRoute extends BaseServletTest {
         assertThat(testStructure.getRunName()).isEqualTo(run.getName());
         assertThat(testStructure.getBundle()).isEqualTo(run.getTestBundleName());
         assertThat(testStructure.getTestName()).isEqualTo(run.getTestClassName());
-        assertThat(testStructure.getTestShortName()).isEqualTo("class");
         assertThat(testStructure.getSubmissionId()).isEqualTo(run.getSubmissionId());
         assertThat(testStructure.getRequestor()).isEqualTo(run.getRequestor());
         assertThat(testStructure.getGroup()).isEqualTo(run.getGroup());

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -8,8 +8,11 @@ package dev.galasa.framework.api.runs.routes;
 import static dev.galasa.framework.spi.rbac.BuiltInAction.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -19,6 +22,10 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Test;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import dev.galasa.framework.api.common.BaseServletTest;
 import dev.galasa.framework.api.common.HttpMethod;
 import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.ResponseBuilder;
@@ -27,13 +34,110 @@ import dev.galasa.framework.api.common.mocks.MockEnvironment;
 import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
-import dev.galasa.framework.api.runs.RunsServletTest;
+import dev.galasa.framework.api.common.mocks.MockIFrameworkRuns;
+import dev.galasa.framework.api.common.mocks.MockIRun;
 import dev.galasa.framework.api.runs.mocks.MockRunsServlet;
 import dev.galasa.framework.mocks.FilledMockRBACService;
+import dev.galasa.framework.mocks.MockIResultArchiveStore;
 import dev.galasa.framework.mocks.MockRBACService;
+import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.rbac.Action;
 
-public class TestGroupRunsRoute extends RunsServletTest{
+public class TestGroupRunsRoute extends BaseServletTest {
+
+    private static final Map<String, String> REQUIRED_HEADERS = new HashMap<>(Map.of("Authorization", "Bearer " + DUMMY_JWT));
+
+    private String generateStatusUpdateJson(String result) {
+		JsonObject statusUpdateJson = new JsonObject();
+        statusUpdateJson.addProperty("result", result);
+
+        return gson.toJson(statusUpdateJson);
+	}
+
+	private String generateExpectedJson(List<IRun> runs, boolean complete) {
+
+        JsonObject expectedJsonObj = new JsonObject();
+
+        expectedJsonObj.addProperty("complete", complete);
+
+        JsonArray runsJsonArray = new JsonArray();
+
+        for (IRun run : runs) {
+            JsonObject runJson = new JsonObject();
+            runJson.addProperty("name", run.getName());
+            runJson.addProperty("heartbeat", "2023-10-12T12:16:49.832925Z");
+            runJson.addProperty("type", run.getType());
+            runJson.addProperty("group", run.getGroup());
+            runJson.addProperty("submissionId", run.getSubmissionId());
+            runJson.addProperty("test", run.getTestClassName());
+            runJson.addProperty("bundleName", run.getTestBundleName());
+            runJson.addProperty("testName", run.getTest());
+
+            if (!run.getStatus().equals("submitted")) {
+                runJson.addProperty("status", run.getStatus());
+            }
+
+            runJson.addProperty("result", "Passed");
+            runJson.addProperty("queued", "2023-10-12T12:16:49.832925Z");
+            runJson.addProperty("finished", "2023-10-12T12:16:49.832925Z");
+            runJson.addProperty("waitUntil", "2023-10-12T12:16:49.832925Z");
+            runJson.addProperty("requestor", run.getRequestor());
+            runJson.addProperty("isLocal", false);
+            runJson.addProperty("isTraceEnabled", false);
+            runJson.addProperty("rasRunId", "cdb-" + run.getName());
+
+            JsonArray tagsArray = new JsonArray();
+            for( String tag : run.getTags() ) {
+                tagsArray.add(tag);
+            }
+            runJson.add("tags", tagsArray);
+
+            runsJsonArray.add(runJson);
+        }
+
+        expectedJsonObj.add("runs", runsJsonArray);
+
+        String expectedJson = gson.toJson(expectedJsonObj);
+        return expectedJson;
+    }
+
+
+    private String generatePayload(String[] classNames, String requestorType, String requestor, String testStream, String groupName, String overrideExpectedRequestor, String submissionId, Set<String>tags) {
+        if (overrideExpectedRequestor != null) {
+            requestor = overrideExpectedRequestor;
+        }
+
+        JsonArray classNamesArray = new JsonArray();
+        for (String className : classNames) {
+            classNamesArray.add(className);
+        }
+
+        JsonObject payloadJson = new JsonObject();
+        payloadJson.add("classNames", classNamesArray);
+        payloadJson.addProperty("requestorType", requestorType);
+        payloadJson.addProperty("requestor", requestor);
+
+        payloadJson.addProperty("testStream", testStream);
+
+        payloadJson.addProperty("obr", "this.obr");
+        payloadJson.addProperty("mavenRepository", "this.maven.repo");
+        payloadJson.addProperty("sharedEnvironmentRunTime", "envRunTime");
+        payloadJson.add("overrides", new JsonObject());
+        payloadJson.addProperty("trace", true);
+
+        return gson.toJson(payloadJson);
+        // String payload = "{\"classNames\": ["+classes+"]," +
+        //     "\"requestorType\": \""+requestorType+"\"," +
+        //     "\"requestor\": \""+requestor+"\"," +
+        //     "\"testStream\": \""+testStream+"\"," +
+        //     "\"obr\": \"this.obr\","+
+        //     "\"mavenRepository\": \"this.maven.repo\"," +
+        //     "\"sharedEnvironmentRunTime\": \"envRunTime\"," +
+        //     "\"overrides\": {}," +
+        //     "\"trace\": true }";
+            
+        // return payload;
+    }
 
     /*
      * Regex Path
@@ -165,10 +269,15 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
         // /runs/empty is an empty runs set and should return an error as runs can not be null
 		String groupName = "invalid";
-        setServlet("/"+groupName, groupName, this.runs);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+
+        List<IRun> runs = new ArrayList<IRun>();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -189,10 +298,15 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
         // /runs/empty is an empty runs set and should return an error as runs can not be null
 		String groupName = "nullgroup";
-        setServlet("/"+groupName, groupName, this.runs);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+
+        List<IRun> runs = new ArrayList<IRun>();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -213,10 +327,15 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
         // /runs/empty is an empty runs set and should return an error as runs can not be null
 		String groupName = "empty";
-        setServlet("/"+groupName, groupName, this.runs);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+
+        List<IRun> runs = new ArrayList<IRun>();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -234,11 +353,16 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "framework";
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
-        addRun("name1", "type1", "requestor1", "test1", "FINISHED","bundle1", "testClass1", groupName, submissionId,tags);
-        setServlet("/"+groupName, groupName, this.runs);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        List<IRun> runs = new ArrayList<IRun>();
+        runs.add(new MockIRun("name1", "type1", "requestor1", "test1", "FINISHED","bundle1", "testClass1", groupName, submissionId,tags));
+
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -257,12 +381,17 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "framework";
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags);
-        setServlet("/"+groupName, groupName, this.runs);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        List<IRun> runs = new ArrayList<IRun>();
+        runs.add(new MockIRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags));
+        runs.add(new MockIRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags));
+
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -281,20 +410,25 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "framework";
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags);
-        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId,tags);
-        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId,tags);
-        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId,tags);
-        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId,tags);
-        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId,tags);
-        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId,tags);
-        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId,tags);
-        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId,tags);
-        setServlet("/"+groupName, groupName, this.runs);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        List<IRun> runs = new ArrayList<IRun>();
+        runs.add(new MockIRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags));
+        runs.add(new MockIRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags));
+        runs.add(new MockIRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId,tags));
+        runs.add(new MockIRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId,tags));
+        runs.add(new MockIRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId,tags));
+        runs.add(new MockIRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId,tags));
+        runs.add(new MockIRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId,tags));
+        runs.add(new MockIRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId,tags));
+        runs.add(new MockIRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId,tags));
+        runs.add(new MockIRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId,tags));
+
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -313,20 +447,25 @@ public class TestGroupRunsRoute extends RunsServletTest{
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags);
-        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId,tags);
-        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId,tags);
-        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId,tags);
-        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId,tags);
-        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId,tags);
-        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId,tags);
-        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId,tags);
-        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId,tags);
-        setServlet("/"+groupName, groupName, this.runs);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        List<IRun> runs = new ArrayList<IRun>();
+        runs.add(new MockIRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags));
+        runs.add(new MockIRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags));
+        runs.add(new MockIRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId,tags));
+        runs.add(new MockIRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId,tags));
+        runs.add(new MockIRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId,tags));
+        runs.add(new MockIRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId,tags));
+        runs.add(new MockIRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId,tags));
+        runs.add(new MockIRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId,tags));
+        runs.add(new MockIRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId,tags));
+        runs.add(new MockIRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId,tags));
+
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -357,12 +496,13 @@ public class TestGroupRunsRoute extends RunsServletTest{
         "\"overrides\": {}," +
         "\"trace\": true }";
 
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockFramework mockFramework = new MockFramework();
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
 
-        setServlet("/group", null, payload, "POST");
-        MockRunsServlet servlet = getServlet();
-        HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();
+		HttpServletRequest req = new MockHttpServletRequest("/group", payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
+        ServletOutputStream outStream = resp.getOutputStream();
 
         //When...
         servlet.init();
@@ -385,10 +525,15 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "valid";
         String value = "";
-        setServlet("/"+groupName, groupName, value, "POST");
-;		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        List<IRun> runs = new ArrayList<IRun>();
+
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, value, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -409,10 +554,15 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "valid";
         String value = "Invalid";
-        setServlet("/"+groupName, groupName, value, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        List<IRun> runs = new ArrayList<IRun>();
+
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, value, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -442,11 +592,15 @@ public class TestGroupRunsRoute extends RunsServletTest{
         "\"sharedEnvironmentRunTime\": \"envRunTime\"," +
         "\"overrides\": {}" +
         "\"trace\": true }";
+        List<IRun> runs = new ArrayList<IRun>();
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -475,11 +629,15 @@ public class TestGroupRunsRoute extends RunsServletTest{
         "\"sharedEnvironmentRunTime\": \"envRunTime\"," +
         "\"overrides\": {}," +
         "\"trace\": true }";
+        List<IRun> runs = new ArrayList<IRun>();
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -510,13 +668,21 @@ public class TestGroupRunsRoute extends RunsServletTest{
         "\"overrides\": {}," +
         "\"trace\": true }";
         Set<String> tags = new HashSet<>();
-        addRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted",
-               "Class", "java", groupName, submissionId,tags);
+        List<IRun> runs = new ArrayList<IRun>();
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted",
+               "Class", "java", groupName, submissionId,tags));
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+        mockFramework.setResultArchiveStore(mockRasStore);
+
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -534,15 +700,27 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testPostRunsWithValidBodyReturnsOK() throws Exception {
         // Given...
 		String groupName = "valid";
-        String[] classes = new String[]{"Class/name"};
+        String class1 = "Class/name";
+        String[] classes = new String[]{class1};
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
+        List<IRun> runs = new ArrayList<IRun>();
+
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
+
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId,tags);
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+        mockFramework.setResultArchiveStore(mockRasStore);
+
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -559,15 +737,27 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testPostRunsWithEmptyDetailsBodyReturnsError() throws Exception {
         // Given...
 		String groupName = "valid";
-        String[] classes = new String[]{"Class/name"};
+        String class1 = "Class/name";
+        String[] classes = new String[]{class1};
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
-        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, null, groupName, null, submissionId,tags);
+        List<IRun> runs = new ArrayList<IRun>();
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
+
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "null", groupName, null, submissionId,tags);
+
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+        mockFramework.setResultArchiveStore(mockRasStore);
+
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -586,15 +776,29 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testPostRunsWithValidBodyAndMultipleClassesReturnsOK() throws Exception {
         // Given...
 		String groupName = "valid";
-        String[] classes = new String[]{"Class1/name", "Class2/name"};
+        String class1 = "Class1/name";
+        String class2 = "Class2/name";
+        String[] classes = new String[]{class1, class2};
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
+        List<IRun> runs = new ArrayList<IRun>();
+
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class2.split("/")[0], "java", groupName, submissionId, tags));
+
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId,tags);
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+        mockFramework.setResultArchiveStore(mockRasStore);
+
+        MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -611,15 +815,29 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testPostUUIDGroupNameRunsWithValidBodyAndMultipleClassesReturnsOK() throws Exception {
         // Given...
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
-        String[] classes = new String[]{"Class1/name", "Class2/name"};
+        String class1 = "Class1/name";
+        String class2 = "Class2/name";
+        String[] classes = new String[]{class1, class2};
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
+        List<IRun> runs = new ArrayList<IRun>();
+
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class2.split("/")[0], "java", groupName, submissionId, tags));
+
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, null, submissionId, tags);
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+        mockFramework.setResultArchiveStore(mockRasStore);
+
+        MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -653,13 +871,21 @@ public class TestGroupRunsRoute extends RunsServletTest{
         "\"trace\": true }";
 
         Set<String> tags = new HashSet<>();
-        addRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted",
-               "Class", "java", groupName, submissionId,tags);
+        List<IRun> runs = new ArrayList<IRun>();
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted",
+               "Class", "java", groupName, submissionId,tags));
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+        mockFramework.setResultArchiveStore(mockRasStore);
+
+        MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -677,15 +903,27 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testPostRunsWithValidBodyAndJWTReturnsOKWithRequestorFromJWT() throws Exception {
         // Given...
 		String groupName = "valid";
-        String[] classes = new String[]{"Class/name"};
+        String class1 = "Class/name";
+        String[] classes = new String[]{class1};
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
+        List<IRun> runs = new ArrayList<IRun>();
+
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
+
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId, tags);
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+        mockFramework.setResultArchiveStore(mockRasStore);
+
+        MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -703,14 +941,28 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "valid";
         String submissionId = "submission1";
-        String[] classes = new String[]{"Class1/name", "Class2/name"};
+        String class1 = "Class1/name";
+        String class2 = "Class2/name";
+        String[] classes = new String[]{class1, class2};
         Set<String> tags = new HashSet<>();
+        List<IRun> runs = new ArrayList<IRun>();
+
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class2.split("/")[0], "java", groupName, submissionId, tags));
+
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId,tags);
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+        mockFramework.setResultArchiveStore(mockRasStore);
+
+        MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -727,15 +979,29 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testPostUUIDGroupNameRunsWithValidBodyAndMultipleClassesReturnsWithRequestorFromJWT() throws Exception {
         // Given...
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
-        String[] classes = new String[]{"Class1/name", "Class2/name"};
+        String class1 = "Class1/name";
+        String class2 = "Class2/name";
+        String[] classes = new String[]{class1, class2};
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
+        List<IRun> runs = new ArrayList<IRun>();
+
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class1.split("/")[0], "java", groupName, submissionId, tags));
+        runs.add(new MockIRun("runnamename", "requestorType", JWT_USERNAME, "name", "submitted", class2.split("/")[0], "java", groupName, submissionId, tags));
+
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId,tags);
 
-        setServlet("/"+groupName, groupName, payload, "POST");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+        mockFramework.setResultArchiveStore(mockRasStore);
+
+        MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -753,11 +1019,15 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
         String payload = generateStatusUpdateJson("cancelled");
+        List<IRun> runs = new ArrayList<IRun>();
 
-        setServlet("/"+groupName, groupName, payload, "PUT");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.PUT.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -777,21 +1047,25 @@ public class TestGroupRunsRoute extends RunsServletTest{
         String payload = generateStatusUpdateJson("cancelled");
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags);
-        addRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId,tags);
-        addRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId,tags);
-        addRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId,tags);
-        addRun("name6", "type6", "requestor6", "test6", "FINISHED","bundle6", "testClass6", groupName, submissionId,tags);
-        addRun("name7", "type7", "requestor7", "test7", "FINISHED","bundle7", "testClass7", groupName, submissionId,tags);
-        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId,tags);
-        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId,tags);
-        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId,tags);
+        List<IRun> runs = new ArrayList<IRun>();
+        runs.add(new MockIRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags));
+        runs.add(new MockIRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags));
+        runs.add(new MockIRun("name3", "type3", "requestor3", "test3", "FINISHED","bundle3", "testClass3", groupName, submissionId,tags));
+        runs.add(new MockIRun("name4", "type4", "requestor4", "test4", "UP","bundle4", "testClass4", groupName, submissionId,tags));
+        runs.add(new MockIRun("name5", "type6", "requestor5", "test5", "DISCARDED","bundle5", "testClass6", groupName, submissionId,tags));
+        runs.add(new MockIRun("name6", "type6", "requestor6", "test6", "FINISHED","bundle6", "testClass6", groupName, submissionId,tags));
+        runs.add(new MockIRun("name7", "type7", "requestor7", "test7", "FINISHED","bundle7", "testClass7", groupName, submissionId,tags));
+        runs.add(new MockIRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId,tags));
+        runs.add(new MockIRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId,tags));
+        runs.add(new MockIRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId,tags));
 
-        setServlet("/" + groupName, groupName, payload, "PUT", this.runs);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.PUT.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -811,21 +1085,25 @@ public class TestGroupRunsRoute extends RunsServletTest{
         String payload = generateStatusUpdateJson("cancelled");
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
-        addRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags);
-        addRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags);
-        addRun("name3", "type3", "requestor3", "test3", "BUILDING","bundle3", "testClass3", groupName, submissionId,tags);
-        addRun("name4", "type4", "requestor4", "test4", "BUILDING","bundle4", "testClass4", groupName, submissionId,tags);
-        addRun("name5", "type6", "requestor5", "test5", "BUILDING","bundle5", "testClass6", groupName, submissionId,tags);
-        addRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId,tags);
-        addRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId,tags);
-        addRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId,tags);
-        addRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId,tags);
-        addRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId,tags);
+        List<IRun> runs = new ArrayList<IRun>();
+        runs.add(new MockIRun("name1", "type1", "requestor1", "test1", "BUILDING","bundle1", "testClass1", groupName, submissionId,tags));
+        runs.add(new MockIRun("name2", "type2", "requestor2", "test2", "BUILDING","bundle2", "testClass2", groupName, submissionId,tags));
+        runs.add(new MockIRun("name3", "type3", "requestor3", "test3", "BUILDING","bundle3", "testClass3", groupName, submissionId,tags));
+        runs.add(new MockIRun("name4", "type4", "requestor4", "test4", "BUILDING","bundle4", "testClass4", groupName, submissionId,tags));
+        runs.add(new MockIRun("name5", "type6", "requestor5", "test5", "BUILDING","bundle5", "testClass6", groupName, submissionId,tags));
+        runs.add(new MockIRun("name6", "type6", "requestor6", "test6", "BUILDING","bundle6", "testClass6", groupName, submissionId,tags));
+        runs.add(new MockIRun("name7", "type7", "requestor7", "test7", "BUILDING","bundle7", "testClass7", groupName, submissionId,tags));
+        runs.add(new MockIRun("name8", "type8", "requestor8", "test8", "BUILDING","bundle8", "testClass8", groupName, submissionId,tags));
+        runs.add(new MockIRun("name9", "type9", "requestor9", "test9", "BUILDING","bundle9", "testClass9", groupName, submissionId,tags));
+        runs.add(new MockIRun("name10", "type10", "requestor10", "test10", "BUILDING","bundle10", "testClass10", groupName, submissionId,tags));
 
-        setServlet("/" + groupName, groupName, payload, "PUT", this.runs);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.PUT.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -843,11 +1121,15 @@ public class TestGroupRunsRoute extends RunsServletTest{
         // Given...
 		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
         String payload = generateStatusUpdateJson("some-fake-status");
+        List<IRun> runs = new ArrayList<IRun>();
 
-        setServlet("/" + groupName, groupName, payload, "PUT");
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.PUT.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
         ServletOutputStream outStream = resp.getOutputStream();
 
         // When...
@@ -863,9 +1145,11 @@ public class TestGroupRunsRoute extends RunsServletTest{
     public void testLaunchTestWithMissingPermissionsReturnsForbidden() throws Exception {
         // Given...
 		String groupName = "valid";
-        String[] classes = new String[]{"Class/name"};
+        String class1 = "Class/name";
+        String[] classes = new String[]{class1};
         String submissionId = "submission1";
         Set<String> tags = new HashSet<>();
+
         String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "this.test.stream", groupName, "testRequestor", submissionId, tags);
 
         // Set up permissions without the TEST_RUN_LAUNCH action
@@ -876,9 +1160,8 @@ public class TestGroupRunsRoute extends RunsServletTest{
         mockFramework.setRBACService(mockRbacService);
 
         MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
-        MockRunsServlet servlet = new MockRunsServlet(mockEnv);
+        MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
         servlet.setResponseBuilder(new ResponseBuilder(mockEnv));
-        servlet.setFramework(mockFramework);
 
 		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
 		HttpServletResponse resp = new MockHttpServletResponse();

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
@@ -230,7 +230,7 @@ public class K8sController {
         scheduledExecutorService.scheduleWithFixedDelay(runInterruptWatcher, 0, INTERRUPTED_RUN_WATCH_POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
 
         IRunRasActionProcessor rasActionProcessor = new RunRasActionProcessor(ras);
-        InterruptedRunEventProcessor interruptEventProcessor = new InterruptedRunEventProcessor(interruptEventQueue, frameworkRuns, rasActionProcessor, kubeEngineFacade);
+        InterruptedRunEventProcessor interruptEventProcessor = new InterruptedRunEventProcessor(interruptEventQueue, frameworkRuns, rasActionProcessor, kubeEngineFacade, ras);
         scheduledExecutorService.scheduleWithFixedDelay(interruptEventProcessor, 0, INTERRUPTED_RUN_WATCH_POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -111,11 +111,11 @@ public class TestPodScheduler implements Runnable {
                 List<IRun> queuedRuns = this.runs.getQueuedRuns();
                 // TODO filter by capability
     
-                // *** Remove all the local runs
+                // Remove all the local runs and any runs that have been interrupted
                 Iterator<IRun> queuedRunsIterator = queuedRuns.iterator();
                 while (queuedRunsIterator.hasNext()) {
                     IRun run = queuedRunsIterator.next();
-                    if (run.isLocal()) {
+                    if (run.isLocal() || run.getInterruptReason() != null) {
                         queuedRunsIterator.remove();
                     }
                 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/InterruptedRunEventProcessorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/InterruptedRunEventProcessorTest.java
@@ -102,7 +102,7 @@ public class InterruptedRunEventProcessorTest {
         RunInterruptEvent interruptEvent = new RunInterruptEvent(rasActions, runName, interruptReason);
         eventQueue.add(interruptEvent);
 
-        InterruptedRunEventProcessor processor = new InterruptedRunEventProcessor(eventQueue, mockFrameworkRuns, rasActionProcessor, facade);
+        InterruptedRunEventProcessor processor = new InterruptedRunEventProcessor(eventQueue, mockFrameworkRuns, rasActionProcessor, facade, mockRas);
 
         // When...
         processor.run();
@@ -152,7 +152,7 @@ public class InterruptedRunEventProcessorTest {
         RunInterruptEvent interruptEvent = new RunInterruptEvent(rasActions, runName, interruptReason);
         eventQueue.add(interruptEvent);
 
-        InterruptedRunEventProcessor processor = new InterruptedRunEventProcessor(eventQueue, mockFrameworkRuns, rasActionProcessor, facade);
+        InterruptedRunEventProcessor processor = new InterruptedRunEventProcessor(eventQueue, mockFrameworkRuns, rasActionProcessor, facade, mockRas);
 
         // When...
         processor.run();
@@ -203,7 +203,7 @@ public class InterruptedRunEventProcessorTest {
         RunInterruptEvent interruptEvent = new RunInterruptEvent(rasActions, runName, interruptReason);
         eventQueue.add(interruptEvent);
 
-        InterruptedRunEventProcessor processor = new InterruptedRunEventProcessor(eventQueue, mockFrameworkRuns, rasActionProcessor, facade);
+        InterruptedRunEventProcessor processor = new InterruptedRunEventProcessor(eventQueue, mockFrameworkRuns, rasActionProcessor, facade, mockRas);
 
         // Check that we have one element in the event queue before processing
         assertThat(eventQueue).hasSize(1);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -317,8 +317,12 @@ public class FrameworkRuns implements IFrameworkRuns {
             keysToDelete.add(getSuffixedRunDssKey(runName, "interruptReason"));
             this.dss.delete(keysToDelete);
 
-            // Set the status of the run back to 'queued'
-            this.dss.put(getSuffixedRunDssKey(runName, "status"), TestRunLifecycleStatus.QUEUED.toString());
+            // Set the status of the run back to 'queued' and generate a new run ID
+            Map<String, String> propertiesToSet = new HashMap<>();
+            propertiesToSet.put(getSuffixedRunDssKey(runName, "status"), TestRunLifecycleStatus.QUEUED.toString());
+            propertiesToSet.put(getSuffixedRunDssKey(runName, "rasrunid"), generateRasRunId(runName));
+            this.dss.put(propertiesToSet);
+
             isReset = true;
         }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -226,11 +226,13 @@ public class FrameworkRuns implements IFrameworkRuns {
         boolean local = runRequest.isLocalRun();
         boolean trace = runRequest.isTraceEnabled();
         Set<String> tags = runRequest.getTags();
+        String runId = generateRasRunId(runName);
 
         String runPropertyPrefix = RUN_PREFIX + runName;
 
         // *** Set up the otherRunProperties that will go with the Run number
         HashMap<String, String> otherRunProperties = new HashMap<>();
+        otherRunProperties.put(runPropertyPrefix + ".rasrunid", runId);
         otherRunProperties.put(runPropertyPrefix + ".status", "queued");
         otherRunProperties.put(runPropertyPrefix + ".queued", Instant.now().toString());
         otherRunProperties.put(runPropertyPrefix + ".testbundle", bundleName);
@@ -448,6 +450,10 @@ public class FrameworkRuns implements IFrameworkRuns {
         if (!this.dss.putSwap(runPropertyPrefix + ".status", "up", "queued", otherProperties)) {
             throw new FrameworkException("Failed to switch Shared Environment " + sharedEnvironmentRunName + " to discard");
         }
+    }
+
+    private String generateRasRunId(String runName) {
+        return UUID.randomUUID().toString() + "-" + timeService.now().toEpochMilli() + "-" + runName;
     }
 
     private String assignNewRunName(SubmitRunRequest runRequest) throws FrameworkException, InterruptedException {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
@@ -13,7 +13,6 @@ import java.util.Base64;
 import java.util.List;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
-import java.time.Instant;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -73,14 +73,17 @@ public class TestRunner extends BaseTestRunner {
 
         String testBundleName = run.getTestBundleName();
         String testClassName = run.getTestClassName();
-
-        this.testStructure = createNewTestStructure(run);
-        writeTestStructure();
             
         try {
+            this.testStructure = createNewTestStructure(run);
 
-            String rasRunId = this.ras.calculateRasRunId();
-            storeRasRunIdInDss(dss, rasRunId);
+            String rasRunId = run.getRasRunId();
+            if (rasRunId == null) {
+                writeTestStructure();
+
+                rasRunId = this.ras.calculateRasRunId();
+                storeRasRunIdInDss(dss, rasRunId);
+            }
 
             Class<?> testClass ;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/FrameworkMultipleResultArchiveStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/FrameworkMultipleResultArchiveStore.java
@@ -145,4 +145,12 @@ public class FrameworkMultipleResultArchiveStore implements IResultArchiveStoreS
     public long retrieveRunLogLineCount() {
         throw new UnsupportedOperationException("Unimplemented method 'retrieveRunLogLineCount'");
     }
+
+    @Override
+    public void createTestStructure(@NotNull String runId, @NotNull TestStructure testStructure)
+            throws ResultArchiveStoreException {
+        for (IResultArchiveStoreService rasService : this.rasServices) {
+            rasService.createTestStructure(runId, testStructure);
+        }
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryResultArchiveStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryResultArchiveStoreService.java
@@ -262,5 +262,11 @@ public class DirectoryResultArchiveStoreService implements IResultArchiveStoreSe
         return this.runLogLineCount;
     }
 
+    @Override
+    public void createTestStructure(@NotNull String runId, @NotNull TestStructure testStructure)
+            throws ResultArchiveStoreException {
+        throw new UnsupportedOperationException("Unimplemented method 'createTestStructure'");
+    }
+
 
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStore.java
@@ -80,7 +80,15 @@ public interface IResultArchiveStore {
      * @throws ResultArchiveStoreException - If there is a problem accessing or writing to the RAS
      */
     void updateTestStructure(@NotNull String runId, @NotNull TestStructure testStructure) throws ResultArchiveStoreException;
-
+    
+    /**
+     * Creates a new RAS record for a run with the given ID and test structure
+     * 
+     * @param runId - the ID of the run to create the record for
+     * @param testStructure - the new test structure to write
+     * @throws ResultArchiveStoreException - if there is a problem accessing or writing to the RAS
+     */
+    void createTestStructure(@NotNull String runId, @NotNull TestStructure testStructure) throws ResultArchiveStoreException;
 
     /**
      * Obtain the root directory of the stored artifacts file system

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Set;
 
 import dev.galasa.api.run.Run;
+import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public interface IRun {
 
@@ -63,4 +64,6 @@ public interface IRun {
 
     List<RunRasAction> getRasActions();
     public Set<String> getTags();
+
+    TestStructure toTestStructure();
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/teststructure/TestStructure.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/teststructure/TestStructure.java
@@ -56,6 +56,7 @@ public class TestStructure {
     public TestStructure( TestStructure source ) {
         if (source!=null) {
             this.runName = source.runName;
+            this.group = source.group;
             this.bundle = source.bundle;
             this.testName = source.testName;
             this.submissionId = source.submissionId;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestRunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestRunImpl.java
@@ -7,17 +7,14 @@ package dev.galasa.framework;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
-import java.io.ObjectOutputStream;
+import java.time.Instant;
 import java.util.*;
 
-import org.assertj.core.api.ByteArrayAssert;
 import org.junit.Test;
 
 import dev.galasa.framework.mocks.*;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.teststructure.TestStructure;
 import dev.galasa.framework.spi.utils.GalasaGson;
 
 public class TestRunImpl {
@@ -49,4 +46,83 @@ public class TestRunImpl {
         assertThat( tagsGotBack).containsExactly("tag1","tag2");
     }
 
+    @Test
+    public void testCanConvertARunImplToATestStructure() throws Exception  {
+        // Given...
+        String name = "U1234";
+        Map<String,String> dssProps = new HashMap<String,String>();
+
+        Set<String> tagsValueGoingIn = new HashSet<String>();
+        tagsValueGoingIn.add("tag1");
+        tagsValueGoingIn.add("tag2");
+        GalasaGson gson = new GalasaGson();
+
+        String queuedTimeAsString = Instant.now().toString();
+
+        String tagsAsJsonString = gson.toJson(tagsValueGoingIn);
+        dssProps.put("run.U1234"+".tags", tagsAsJsonString);
+
+        dssProps.put("run.U1234"+".test", "bundle/package.testclass");
+        dssProps.put("run.U1234"+".group", "my-test-group");
+        dssProps.put("run.U1234"+".submissionId", "my-submission-id");
+        dssProps.put("run.U1234"+".queued", queuedTimeAsString);
+        dssProps.put("run.U1234"+".requestor", "duck");
+
+        IDynamicStatusStoreService dss = new MockDSSStore(dssProps);
+        RunImpl run = new RunImpl(name,dss);
+
+        // When...
+        TestStructure testStructureGotBack = run.toTestStructure();
+
+        // Then...
+        assertThat(testStructureGotBack.getRunName()).isEqualTo(name);
+        assertThat(testStructureGotBack.getBundle()).isEqualTo("bundle");
+        assertThat(testStructureGotBack.getTestName()).isEqualTo("package.testclass");
+        assertThat(testStructureGotBack.getTestShortName()).isEqualTo("testclass");
+        assertThat(testStructureGotBack.getQueued()).isEqualTo(queuedTimeAsString);
+        assertThat(testStructureGotBack.getGroup()).isEqualTo("my-test-group");
+        assertThat(testStructureGotBack.getRequestor()).isEqualTo("duck");
+        assertThat(testStructureGotBack.getSubmissionId()).isEqualTo("my-submission-id");
+        assertThat(testStructureGotBack.getTags()).containsExactly("tag1", "tag2");
+    }
+
+    @Test
+    public void testCanConvertARunImplWithAShortTestNameToATestStructure() throws Exception  {
+        // Given...
+        String name = "U1234";
+        Map<String,String> dssProps = new HashMap<String,String>();
+
+        Set<String> tagsValueGoingIn = new HashSet<String>();
+        tagsValueGoingIn.add("tag1");
+        tagsValueGoingIn.add("tag2");
+        GalasaGson gson = new GalasaGson();
+
+        String queuedTimeAsString = Instant.now().toString();
+
+        String tagsAsJsonString = gson.toJson(tagsValueGoingIn);
+        dssProps.put("run.U1234"+".tags", tagsAsJsonString);
+
+        dssProps.put("run.U1234"+".test", "bundle/class");
+        dssProps.put("run.U1234"+".group", "my-test-group");
+        dssProps.put("run.U1234"+".submissionId", "my-submission-id");
+        dssProps.put("run.U1234"+".queued", queuedTimeAsString);
+        dssProps.put("run.U1234"+".requestor", "duck");
+
+        IDynamicStatusStoreService dss = new MockDSSStore(dssProps);
+        RunImpl run = new RunImpl(name,dss);
+
+        // When...
+        TestStructure testStructureGotBack = run.toTestStructure();
+
+        // Then...
+        assertThat(testStructureGotBack.getRunName()).isEqualTo(name);
+        assertThat(testStructureGotBack.getBundle()).isEqualTo("bundle");
+        assertThat(testStructureGotBack.getTestName()).isEqualTo("class");
+        assertThat(testStructureGotBack.getTestShortName()).isNull();
+        assertThat(testStructureGotBack.getQueued()).isEqualTo(queuedTimeAsString);
+        assertThat(testStructureGotBack.getGroup()).isEqualTo("my-test-group");
+        assertThat(testStructureGotBack.getRequestor()).isEqualTo("duck");
+        assertThat(testStructureGotBack.getSubmissionId()).isEqualTo("my-submission-id");
+        assertThat(testStructureGotBack.getTags()).containsExactly("tag1", "tag2");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import dev.galasa.api.run.Run;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.RunRasAction;
+import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class MockRun implements IRun {
 
@@ -148,5 +149,10 @@ public class MockRun implements IRun {
     
     public Set<String> getTags() {
         throw new UnsupportedOperationException("Unimplemented method 'getTags'");
+    }
+
+    @Override
+    public TestStructure toTestStructure() {
+        throw new UnsupportedOperationException("Unimplemented method 'toTestStructure'");
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIResultArchiveStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIResultArchiveStore.java
@@ -27,7 +27,7 @@ public class MockIResultArchiveStore implements IResultArchiveStore {
     private String runId ;
 
     public MockIResultArchiveStore() {
-        // No-op constructor
+        // Do nothing...
     }
 
     public MockIResultArchiveStore(String runId, MockFileSystem mockFileSystem) {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIResultArchiveStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIResultArchiveStore.java
@@ -26,6 +26,10 @@ public class MockIResultArchiveStore implements IResultArchiveStore {
     StringBuffer runLog = new StringBuffer();
     private String runId ;
 
+    public MockIResultArchiveStore() {
+        // No-op constructor
+    }
+
     public MockIResultArchiveStore(String runId, MockFileSystem mockFileSystem) {
         this.runId = runId;
         this.mockFS = mockFileSystem;
@@ -42,6 +46,13 @@ public class MockIResultArchiveStore implements IResultArchiveStore {
 
     @Override
     public void updateTestStructure(@NotNull String runId, @NotNull TestStructure testStructure)
+            throws ResultArchiveStoreException {
+        TestStructure historyRecord = new TestStructure(testStructure);
+        testStructureHistory.add(historyRecord);
+    }
+
+    @Override
+    public void createTestStructure(@NotNull String runId, @NotNull TestStructure testStructure)
             throws ResultArchiveStoreException {
         TestStructure historyRecord = new TestStructure(testStructure);
         testStructureHistory.add(historyRecord);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRASStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRASStoreService.java
@@ -92,4 +92,10 @@ public class MockRASStoreService implements IResultArchiveStoreService{
         throw new UnsupportedOperationException("Unimplemented method 'updateTestStructure'");
     }
 
+    @Override
+    public void createTestStructure(@NotNull String runId, @NotNull TestStructure testStructure)
+            throws ResultArchiveStoreException {
+        throw new UnsupportedOperationException("Unimplemented method 'createTestStructure'");
+    }
+
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import dev.galasa.api.run.Run;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.RunRasAction;
+import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class MockRun implements IRun {
     private String testBundleName;
@@ -201,6 +202,23 @@ public class MockRun implements IRun {
     @Override
     public boolean isTrace() {
         return true;
+    }
+
+    @Override
+    public TestStructure toTestStructure() {
+        TestStructure testStructure = new TestStructure();
+
+        testStructure.setBundle(testBundleName);
+        testStructure.setTestName(testClassName);
+        testStructure.setRunName(testRunName);
+        testStructure.setRequestor(requestorName);
+        testStructure.setSubmissionId(submissionId);
+
+        for (String tag : tags) {
+            testStructure.addTag(tag);
+        }
+
+        return testStructure;
     }
 
     // ------------- un-implemented methods follow ----------------


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2317

## Changes
- When queued runs are cancelled, the engine controller will no longer schedule a new test pod for those runs.
- When a request to submit runs is made, the API server will now create a run document in the RAS for each submitted run, rather than only creating the document when the test pod starts.
  - When a test pod starts, it will update the existing RAS document for the submitted run instead of creating a new document. If a run ID was not set into the DSS for the run, the test runner will create a new document and associated run ID.
  - For local runs, the test runner will continue to create the run record in the RAS as long as no RAS run ID already exists in the DSS for that run.
- As soon as a run is requeued, a new run ID will be assigned to the run and a new RAS document will be created up-front before the new test pod starts in case the new run gets cancelled before being scheduled