### PR TITLE
Making sure the the @AfterClass methods are executed even if a test method throws an exception

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -306,7 +306,7 @@ public class TestRunner extends BaseTestRunner {
             TestStructure testStructure) throws TestRunException {
         TestClassWrapper testClassWrapper;
         try {
-            testClassWrapper = new TestClassWrapper(this, testBundleName, testClass, testStructure);
+            testClassWrapper = new TestClassWrapper(testBundleName, testClass, testStructure, this.getContinueOnTestFailureFromCPS(), this.getFramework());
         } catch (Exception e) {
             String msg = "Problem with the CPS when adding a wrapper";
             logger.error(msg + " " + e.getMessage());

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/teststructure/TestStructure.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/teststructure/TestStructure.java
@@ -202,9 +202,12 @@ public class TestStructure {
         sb.append(" status=");
         sb.append(actualStatus);
 
-        String methodPrefix = prefix + "    ";
-        for (TestMethod method : this.methods) {
-            method.report(methodPrefix, sb);
+        // Don't report any method data if there are no methods.
+        if (this.methods != null) {
+            String methodPrefix = prefix + "    ";
+            for (TestMethod method : this.methods) {
+                method.report(methodPrefix, sb);
+            }
         }
 
         return sb.toString();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestMethodWrapperTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestMethodWrapperTest.java
@@ -83,7 +83,6 @@ public class TestMethodWrapperTest {
     }
 
     private TestClassWrapper createTestClassWrapper() throws Exception {
-        TestRunner testRunner = new TestRunner();
 
         IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
         MockIDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
@@ -98,12 +97,10 @@ public class TestMethodWrapperTest {
 
         mockDataProvider.setFramework(mockFramework);
 
-        testRunner.init(mockDataProvider);
-
         TestStructure testStructure = new TestStructure();
 
         String testBundle = "my/testbundle";
-        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClass.class, testStructure);
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testBundle, MockTestClass.class, testStructure, true , mockFramework);
         return testClassWrapper;
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestClassWrapper.java
@@ -7,14 +7,22 @@ package dev.galasa.framework;
 
 import static org.assertj.core.api.Assertions.*;
 
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.logging.Log;
 import org.junit.Test;
 
 import dev.galasa.ContinueOnTestFailure;
+import dev.galasa.framework.mocks.MockFramework;
 import dev.galasa.framework.mocks.MockIConfigurationPropertyStoreService;
 import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
+import dev.galasa.framework.mocks.MockLog;
 import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.mocks.MockTestRunManagers;
 import dev.galasa.framework.mocks.MockTestRunnerDataProvider;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 
@@ -52,7 +60,8 @@ public class TestTestClassWrapper {
     @Test
     public void testClassAnnotatedWithContinueOnTestFailureReturnsTrue() throws Exception {
         // Given...
-        TestRunner testRunner = new TestRunner();
+        boolean isContinueOnTestFailureFromCPS = true ;
+        Framework mockFramework = new MockFramework();
 
         IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
         MockIDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
@@ -62,12 +71,10 @@ public class TestTestClassWrapper {
         mockDataProvider.setDss(dss);
         mockDataProvider.setRun(createMockRun(MockTestClassWithContinueOnTestFailure.class));
 
-        testRunner.init(mockDataProvider);
-
         TestStructure testStructure = new TestStructure();
 
         String testBundle = "my/testbundle";
-        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClassWithContinueOnTestFailure.class, testStructure);
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testBundle, MockTestClassWithContinueOnTestFailure.class, testStructure, isContinueOnTestFailureFromCPS, mockFramework);
 
         // When...
         boolean isContinueOnTestFailure = testClassWrapper.isContinueOnTestFailureSet();
@@ -79,7 +86,8 @@ public class TestTestClassWrapper {
     @Test
     public void testClassWithoutContinueOnTestFailureReturnsFalse() throws Exception {
         // Given...
-        TestRunner testRunner = new TestRunner();
+        boolean isContinueOnTestFailureFromCPS = false ;
+        Framework mockFramework = new MockFramework();
 
         IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
         MockIDynamicStatusStoreService dss = new MockIDynamicStatusStoreService();
@@ -89,12 +97,10 @@ public class TestTestClassWrapper {
         mockDataProvider.setDss(dss);
         mockDataProvider.setRun(createMockRun(MockTestClassWithoutContinueOnTestFailure.class));
 
-        testRunner.init(mockDataProvider);
-
         TestStructure testStructure = new TestStructure();
 
         String testBundle = "my/testbundle";
-        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClassWithoutContinueOnTestFailure.class, testStructure);
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testBundle, MockTestClassWithoutContinueOnTestFailure.class, testStructure, isContinueOnTestFailureFromCPS, mockFramework);
 
         // When...
         boolean isContinueOnTestFailure = testClassWrapper.isContinueOnTestFailureSet();
@@ -106,7 +112,8 @@ public class TestTestClassWrapper {
     @Test
     public void testClassWithCPSContinueOnTestFailureReturnsTrue() throws Exception {
         // Given...
-        TestRunner testRunner = new TestRunner();
+        boolean isContinueOnTestFailureFromCPS = true ;
+        Framework mockFramework = new MockFramework();
 
         IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
         cps.setProperty("continue.on.test.failure", "true");
@@ -118,12 +125,10 @@ public class TestTestClassWrapper {
         mockDataProvider.setDss(dss);
         mockDataProvider.setRun(createMockRun(MockTestClassWithoutContinueOnTestFailure.class));
 
-        testRunner.init(mockDataProvider);
-
         TestStructure testStructure = new TestStructure();
 
         String testBundle = "my/testbundle";
-        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClassWithoutContinueOnTestFailure.class, testStructure);
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testBundle, MockTestClassWithoutContinueOnTestFailure.class, testStructure, isContinueOnTestFailureFromCPS, mockFramework );
 
         // When...
         boolean isContinueOnTestFailure = testClassWrapper.isContinueOnTestFailureSet();
@@ -135,7 +140,8 @@ public class TestTestClassWrapper {
     @Test
     public void testClassWithCPSContinueOnTestFailureSetToFalseReturnsFalse() throws Exception {
         // Given...
-        TestRunner testRunner = new TestRunner();
+        boolean isContinueOnTestFailureFromCPS = false ;
+        Framework mockFramework = new MockFramework();
 
         IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
         cps.setProperty("continue.on.test.failure", "false");
@@ -147,12 +153,11 @@ public class TestTestClassWrapper {
         mockDataProvider.setDss(dss);
         mockDataProvider.setRun(createMockRun(MockTestClassWithoutContinueOnTestFailure.class));
 
-        testRunner.init(mockDataProvider);
 
         TestStructure testStructure = new TestStructure();
 
         String testBundle = "my/testbundle";
-        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClassWithoutContinueOnTestFailure.class, testStructure);
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testBundle, MockTestClassWithoutContinueOnTestFailure.class, testStructure, isContinueOnTestFailureFromCPS, mockFramework);
 
         // When...
         boolean isContinueOnTestFailure = testClassWrapper.isContinueOnTestFailureSet();
@@ -164,7 +169,8 @@ public class TestTestClassWrapper {
     @Test
     public void testClassWithAnnotationAndCPSContinueOnTestFailureSetToFalseReturnsTrue() throws Exception {
         // Given...
-        TestRunner testRunner = new TestRunner();
+        boolean isContinueOnTestFailureFromCPS = true ;
+        Framework mockFramework = new MockFramework();
 
         IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
         cps.setProperty("continue.on.test.failure", "false");
@@ -176,17 +182,151 @@ public class TestTestClassWrapper {
         mockDataProvider.setDss(dss);
         mockDataProvider.setRun(createMockRun(MockTestClassWithoutContinueOnTestFailure.class));
 
-        testRunner.init(mockDataProvider);
-
         TestStructure testStructure = new TestStructure();
 
         String testBundle = "my/testbundle";
-        TestClassWrapper testClassWrapper = new TestClassWrapper(testRunner, testBundle, MockTestClassWithContinueOnTestFailure.class, testStructure);
+        TestClassWrapper testClassWrapper = new TestClassWrapper(testBundle, MockTestClassWithContinueOnTestFailure.class, testStructure, isContinueOnTestFailureFromCPS, mockFramework);
 
         // When...
         boolean isContinueOnTestFailure = testClassWrapper.isContinueOnTestFailureSet();
 
         // Then...
         assertThat(isContinueOnTestFailure).isTrue();
+    }
+
+
+    // We noticed on code inspection that if the test running fails with an exception, that the 
+    // @AfterClass method(s) will never get called.
+    // This test simulates a failure and checks that the @AfterCLass methods got called regardless.
+    // And that the original test failure exception still gets thrown.
+    @Test
+    public void testAfterClassTestMethodsGetCalledIfRunTestMethodThrowsException() throws Exception {
+
+
+        String fakeExceptionMessage = "My Fake exception message";
+
+        // Given...
+        class TestClassWrapperWhichThrowsExceptionInRunTestMethod extends TestClassWrapper{
+
+            public boolean isAfterMethodAlreadyCalled = false ;
+
+            public TestClassWrapperWhichThrowsExceptionInRunTestMethod(String testBundle,
+                    Class<?> testClass, TestStructure testStructure, boolean isContinueOnTestFailureFromCPS, Framework framework) throws ConfigurationPropertyStoreException {
+                super(testBundle, testClass, testStructure, isContinueOnTestFailureFromCPS , framework );
+            }
+            
+            // runTestMethods should throw a fake exception so we can check that other methods get called despite the exception.
+            protected void runTestMethods(@NotNull ITestRunManagers managers, IDynamicStatusStoreService dss, String runName) throws TestRunException {
+                throw new TestRunException(fakeExceptionMessage);
+            }
+
+            protected void runBeforeClassMethods( @NotNull ITestRunManagers managers ) throws TestRunException {
+                // Do nothing.
+            }
+
+            protected void runAfterClassMethods( @NotNull ITestRunManagers managers ) throws TestRunException {
+                isAfterMethodAlreadyCalled = true;
+            }
+
+        };
+
+        String testBundle = null;
+
+        class FakeTest {
+        }
+
+        Class<?> testClass = new FakeTest().getClass();
+        TestStructure testStructure = new TestStructure();
+        boolean isContinueOnTestFailureFromCPS = true ;
+        Framework mockFramework = new MockFramework();
+
+        TestClassWrapperWhichThrowsExceptionInRunTestMethod wrapper = new TestClassWrapperWhichThrowsExceptionInRunTestMethod(
+            testBundle, testClass, testStructure, isContinueOnTestFailureFromCPS , mockFramework );
+
+        ITestRunManagers managers = new MockTestRunManagers(isContinueOnTestFailureFromCPS, null);
+
+        IDynamicStatusStoreService dss = null;
+        String runName = null;
+
+        // When...
+        TestRunException exGotBack = catchThrowableOfType( () -> wrapper.runMethods( managers, dss, runName), TestRunException.class );
+
+
+        // Then...
+        assertThat(exGotBack).hasMessage(fakeExceptionMessage);
+        assertThat(wrapper.isAfterMethodAlreadyCalled)
+            .as("The AfterClass method of the test class was not called. When the methods fail with an exception")
+            .isTrue();
+        
+    }
+
+
+    // We noticed on code inspection that if the test running fails with an exception, that the 
+    // Managers are never told that the test has failed.
+    // This test simulates a failure and checks that the managers get told about the failure regardless.
+    // And that the original test failure exception still gets thrown.
+    @Test
+    public void testManagersToldAboutTestMethodFailure() throws Exception {
+
+        String fakeExceptionMessage = "My Fake exception message";
+
+        // Given...
+        class TestClassWrapperWhichThrowsExceptionInRunTestMethod extends TestClassWrapper{
+
+            public boolean isAfterMethodAlreadyCalled = false ;
+
+            public TestClassWrapperWhichThrowsExceptionInRunTestMethod(String testBundle,
+                    Class<?> testClass, TestStructure testStructure, boolean isContinueOnTestFailureFromCPS, Framework framework, Log logger) throws ConfigurationPropertyStoreException {
+                super(testBundle, testClass, testStructure, isContinueOnTestFailureFromCPS , framework, logger );
+            }
+            
+            // runTestMethods should throw a fake exception so we can check that other methods get called despite the exception.
+            protected void runTestMethods(@NotNull ITestRunManagers managers, IDynamicStatusStoreService dss, String runName) throws TestRunException {
+                throw new TestRunException(fakeExceptionMessage);
+            }
+
+            protected void runBeforeClassMethods( @NotNull ITestRunManagers managers ) throws TestRunException {
+                // Do nothing.
+            }
+
+            protected void runAfterClassMethods( @NotNull ITestRunManagers managers ) throws TestRunException {
+                // Do nothing.
+            }
+
+        };
+
+        String testBundle = null;
+
+        class FakeTestClass {
+        }
+
+        Class<?> testClass = new FakeTestClass().getClass();
+        TestStructure testStructure = new TestStructure();
+        boolean isContinueOnTestFailureFromCPS = true ;
+        Framework mockFramework = new MockFramework();
+
+
+        MockLog logger = new MockLog();
+        
+        TestClassWrapperWhichThrowsExceptionInRunTestMethod wrapper = new TestClassWrapperWhichThrowsExceptionInRunTestMethod(
+            testBundle, testClass, testStructure, isContinueOnTestFailureFromCPS , mockFramework , (Log)logger);
+
+        MockTestRunManagers managers = new MockTestRunManagers(isContinueOnTestFailureFromCPS, null);
+
+        IDynamicStatusStoreService dss = null;
+        String runName = null;
+
+        // When...
+        TestRunException exGotBack = catchThrowableOfType( ()-> wrapper.runMethods( managers, dss, runName), TestRunException.class );
+
+
+        // Then...
+        assertThat(exGotBack).hasMessage(fakeExceptionMessage);
+        assertThat(managers.calledCountEndOfTestClass)
+            .as("The managers were not told to end the test if a test method throws an exception!")
+            .isEqualTo(1);
+
+        assertThat(logger.contains("Finishing Test Class structure:-")).isTrue();
+        
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/runner/TestTagHarvester.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/runner/TestTagHarvester.java
@@ -7,8 +7,6 @@ package dev.galasa.framework.internal.runner;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/teststructure/TestTestStructure.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/teststructure/TestTestStructure.java
@@ -62,4 +62,11 @@ public class TestTestStructure {
         t.removeTag("tag1");
         assertThat(t.getTags()).containsExactlyInAnyOrder("tag2");
     }
+
+    @Test
+    public void testCanReportEvenWhenThereAreNoMethods() throws Exception {
+        TestStructure t = getPopulatedTestStructure();
+        t.setMethods(null);
+        t.report("***");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockLog.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockLog.java
@@ -170,7 +170,8 @@ public class MockLog implements Log {
     public boolean contains(String containsSubString) {
         boolean contains = false ;
         for (MockLogRecord record : lines) {
-            contains = record.getContent().contains(containsSubString);
+            String content = record.getContent();
+            contains = content.contains(containsSubString);
             if (contains) {
                 break;
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockTestRunManagers.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockTestRunManagers.java
@@ -30,6 +30,7 @@ public class MockTestRunManagers implements ITestRunManagers {
     public int calledCountEndOfTestClass = 0 ;
     public int calledCountTestClassResult = 0 ;
     public int calledCountAnyReasonTestMethodShouldBeIgnored = 0 ;
+    public int calledCountEndOfTestMethod = 0 ;
 
     private Result resultToReturn;
     private Result testMethodResultToReturn;
@@ -118,6 +119,7 @@ public class MockTestRunManagers implements ITestRunManagers {
     @Override
     public Result endOfTestMethod(@NotNull GalasaMethod galasaMethod, @NotNull Result currentResult,
             Throwable currentException) throws FrameworkException {
+        calledCountEndOfTestMethod +=1;
         return this.testMethodResultToReturn;
     }
 


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?

- Noticed by code inspection that a test which throws an exception when running the test supresses any calls to the @AfterClass
- Also, that it supresses any calls to tell the managers that the test has finished.
- Re-factored the testClassWrapper to make it easier to unit test
