### PR TITLE
Minor changes to make local builds work better

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,20 @@ This is the main source code repository for the Galasa open source project.
 - [`modules`](./modules/) - The code
 - [`tools`](./tools/) - Build tools and useful scripts
 
-## building locally
 
+
+## Building locally
+
+### Pre-reqs
+
+These are the versions of code we know work for sure:
+- Python v3.11.0
+- Gradle 8.9
+- Apache Maven 3.9.0
+- openjdk 17.0.12
+- go1.23.5
+
+### To build...
 Use the `./tools/build-locally.sh` script. `--help` shows you the options.
 
 Basic usage to build everything: `build-locally.sh`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the main source code repository for the Galasa open source project.
 
 ### Pre-reqs
 
-These are the versions of code we know work for sure:
+These are the versions of software which are known to work:
 - Python v3.11.0
 - Gradle 8.9
 - Apache Maven 3.9.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These are the versions of code we know work for sure:
 - Gradle 8.9
 - Apache Maven 3.9.0
 - openjdk 17.0.12
-- go1.23.5
+- go 1.23.5
 
 ### To build...
 Use the `./tools/build-locally.sh` script. `--help` shows you the options.

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -14,6 +14,9 @@ version="0.43.0"
 repositories {
     gradlePluginPortal()
     mavenLocal()
+    maven {
+        url = "$sourceMaven"
+    }
     mavenCentral()
 }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -14,9 +14,6 @@ version="0.43.0"
 repositories {
     gradlePluginPortal()
     mavenLocal()
-    maven {
-        url = "$sourceMaven"
-    }
     mavenCentral()
 }
 

--- a/tools/detect-secrets.sh
+++ b/tools/detect-secrets.sh
@@ -135,7 +135,6 @@ function check_if_detect_secrets_is_installed() {
             info "detect-secrets was installed correctly"
         else
             error "Failed to install detect-secrets"
-            # deactivate
             exit 1
         fi
     fi

--- a/tools/detect-secrets.sh
+++ b/tools/detect-secrets.sh
@@ -85,8 +85,22 @@ function check_if_python3_is_installed() {
 
     if command -v python3 &>/dev/null; then
         success "Python3 is already installed."
+
+        python_version=$(python3 --version | cut -f2 -d' ')
+        ver=$(echo -n "$python_version" | cut -f1 -d'.' )
+        if (( ver < 3 )); then
+            error "Python version must be v3.11.0 or above."
+            exit 1
+        fi
+
+        rel=$(echo -n "$python_version" | cut -f2 -d'.' )
+        if (( ver == 3)) && (( rel < 11 )); then
+            error "Python version must be v3.11.0 or above. Release $python_version is too low."
+            exit 1
+        fi
+
     else
-        error "Please install Python3 to conitnue."
+        error "Please install python v3.11.0 or above."
         exit 1
     fi
 }
@@ -121,7 +135,7 @@ function check_if_detect_secrets_is_installed() {
             info "detect-secrets was installed correctly"
         else
             error "Failed to install detect-secrets"
-            deactivate
+            # deactivate
             exit 1
         fi
     fi


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
- detect-secrets didn't fail if the version was less than 3.11.0 We should force people to upgrade them.
- readme didn't contain a list of pre-reqs which we need
- docs shouldn't need sourceMaven environment variable set to build locally.