### PR TITLE
Add toJsonString() method to ITerminal interface and add a test to Zos3270IVT testing the new method

### DIFF
--- a/modules/ivts/galasa-ivts-parent/dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos3270/build.gradle
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos3270/build.gradle
@@ -7,4 +7,5 @@ description = 'Galasa zOS 3270 Terminal Manager - IVTs'
 dependencies {
     implementation 'dev.galasa:dev.galasa.zos3270.manager'
     implementation 'dev.galasa:dev.galasa.core.manager'
+    implementation 'com.google.code.gson:gson'
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/bnd.bnd
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/bnd.bnd
@@ -4,5 +4,6 @@ Export-Package: dev.galasa.zos3270.common.screens,\
     dev.galasa.zos3270.common.screens.json
 Import-Package: javax.validation.constraints;resolution:=optional,\
     javax.imageio,\
-    dev.galasa.framework.spi
-
+    com.google.gson,\
+    dev.galasa.framework.spi,\
+    dev.galasa.framework.spi.utils

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/src/main/java/dev/galasa/zos3270/common/screens/json/TerminalJsonTransform.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/src/main/java/dev/galasa/zos3270/common/screens/json/TerminalJsonTransform.java
@@ -6,8 +6,14 @@
 package dev.galasa.zos3270.common.screens.json;
 
 
+import java.util.ArrayList;
+import java.util.Map.Entry;
+
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
 import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
 import dev.galasa.zos3270.common.screens.Terminal;
@@ -19,22 +25,48 @@ public class TerminalJsonTransform {
 
     private Gson gson ;
 
+    public TerminalJsonTransform() {
+        this(true);
+    }
+
     public TerminalJsonTransform( boolean isPrettyPrinting ) {
         this.gson = new GalasaGsonBuilder(isPrettyPrinting).getGson();
     }
     
     public JsonObject toJsonObject(Terminal terminal) {
-        JsonObject json = (JsonObject) gson.toJsonTree(terminal);
-        return json;
+        return (JsonObject) gson.toJsonTree(terminal);
     }
     
     public String toJsonString(Terminal terminal) {
         JsonObject jsonObj = toJsonObject(terminal);
-        String jsonString = gson.toJson(jsonObj);
-        return jsonString;
+        stripFalseBooleans(jsonObj);
+        return gson.toJson(jsonObj);
     }
 
     public Terminal toTerminal(String tempJson) {
         return gson.fromJson(tempJson, Terminal.class);
+    }
+
+    private void stripFalseBooleans(JsonObject json) {
+        ArrayList<Entry<String, JsonElement>> entries = new ArrayList<>();
+        entries.addAll(json.entrySet());
+
+        for (Entry<String, JsonElement> entry : entries) {
+            JsonElement element = entry.getValue();
+
+            if (element.isJsonPrimitive() && ((JsonPrimitive) element).isBoolean()
+                    && !((JsonPrimitive) element).getAsBoolean()) {
+                json.remove(entry.getKey());
+            } else if (element.isJsonObject()) {
+                stripFalseBooleans((JsonObject) element);
+            } else if (element.isJsonArray()) {
+                JsonArray array = (JsonArray) element;
+                for (int i = 0; i < array.size(); i++) {
+                    if (array.get(i).isJsonObject()) {
+                        stripFalseBooleans((JsonObject) array.get(i));
+                    }
+                }
+            }
+        }
     }
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/ITerminal.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/ITerminal.java
@@ -311,6 +311,12 @@ public interface ITerminal {
      */
     Highlight retrieveHighlightAtPosition(int row, int col) throws Zos3270Exception;
     
+    /**
+     * Returns the current terminal screen in JSON format.
+     * 
+     * @return the current terminal screen in JSON format
+     */
+    String toJsonString();
     
 
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/ITerminal.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/ITerminal.java
@@ -312,9 +312,9 @@ public interface ITerminal {
     Highlight retrieveHighlightAtPosition(int row, int col) throws Zos3270Exception;
     
     /**
-     * Returns the current terminal screen in JSON format.
+     * Returns the current terminal screen in JSON format or null if there is no current terminal screen.
      * 
-     * @return the current terminal screen in JSON format
+     * @return the current terminal screen in JSON format or null if there is no current terminal screen
      */
     String toJsonString();
     

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
@@ -28,6 +28,7 @@ import dev.galasa.zos3270.TextNotFoundException;
 import dev.galasa.zos3270.TimeoutException;
 import dev.galasa.zos3270.Zos3270Exception;
 import dev.galasa.zos3270.common.screens.TerminalSize;
+import dev.galasa.zos3270.common.screens.json.TerminalJsonTransform;
 import dev.galasa.zos3270.internal.comms.Network;
 import dev.galasa.zos3270.internal.comms.NetworkThread;
 
@@ -38,6 +39,9 @@ public class Terminal implements ITerminal {
     public static final long MAX_MILLISECS_TO_WAIT_FOR_NETWORK_THREAD_TO_FINISH = 20 * 1000 ; // 20 seconds
 
 	public ITextScannerManagerSpi textScan;
+
+    private final TerminalJsonTransform terminalJsonTransform = new TerminalJsonTransform();
+    private dev.galasa.zos3270.common.screens.Terminal currentTerminal;
     private final Screen  screen;
     private final Network network;
     private final String  id;
@@ -779,5 +783,13 @@ public class Terminal implements ITerminal {
         return screen.getHighlightAtPosition(pos);
     }
 
+    @Override
+    public String toJsonString() {
+        return this.terminalJsonTransform.toJsonString(currentTerminal);
+    }
+
+    protected void setCurrentTerminal(dev.galasa.zos3270.common.screens.Terminal currentTerminal) {
+        this.currentTerminal = currentTerminal;
+    }
 
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
@@ -785,7 +785,11 @@ public class Terminal implements ITerminal {
 
     @Override
     public String toJsonString() {
-        return this.terminalJsonTransform.toJsonString(currentTerminal);
+        String terminalJsonStr = null;
+        if (currentTerminal != null) {
+            terminalJsonStr = this.terminalJsonTransform.toJsonString(currentTerminal);
+        }
+        return terminalJsonStr;
     }
 
     protected void setCurrentTerminal(dev.galasa.zos3270.common.screens.Terminal currentTerminal) {

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/spi/TerminalTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/spi/TerminalTest.java
@@ -52,6 +52,34 @@ public class TerminalTest {
     }
 
     @Test
+    public void testConvertNullTerminalToJsonReturnsNull() throws Exception {
+
+        String terminalId = "abcdef";
+        String host = "myHost";
+        int port = 1234;
+        boolean isSSL = false;
+        boolean isVerifyServer = false;
+        TerminalSize primarySize = new TerminalSize(80,24);
+        TerminalSize alternateSize = new TerminalSize(80,24);
+        ITextScannerManagerSpi textScan = null ;
+        Charset codePage = Charset.availableCharsets().get("1024");
+
+        ByteArrayOutputStream networkOut = new ByteArrayOutputStream();
+
+        MockNetwork network = new MockNetwork(networkOut) {
+            public boolean connectClient() throws NetworkException {
+                return true;
+            }
+        };
+
+        Terminal terminal = new Terminal(terminalId, host, port, isSSL, isVerifyServer, primarySize, alternateSize,
+        textScan, codePage, network);
+
+        String terminalJsonStr = terminal.toJsonString();
+        assertThat(terminalJsonStr).isNull();
+    }
+
+    @Test
     public void testCanConvertTerminalToJson() throws Exception {
         GalasaGson gson = new GalasaGson();
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/spi/TerminalTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/spi/TerminalTest.java
@@ -9,12 +9,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 
 import org.junit.Test;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import dev.galasa.framework.spi.utils.GalasaGson;
 import dev.galasa.textscan.spi.ITextScannerManagerSpi;
-import dev.galasa.zos3270.TerminalInterruptedException;
+import dev.galasa.zos3270.common.screens.FieldContents;
+import dev.galasa.zos3270.common.screens.TerminalField;
+import dev.galasa.zos3270.common.screens.TerminalImage;
 import dev.galasa.zos3270.common.screens.TerminalSize;
 import dev.galasa.zos3270.mocks.MockNetwork;
 
@@ -44,6 +49,79 @@ public class TerminalTest {
         new Terminal(terminalId, host, port, isSSL, isVerifyServer, primarySize, alternateSize,
         textScan, codePage, network);
 
+    }
+
+    @Test
+    public void testCanConvertTerminalToJson() throws Exception {
+        GalasaGson gson = new GalasaGson();
+
+        String terminalId = "abcdef";
+        String host = "myHost";
+        int port = 1234;
+        boolean isSSL = false;
+        boolean isVerifyServer = false;
+        TerminalSize primarySize = new TerminalSize(80,24);
+        TerminalSize alternateSize = new TerminalSize(80,24);
+        ITextScannerManagerSpi textScan = null ;
+        Charset codePage = Charset.availableCharsets().get("1024");
+
+        ByteArrayOutputStream networkOut = new ByteArrayOutputStream();
+
+        MockNetwork network = new MockNetwork(networkOut) {
+            public boolean connectClient() throws NetworkException {
+                return true;
+            }
+        };
+
+        Terminal terminal = new Terminal(terminalId, host, port, isSSL, isVerifyServer, primarySize, alternateSize,
+        textScan, codePage, network);
+
+        String textContent = "Hello, world!";
+        Character[] fieldChars = textContent.chars().mapToObj(c -> (char)c).toArray(Character[]::new);
+        String runId = "run1";
+        int sequenceNo = 0;
+        boolean isInbound = true;
+        String type = "test";
+        String aid = "ENTER";
+        int cursorColumn = 0;
+        int cursorRow = 10;
+        dev.galasa.zos3270.common.screens.Terminal rasTerminal = new dev.galasa.zos3270.common.screens.Terminal(terminalId, runId, sequenceNo, primarySize);
+        TerminalImage image = new TerminalImage(0, terminalId, isInbound, type, aid, primarySize, cursorColumn, cursorRow);
+
+        TerminalField field = new TerminalField(0, 0, false, false, false,
+            true, false, false, false, Colour.BLUE.getLetter(),
+                Colour.DEFAULT.getLetter(), Highlight.DEFAULT.getLetter()
+        );
+        FieldContents fieldContents = new FieldContents(fieldChars);
+        field.getContents().add(fieldContents);
+        image.getFields().add(field);
+
+        rasTerminal.addImage(image);
+
+        terminal.setCurrentTerminal(rasTerminal);
+
+        String terminalJsonStr = terminal.toJsonString();
+        JsonObject terminalJsonObj = gson.fromJson(terminalJsonStr, JsonObject.class);
+
+        assertThat(terminalJsonObj.get("id").getAsString()).isEqualTo(terminalId);
+        assertThat(terminalJsonObj.get("runId").getAsString()).isEqualTo(runId);
+
+        JsonArray imagesJsonArr = terminalJsonObj.get("images").getAsJsonArray();
+        assertThat(imagesJsonArr).hasSize(1);
+        JsonObject imageJsonObj = imagesJsonArr.get(0).getAsJsonObject();
+        assertThat(imageJsonObj.get("id").getAsString()).isEqualTo(terminalId);
+        assertThat(imageJsonObj.get("type").getAsString()).isEqualTo(type);
+        assertThat(imageJsonObj.get("aid").getAsString()).isEqualTo(aid);
+
+        JsonArray imageFieldsArr = imageJsonObj.get("fields").getAsJsonArray();
+        assertThat(imageFieldsArr).hasSize(1);
+        JsonObject imageFieldJsonObj = imageFieldsArr.get(0).getAsJsonObject();
+        assertThat(imageFieldJsonObj.get("foregroundColour").getAsString()).isEqualTo(String.valueOf(Colour.BLUE.getLetter()));
+
+        JsonArray fieldContentsArr = imageFieldJsonObj.get("contents").getAsJsonArray();
+        assertThat(fieldContentsArr).hasSize(1);
+        JsonObject contentJson = fieldContentsArr.get(0).getAsJsonObject();
+        assertThat(contentJson.get("text").getAsString()).isEqualTo(textContent);
     }
     
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/spi/TerminalTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/test/java/dev/galasa/zos3270/spi/TerminalTest.java
@@ -52,7 +52,7 @@ public class TerminalTest {
     }
 
     @Test
-    public void testConvertNullTerminalToJsonReturnsNull() throws Exception {
+    public void testConvertNullTerminalScreenToJsonReturnsNull() throws Exception {
 
         String terminalId = "abcdef";
         String host = "myHost";
@@ -72,8 +72,11 @@ public class TerminalTest {
             }
         };
 
+        // Create the actual terminal instance
         Terminal terminal = new Terminal(terminalId, host, port, isSSL, isVerifyServer, primarySize, alternateSize,
         textScan, codePage, network);
+
+        // Do not call terminal.setCurrentTerminal() to set the current terminal pojo
 
         String terminalJsonStr = terminal.toJsonString();
         assertThat(terminalJsonStr).isNull();
@@ -81,6 +84,7 @@ public class TerminalTest {
 
     @Test
     public void testCanConvertTerminalToJson() throws Exception {
+        // Given...
         GalasaGson gson = new GalasaGson();
 
         String terminalId = "abcdef";
@@ -113,22 +117,31 @@ public class TerminalTest {
         String aid = "ENTER";
         int cursorColumn = 0;
         int cursorRow = 10;
-        dev.galasa.zos3270.common.screens.Terminal rasTerminal = new dev.galasa.zos3270.common.screens.Terminal(terminalId, runId, sequenceNo, primarySize);
-        TerminalImage image = new TerminalImage(0, terminalId, isInbound, type, aid, primarySize, cursorColumn, cursorRow);
 
+        // Create the terminal pojo that will be converted into JSON format
+        dev.galasa.zos3270.common.screens.Terminal currentTerminal = new dev.galasa.zos3270.common.screens.Terminal(terminalId, runId, sequenceNo, primarySize);
+        
+        // Create a mock image of the terminal, which contains a field with content inside
+        TerminalImage image = new TerminalImage(0, terminalId, isInbound, type, aid, primarySize, cursorColumn, cursorRow);
         TerminalField field = new TerminalField(0, 0, false, false, false,
             true, false, false, false, Colour.BLUE.getLetter(),
                 Colour.DEFAULT.getLetter(), Highlight.DEFAULT.getLetter()
         );
         FieldContents fieldContents = new FieldContents(fieldChars);
+
+        // Add some text into the terminal field, then add the field into the terminal image
         field.getContents().add(fieldContents);
         image.getFields().add(field);
 
-        rasTerminal.addImage(image);
+        // Add the built image to the terminal pojo
+        currentTerminal.addImage(image);
+        terminal.setCurrentTerminal(currentTerminal);
 
-        terminal.setCurrentTerminal(rasTerminal);
-
+        // When...
         String terminalJsonStr = terminal.toJsonString();
+
+        // Then...
+        // Check that the JSON returned contains the correct information
         JsonObject terminalJsonObj = gson.fromJson(terminalJsonStr, JsonObject.class);
 
         assertThat(terminalJsonObj.get("id").getAsString()).isEqualTo(terminalId);


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2353

## Changes
- Added a new `toJsonString()` method to the 3270 manager's `ITerminal` interface which converts the current ITerminal instance into a string in JSON format
- Added a test to the Zos3270IVT test suite to exercise this new method
