### PR TITLE
Fix bug where structure.json was not being updated for all `Before`/`After` methods

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
@@ -44,12 +44,17 @@ public class GenericMethodWrapper {
     private Type       type;
     private Result     result;
 
-    private TestMethod testStructureMethod;
+    private TestMethod genericMethodStructure;
 
     public GenericMethodWrapper(Method executionMethod, Class<?> testClass, Type type) {
         this.executionMethod = executionMethod;
         this.testClass = testClass;
         this.type = type;
+    }
+
+    public GenericMethodWrapper createCopyGenericMethodWrapper() {
+        GenericMethodWrapper genericMethodWrapper = new GenericMethodWrapper(this.executionMethod, this.testClass, this.type);
+        return genericMethodWrapper;
     }
 
     /**
@@ -79,8 +84,8 @@ public class GenericMethodWrapper {
                     + TestClassWrapper.LOG_START_LINE + "*** Start of test method " + testClass.getName() + "#"
                     + executionMethod.getName() + methodType + TestClassWrapper.LOG_START_LINE
                     + TestClassWrapper.LOG_ASTERS);
-            testStructureMethod.setStartTime(Instant.now());
-            testStructureMethod.setStatus("started");
+            this.genericMethodStructure.setStartTime(Instant.now());
+            this.genericMethodStructure.setStatus("started");
 
             try {
                 this.executionMethod.invoke(testClassObject);
@@ -96,16 +101,16 @@ public class GenericMethodWrapper {
                 this.result = overrideResult;
             }
 
-            this.testStructureMethod.setResult(this.result.getName());
+            this.genericMethodStructure.setResult(this.result.getName());
             if (this.result.getThrowable() != null) {
                 Throwable t = this.getResult().getThrowable();
                 try {
                     StringWriter sw = new StringWriter();
                     PrintWriter pw = new PrintWriter(sw);
                     t.printStackTrace(pw);
-                    this.testStructureMethod.setException(sw.toString());
+                    this.genericMethodStructure.setException(sw.toString());
                 } catch (Exception e) {
-                    this.testStructureMethod.setException("Unable to report exception because of " + e.getMessage());
+                    this.genericMethodStructure.setException("Unable to report exception because of " + e.getMessage());
                 }
             }
 
@@ -120,8 +125,8 @@ public class GenericMethodWrapper {
                         + TestClassWrapper.LOG_ASTERS);
             } else {
                 String exception = "";
-                if (this.testStructureMethod.getException() != null) {
-                    exception = "\n" + this.testStructureMethod.getException();
+                if (this.genericMethodStructure.getException() != null) {
+                    exception = "\n" + this.genericMethodStructure.getException();
                 }
                 logger.error(TestClassWrapper.LOG_ENDING + TestClassWrapper.LOG_START_LINE + TestClassWrapper.LOG_ASTERS
                         + TestClassWrapper.LOG_START_LINE + "*** " + this.result.getName() + " - Test method "
@@ -129,8 +134,8 @@ public class GenericMethodWrapper {
                         + TestClassWrapper.LOG_START_LINE + TestClassWrapper.LOG_ASTERS + exception);
             }
 
-            testStructureMethod.setEndTime(Instant.now());
-            testStructureMethod.setStatus("finished");
+            this.genericMethodStructure.setEndTime(Instant.now());
+            this.genericMethodStructure.setStatus("finished");
         } catch (FrameworkException e) {
             throw new TestRunException("There was a problem with the framework, please check stacktrace", e);
         }
@@ -150,6 +155,16 @@ public class GenericMethodWrapper {
         return;
     }
 
+    public void initialiseGenericMethodStructure() {
+        this.genericMethodStructure = new TestMethod(testClass);
+        this.genericMethodStructure.setMethodName(executionMethod.getName());
+        this.genericMethodStructure.setType(this.type.toString());
+    }
+
+    public TestMethod getGenericMethodStructure() {
+        return this.genericMethodStructure;
+    }
+
     public boolean fullStop() {
         return this.result.isFailed();
     }
@@ -161,25 +176,17 @@ public class GenericMethodWrapper {
     public void setResult(Result result) {
         this.result = result;
 
-        if (this.testStructureMethod != null) {
-            this.testStructureMethod.setResult(result.getName());
+        if (this.genericMethodStructure != null) {
+            this.genericMethodStructure.setResult(result.getName());
         }
     }
 
     public void setRunLogStart(long runLogStart) {
-        this.testStructureMethod.setRunLogStart(runLogStart);
+        this.genericMethodStructure.setRunLogStart(runLogStart);
     }
 
     public void setRunLogEnd(long runLogEnd) {
-        this.testStructureMethod.setRunLogEnd(runLogEnd);
-    }
-
-    public TestMethod getStructure() {
-        this.testStructureMethod = new TestMethod(testClass);
-        this.testStructureMethod.setMethodName(executionMethod.getName());
-        this.testStructureMethod.setType(this.type.toString());
-
-        return this.testStructureMethod;
+        this.genericMethodStructure.setRunLogEnd(runLogEnd);
     }
     
     public String getName() {
@@ -192,9 +199,5 @@ public class GenericMethodWrapper {
 
     public Method getExecutionMethod() {
         return executionMethod;
-    }
-
-    public TestMethod getTestStructureMethod() {
-        return testStructureMethod;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -125,8 +125,19 @@ public class TestClassWrapper {
 
         // *** Build the wrappers for the test methods
         for (Method method : temporaryTestMethods) {
-            this.testMethods
-            .add(new TestMethodWrapper(method, this.testClass, temporaryBeforeMethods, temporaryAfterMethods));
+
+            ArrayList<GenericMethodWrapper> beforesForThisTestMethod = new ArrayList<>();
+            for (GenericMethodWrapper before : temporaryBeforeMethods) {
+                beforesForThisTestMethod.add(before.createCopyGenericMethodWrapper());
+            }
+
+            ArrayList<GenericMethodWrapper> afterMethodsForThisTestMethod = new ArrayList<>();
+            for (GenericMethodWrapper after : temporaryAfterMethods) {
+                afterMethodsForThisTestMethod.add(after.createCopyGenericMethodWrapper());
+            }
+
+            TestMethodWrapper testMethodWrapper = new TestMethodWrapper(method, this.testClass, beforesForThisTestMethod, afterMethodsForThisTestMethod);
+            this.testMethods.add(testMethodWrapper);
         }
 
         // Populate more fields in the test structure so reporting has more information.
@@ -134,15 +145,21 @@ public class TestClassWrapper {
         this.testStructure.setMethods(structureMethods);
 
         for (GenericMethodWrapper before : this.beforeClassMethods) {
-            structureMethods.add(before.getStructure());
+            before.initialiseGenericMethodStructure();
+            TestMethod beforeTestStructureMethod = before.getGenericMethodStructure();
+            structureMethods.add(beforeTestStructureMethod);
         }
 
         for (TestMethodWrapper testMethod : this.testMethods) {
-            structureMethods.add(testMethod.getStructure());
+            testMethod.initialiseTestMethodStructure();
+            TestMethod testTestStructureMethod = testMethod.getTestStructureMethod();
+            structureMethods.add(testTestStructureMethod);
         }
 
         for (GenericMethodWrapper after : this.afterClassMethods) {
-            structureMethods.add(after.getStructure());
+            after.initialiseGenericMethodStructure();
+            TestMethod afterTestStructureMethod = after.getGenericMethodStructure();
+            structureMethods.add(afterTestStructureMethod);
         }
 
         String report = this.testStructure.report(LOG_START_LINE);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
@@ -21,7 +21,7 @@ import dev.galasa.framework.spi.teststructure.TestMethod;
 
 public class TestMethodWrapper {
     
-    private Log                              logger        = LogFactory.getLog(TestMethodWrapper.class);
+    private final Log                        logger;
 
     private final List<GenericMethodWrapper> befores  = new ArrayList<>();
     private GenericMethodWrapper             testMethod;
@@ -30,8 +30,16 @@ public class TestMethodWrapper {
     private Result                           result;
     private boolean                          fullStop = false;
 
-    protected TestMethodWrapper(Method testMethod, Class<?> testClass, ArrayList<GenericMethodWrapper> beforeMethods,
-            ArrayList<GenericMethodWrapper> afterMethods) {
+    private TestMethod                       testMethodStructure;
+
+    protected TestMethodWrapper(
+        Method testMethod, 
+        Class<?> testClass, 
+        ArrayList<GenericMethodWrapper> beforeMethods,
+        ArrayList<GenericMethodWrapper> afterMethods
+        ) {
+
+        this.logger = LogFactory.getLog(TestMethodWrapper.class);
 
         this.testMethod = new GenericMethodWrapper(testMethod, testClass, GenericMethodWrapper.Type.Test);
 
@@ -48,7 +56,12 @@ public class TestMethodWrapper {
         return;
     }
 
-    public void invoke(@NotNull ITestRunManagers managers, Object testClassObject, boolean continueOnTestFailure, TestClassWrapper testClassWrapper) throws TestRunException {
+    public void invoke(
+        @NotNull ITestRunManagers managers, 
+        Object testClassObject, 
+        boolean continueOnTestFailure, 
+        TestClassWrapper testClassWrapper
+        ) throws TestRunException {
         try {
             // Check if the test method should be ignored, and if so, mark it as ignored along
             // with any @Before and @After methods associated with the test method
@@ -63,51 +76,103 @@ public class TestMethodWrapper {
 
                 markTestAndLinkedMethodsIgnored(ignoredResult, testClassWrapper, managers);
             } else {
-                // run all the @Befores before the test method
-                for (GenericMethodWrapper before : this.befores) {
-                    before.invoke(managers, testClassObject, testMethod, testClassWrapper);
-                    testClassWrapper.setResult(before.getResult(), managers);
-                    if (before.getResult().isFullStop()) {
-                        this.fullStop = true;
-                        this.result = Result.failed("Before method failed");
-                        break;
-                    }
-                }
+
+                runBeforeMethods(managers, testClassObject, testClassWrapper);
 
                 if (this.result == null) {
-                    testMethod.invoke(managers, testClassObject, null, testClassWrapper);
-                    testClassWrapper.setResult(testMethod.getResult(), managers);
-                    if (this.testMethod.fullStop()) {
-                        if (continueOnTestFailure) {
-                            logger.warn("Test method failed, however, continue on test failure was requested, so carrying on");
-                        } else {
-                            this.fullStop = this.testMethod.fullStop();
-                        }
-                    }
-                    
-                    this.result = this.testMethod.getResult();
+                    runTestMethod(managers, testClassObject, testClassWrapper, continueOnTestFailure);
                 }
 
-                // run all the @Afters after the test method
-                Result afterResult = null;
-                for (GenericMethodWrapper after : this.afters) {
-                    after.invoke(managers, testClassObject, testMethod, testClassWrapper);
-                    testClassWrapper.setResult(after.getResult(), managers);
-                    if (after.fullStop()) {
-                        this.fullStop = true;
-                        if (afterResult == null) {
-                            afterResult = Result.failed("After method failed");
-                            if (this.result == null || this.result.isPassed()) {
-                                this.result = afterResult;
-                            }
-                        }
-                    }
-                }
+                runAfterMethods(managers, testClassObject, testClassWrapper);
+
             }
         } catch (FrameworkException ex) {
             throw new TestRunException("Failure occurred when invoking methods in the given test class", ex);
         }
     }
+
+    protected void runBeforeMethods(ITestRunManagers managers, Object testClassObject, TestClassWrapper testClassWrapper) throws TestRunException {
+        // run all the @Befores before the test method
+        for (GenericMethodWrapper before : this.befores) {
+            before.invoke(managers, testClassObject, testMethod, testClassWrapper);
+            testClassWrapper.setResult(before.getResult(), managers);
+            if (before.getResult().isFullStop()) {
+                this.fullStop = true;
+                this.result = Result.failed("Before method failed");
+                break;
+            }
+        }
+    }
+
+    protected void runAfterMethods(ITestRunManagers managers, Object testClassObject, TestClassWrapper testClassWrapper) throws TestRunException {
+        // run all the @Afters after the test method
+        Result afterResult = null;
+        for (GenericMethodWrapper after : this.afters) {
+            after.invoke(managers, testClassObject, testMethod, testClassWrapper);
+            testClassWrapper.setResult(after.getResult(), managers);
+            if (after.fullStop()) {
+                this.fullStop = true;
+                if (afterResult == null) {
+                    afterResult = Result.failed("After method failed");
+                    if (this.result == null || this.result.isPassed()) {
+                        this.result = afterResult;
+                    }
+                }
+            }
+        }
+    }
+
+    protected void runTestMethod(ITestRunManagers managers, Object testClassObject, TestClassWrapper testClassWrapper, boolean continueOnTestFailure) throws TestRunException {
+        testMethod.invoke(managers, testClassObject, null, testClassWrapper);
+        testClassWrapper.setResult(testMethod.getResult(), managers);
+        if (this.testMethod.fullStop()) {
+            if (continueOnTestFailure) {
+                logger.warn("Test method failed, however, continue on test failure was requested, so carrying on");
+            } else {
+                this.fullStop = this.testMethod.fullStop();
+            }
+        }
+        
+        this.result = this.testMethod.getResult();
+    }
+
+    /**
+     * This creates a new test structure for this @Test method, priming
+     * it with the @Before and @After methods that belong to it. It is
+     * then set as a class variable. It can be retrieved with getTestStructureMethod().
+     */
+    public void initialiseTestMethodStructure() {
+
+        testMethod.initialiseGenericMethodStructure();
+        this.testMethodStructure = testMethod.getGenericMethodStructure();
+
+        ArrayList<TestMethod> structureBefores = new ArrayList<>();
+        ArrayList<TestMethod> structureAfters = new ArrayList<>();
+
+        for (GenericMethodWrapper before : this.befores) {
+            before.initialiseGenericMethodStructure();
+            TestMethod beforeTestMethodStructure = before.getGenericMethodStructure();
+            structureBefores.add(beforeTestMethodStructure);
+        }
+
+        for (GenericMethodWrapper after : this.afters) {
+            after.initialiseGenericMethodStructure();
+            TestMethod afterTestMethodStructure = after.getGenericMethodStructure();
+            structureAfters.add(afterTestMethodStructure);
+        }
+
+        this.testMethodStructure.setBefores(structureBefores);
+        this.testMethodStructure.setAfters(structureAfters);
+    }
+
+    /**
+     * This returns the test structure for this @Test method.
+     * @return the existing TestMethod structure for this @Test method.
+     */
+    public TestMethod getTestStructureMethod() {
+        return this.testMethodStructure;
+    }
+
 
     public boolean fullStop() {
         return this.fullStop;
@@ -119,38 +184,6 @@ public class TestMethodWrapper {
 
     public String getName() {
         return this.testMethod.getName();
-    }
-
-    /**
-     * This returns the test structure for this @Test method.
-     * @return the existing TestMethod structure for a @Test method.
-     */
-    public TestMethod getTestStructureMethod() {
-        return testMethod.getTestStructureMethod();
-    }
-
-    /**
-     * This creates a new test structure for this @Test method, priming
-     * it with the @Before and @After methods that belong to it.
-     * @return a new TestMethod structure for a @Test method.
-     */
-    public TestMethod getStructure() {
-        TestMethod methodStructure = testMethod.getStructure();
-        ArrayList<TestMethod> structureBefores = new ArrayList<>();
-        ArrayList<TestMethod> structureAfters = new ArrayList<>();
-
-        methodStructure.setBefores(structureBefores);
-        methodStructure.setAfters(structureAfters);
-
-        for (GenericMethodWrapper before : this.befores) {
-            structureBefores.add(before.getStructure());
-        }
-
-        for (GenericMethodWrapper after : this.afters) {
-            structureAfters.add(after.getStructure());
-        }
-
-        return methodStructure;
     }
 
     private void markTestAndLinkedMethodsIgnored(Result ignoredResult, TestClassWrapper testClassWrapper, ITestRunManagers managers) {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestMethodWrapperTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestMethodWrapperTest.java
@@ -136,7 +136,7 @@ public class TestMethodWrapperTest {
         MockTestClass mockTestClass = new MockTestClass(new ArrayList<String>());
 
         // When...
-        testMethodWrapper.getStructure();
+        testMethodWrapper.initialiseTestMethodStructure();
         testMethodWrapper.invoke(mockTestRunManagers, mockTestClass, continueOnTestFailure, testClassWrapper);
 
         // Then...
@@ -180,7 +180,7 @@ public class TestMethodWrapperTest {
         MockTestClass mockTestClass = new MockTestClass(new ArrayList<String>());
 
         // When...
-        testMethodWrapper.getStructure();
+        testMethodWrapper.initialiseTestMethodStructure();
         testMethodWrapper.invoke(mockTestRunManagers, mockTestClass, continueOnTestFailure, testClassWrapper);
 
         // Then...
@@ -221,7 +221,7 @@ public class TestMethodWrapperTest {
         MockTestRunManagersExtended mockTestRunManagers = new MockTestRunManagersExtended(ignoreTestClass, resultToReturn);
 
         // When...
-        testMethodWrapper.getStructure();
+        testMethodWrapper.initialiseTestMethodStructure();
         testMethodWrapper.invoke(mockTestRunManagers, new MockTestClass(new ArrayList<String>()), continueOnTestFailure, testClassWrapper);
 
         // Then...
@@ -249,7 +249,7 @@ public class TestMethodWrapperTest {
         ArrayList<GenericMethodWrapper> afterMethods = new ArrayList<>();
 
         TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, mockClass, beforeMethods, afterMethods);
-        testMethodWrapper.getStructure();
+        testMethodWrapper.initialiseTestMethodStructure();
 
         ITestRunManagers mockTestRunManagers = new MockTestRunManagers(false, null);
 
@@ -281,7 +281,7 @@ public class TestMethodWrapperTest {
         ArrayList<GenericMethodWrapper> afterMethods = new ArrayList<>();
 
         TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, mockClass, beforeMethods, afterMethods);
-        testMethodWrapper.getStructure();
+        testMethodWrapper.initialiseTestMethodStructure();
 
         ITestRunManagers mockTestRunManagers = new MockTestRunManagers(false, null);
 
@@ -310,7 +310,7 @@ public class TestMethodWrapperTest {
         ArrayList<GenericMethodWrapper> afterMethods = new ArrayList<>();
 
         TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, mockClass, beforeMethods, afterMethods);
-        testMethodWrapper.getStructure();
+        testMethodWrapper.initialiseTestMethodStructure();
 
         ITestRunManagers mockTestRunManagers = new MockTestRunManagers(false, null);
 
@@ -339,16 +339,16 @@ public class TestMethodWrapperTest {
 
         ArrayList<GenericMethodWrapper> beforeMethods = new ArrayList<>();
         GenericMethodWrapper beforeMethodWrapper = new GenericMethodWrapper(beforeMethod, mockClass, Type.Before);
-        beforeMethodWrapper.getStructure();
+        beforeMethodWrapper.initialiseGenericMethodStructure();
         beforeMethods.add(beforeMethodWrapper);
 
         ArrayList<GenericMethodWrapper> afterMethods = new ArrayList<>();
         GenericMethodWrapper afterMethodWrapper = new GenericMethodWrapper(afterMethod, mockClass, Type.After);
-        afterMethodWrapper.getStructure();
+        afterMethodWrapper.initialiseGenericMethodStructure();
         afterMethods.add(afterMethodWrapper);
 
         TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, mockClass, beforeMethods, afterMethods);
-        testMethodWrapper.getStructure();
+        testMethodWrapper.initialiseTestMethodStructure();
 
         ITestRunManagers mockTestRunManagers = new MockTestRunManagers(false, null);
 
@@ -358,14 +358,14 @@ public class TestMethodWrapperTest {
         testMethodWrapper.invoke(mockTestRunManagers, mockClassInstance, false, testClassWrapper);
 
         // Then...
-        assertThat(beforeMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(1);
-        assertThat(beforeMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(1);
+        assertThat(beforeMethodWrapper.getGenericMethodStructure().getRunLogStart()).isEqualTo(1);
+        assertThat(beforeMethodWrapper.getGenericMethodStructure().getRunLogEnd()).isEqualTo(1);
 
         assertThat(testMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(2);
         assertThat(testMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(2);
 
-        assertThat(afterMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(3);
-        assertThat(afterMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(3);
+        assertThat(afterMethodWrapper.getGenericMethodStructure().getRunLogStart()).isEqualTo(3);
+        assertThat(afterMethodWrapper.getGenericMethodStructure().getRunLogEnd()).isEqualTo(3);
     }
 
     @Test
@@ -382,16 +382,16 @@ public class TestMethodWrapperTest {
 
         ArrayList<GenericMethodWrapper> beforeMethods = new ArrayList<>();
         GenericMethodWrapper beforeMethodWrapper = new GenericMethodWrapper(beforeMethod, mockClass, Type.Before);
-        beforeMethodWrapper.getStructure();
+        beforeMethodWrapper.initialiseGenericMethodStructure();
         beforeMethods.add(beforeMethodWrapper);
 
         ArrayList<GenericMethodWrapper> afterMethods = new ArrayList<>();
         GenericMethodWrapper afterMethodWrapper = new GenericMethodWrapper(afterMethod, mockClass, Type.After);
-        afterMethodWrapper.getStructure();
+        afterMethodWrapper.initialiseGenericMethodStructure();
         afterMethods.add(afterMethodWrapper);
 
         TestMethodWrapper testMethodWrapper = new TestMethodWrapper(testMethod, mockClass, beforeMethods, afterMethods);
-        testMethodWrapper.getStructure();
+        testMethodWrapper.initialiseTestMethodStructure();
 
         ITestRunManagers mockTestRunManagers = new MockTestRunManagers(false, null);
 
@@ -401,14 +401,14 @@ public class TestMethodWrapperTest {
         testMethodWrapper.invoke(mockTestRunManagers, mockClassInstance, false, testClassWrapper);
 
         // Then...
-        assertThat(beforeMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(1);
-        assertThat(beforeMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(1);
+        assertThat(beforeMethodWrapper.getGenericMethodStructure().getRunLogStart()).isEqualTo(1);
+        assertThat(beforeMethodWrapper.getGenericMethodStructure().getRunLogEnd()).isEqualTo(1);
 
         assertThat(testMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(0);
         assertThat(testMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(0);
 
-        assertThat(afterMethodWrapper.getTestStructureMethod().getRunLogStart()).isEqualTo(2);
-        assertThat(afterMethodWrapper.getTestStructureMethod().getRunLogEnd()).isEqualTo(2);
+        assertThat(afterMethodWrapper.getGenericMethodStructure().getRunLogStart()).isEqualTo(2);
+        assertThat(afterMethodWrapper.getGenericMethodStructure().getRunLogEnd()).isEqualTo(2);
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>

## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2291

## Changes

- Fixed bug where the test structure was not updated for all `Before` and `After` methods, only the ones belonging to the last `Test` method to execute. This is because the same ArrayList of `GenericMethodWrapper`s was being pointed to for each `TestMethodWrapper` and so the structure would be re-initialised (set back to empty) each test method, with only the last Before and After having updates saved to the test structure.
- Renamed some variables for readability. As `TestMethodWrapper` and `GenericMethodWrapper` contain similar code, it was  sometimes confusing to read.
- Split the method originally called `getStructure` into two separate methods: an `initialise` which creates a new test structure and sets that as a class variable, and a `get` which returns that class variable. It didn't make sense to me that the original `getStructure` was doing two things, both setting and getting something.
- More refactoring for readability.
