### PR TITLE
make codeql(go) workflow work with gradle 9.0.0 options

### DIFF
--- a/.github/workflows/codeql-go.yml
+++ b/.github/workflows/codeql-go.yml
@@ -114,7 +114,7 @@ jobs:
       working-directory: ${{ github.workspace }}/modules/cli
       run: |
         set -o pipefail
-        gradle -b build.gradle installJarsIntoTemplates --info \
+        gradle installJarsIntoTemplates --info \
         --no-daemon --console plain \
         -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr \
         -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/.github/workflows/codeql-go.yml
+++ b/.github/workflows/codeql-go.yml
@@ -115,7 +115,7 @@ jobs:
       run: |
         set -o pipefail
         gradle installJarsIntoTemplates --info \
-        --no-daemon --console plain \
+        --console plain \
         -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr \
         -PcentralMaven=https://repo.maven.apache.org/maven2/ \
         -PtargetMaven=/home/runner/.m2/repository 2>&1 | tee build.log

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -1,6 +1,6 @@
 # Galasa CLI
 
-The Galasa command line interface (Galasa CLI) is used to interact with the Galasa ecosystem or local development environment.
+The Galasa command line interface (Galasa CLI) is used to interact with a deployed Galasa service or local development environment.
 
 [![Main build](https://github.com/galasa-dev/cli/actions/workflows/build.yml/badge.svg)](https://github.com/galasa-dev/cli/actions/workflows/build.yml)
 
@@ -99,7 +99,7 @@ If you wish the generated code to depend upon the very latest/bleeding-edge of g
 
 ## auth login
 
-Before interacting with a Galasa ecosystem using `galasactl`, you must be authenticated with it. The `auth login` command allows you to log in to an ecosystem provided by your `GALASA_BOOTSTRAP` environment variable or through the `--bootstrap` flag.
+Before interacting with a deployed Galasa service using `galasactl`, you must be authenticated with it. The `auth login` command allows you to log in to a Galasa service provided by your `GALASA_BOOTSTRAP` environment variable or through the `--bootstrap` flag.
 
 Prior to running this command, you must have a `galasactl.properties` file in your `GALASA_HOME` directory, which is automatically created when running `galasactl local init`, that contains a `GALASA_TOKEN` property with the following format:
 


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
As a quick change to get the build working... make the codeql(go) workflow execute using gradle 9.0.0

- The `-b` option has gone since 8.14.3
- The `--no-demon` option has gone also.