### PR TITLE
trace statements look too similar, can't tell which one is being logged

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/main/java/dev/galasa/framework/maven/repository/internal/GalasaMavenUrlHandlerService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/main/java/dev/galasa/framework/maven/repository/internal/GalasaMavenUrlHandlerService.java
@@ -253,7 +253,7 @@ public class GalasaMavenUrlHandlerService extends AbstractURLStreamHandlerServic
 
         URL urlRemoteFile = buildArtifactUrl(repository, groupid, artifactid, version,
                 buildArtifactFilename(artifactid, snapshotSuffix, type));
-        logger.debug("Attempting to download " + urlRemoteFile);
+        logger.debug("Attempting to download snapshot" + urlRemoteFile);
 
         URLConnection connection = urlRemoteFile.openConnection();
         connection.setConnectTimeout(300000);
@@ -278,7 +278,7 @@ public class GalasaMavenUrlHandlerService extends AbstractURLStreamHandlerServic
       Path tempMetadata = Files.createTempFile("metadata", ".xml");
       try {
           URL urlRemoteFile = buildArtifactUrl(repository, groupid, artifactid, version, "maven-metadata.xml");
-          logger.debug("Attempting to download " + urlRemoteFile);
+          logger.debug("Attempting to download temporary metadata " + urlRemoteFile);
 
           URLConnection connection = urlRemoteFile.openConnection();
           connection.setConnectTimeout(300000);


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
Looking at a log, I can't tell which trace statement is being logged easily.
Changing some of the logged text to make it more obvious.
