### PR TITLE
Add test pod interrupt timeout to only delete pods and process interrupt events after a given amount of time

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
@@ -160,4 +160,9 @@ public class MockIRun implements IRun {
     public TestStructure toTestStructure() {
         throw new UnsupportedOperationException("Unimplemented method 'toTestStructure'");
     }
+
+    @Override
+    public Instant getInterruptedAt() {
+        throw new UnsupportedOperationException("Unimplemented method 'getInterruptedAt'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
@@ -213,4 +213,9 @@ public class MockIRun implements IRun{
     public List<RunRasAction> getRasActions() {
         throw new UnsupportedOperationException("Unimplemented method 'getRasActions'");
     }
+
+    @Override
+    public Instant getInterruptedAt() {
+        throw new UnsupportedOperationException("Unimplemented method 'getInterruptedAt'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/ISettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/ISettings.java
@@ -49,5 +49,7 @@ public interface ISettings {
     public long getKubeLaunchIntervalMillisecs();
 
     public int getMaxTestPodRetryLimit();
+
+    public long getTestPodInterruptTimeoutSecs();
 }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/ISettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/ISettings.java
@@ -50,6 +50,6 @@ public interface ISettings {
 
     public int getMaxTestPodRetryLimit();
 
-    public long getTestPodInterruptTimeoutSecs();
+    public long getInterruptedTestRunCleanupGracePeriodSeconds();
 }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
@@ -226,7 +226,7 @@ public class K8sController {
         schedulePoll();
 
         Queue<RunInterruptEvent> interruptEventQueue = new LinkedBlockingQueue<RunInterruptEvent>();
-        RunInterruptMonitor runInterruptWatcher = new RunInterruptMonitor(kubeEngineFacade, frameworkRuns, interruptEventQueue, settings);
+        RunInterruptMonitor runInterruptWatcher = new RunInterruptMonitor(kubeEngineFacade, frameworkRuns, interruptEventQueue, settings, timeService);
         scheduledExecutorService.scheduleWithFixedDelay(runInterruptWatcher, 0, INTERRUPTED_RUN_WATCH_POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
 
         IRunRasActionProcessor rasActionProcessor = new RunRasActionProcessor(ras);

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunInterruptEvent.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunInterruptEvent.java
@@ -5,6 +5,7 @@
  */
 package dev.galasa.framework.k8s.controller;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -23,11 +24,13 @@ public class RunInterruptEvent {
     private final List<RunRasAction> rasActions;
     private final String runName;
     private final String interruptReason;
+    private final Instant interruptedAt;
 
-    public RunInterruptEvent(List<RunRasAction> rasActions, String runName, String interruptReason) {
+    public RunInterruptEvent(List<RunRasAction> rasActions, String runName, String interruptReason, Instant interruptedAt) {
         this.rasActions = rasActions;
         this.runName = runName;
         this.interruptReason = interruptReason;
+        this.interruptedAt = interruptedAt;
 
         logger.debug("Created: " + this.toString());
     }
@@ -47,5 +50,9 @@ public class RunInterruptEvent {
 
     public String getInterruptReason() {
         return this.interruptReason;
+    }
+
+    public Instant getInterruptedAt() {
+        return this.interruptedAt;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -29,8 +29,8 @@ public class Settings implements Runnable, ISettings {
     public static final int MAX_TEST_POD_RETRY_LIMIT_DEFAULT = 5;
     public static final String MAX_TEST_POD_RETRY_LIMIT_CONFIG_MAP_PROPERTY_NAME = "max_test_pod_retry_limit";
 
-    public static final int TEST_POD_INTERRUPT_TIMEOUT_SECS_DEFAULT = 300;
-    public static final String TEST_POD_INTERRUPT_TIMEOUT_SECS_PROPERTY_NAME = "test_pod_interrupt_timeout_secs";
+    public static final int INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_DEFAULT = 300;
+    public static final String INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_PROPERTY_NAME = "interrupted_test_run_cleanup_grace_period_seconds";
 
     private final Log         logger                      = LogFactory.getLog(getClass());
 
@@ -65,7 +65,7 @@ public class Settings implements Runnable, ISettings {
     private String            reportCapabilties           = null;
 
     private long              kubeLaunchIntervalMillisecs = 1000L;
-    private long              testPodInterruptTimeoutSecs = TEST_POD_INTERRUPT_TIMEOUT_SECS_DEFAULT;
+    private long              interruptedTestRunCleanupGracePeriodSeconds = INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_DEFAULT;
 
     // Poll loop interval which is looking for queued test runs, so they can be launched in a pod.
     private int               runPollSeconds              = 60;
@@ -199,7 +199,7 @@ public class Settings implements Runnable, ISettings {
         this.engineLabel = updateProperty(configMapData, "engine_label", "k8s-standard-engine", this.engineLabel);
         this.engineImage = updateProperty(configMapData, "engine_image", "ghcr.io/galasa-dev/galasa-boot-embedded-amd64", this.engineImage);
         this.kubeLaunchIntervalMillisecs = updateProperty(configMapData, "kube_launch_interval_milliseconds", kubeLaunchIntervalMillisecs, this.kubeLaunchIntervalMillisecs);
-        this.testPodInterruptTimeoutSecs = updateProperty(configMapData, TEST_POD_INTERRUPT_TIMEOUT_SECS_PROPERTY_NAME, TEST_POD_INTERRUPT_TIMEOUT_SECS_DEFAULT, this.testPodInterruptTimeoutSecs);
+        this.interruptedTestRunCleanupGracePeriodSeconds = updateProperty(configMapData, INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_PROPERTY_NAME, INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_DEFAULT, this.interruptedTestRunCleanupGracePeriodSeconds);
 
         this.engineMemoryRequestMi = updateProperty(configMapData, "engine_memory_request", engineMemoryRequestMi, this.engineMemoryRequestMi);
         this.engineMemoryLimitMi = updateProperty(configMapData, "engine_memory_limit", engineMemoryLimitMi, this.engineMemoryLimitMi);
@@ -388,7 +388,7 @@ public class Settings implements Runnable, ISettings {
         return this.maxTestPodRetryLimit;
     }
 
-    public long getTestPodInterruptTimeoutSecs() {
-        return this.testPodInterruptTimeoutSecs;
+    public long getInterruptedTestRunCleanupGracePeriodSeconds() {
+        return this.interruptedTestRunCleanupGracePeriodSeconds;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -29,6 +29,9 @@ public class Settings implements Runnable, ISettings {
     public static final int MAX_TEST_POD_RETRY_LIMIT_DEFAULT = 5;
     public static final String MAX_TEST_POD_RETRY_LIMIT_CONFIG_MAP_PROPERTY_NAME = "max_test_pod_retry_limit";
 
+    public static final int TEST_POD_INTERRUPT_TIMEOUT_SECS_DEFAULT = 300;
+    public static final String TEST_POD_INTERRUPT_TIMEOUT_SECS_PROPERTY_NAME = "test_pod_interrupt_timeout_secs";
+
     private final Log         logger                      = LogFactory.getLog(getClass());
 
     private final K8sController controller;
@@ -62,6 +65,7 @@ public class Settings implements Runnable, ISettings {
     private String            reportCapabilties           = null;
 
     private long              kubeLaunchIntervalMillisecs = 1000L;
+    private long              testPodInterruptTimeoutSecs = TEST_POD_INTERRUPT_TIMEOUT_SECS_DEFAULT;
 
     // Poll loop interval which is looking for queued test runs, so they can be launched in a pod.
     private int               runPollSeconds              = 60;
@@ -195,6 +199,7 @@ public class Settings implements Runnable, ISettings {
         this.engineLabel = updateProperty(configMapData, "engine_label", "k8s-standard-engine", this.engineLabel);
         this.engineImage = updateProperty(configMapData, "engine_image", "ghcr.io/galasa-dev/galasa-boot-embedded-amd64", this.engineImage);
         this.kubeLaunchIntervalMillisecs = updateProperty(configMapData, "kube_launch_interval_milliseconds", kubeLaunchIntervalMillisecs, this.kubeLaunchIntervalMillisecs);
+        this.testPodInterruptTimeoutSecs = updateProperty(configMapData, TEST_POD_INTERRUPT_TIMEOUT_SECS_PROPERTY_NAME, TEST_POD_INTERRUPT_TIMEOUT_SECS_DEFAULT, this.testPodInterruptTimeoutSecs);
 
         this.engineMemoryRequestMi = updateProperty(configMapData, "engine_memory_request", engineMemoryRequestMi, this.engineMemoryRequestMi);
         this.engineMemoryLimitMi = updateProperty(configMapData, "engine_memory_limit", engineMemoryLimitMi, this.engineMemoryLimitMi);
@@ -381,5 +386,9 @@ public class Settings implements Runnable, ISettings {
 
     public int getMaxTestPodRetryLimit() {
         return this.maxTestPodRetryLimit;
+    }
+
+    public long getTestPodInterruptTimeoutSecs() {
+        return this.testPodInterruptTimeoutSecs;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/InterruptedRunEventProcessorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/InterruptedRunEventProcessorTest.java
@@ -8,6 +8,7 @@ package dev.galasa.framework.k8s.controller;
 import static org.assertj.core.api.Assertions.*;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -74,6 +75,7 @@ public class InterruptedRunEventProcessorTest {
         String runName = "RUN1";
         String status = "running";
         String interruptReason = Result.CANCELLED;
+        Instant interruptedAt = Instant.now();
 
         RunRasAction mockRasAction = new RunRasAction(runId, TestRunLifecycleStatus.FINISHED.toString(), interruptReason);
         List<RunRasAction> rasActions = List.of(mockRasAction);
@@ -99,7 +101,7 @@ public class InterruptedRunEventProcessorTest {
         KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", galasaServiceInstallName);
 
         Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
-        RunInterruptEvent interruptEvent = new RunInterruptEvent(rasActions, runName, interruptReason);
+        RunInterruptEvent interruptEvent = new RunInterruptEvent(rasActions, runName, interruptReason, interruptedAt);
         eventQueue.add(interruptEvent);
 
         InterruptedRunEventProcessor processor = new InterruptedRunEventProcessor(eventQueue, mockFrameworkRuns, rasActionProcessor, facade, mockRas);
@@ -124,6 +126,7 @@ public class InterruptedRunEventProcessorTest {
         String runName = "RUN1";
         String status = "running";
         String interruptReason = Result.REQUEUED;
+        Instant interruptedAt = Instant.now();
 
         RunRasAction mockRasAction = new RunRasAction(runId, TestRunLifecycleStatus.FINISHED.toString(), interruptReason);
         List<RunRasAction> rasActions = List.of(mockRasAction);
@@ -149,7 +152,7 @@ public class InterruptedRunEventProcessorTest {
         KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", galasaServiceInstallName);
 
         Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
-        RunInterruptEvent interruptEvent = new RunInterruptEvent(rasActions, runName, interruptReason);
+        RunInterruptEvent interruptEvent = new RunInterruptEvent(rasActions, runName, interruptReason, interruptedAt);
         eventQueue.add(interruptEvent);
 
         InterruptedRunEventProcessor processor = new InterruptedRunEventProcessor(eventQueue, mockFrameworkRuns, rasActionProcessor, facade, mockRas);
@@ -173,6 +176,7 @@ public class InterruptedRunEventProcessorTest {
         String runName = "RUN1";
         String status = "running";
         String interruptReason = Result.CANCELLED;
+        Instant interruptedAt = Instant.now();
 
         RunRasAction mockRasAction = new RunRasAction(runId, TestRunLifecycleStatus.FINISHED.toString(), interruptReason);
         List<RunRasAction> rasActions = List.of(mockRasAction);
@@ -200,7 +204,7 @@ public class InterruptedRunEventProcessorTest {
         KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", galasaServiceInstallName);
 
         Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
-        RunInterruptEvent interruptEvent = new RunInterruptEvent(rasActions, runName, interruptReason);
+        RunInterruptEvent interruptEvent = new RunInterruptEvent(rasActions, runName, interruptReason, interruptedAt);
         eventQueue.add(interruptEvent);
 
         InterruptedRunEventProcessor processor = new InterruptedRunEventProcessor(eventQueue, mockFrameworkRuns, rasActionProcessor, facade, mockRas);

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunInterruptMonitorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunInterruptMonitorTest.java
@@ -7,6 +7,7 @@ package dev.galasa.framework.k8s.controller;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
@@ -21,15 +22,23 @@ import dev.galasa.framework.k8s.controller.mocks.MockKubernetesApiClient;
 import dev.galasa.framework.k8s.controller.mocks.MockKubernetesPodTestUtils;
 import dev.galasa.framework.mocks.MockFrameworkRuns;
 import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.mocks.MockTimeService;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.RunRasAction;
+import dev.galasa.framework.spi.utils.ITimeService;
 import io.kubernetes.client.openapi.models.V1Pod;
 
 public class RunInterruptMonitorTest {
 
     private MockKubernetesPodTestUtils mockKubeTestUtils = new MockKubernetesPodTestUtils();
 
-    private MockRun createMockRun(String runIdToMarkFinished, String runName, String status, String interruptReason) {
+    private MockRun createMockRun(
+        String runIdToMarkFinished,
+        String runName,
+        String status,
+        String interruptReason,
+        Instant interruptedAt
+    ) {
         // We only care about the run's name, status, and interrupt reason
         MockRun mockRun = new MockRun(
             "bundle",
@@ -43,6 +52,7 @@ public class RunInterruptMonitorTest {
         );
 
         mockRun.setInterruptReason(interruptReason);
+        mockRun.setInterruptedAt(interruptedAt);
         mockRun.setStatus(status);
 
         if (runIdToMarkFinished != null) {
@@ -53,12 +63,15 @@ public class RunInterruptMonitorTest {
     }
 
     @Test
-    public void testPodForAnInterruptedRunIsDeletedOk() throws Exception {
+    public void testPodForAnInterruptedRunIsNotDeletedBeforeInterruptTimeout() throws Exception {
         // Given...
         String runName1 = "run1";
         String runName2 = "run2";
         String runName3 = "run3";
         String runIdToMarkFinished = "run3-id";
+        
+        Instant currentTime = Instant.now();
+        ITimeService timeService = new MockTimeService(currentTime);
 
         String interruptReason = "cancelled";
 
@@ -75,9 +88,9 @@ public class RunInterruptMonitorTest {
 
         // Create runs associated with the pods
         List<IRun> mockRuns = new ArrayList<>();
-        mockRuns.add(createMockRun(null, runName1, TestRunLifecycleStatus.FINISHED.toString(), null));
-        mockRuns.add(createMockRun(null, runName2, TestRunLifecycleStatus.FINISHED.toString(), null));
-        mockRuns.add(createMockRun(runIdToMarkFinished, runName3, TestRunLifecycleStatus.RUNNING.toString(), interruptReason));
+        mockRuns.add(createMockRun(null, runName1, TestRunLifecycleStatus.FINISHED.toString(), null, null));
+        mockRuns.add(createMockRun(null, runName2, TestRunLifecycleStatus.FINISHED.toString(), null, null));
+        mockRuns.add(createMockRun(runIdToMarkFinished, runName3, TestRunLifecycleStatus.RUNNING.toString(), interruptReason, currentTime));
 
         MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
         MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
@@ -86,7 +99,57 @@ public class RunInterruptMonitorTest {
         Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
 
         MockISettings settings = new MockISettings();
-        RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings);
+        RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings, timeService);
+
+        // When...
+        runPodInterrupt.run();
+
+        // Then...
+        assertThat(kube.getTestPods(MockISettings.ENGINE_LABEL)).hasSize(3);
+        assertThat(mockPods).contains(cancelledPod);
+
+        // No events should have been added to the event queue yet
+        assertThat(eventQueue).isEmpty();
+    }
+
+    @Test
+    public void testPodForAnInterruptedRunIsDeletedOk() throws Exception {
+        // Given...
+        String runName1 = "run1";
+        String runName2 = "run2";
+        String runName3 = "run3";
+        String runIdToMarkFinished = "run3-id";
+        
+        Instant interruptedAt = Instant.EPOCH;
+        ITimeService timeService = new MockTimeService(Instant.now());
+
+        String interruptReason = "cancelled";
+
+        List<V1Pod> mockPods = new ArrayList<>();
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName1));
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName2));
+
+        String galasaServiceInstallName = "myGalasaService";
+        boolean isReady = true;
+        mockPods.addAll(mockKubeTestUtils.createEtcdAndRasPods(galasaServiceInstallName, isReady));
+
+        V1Pod cancelledPod = mockKubeTestUtils.createMockTestPod(runName3);
+        mockPods.add(cancelledPod);
+
+        // Create runs associated with the pods
+        List<IRun> mockRuns = new ArrayList<>();
+        mockRuns.add(createMockRun(null, runName1, TestRunLifecycleStatus.FINISHED.toString(), null, null));
+        mockRuns.add(createMockRun(null, runName2, TestRunLifecycleStatus.FINISHED.toString(), null, null));
+        mockRuns.add(createMockRun(runIdToMarkFinished, runName3, TestRunLifecycleStatus.RUNNING.toString(), interruptReason, interruptedAt));
+
+        MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
+
+        KubernetesEngineFacade kube = new KubernetesEngineFacade(mockApiClient, "myNamespace", galasaServiceInstallName);
+        Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
+
+        MockISettings settings = new MockISettings();
+        RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings, timeService);
 
         // When...
         runPodInterrupt.run();
@@ -101,6 +164,69 @@ public class RunInterruptMonitorTest {
         RunInterruptEvent interruptEvent = eventQueue.peek();
         assertThat(interruptEvent.getRunName()).isEqualTo(runName3);
         assertThat(interruptEvent.getInterruptReason()).isEqualTo(interruptReason);
+        assertThat(interruptEvent.getInterruptedAt()).isEqualTo(interruptedAt);
+
+        List<RunRasAction> rasActions = interruptEvent.getRasActions();
+        assertThat(rasActions).hasSize(1);
+        assertThat(rasActions.get(0).getRunId()).isEqualTo(runIdToMarkFinished);
+
+        // No runs should have been deleted, only their pods
+        assertThat(mockFrameworkRuns.getAllRuns()).hasSize(3);
+    }
+
+    @Test
+    public void testPodForAnInterruptedRunWithNoInterruptedAtIsDeletedOk() throws Exception {
+        // Given...
+        String runName1 = "run1";
+        String runName2 = "run2";
+        String runName3 = "run3";
+        String runIdToMarkFinished = "run3-id";
+
+        ITimeService timeService = new MockTimeService(Instant.now());
+
+        Instant interruptedAt = null;
+        String interruptReason = "cancelled";
+
+        List<V1Pod> mockPods = new ArrayList<>();
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName1));
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName2));
+
+        String galasaServiceInstallName = "myGalasaService";
+        boolean isReady = true;
+        mockPods.addAll(mockKubeTestUtils.createEtcdAndRasPods(galasaServiceInstallName, isReady));
+
+        V1Pod cancelledPod = mockKubeTestUtils.createMockTestPod(runName3);
+        mockPods.add(cancelledPod);
+
+        // Create runs associated with the pods
+        List<IRun> mockRuns = new ArrayList<>();
+        mockRuns.add(createMockRun(null, runName1, TestRunLifecycleStatus.FINISHED.toString(), null, null));
+        mockRuns.add(createMockRun(null, runName2, TestRunLifecycleStatus.FINISHED.toString(), null, null));
+        mockRuns.add(createMockRun(runIdToMarkFinished, runName3, TestRunLifecycleStatus.RUNNING.toString(), interruptReason, interruptedAt));
+
+        MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
+
+        KubernetesEngineFacade kube = new KubernetesEngineFacade(mockApiClient, "myNamespace", galasaServiceInstallName);
+        Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
+
+        MockISettings settings = new MockISettings();
+        RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings, timeService);
+
+        // When...
+        runPodInterrupt.run();
+
+        // Then...
+        assertThat(kube.getTestPods(MockISettings.ENGINE_LABEL)).hasSize(2);
+        assertThat(mockPods).doesNotContain(cancelledPod);
+
+        // One event should have been added
+        assertThat(eventQueue).hasSize(1);
+
+        RunInterruptEvent interruptEvent = eventQueue.peek();
+        assertThat(interruptEvent.getRunName()).isEqualTo(runName3);
+        assertThat(interruptEvent.getInterruptReason()).isEqualTo(interruptReason);
+        assertThat(interruptEvent.getInterruptedAt()).isEqualTo(interruptedAt);
 
         List<RunRasAction> rasActions = interruptEvent.getRasActions();
         assertThat(rasActions).hasSize(1);
@@ -119,7 +245,10 @@ public class RunInterruptMonitorTest {
         String runName1 = "run1";
         String runName2 = "run2";
 
+        Instant interruptedAt = Instant.EPOCH;
         String interruptReason = "cancelled";
+
+        ITimeService timeService = new MockTimeService(Instant.now());
 
         List<V1Pod> mockPods = new ArrayList<>();
         V1Pod cancelledPod1 = mockKubeTestUtils.createMockTestPod(runName1);
@@ -134,8 +263,8 @@ public class RunInterruptMonitorTest {
 
         // Create runs associated with the pods
         List<IRun> mockRuns = new ArrayList<>();
-        mockRuns.add(createMockRun(runIdToMarkFinished1, runName1, TestRunLifecycleStatus.STARTED.toString(), interruptReason));
-        mockRuns.add(createMockRun(runIdToMarkFinished2, runName2, TestRunLifecycleStatus.RUNNING.toString(), interruptReason));
+        mockRuns.add(createMockRun(runIdToMarkFinished1, runName1, TestRunLifecycleStatus.STARTED.toString(), interruptReason, interruptedAt));
+        mockRuns.add(createMockRun(runIdToMarkFinished2, runName2, TestRunLifecycleStatus.RUNNING.toString(), interruptReason, interruptedAt));
 
         MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
         MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
@@ -144,7 +273,7 @@ public class RunInterruptMonitorTest {
         Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
 
         MockISettings settings = new MockISettings();
-        RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings);
+        RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings, timeService);
 
         // When...
         runPodInterrupt.run();
@@ -176,6 +305,8 @@ public class RunInterruptMonitorTest {
     @Test
     public void testPodWithNoRunNameShouldNotBeDeleted() throws Exception {
         // Given...
+        ITimeService timeService = new MockTimeService(Instant.now());
+
         // Simulate a situation where the current kubernetes namespace has a pod that may
         // not be a Galasa-related pod, so it doesn't have a "galasa-run" label with a run name.
         List<V1Pod> mockPods = new ArrayList<>();
@@ -195,7 +326,7 @@ public class RunInterruptMonitorTest {
         Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
 
         MockISettings settings = new MockISettings();
-        RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings);
+        RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings, timeService);
 
         // When...
         runPodInterrupt.run();
@@ -216,6 +347,9 @@ public class RunInterruptMonitorTest {
 
         String interruptReason = "cancelled";
 
+        Instant interruptedAt = Instant.EPOCH;
+        ITimeService timeService = new MockTimeService(Instant.now());
+
         List<V1Pod> mockPods = new ArrayList<>();
         mockPods.add(mockKubeTestUtils.createMockTestPod(runName1));
         mockPods.add(mockKubeTestUtils.createMockTestPod(runName2));
@@ -231,9 +365,9 @@ public class RunInterruptMonitorTest {
 
         // Create runs associated with the pods
         List<IRun> mockRuns = new ArrayList<>();
-        mockRuns.add(createMockRun(null, runName1, TestRunLifecycleStatus.FINISHED.toString(), null));
-        mockRuns.add(createMockRun(null, runName2, TestRunLifecycleStatus.FINISHED.toString(), null));
-        mockRuns.add(createMockRun(runIdToMarkFinished, runName3, TestRunLifecycleStatus.RUNNING.toString(), interruptReason));
+        mockRuns.add(createMockRun(null, runName1, TestRunLifecycleStatus.FINISHED.toString(), null, null));
+        mockRuns.add(createMockRun(null, runName2, TestRunLifecycleStatus.FINISHED.toString(), null, null));
+        mockRuns.add(createMockRun(runIdToMarkFinished, runName3, TestRunLifecycleStatus.RUNNING.toString(), interruptReason, interruptedAt));
 
         MockKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
         MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(mockRuns);
@@ -242,7 +376,7 @@ public class RunInterruptMonitorTest {
         Queue<RunInterruptEvent> eventQueue = new LinkedBlockingQueue<>();
 
         MockISettings settings = new MockISettings();
-        RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings);
+        RunInterruptMonitor runPodInterrupt = new RunInterruptMonitor(kube, mockFrameworkRuns, eventQueue, settings, timeService);
 
         // Make sure that all 3 test pods exist before processing
         assertThat(kube.getTestPods(MockISettings.ENGINE_LABEL)).hasSize(3);

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
@@ -119,4 +119,33 @@ public class SettingsTest {
 
         assertThat(gotBack).isEqualTo(Settings.MAX_TEST_POD_RETRY_LIMIT_DEFAULT);
     }
+
+
+    @Test
+    public void testCanReadNonDefaultTestPodInterruptTimeoutSecsIfPresentInConfigMap() throws Exception {
+        K8sController controller = new K8sController();
+        KubernetesEngineFacade kube = null;
+        Settings settings = new Settings(controller, kube, "myPod", "myConfigMapName");
+        Map<String,String> configMap = new HashMap<String,String>();
+        configMap.put(Settings.TEST_POD_INTERRUPT_TIMEOUT_SECS_PROPERTY_NAME, "50");
+        settings.updateConfigMapProperties(configMap);
+
+        long gotBack = settings.getTestPodInterruptTimeoutSecs();
+
+        assertThat(gotBack).isEqualTo(50);
+    }
+
+    @Test
+    public void testUsesDefaultTestPodInterruptTimeoutSecsIfMissingFromConfigMap() throws Exception {
+        K8sController controller = new K8sController();
+        KubernetesEngineFacade kube = null;
+        Settings settings = new Settings(controller, kube, "myPod", "myConfigMapName");
+        Map<String,String> configMap = new HashMap<String,String>();
+
+        settings.updateConfigMapProperties(configMap);
+
+        long gotBack = settings.getTestPodInterruptTimeoutSecs();
+
+        assertThat(gotBack).isEqualTo(300);
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
@@ -122,21 +122,21 @@ public class SettingsTest {
 
 
     @Test
-    public void testCanReadNonDefaultTestPodInterruptTimeoutSecsIfPresentInConfigMap() throws Exception {
+    public void testCanReadNonDefaultInterruptedTestRunCleanupGracePeriodSecsIfPresentInConfigMap() throws Exception {
         K8sController controller = new K8sController();
         KubernetesEngineFacade kube = null;
         Settings settings = new Settings(controller, kube, "myPod", "myConfigMapName");
         Map<String,String> configMap = new HashMap<String,String>();
-        configMap.put(Settings.TEST_POD_INTERRUPT_TIMEOUT_SECS_PROPERTY_NAME, "50");
+        configMap.put(Settings.INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_PROPERTY_NAME, "50");
         settings.updateConfigMapProperties(configMap);
 
-        long gotBack = settings.getTestPodInterruptTimeoutSecs();
+        long gotBack = settings.getInterruptedTestRunCleanupGracePeriodSeconds();
 
         assertThat(gotBack).isEqualTo(50);
     }
 
     @Test
-    public void testUsesDefaultTestPodInterruptTimeoutSecsIfMissingFromConfigMap() throws Exception {
+    public void testUsesDefaultInterruptedTestRunCleanupGracePeriodSecsIfMissingFromConfigMap() throws Exception {
         K8sController controller = new K8sController();
         KubernetesEngineFacade kube = null;
         Settings settings = new Settings(controller, kube, "myPod", "myConfigMapName");
@@ -144,7 +144,7 @@ public class SettingsTest {
 
         settings.updateConfigMapProperties(configMap);
 
-        long gotBack = settings.getTestPodInterruptTimeoutSecs();
+        long gotBack = settings.getInterruptedTestRunCleanupGracePeriodSeconds();
 
         assertThat(gotBack).isEqualTo(300);
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockISettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockISettings.java
@@ -7,7 +7,7 @@ import dev.galasa.framework.k8s.controller.ISettings;
 public class MockISettings implements ISettings {
 
     public int maxTestPodRetriesLimit = 2;
-    public int testPodInterruptTimeoutSecs = 10;
+    public int interruptedTestRunCleanupGracePeriodSecs = 10;
     public static final String ENGINE_LABEL = "myEngineLabel";
 
     @Override
@@ -96,8 +96,8 @@ public class MockISettings implements ISettings {
     }
 
     @Override
-    public long getTestPodInterruptTimeoutSecs() {
-        return testPodInterruptTimeoutSecs;
+    public long getInterruptedTestRunCleanupGracePeriodSeconds() {
+        return interruptedTestRunCleanupGracePeriodSecs;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockISettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockISettings.java
@@ -7,6 +7,7 @@ import dev.galasa.framework.k8s.controller.ISettings;
 public class MockISettings implements ISettings {
 
     public int maxTestPodRetriesLimit = 2;
+    public int testPodInterruptTimeoutSecs = 10;
     public static final String ENGINE_LABEL = "myEngineLabel";
 
     @Override
@@ -94,10 +95,13 @@ public class MockISettings implements ISettings {
         return maxTestPodRetriesLimit;
     }
 
-        @Override
+    @Override
+    public long getTestPodInterruptTimeoutSecs() {
+        return testPodInterruptTimeoutSecs;
+    }
+
+    @Override
     public List<String> getRequestorsByGroup() {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getRequestorsByGroup'");
     }
-    
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -63,12 +63,17 @@ public class FrameworkRuns implements IFrameworkRuns {
 
     private final String                             RUN_PREFIX   = "run.";
 
-    private ITimeService timeService = new SystemTimeService();
+    private ITimeService timeService;
 
     private final GalasaGson gson = new GalasaGson();
 
     public FrameworkRuns(IFramework framework) throws FrameworkException {
+        this(framework, new SystemTimeService());
+    }
+
+    public FrameworkRuns(IFramework framework, ITimeService timeService) throws FrameworkException {
         this.framework = framework;
+        this.timeService = timeService;
         this.dss = framework.getDynamicStatusStoreService("framework");
         this.cps = framework.getConfigurationPropertyService("framework");
         gson.setGsonBuilder(new GalasaGsonBuilder(false));
@@ -317,6 +322,7 @@ public class FrameworkRuns implements IFrameworkRuns {
             Set<String> keysToDelete = new HashSet<>();
             keysToDelete.add(getSuffixedRunDssKey(runName, "heartbeat"));
             keysToDelete.add(getSuffixedRunDssKey(runName, "interruptReason"));
+            keysToDelete.add(getSuffixedRunDssKey(runName, "interruptedAt"));
             this.dss.delete(keysToDelete);
 
             // Set the status of the run back to 'queued' and generate a new run ID
@@ -359,6 +365,7 @@ public class FrameworkRuns implements IFrameworkRuns {
             propertiesToSet.put(getSuffixedRunDssKey(runName, "rasActions"), encodedRasActions);
         }
 
+        propertiesToSet.put(getSuffixedRunDssKey(runName, "interruptedAt"), timeService.now().toString());
         propertiesToSet.put(getSuffixedRunDssKey(runName, "interruptReason"), interruptReason);
 
         this.dss.put(propertiesToSet);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
@@ -54,6 +54,7 @@ public class RunImpl implements IRun {
     private final boolean sharedEnvironment;
     private final String  rasRunId;
     private final String  interruptReason;
+    private final Instant interruptedAt;
     private List<RunRasAction> rasActions = new ArrayList<>();
     private final Set<String> tags;
 
@@ -91,6 +92,7 @@ public class RunImpl implements IRun {
         sharedEnvironment = Boolean.parseBoolean(runProperties.get(prefix + "shared.environment"));
         gherkin = runProperties.get(prefix + "gherkin");
         tags = getTagsFromDss(runProperties, prefix);
+        interruptedAt = getInterruptedAtTimeFromDss(runProperties, prefix);
 
         String encodedRasActions = runProperties.get(prefix + "rasActions");
         if (encodedRasActions != null) {
@@ -137,6 +139,15 @@ public class RunImpl implements IRun {
         }
 
         logger.info("RunImpl created: "+this.toString());
+    }
+
+    private Instant getInterruptedAtTimeFromDss(Map<String, String> runProperties, String prefix) {
+        Instant interruptedAt = null;
+        String interruptedAtStr = runProperties.get(prefix + "interruptedAt");
+        if (interruptedAtStr != null) {
+            interruptedAt = Instant.parse(interruptedAtStr);
+        }
+        return interruptedAt;
     }
 
     private Set<String> getTagsFromDss(Map<String, String> runProperties, String prefix) {
@@ -292,6 +303,11 @@ public class RunImpl implements IRun {
     @Override
     public String getInterruptReason() {
         return this.interruptReason;
+    }
+
+    @Override
+    public Instant getInterruptedAt() {
+        return this.interruptedAt;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
@@ -60,6 +60,8 @@ public interface IRun {
 
     String getInterruptReason();
 
+    Instant getInterruptedAt();
+
     String getRasRunId();
 
     List<RunRasAction> getRasActions();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
@@ -27,6 +27,7 @@ import dev.galasa.framework.mocks.MockCPSStore;
 import dev.galasa.framework.mocks.MockDSSStore;
 import dev.galasa.framework.mocks.MockFramework;
 import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.mocks.MockTimeService;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.Result;
@@ -825,7 +826,10 @@ public class FrameworkRunsTest {
         MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
         MockFramework mockFramework = new MockFramework(mockCps, mockDss);
 
-        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework, mockTimeService);
 
         String runName = "mytestrun1";
         String rasRunId = "my-run-document-id";
@@ -839,6 +843,7 @@ public class FrameworkRunsTest {
         // Then...
         assertThat(isRunMarkedCancelled).isTrue();
         assertThat(mockDss.get("run." + runName + ".interruptReason")).isEqualTo(Result.CANCELLED);
+        assertThat(mockDss.get("run." + runName + ".interruptedAt")).isEqualTo(currentTime.toString());
 
         // We expect the 'rasActions' property to be populated with a base64-encoded JSON structure
         List<RunRasAction> expectedRasActions = new ArrayList<>();
@@ -851,13 +856,16 @@ public class FrameworkRunsTest {
     }
 
     @Test
-    public void testCancelRunWithoutRunIdSetsInterruptReasonOnly() throws Exception {
+    public void testCancelRunWithoutRunIdSetsInterruptReasonAndTimeOnly() throws Exception {
         // Given...
         MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
         MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
         MockFramework mockFramework = new MockFramework(mockCps, mockDss);
 
-        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework, mockTimeService);
 
         String runName = "mytestrun1";
         String status = "allocated";
@@ -871,6 +879,7 @@ public class FrameworkRunsTest {
         // Then...
         assertThat(isRunMarkedCancelled).isTrue();
         assertThat(mockDss.get("run." + runName + ".interruptReason")).isEqualTo(Result.CANCELLED);
+        assertThat(mockDss.get("run." + runName + ".interruptedAt")).isEqualTo(currentTime.toString());
 
         // We expect the 'rasActions' property to be empty
         assertThat(mockDss.get("run." + runName + ".rasActions")).isNull();
@@ -936,7 +945,10 @@ public class FrameworkRunsTest {
         MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
         MockFramework mockFramework = new MockFramework(mockCps, mockDss);
 
-        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework, mockTimeService);
 
         String runName = "mytestrun1";
         String rasRunId = "my-run-document-id";
@@ -951,6 +963,7 @@ public class FrameworkRunsTest {
         // Mark the run as cancelled already
         mockDss.put("run." + runName + ".rasrunid", rasRunId);
         mockDss.put("run." + runName + ".interruptReason", Result.CANCELLED);
+        mockDss.put("run." + runName + ".interruptedAt", currentTime.toString());
         mockDss.put("run." + runName + ".rasActions", encodedRasActionStr);
 
         // When...
@@ -992,13 +1005,16 @@ public class FrameworkRunsTest {
     }
 
     @Test
-    public void testmarkRunInterruptedSetsInterruptReasonAndRasActionOk() throws Exception {
+    public void testMarkRunInterruptedSetsInterruptPropertiesAndRasActionOk() throws Exception {
         // Given...
         MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
         MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
         MockFramework mockFramework = new MockFramework(mockCps, mockDss);
 
-        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework, mockTimeService);
 
         String runName = "mytestrun1";
         String rasRunId = "my-run-document-id";
@@ -1012,6 +1028,7 @@ public class FrameworkRunsTest {
         // Then...
         assertThat(isRunMarkedRequeued).isTrue();
         assertThat(mockDss.get("run." + runName + ".interruptReason")).isEqualTo(Result.REQUEUED);
+        assertThat(mockDss.get("run." + runName + ".interruptedAt")).isEqualTo(currentTime.toString());
 
         // We expect the 'rasActions' property to be populated with a base64-encoded JSON structure
         List<RunRasAction> expectedRasActions = new ArrayList<>();
@@ -1030,7 +1047,10 @@ public class FrameworkRunsTest {
         MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
         MockFramework mockFramework = new MockFramework(mockCps, mockDss);
 
-        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework, mockTimeService);
 
         String runName = "mytestrun1";
         String rasRunId = "my-run-document-id";
@@ -1124,13 +1144,17 @@ public class FrameworkRunsTest {
         MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
         MockFramework mockFramework = new MockFramework(mockCps, mockDss);
 
-        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+        Instant currentTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework, mockTimeService);
 
         String runName = "mytestrun1";
         String rasRunId = "my-run-document-id";
 
         mockDss.put("run." + runName + ".rasrunid", rasRunId);
         mockDss.put("run." + runName + ".interruptReason", Result.REQUEUED);
+        mockDss.put("run." + runName + ".interruptedAt", currentTime.toString());
         mockDss.put("run." + runName + ".heartbeat", Instant.now().toString());
 
         // When...
@@ -1139,6 +1163,7 @@ public class FrameworkRunsTest {
         // Then...
         assertThat(isRunReset).isTrue();
         assertThat(mockDss.get("run." + runName + ".interruptReason")).isNull();
+        assertThat(mockDss.get("run." + runName + ".interruptedAt")).isNull();
         assertThat(mockDss.get("run." + runName + ".heartbeat")).isNull();
         assertThat(mockDss.get("run." + runName + ".status")).isEqualTo(TestRunLifecycleStatus.QUEUED.toString());
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
@@ -155,4 +155,9 @@ public class MockRun implements IRun {
     public TestStructure toTestStructure() {
         throw new UnsupportedOperationException("Unimplemented method 'toTestStructure'");
     }
+
+    @Override
+    public Instant getInterruptedAt() {
+        throw new UnsupportedOperationException("Unimplemented method 'getInterruptedAt'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
@@ -32,6 +32,7 @@ public class MockRun implements IRun {
     private String submissionId;
     private String status;
     private String interruptReason;
+    private Instant interruptedAt;
     private String result;
     private String runId;
     private List<RunRasAction> rasActions = new ArrayList<>();
@@ -173,6 +174,15 @@ public class MockRun implements IRun {
     }
 
     @Override
+    public Instant getInterruptedAt() {
+        return this.interruptedAt;
+    }
+
+    public void setInterruptedAt(Instant interruptedAt) {
+        this.interruptedAt = interruptedAt;
+    }
+
+    @Override
     public String getResult() {
         return this.result;
     }
@@ -249,5 +259,4 @@ public class MockRun implements IRun {
     public Run getSerializedRun() {
         throw new UnsupportedOperationException("Unimplemented method 'getSerializedRun'");
     }
-
 }


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2317

## Changes
- Added a grace period via the loaded ConfigMap from the Helm chart to make the engine controller wait before deleting the test run's pod and updating the test run's DSS properties and RAS record, giving the test run time to notice that it's been interrupted and allowing it to update its own DSS properties and RAS record after cleaning up
  - The grace period is set via a Helm chart value, which defaults to 5 minutes (in seconds)
- Added an `interruptedAt` DSS property to runs denoting the time at which the run was interrupted