### PR TITLE
New test run gets put into the queued state in the RAS record when it is first created.

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
@@ -20,6 +20,7 @@ import dev.galasa.framework.spi.IFrameworkRuns.SharedEnvironmentPhase;
 import dev.galasa.framework.spi.IResultArchiveStore;
 import dev.galasa.api.runs.ScheduleRequest;
 import dev.galasa.api.runs.ScheduleStatus;
+import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.ProtectedRoute;
 import dev.galasa.framework.api.common.ResponseBuilder;
@@ -150,7 +151,7 @@ public class GroupRuns extends ProtectedRoute {
 
     protected void createRunRasRecord(IRun newRun, IResultArchiveStore rasStore, ITimeService timeService) throws InternalServletException {
         TestStructure newTestStructure = newRun.toTestStructure();
-        newTestStructure.setStatus("queued");
+        newTestStructure.setStatus(TestRunLifecycleStatus.QUEUED.toString());
         newTestStructure.setQueued(timeService.now());
         String runId = newRun.getRasRunId();
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/routes/GroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/routes/GroupRunsRoute.java
@@ -32,6 +32,7 @@ import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.rbac.BuiltInAction;
 import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.utils.GalasaGson;
+import dev.galasa.framework.spi.utils.SystemTimeService;
 
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 public class GroupRunsRoute extends GroupRuns{
@@ -44,7 +45,7 @@ public class GroupRunsRoute extends GroupRuns{
         // Regex to match endpoints:
 		// -> /runs/{GroupID}
 		//
-        super(responseBuilder, path, framework);
+        super(responseBuilder, path, framework, new SystemTimeService() );
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/common/TestGroupRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/common/TestGroupRuns.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.runs.common;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import org.junit.Test;
+
+import dev.galasa.framework.api.common.ResponseBuilder;
+import dev.galasa.framework.api.common.mocks.MockFramework;
+import dev.galasa.framework.mocks.MockIResultArchiveStore;
+import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.mocks.MockTimeService;
+import dev.galasa.framework.spi.IRun;
+import dev.galasa.framework.spi.teststructure.TestStructure;
+
+public class TestGroupRuns {
+
+
+    @Test
+    public void testCanCreateRunRasRecordOK() throws Exception {
+        // Given...
+        ResponseBuilder responseBuidler = new ResponseBuilder();
+        MockIResultArchiveStore ras = new MockIResultArchiveStore();
+        MockFramework mockFramework = new MockFramework(ras);
+        MockTimeService mockTimeService = new MockTimeService(Instant.MIN);
+        GroupRuns groupRuns = new GroupRuns(responseBuidler, "/my/path", mockFramework, mockTimeService);
+        IRun run = new MockRun("myBundle", "myClassName", "U12345" , "myStream" , "myOBR", "http://my/stream/repo/url", "myRequestorName", false);
+
+        // When...
+        groupRuns.createRunRasRecord(run, ras, mockTimeService);
+
+        // Then...
+        List<TestStructure> history = ras.getTestStructureHistory();
+
+        assertThat(history).hasSize(1);
+        TestStructure testStructure = history.get(0);
+
+        assertThat(testStructure.getStatus()).isEqualTo("queued");
+        assertThat(testStructure.getQueued()).isNotNull();
+    }
+
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/InterruptedRunEventProcessorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/InterruptedRunEventProcessorTest.java
@@ -39,7 +39,7 @@ public class InterruptedRunEventProcessorTest {
 
     private MockKubernetesPodTestUtils mockKubeTestUtils = new MockKubernetesPodTestUtils();
 
-    private MockRun createMockRun(String runName, String status, String interruptReason) {
+    private MockRun createMockRun(String runName, TestRunLifecycleStatus status, String interruptReason) {
         // We only care about the run's name, status, and interrupt reason
         MockRun mockRun = new MockRun(
             "bundle",
@@ -53,16 +53,16 @@ public class InterruptedRunEventProcessorTest {
         );
 
         mockRun.setInterruptReason(interruptReason);
-        mockRun.setStatus(status);
+        mockRun.setStatus(status.toString());
         return mockRun;
     }
 
-    private MockRunResult createMockRunResult(String rasRunId, String status) {
+    private MockRunResult createMockRunResult(String rasRunId, TestRunLifecycleStatus status) {
         Path artifactRoot = null;
         String log = null;
 
         TestStructure testStructure = new TestStructure();
-        testStructure.setStatus(status);
+        testStructure.setStatus(status.toString());
 
         MockRunResult mockRunResult = new MockRunResult(rasRunId, testStructure, artifactRoot, log);
         return mockRunResult;
@@ -73,7 +73,7 @@ public class InterruptedRunEventProcessorTest {
         // Given...
         String runId = "this-is-a-run-id";
         String runName = "RUN1";
-        String status = "running";
+        TestRunLifecycleStatus status = TestRunLifecycleStatus.RUNNING;
         String interruptReason = Result.CANCELLED;
         Instant interruptedAt = Instant.now();
 
@@ -124,7 +124,7 @@ public class InterruptedRunEventProcessorTest {
         // Given...
         String runId = "this-is-a-run-id";
         String runName = "RUN1";
-        String status = "running";
+        TestRunLifecycleStatus status = TestRunLifecycleStatus.RUNNING;
         String interruptReason = Result.REQUEUED;
         Instant interruptedAt = Instant.now();
 
@@ -174,7 +174,7 @@ public class InterruptedRunEventProcessorTest {
         // Given...
         String runId = "this-is-a-run-id";
         String runName = "RUN1";
-        String status = "running";
+        TestRunLifecycleStatus status = TestRunLifecycleStatus.RUNNING;
         String interruptReason = Result.CANCELLED;
         Instant interruptedAt = Instant.now();
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -238,7 +238,7 @@ public class FrameworkRuns implements IFrameworkRuns {
         // *** Set up the otherRunProperties that will go with the Run number
         HashMap<String, String> otherRunProperties = new HashMap<>();
         otherRunProperties.put(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.RAS_RUN_ID), runId);
-        otherRunProperties.put(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.STATUS), "queued");
+        otherRunProperties.put(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.STATUS), TestRunLifecycleStatus.QUEUED.toString());
         otherRunProperties.put(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.QUEUED), Instant.now().toString());
         otherRunProperties.put(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.TEST_BUNDLE), bundleName);
         otherRunProperties.put(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.TEST_CLASS), testName);


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
See [Cancelling of run groups not working as expected #2317](https://github.com/galasa-dev/projectmanagement/issues/2317)

When the test is launched, the record which gets placed into RAS initially should have the Queued state, with the queued time.

