### PR TITLE
Add accept cookies dialog to docs, and link to privacy policy in docs header.

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -19,7 +19,10 @@ edit_uri: edit/main/docs/content/
 use_directory_urls: true
 
 # Copyright
-copyright: Copyright &copy; Open Mainframe Project
+copyright: >
+  Copyright &copy; Open Mainframe Project -
+  <a href="#__consent">Change cookie settings</a> -
+  <a href="https://github.com/galasa-dev/galasa-docs/blob/main/privacy.md">Privacy policy</a>
 
 # Configuration
 docs_dir: content
@@ -114,6 +117,7 @@ plugins:
   - offline:
       enabled: !ENV [OFFLINE, false]
   - search
+  - privacy
   - blog:
       blog_dir: hub
       blog_toc: true
@@ -143,6 +147,15 @@ extra:
       link: https://github.com/galasa-dev
     - icon: fontawesome/brands/slack
       link: https://openmainframeproject.slack.com/signup#/domain-signup
+
+  consent:
+    title: Cookie consent
+    description: >- 
+      We use cookies to recognize your repeated visits and preferences, as well
+      as to measure the effectiveness of our documentation and whether users
+      find what they're searching for. For more detail see <a href="https://github.com/galasa-dev/galasa-docs/blob/main/privacy.md">here</a>
+
+  generator: false
 
 # Page tree
 nav:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -22,7 +22,7 @@ use_directory_urls: true
 copyright: >
   Copyright &copy; Open Mainframe Project -
   <a href="#__consent">Change cookie settings</a> -
-  <a href="https://github.com/galasa-dev/galasa-docs/blob/main/privacy.md">Privacy policy</a>
+  <a href="https://github.com/galasa-dev/galasa-docs/blob/main/docs/privacy.md">Privacy policy</a>
 
 # Configuration
 docs_dir: content
@@ -153,7 +153,7 @@ extra:
     description: >- 
       We use cookies to recognize your repeated visits and preferences, as well
       as to measure the effectiveness of our documentation and whether users
-      find what they're searching for. For more detail see <a href="https://github.com/galasa-dev/galasa-docs/blob/main/privacy.md">here</a>
+      find what they're searching for. For more detail see <a href="https://github.com/galasa-dev/galasa-docs/blob/main/docs/privacy.md">here</a>
 
   generator: false
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -22,7 +22,7 @@ use_directory_urls: true
 copyright: >
   Copyright &copy; Open Mainframe Project -
   <a href="#__consent">Change cookie settings</a> -
-  <a href="https://github.com/galasa-dev/galasa-docs/blob/main/docs/privacy.md">Privacy policy</a>
+  <a href="https://github.com/galasa-dev/galasa/blob/main/docs/privacy.md">Privacy policy</a>
 
 # Configuration
 docs_dir: content
@@ -153,7 +153,7 @@ extra:
     description: >- 
       We use cookies to recognize your repeated visits and preferences, as well
       as to measure the effectiveness of our documentation and whether users
-      find what they're searching for. For more detail see <a href="https://github.com/galasa-dev/galasa-docs/blob/main/docs/privacy.md">here</a>
+      find what they're searching for. For more detail see <a href="https://github.com/galasa-dev/galasa/blob/main/docs/privacy.md">here</a>
 
   generator: false
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -151,7 +151,7 @@ extra:
   consent:
     title: Cookie consent
     description: >- 
-      We use cookies to recognize your repeated visits and preferences, and to enhance the experience interracting with Github.
+      We use cookies to recognize your repeated visits and preferences, and to enhance the experience when interacting with Github.
       For more detail see our notes on <a href="https://github.com/galasa-dev/galasa/blob/main/docs/privacy.md">cookie usage</a>.
 
   generator: false

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -151,9 +151,8 @@ extra:
   consent:
     title: Cookie consent
     description: >- 
-      We use cookies to recognize your repeated visits and preferences, as well
-      as to measure the effectiveness of our documentation and whether users
-      find what they're searching for. For more detail see <a href="https://github.com/galasa-dev/galasa/blob/main/docs/privacy.md">here</a>
+      We use cookies to recognize your repeated visits and preferences, and to enhance the experience interracting with Github.
+      For more detail see our notes on <a href="https://github.com/galasa-dev/galasa/blob/main/docs/privacy.md">cookie usage</a>.
 
   generator: false
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,15 @@
+# Cookies used by the Galasa web site
+
+[The Galasa documentation](http://galasa.dev) web site uses cookies to store user preferences, such as light or dark theme, so that when re-visiting the site the settings and visual look are preserved.
+
+It also optionally uses the Github API to contact github. Which is managed by the 'github' cookie in the cookie settings.
+
+
+# Privacy when using the Galasa web site
+
+[The Galasa documentation](http://galasa.dev) web site is hosted using Github pages. Github may collect HTTP logs and traffic statistics to monitor its hosting capabilities and workload.
+
+All fonts and images resources used on the site are hosted from the same place as the text. No attempt to dynamically load resources from external sources are made. 
+
+No attempt is made to monitor user activity by the Galasa team or Linux Foundation.
+


### PR DESCRIPTION
# Why ?

As part of the defect https://github.com/galasa-dev/projectmanagement/issues/2342 

- [x] Added cookie consent and privacy policy footer
- [x] Privacy document added to the github source so we can reference it without a cookie
- [x] Turned on github cookie management so new user gets the accept dialog 
