### PR TITLE
build: Build docker image that hosts the docs site in a web server so can be run and find docs at localhost

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -103,6 +103,31 @@ jobs:
           name: galasa-docs-site
           path: docs/build/site
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        env:
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
+
+      - name: Extract metadata for galasa-docs-site image
+        id: metadata
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasa-docs-site
+        
+      - name: Build galasa-docs-site image
+        uses: docker/build-push-action@v5
+        with:
+          context: docs
+          file: docs/dockerfile.galasadocssite
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+
   deploy-docs-pr-preview-to-github-pages:
 
     if: ${{ (github.ref_name == 'main') }}

--- a/.github/workflows/pr-docs.yaml
+++ b/.github/workflows/pr-docs.yaml
@@ -158,3 +158,11 @@ jobs:
         with:
           name: galasa-docs-site
           path: docs/build/site
+ 
+      - name: Build galasa-docs-site image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: docs
+          file: docs/dockerfile.galasadocssite
+          load: true
+          tags: galasa-docs-site:test

--- a/docs/build-locally.sh
+++ b/docs/build-locally.sh
@@ -106,3 +106,10 @@ check_exit_code $? "Failed to build"
 success "OK"
 
 info "To preview, the docs are at: file://$BASEDIR/build/site/index.html"
+
+h2 "Building galasa-docs-site Docker image that hosts the website in a local web server"
+docker build -f dockerfile.galasadocssite -t galasa-docs-site .
+check_exit_code $? "Failed to build"
+success "OK"
+
+info "To run the image and access the docs in localhost:8080, run: docker run -d -p 8080:80 galasa-docs-site"

--- a/docs/content/docs/cli-command-reference/installing-offline.md
+++ b/docs/content/docs/cli-command-reference/installing-offline.md
@@ -2,13 +2,13 @@
 title: "Installing the Galasa CLI offline"
 ---
 
-The Galasa _isolated.zip_ file is available from the [https://resources.galasa.dev/](https://resources.galasa.dev){target="_blank"} site and can be downloaded and extracted to a directory of your choice. The zip file contains three directories (galasactl, maven, and javadoc), an `isolated.tar` file and a `docs.jar` file. 
+The Galasa _isolated.zip_ file is available from the [https://resources.galasa.dev/](https://resources.galasa.dev){target="_blank"} site and can be downloaded and extracted to a directory of your choice. The zip file contains three directories (galasactl, maven, and javadoc), an `isolated.tar` file and a `docs.tar` file. 
 
-The `galasactl` directory contains the binaries that are required to run the Galasa command line interface tool (Galasa CLI). The `maven` directory contains dependencies that are required for building Galasa tests. The `javadoc` directory contains the Javadoc API documentation for the Galasa Managers.
+The `galasactl` directory contains the binaries that are required to run the Galasa command line interface tool (Galasa CLI). The `maven` directory contains dependencies that are required for running Galasa tests. The `javadoc` directory contains the Javadoc API documentation for the Galasa Managers.
+
+The `docs.tar` file loads a Docker image that enables you to run the Galasa website locally on your machine or on an internal server. Instructions on how to do this are available in the `README.txt` that is provided in the Galasa zip file. 
 
 The `isolated.tar` file is an optional Docker image that hosts all the artifacts. You might want to use the Docker image if you want to host Galasa on an internal server that can be accessed by other users. If you want to host Galasa on your local machine only, you do not need to use the Docker image. 
-
-The `docs.jar` file enables you to run the Galasa website locally on your machine or on an internal server. Instructions on how to do this are available in the `README.txt` that is provided in the Galasa zip file. 
 
 
 ## Getting started

--- a/docs/dockerfile.galasadocssite
+++ b/docs/dockerfile.galasadocssite
@@ -1,0 +1,7 @@
+FROM ghcr.io/galasa-dev/httpd:alpine
+
+RUN rm -v /usr/local/apache2/htdocs/*
+
+COPY build/site/ /usr/local/apache2/htdocs/
+
+EXPOSE 80


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2345

## Changes?

- Dockerfile that when built and the image is run, the docs site can be accessed at localhost:8080
- Build this image as part of the local build script and GitHub Actions workflows
- In the Main build, publish to GHCR so it can be picked up by the Isolated/MVP build and packaged as a tar
- Update the documentation that referred to the docs.jar to now describe the docs.tar and how that can be loaded/ran
