### PR TITLE
Log more information on why a test has been interrupted

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/InterruptedMonitorImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/runner/InterruptedMonitorImpl.java
@@ -50,11 +50,29 @@ public class InterruptedMonitorImpl implements InterruptedMonitor {
             } else {
                 isInterrupted = true ;
                 logger.info("Run "+testRunName+" has been interrupted. Reason:"+interruptedReason);
+
+                logWhyTestInterupted(testRunName);
             }
         } catch( DynamicStatusStoreException ex) {
             throw new TestRunException("Could not find out if test run "+testRunName+" is interrupted or not.");
         }
         return isInterrupted ;
+    }
+
+    private void logWhyTestInterupted(String testRunName) {
+        String dssKey = "run."+testRunName+"."+DssPropertyKeyRunNameSuffix.INTERRUPTED_AT;
+        try {
+            String interruptedAt = dss.get(dssKey);
+
+            if ( interruptedAt==null || interruptedAt.isBlank() ) {
+                logger.info("Run "+testRunName+" was interrupted, but we don't know when it was interrupted.");
+            } else {
+                logger.info("Run "+testRunName+" was interrupted at "+interruptedAt);
+            }
+        } catch( Exception ex) {
+            logger.info("Something went wrong trying to log why this test run was interrupted.",ex);
+            // Suppress the exception, as we are only trying to log extra detail for diagnostics reasons.
+        }
     }
     
 }


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>
# Why ?
When a test run notices that it has been interrupted, it should log why it's been interrupted so diagnosing issues in the interruption mechanism will be easier to find.

For example, if we know when it was interrupted, we can look in the API server logs at that time for the cause of that.