### PR TITLE
Correct a broken link in the docs

### DIFF
--- a/docs/content/docs/manage-ecosystem/test-streams.md
+++ b/docs/content/docs/manage-ecosystem/test-streams.md
@@ -25,7 +25,7 @@ The following diagram shows the relationship between the test code, test catalog
 The components of the `test.stream` property are set by using `galasactl resources apply -f {yaml-filename}` command.
 The `apply` sub-command will update the stream if it already exists, but you could use the `create` or `update` sub-command as an alternative.
 
-See [the command reference](/docs/content/docs/reference/cli-syntax/galasactl_resources_apply.md) for specific syntax help.
+See [the command reference](../reference/cli-syntax/galasactl_resources_apply.md) for specific syntax help.
 
 Streams are explained in more detail, with an example [here](../ecosystem/ecosystem-manage-resources.md/#test-streams-as-galasastream-resources).
 


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
There is a broken hyperlink in the documentation. This fixes it up nicely.
