### PR TITLE
Encode spaces in RAS paths to stop an illegal character exception from being thrown

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/ResultArchiveStorePath.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/ResultArchiveStorePath.java
@@ -58,6 +58,10 @@ public class ResultArchiveStorePath implements Path {
             path = path.replaceAll("\\Q\\\\E", "/"); // NOSONAR
         }
 
+        if (path.contains(" ")) {
+            path = path.replaceAll(" ", "%20");
+        }
+
         this.absolute = path.startsWith("/");
         if (path.endsWith("/")) {
             path = path.substring(0, path.length() - 1);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/ResultArchiveStorePath.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/ResultArchiveStorePath.java
@@ -59,7 +59,7 @@ public class ResultArchiveStorePath implements Path {
         }
 
         if (path.contains(" ")) {
-            path = path.replaceAll(" ", "%20");
+            path = path.trim().replaceAll(" ", "%20");
         }
 
         this.absolute = path.startsWith("/");

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/ras/RASPathTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/ras/RASPathTest.java
@@ -38,6 +38,20 @@ public class RASPathTest {
     }
 
     @Test
+    public void testPathWithStartingAndTrailingSpacesAreTrimmed() throws Exception {
+        // Given...
+        String pathWithSpaces = "    /this/is/a path with spaces/do not/throw an error  ";
+        FileSystem fileSystem = new MockFileSystem();
+        
+        // When...
+        ResultArchiveStorePath path = new ResultArchiveStorePath(fileSystem, pathWithSpaces);
+
+        // Then...
+        String expectedPath = pathWithSpaces.trim().replaceAll(" ", "%20");
+        Assert.assertEquals("Unexpected path produced", expectedPath, path.toString());
+    }
+
+    @Test
     public void testNameElements() {
         ResultArchiveStorePath path = new ResultArchiveStorePath(new MockFileSystem(), "/this/is/a//path/");
         Assert.assertEquals("Incorrect name count", 4, path.getNameCount());

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/ras/RASPathTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/ras/RASPathTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.ProviderMismatchException;
@@ -20,13 +19,27 @@ import java.util.Iterator;
 import org.junit.Assert;
 import org.junit.Test;
 
-import dev.galasa.framework.spi.ras.ResultArchiveStorePath;
+import dev.galasa.framework.mocks.MockFileSystem;
 
 public class RASPathTest {
 
     @Test
+    public void testPathCanContainSpaces() throws Exception {
+        // Given...
+        String pathWithSpaces = "/this/is/a path with spaces/do not/throw an error";
+        FileSystem fileSystem = new MockFileSystem();
+        
+        // When...
+        ResultArchiveStorePath path = new ResultArchiveStorePath(fileSystem, pathWithSpaces);
+
+        // Then...
+        String expectedPath = pathWithSpaces.replaceAll(" ", "%20");
+        Assert.assertEquals("Unexpected path produced", expectedPath, path.toString());
+    }
+
+    @Test
     public void testNameElements() {
-        ResultArchiveStorePath path = new ResultArchiveStorePath(FileSystems.getDefault(), "/this/is/a//path/");
+        ResultArchiveStorePath path = new ResultArchiveStorePath(new MockFileSystem(), "/this/is/a//path/");
         Assert.assertEquals("Incorrect name count", 4, path.getNameCount());
 
         Iterator<Path> pathElements = path.iterator();
@@ -50,19 +63,20 @@ public class RASPathTest {
         Assert.assertNull("Incorrect Name for subpath 4,5, should be null", path.subpath(4, 5));
         Assert.assertNull("Incorrect Name for subpath 3,4, should be null", path.subpath(3, 4));
 
-        path = new ResultArchiveStorePath(FileSystems.getDefault(), "/");
+        path = new ResultArchiveStorePath(new MockFileSystem(), "/");
         Assert.assertEquals("Incorrect name count", 0, path.getNameCount());
         pathElements = path.iterator();
         Assert.assertFalse("Should be no elements", pathElements.hasNext());
     }
 
     @Test
-    public void testStartsWith() {
-        final ResultArchiveStorePath path = new ResultArchiveStorePath(FileSystems.getDefault(), "/this/is/a/path");
-        final ResultArchiveStorePath path1 = new ResultArchiveStorePath(FileSystems.getDefault(), "/this/is");
-        final ResultArchiveStorePath path2 = new ResultArchiveStorePath(FileSystems.getDefault(), "this/is");
-        final ResultArchiveStorePath path3 = new ResultArchiveStorePath(FileSystems.getDefault(), "/hello/there");
-        final ResultArchiveStorePath path4 = new ResultArchiveStorePath(FileSystems.getDefault(),
+    public void testStartsWith() throws Exception {
+        MockFileSystem mockFileSystem = new MockFileSystem();
+        final ResultArchiveStorePath path = new ResultArchiveStorePath(mockFileSystem, "/this/is/a/path");
+        final ResultArchiveStorePath path1 = new ResultArchiveStorePath(mockFileSystem, "/this/is");
+        final ResultArchiveStorePath path2 = new ResultArchiveStorePath(mockFileSystem, "this/is");
+        final ResultArchiveStorePath path3 = new ResultArchiveStorePath(mockFileSystem, "/hello/there");
+        final ResultArchiveStorePath path4 = new ResultArchiveStorePath(mockFileSystem,
                 "/this/is/a/path/extra");
 
         Assert.assertTrue("same path, so should have been true", path.startsWith(path.toString()));
@@ -84,20 +98,22 @@ public class RASPathTest {
         }
 
         try {
-            path.startsWith(FileSystems.getDefault().getPath("bob"));
+            path.startsWith(mockFileSystem.getPath("bob"));
             fail("Different filesystem paths should caused an exception");
         } catch (final ProviderMismatchException e) {
         }
 
+        mockFileSystem.close();
     }
 
     @Test
-    public void testEndsWith() {
-        final ResultArchiveStorePath path = new ResultArchiveStorePath(FileSystems.getDefault(), "/this/is/a/path");
-        final ResultArchiveStorePath path1 = new ResultArchiveStorePath(FileSystems.getDefault(), "a/path");
-        final ResultArchiveStorePath path2 = new ResultArchiveStorePath(FileSystems.getDefault(), "this/is/a/path");
-        final ResultArchiveStorePath path3 = new ResultArchiveStorePath(FileSystems.getDefault(), "b/path");
-        final ResultArchiveStorePath path4 = new ResultArchiveStorePath(FileSystems.getDefault(),
+    public void testEndsWith() throws Exception {
+        MockFileSystem mockFileSystem = new MockFileSystem();
+        final ResultArchiveStorePath path = new ResultArchiveStorePath(mockFileSystem, "/this/is/a/path");
+        final ResultArchiveStorePath path1 = new ResultArchiveStorePath(mockFileSystem, "a/path");
+        final ResultArchiveStorePath path2 = new ResultArchiveStorePath(mockFileSystem, "this/is/a/path");
+        final ResultArchiveStorePath path3 = new ResultArchiveStorePath(mockFileSystem, "b/path");
+        final ResultArchiveStorePath path4 = new ResultArchiveStorePath(mockFileSystem,
                 "/this/is/a/path/extra");
 
         Assert.assertTrue("same path, so should have been true", path.endsWith(path.toString()));
@@ -118,17 +134,19 @@ public class RASPathTest {
         } catch (final NullPointerException e) {
         }
 
+
         try {
-            path.endsWith(FileSystems.getDefault().getPath("bob"));
+            path.endsWith(mockFileSystem.getPath("bob"));
             fail("Different filesystem paths should caused an exception");
         } catch (final ProviderMismatchException e) {
         }
 
+        mockFileSystem.close();
     }
 
     @Test
     public void testSimpleStuff() throws IOException {
-        final FileSystem fs = FileSystems.getDefault();
+        final FileSystem fs = new MockFileSystem();
 
         final ResultArchiveStorePath path = new ResultArchiveStorePath(fs, "/this/is/a/path");
         Assert.assertEquals("Filesystem is different", fs, path.getFileSystem());
@@ -169,7 +187,7 @@ public class RASPathTest {
         }
 
         try {
-            new ResultArchiveStorePath(FileSystems.getDefault(), "/{}");
+            new ResultArchiveStorePath(new MockFileSystem(), "/{}");
             fail("Should have failed as invalid uri");
         } catch (final AssertionError e) {
         }
@@ -177,7 +195,7 @@ public class RASPathTest {
 
     @Test
     public void testRelativize() {
-        final FileSystem fs = FileSystems.getDefault();
+        final FileSystem fs = new MockFileSystem();
 
         final ResultArchiveStorePath path = new ResultArchiveStorePath(fs, "/this/is/a/path");
         final ResultArchiveStorePath path1 = new ResultArchiveStorePath(fs, "/this/is/a/path/with/extra");
@@ -197,7 +215,7 @@ public class RASPathTest {
 
     @Test
     public void testResolve() {
-        final FileSystem fs = FileSystems.getDefault();
+        final FileSystem fs = new MockFileSystem();
 
         final ResultArchiveStorePath path = new ResultArchiveStorePath(fs, "/this/is/a/path");
         final ResultArchiveStorePath path1 = new ResultArchiveStorePath(fs, "with/extra");
@@ -218,12 +236,12 @@ public class RASPathTest {
     @Test
     public void testAbsolute() {
         String pathName = "/this/is/a/path";
-        ResultArchiveStorePath path = new ResultArchiveStorePath(FileSystems.getDefault(), pathName);
+        ResultArchiveStorePath path = new ResultArchiveStorePath(new MockFileSystem(), pathName);
         Assert.assertTrue("Should be absolute path", path.isAbsolute());
         Assert.assertEquals("path name changed", pathName, path.toString());
 
         pathName = "this/is/a/path";
-        path = new ResultArchiveStorePath(FileSystems.getDefault(), "this/is/a/path");
+        path = new ResultArchiveStorePath(new MockFileSystem(), "this/is/a/path");
         Assert.assertFalse("Should not be absolute path", path.isAbsolute());
         Assert.assertEquals("path name changed", pathName, path.toString());
 
@@ -236,7 +254,7 @@ public class RASPathTest {
     public void testInvalidElements() {
         String path = "/this/./a/path";
         try {
-            new ResultArchiveStorePath(FileSystems.getDefault(), path);
+            new ResultArchiveStorePath(new MockFileSystem(), path);
             fail("Should have failed as . is not allowed");
         } catch (final InvalidPathException e) {
             Assert.assertEquals("Incorrect message", "Path parts of '.' are not allowed: " + path, e.getMessage());
@@ -244,7 +262,7 @@ public class RASPathTest {
 
         path = "/this/../a/path";
         try {
-            new ResultArchiveStorePath(FileSystems.getDefault(), path);
+            new ResultArchiveStorePath(new MockFileSystem(), path);
             fail("Should have failed as .. is not allowed");
         } catch (final InvalidPathException e) {
             Assert.assertEquals("Incorrect message", "Path parts of '..' are not allowed: " + path, e.getMessage());
@@ -252,7 +270,7 @@ public class RASPathTest {
 
         path = "/this/a~a/a/path";
         try {
-            new ResultArchiveStorePath(FileSystems.getDefault(), path);
+            new ResultArchiveStorePath(new MockFileSystem(), path);
             fail("Should have failed as ~ is not allowed");
         } catch (final InvalidPathException e) {
             Assert.assertEquals("Incorrect message", "Path parts with '~' are not allowed: " + path, e.getMessage());
@@ -260,7 +278,7 @@ public class RASPathTest {
 
         path = "/this/a=a/a/path";
         try {
-            new ResultArchiveStorePath(FileSystems.getDefault(), path);
+            new ResultArchiveStorePath(new MockFileSystem(), path);
             fail("Should have failed as ~ is not allowed");
         } catch (final InvalidPathException e) {
             Assert.assertEquals("Incorrect message", "Path parts with '=' are not allowed: " + path, e.getMessage());
@@ -269,7 +287,7 @@ public class RASPathTest {
 
     @Test
     public void testCompareTo() {
-        final FileSystem fs = FileSystems.getDefault();
+        final FileSystem fs = new MockFileSystem();
         "boo".compareTo("eek");
 
         final ResultArchiveStorePath patha = new ResultArchiveStorePath(fs, "/this/is/a/path");

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFileSystem.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFileSystem.java
@@ -246,12 +246,12 @@ public class MockFileSystem extends FileSystem implements IFileSystem {
         return getContentsAsString(path);
     }
 
-    // -------------- Un-implemented methods follow ------------------
-
     @Override
     public void close() throws IOException {
-        throw new UnsupportedOperationException("Unimplemented method 'close'");
+        // Do nothing...
     }
+
+    // -------------- Un-implemented methods follow ------------------
 
     @Override
     public boolean isOpen() {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFileSystemProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFileSystemProvider.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 public class MockFileSystemProvider extends FileSystemProvider {
 
-
+    private String scheme = "file";
     public static class MockDirectoryStream implements DirectoryStream<Path> {
 
         private MockFileSystem mockFS;
@@ -137,7 +137,7 @@ public class MockFileSystemProvider extends FileSystemProvider {
 
     @Override
     public String getScheme() {
-        throw new UnsupportedOperationException("Unimplemented method 'getScheme'");
+        return this.scheme;
     }
 
     @Override

--- a/modules/ivts/galasa-ivts-parent/dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos/src/main/java/dev/galasa/zos/ivts/zos/ZosManagerFileIVT.java
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos/src/main/java/dev/galasa/zos/ivts/zos/ZosManagerFileIVT.java
@@ -114,6 +114,31 @@ public class ZosManagerFileIVT {
     }
     
     @Test
+    public void testCanCreateUnixFileWithSpacesInPath() throws Exception {
+        // Tests the creation of a file with spaces in its path using ZosFileHandler and UNIX File(s)
+        // Establish file name and location
+        String filePath = "/u/" + userName + "/GalasaTests/fileTest/" + runName + "/create me with spaces";
+        IZosUNIXFile unixFile = fileHandler.newUNIXFile(filePath, imagePrimary);
+
+        String commandTestExist = "test -f \"" + filePath + "\" && echo \"File Exists\"";
+        
+        // Check file doesn't exist
+        assertThat(unixFile.exists()).isFalse(); // Using fileManager
+        assertThat(zosUNIXCommand.issueCommand(commandTestExist)).isEqualTo(""); // Using commandManager
+        
+        // Create File
+        unixFile.create();
+        
+        // Check file was created
+        assertThat(unixFile.exists()).isTrue(); // Using fileManager
+        assertThat(zosUNIXCommand.issueCommand(commandTestExist))
+            .isEqualToIgnoringWhitespace("File Exists"); // Using commandManager
+
+        // Try to save the file into the RAS
+        unixFile.saveToResultsArchive("path with spaces");
+    }
+    
+    @Test
     public void unixFileCreateWithPermissions() throws ZosUNIXFileException, ZosUNIXCommandException, CoreManagerException {
         // Tests file creation (with Specified Access Permissions) using ZosFileHandler and UNIX File(s)
         // Establish file name and location


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2363

## Changes
- When a ResultArchiveStorePath is created, spaces in the path are now percent-encoded into `%20`
- Added unit tests to verify this functionality
- Added a test to the ZosFileManagerIVT to test that a unix file with spaces in its file path can be created and saved to the RAS without issue
- Updated existing RAS path tests to use a mock file system instead of the default (real) filesystem