### PR TITLE
Iss2295 - Fix Javadoc for 3270 Manager extra.bundles

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/internal/properties/ExtraBundles.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/internal/properties/ExtraBundles.java
@@ -24,7 +24,8 @@ import dev.galasa.framework.spi.cps.CpsProperties;
  * 
  * @galasa.required No
  * 
- * @galasa.default dev.galasa.cicsts.ceci.manager,dev.galasa.cicsts.ceda.manager,dev.galasa.cicsts.cemt.manager
+ * @galasa.default dev.galasa.cicsts.ceci.manager,dev.galasa.cicsts.ceda.manager,dev.galasa.cicsts.cemt.manager,
+ *                 dev.galasa.cicsts.resource.manager,dev.galasa.zosliberty.manager,dev.galasa.textscan.manager
  * 
  * @galasa.valid_values bundle symbolic names comma separated
  * 

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/internal/properties/ExtraBundles.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/internal/properties/ExtraBundles.java
@@ -48,7 +48,7 @@ public class ExtraBundles extends CpsProperties {
                 list.add("dev.galasa.textscan.manager");
             } else if (list.size() == 1) {
                 if (list.get(0).equalsIgnoreCase("none")) {
-                    return new ArrayList<>(0);
+                    list.clear();
                 }
             }
             

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/properties/ExtraBundles.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/properties/ExtraBundles.java
@@ -42,13 +42,13 @@ public class ExtraBundles extends CpsProperties {
                 list.add("dev.galasa.textscan.manager");
             } else if (list.size() == 1) {
                 if (list.get(0).equalsIgnoreCase("none")) {
-                    return new ArrayList<>(0);
+                    list.clear();
                 }
             }
             
             return list;
         } catch (ConfigurationPropertyStoreException e) {
-            throw new Zos3270ManagerException("Problem asking CPS for the CICS TS extra bundles", e); 
+            throw new Zos3270ManagerException("Problem asking CPS for the z/OS 3270 extra bundles", e); 
         }
     }
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/properties/ExtraBundles.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/properties/ExtraBundles.java
@@ -13,22 +13,22 @@ import dev.galasa.framework.spi.cps.CpsProperties;
 import dev.galasa.zos3270.Zos3270ManagerException;
 
 /**
- * Extra bundles required to implement the CICS TS Manager
+ * Extra bundles required to implement the z/OS 3270 Manager
  * 
  * @galasa.cps.property
  * 
- * @galasa.name cicsts.extra.bundles
+ * @galasa.name zos3270.extra.bundles
  * 
  * @galasa.description The symbolic names of any bundles that need to be loaded
- *                     with the CICS TS Manager
+ *                     with the z/OS 3270 Manager
  * 
  * @galasa.required No
  * 
- * @galasa.default dev.galasa.cicsts.ceci.manager,dev.galasa.cicsts.ceda.manager,dev.galasa.cicsts.cemt.manager
+ * @galasa.default dev.galasa.textscan.manager
  * 
  * @galasa.valid_values bundle symbolic names comma separated
  * 
- * @galasa.examples <code>cicsts.extra.bundles=org.example.cicsts.provisioning</code><br>
+ * @galasa.examples <code>zos3270.extra.bundles=dev.galasa.textscan.manager</code><br>
  *
  */
 public class ExtraBundles extends CpsProperties {


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2295

## Changes

- Fix incorrect Javadoc for zos3270.extra.bundles property that described cicsts.extra.bundles
- Fix incorrect exception statement that mentioned CICS TS in the 3270 Manager
- Update default value for cicsts.extra.bundles
- Use list.clear() instead of return new ArrayList to avoid multiple return statements in a method
