### PR TITLE
Remove the documentation depending upong googleapi fonts.

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,6 +30,12 @@ theme:
   name: material
   logo: assets/galasa-icon-white.svg
   favicon: assets/galasa-icon-white.svg
+
+  # Saying there is no font theme, turns off access to the googleapi fonts which could be used
+  # to track personal activity. See https://github.com/galasa-dev/projectmanagement/issues/2342
+  font:
+    false
+
   icon:
     repo: fontawesome/brands/github
   custom_dir: overrides


### PR DESCRIPTION
# Why ?
See [#2342](https://github.com/galasa-dev/projectmanagement/issues/2342)

Fixes one of the problems described in that defect.

Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

- [x] Stop the web site from using google fonts.

