### PR TITLE
Bump log4j-core from 2.24.1 to 2.25.1

### DIFF
--- a/modules/framework/galasa-parent/galasa-boot/build.gradle
+++ b/modules/framework/galasa-parent/galasa-boot/build.gradle
@@ -52,8 +52,8 @@ dependencies {
 
     bundleDependency 'org.apache.felix:org.apache.felix.bundlerepository:2.0.10'
     bundleDependency 'org.apache.felix:org.apache.felix.scr:2.1.14'
-    bundleDependency 'org.apache.logging.log4j:log4j-api:2.24.1'
-    bundleDependency 'org.apache.logging.log4j:log4j-core:2.24.1'
+    bundleDependency 'org.apache.logging.log4j:log4j-api:2.25.1'
+    bundleDependency 'org.apache.logging.log4j:log4j-core:2.25.1'
     bundleDependency project (':dev.galasa.framework.log4j2.bridge')
     bundleDependency project (':dev.galasa.framework.maven.repository')
     bundleDependency project (':dev.galasa.framework.maven.repository.spi')

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -230,9 +230,9 @@ dependencies {
         api 'org.apache.kafka:kafka-clients:3.9.0'
         api 'org.apache.kafka:kafka-server-common:3.9.0'
 
-        api 'org.apache.logging.log4j:log4j-api:2.24.1' // If updating, also update in galasa-boot build.gradle.
-        api 'org.apache.logging.log4j:log4j-core:2.24.1' // If updating, also update in galasa-boot build.gradle.
-        api 'org.apache.logging.log4j:log4j-slf4j-impl:2.24.1'
+        api 'org.apache.logging.log4j:log4j-api:2.25.1' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.logging.log4j:log4j-core:2.25.1' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.logging.log4j:log4j-slf4j-impl:2.25.1'
 
         api 'org.apache.maven:maven-core:3.9.9'
         api 'org.apache.maven:maven-artifact:3.9.6'


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2362

## Changes
- Bumped log4j-core and dependencies associated with log4j (log4j-api and log4j-sl4j-impl) up to 2.25.1

**Important: Any developers that have a 0.43.0 boot.jar in their `.galasa/lib/0.43.0` folder will need to delete the 0.43.0 folder so that the new boot jar with the updated log4j dependencies can be copied into the folder by galasactl. If this is not done, then a ClassNotFoundException will be thrown. This will not affect users as 0.43.0 has not been released yet. Once this PR is delivered, this message will be relayed on to the galasa-dev channels.**