### PR TITLE
build: Fix missing environment variables in docs build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,6 +9,8 @@ on:
   workflow_call:
 
 env:
+  REGISTRY: ghcr.io
+  NAMESPACE: ${{ github.repository_owner }}
   BRANCH: ${{ github.ref_name }}
 
 jobs:


### PR DESCRIPTION
## Why?

Fix broken build (see https://github.com/galasa-dev/galasa/actions/runs/16938074018/job/48001482626) due to missing environment variables REGISTRY and NAMESPACE that the Docker build steps require.