### PR TITLE
When a test finds out is has been interrupted, log what the reason was.

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/InterruptedMonitorImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/InterruptedMonitorImpl.java
@@ -49,7 +49,7 @@ public class InterruptedMonitorImpl implements InterruptedMonitor {
                 logger.info("Run "+testRunName+" has not been interrupted.");
             } else {
                 isInterrupted = true ;
-                logger.info("Run "+testRunName+" has been interrupted.");
+                logger.info("Run "+testRunName+" has been interrupted. Reason:"+interruptedReason);
             }
         } catch( DynamicStatusStoreException ex) {
             throw new TestRunException("Could not find out if test run "+testRunName+" is interrupted or not.");


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
When a test starts, and finds that it has been interrupted for some reason, it should also log the reason for the interruption for clarity.

This is a small logging change to increase the amount of detail immediately available in this situation.
