### PR TITLE
Iss2369 - Uplift Gradle version to 9.0.0 and update build processes

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
         # gradle-home-cache-excludes: |
         #   caches/modules-2/files-2.1/dev.galasa/**
@@ -103,7 +103,7 @@ jobs:
         working-directory: ./modules/cli
         run : |
           set -o pipefail
-          gradle -b build.gradle installJarsIntoTemplates --info \
+          gradle installJarsIntoTemplates --info \
           --no-daemon --console plain \
           -PsourceMaven=/home/runner/.m2/repository \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
@@ -168,7 +168,7 @@ jobs:
         working-directory: ./modules/cli
         run : |
           set -o pipefail
-          gradle -b build.gradle publish --info --warning-mode all \
+          gradle publish --info --warning-mode all \
           --no-daemon --console plain \
           -PsourceMaven=/home/runner/.m2/repository \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
           gradle-home-cache-excludes: |
             caches/modules-2/files-2.1/dev.galasa/**
@@ -79,7 +79,7 @@ jobs:
         working-directory: ./docs
         run : |
           set -o pipefail
-          gradle -b build.gradle publish --info --warning-mode all \
+          gradle publish --info --warning-mode all \
           --no-daemon --console plain \
           -PsourceMaven=/home/runner/.m2/repository \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
           # gradle-home-cache-excludes: |
           #   caches/modules-2/files-2.1/dev.galasa/**
@@ -92,7 +92,7 @@ jobs:
           path: modules/artifacts
 
       - name: Build Extensions source code with gradle
-        working-directory: modules/extensions
+        working-directory: modules/extensions/galasa-extensions-parent
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           set -o pipefail
-          gradle -b galasa-extensions-parent/build.gradle check publish --info \
+          gradle check publish --info \
           --no-daemon --console plain \
           -PsourceMaven=${{ github.workspace }}/modules/artifacts \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
           # gradle-home-cache-excludes: |
           #   caches/modules-2/files-2.1/dev.galasa/**
@@ -107,7 +107,7 @@ jobs:
           path: modules/artifacts
 
       - name: Build Framework source code
-        working-directory: modules/framework
+        working-directory: modules/framework/galasa-parent
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           set -o pipefail
-          gradle -b galasa-parent/build.gradle check publish --info \
+          gradle check publish --info \
           --no-daemon --console plain \
           -Dorg.gradle.jvmargs=-Xmx5120M \
           -PsourceMaven=${{ github.workspace }}/modules/artifacts \

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
           # gradle-home-cache-excludes: |
           #   caches/modules-2/files-2.1/dev.galasa/**

--- a/.github/workflows/ivts.yaml
+++ b/.github/workflows/ivts.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
           # gradle-home-cache-excludes: |
           #   caches/modules-2/files-2.1/dev.galasa/**

--- a/.github/workflows/managers.yaml
+++ b/.github/workflows/managers.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
           # gradle-home-cache-excludes: |
           #   caches/modules-2/files-2.1/dev.galasa/**
@@ -92,7 +92,7 @@ jobs:
           path: modules/artifacts
 
       - name: Build Managers source code
-        working-directory: modules/managers
+        working-directory: modules/managers/galasa-managers-parent
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           set -o pipefail
-          gradle -b galasa-managers-parent/build.gradle check publish --info \
+          gradle check publish --info \
           --no-daemon --console plain \
           -Dorg.gradle.jvmargs=-Xmx4096M \
           -PsourceMaven=${{ github.workspace }}/modules/artifacts \

--- a/.github/workflows/platform.yaml
+++ b/.github/workflows/platform.yaml
@@ -45,13 +45,13 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
           # gradle-home-cache-excludes: |
           #   caches/modules-2/files-2.1/dev.galasa/**
 
       - name: Build Platform
-        working-directory: modules/platform
+        working-directory: modules/platform/dev.galasa.platform
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GRADLE_PROJECT_signingKeyId:  ${{ secrets.GPG_KEYID }}
@@ -59,7 +59,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           set -o pipefail
-          gradle -b dev.galasa.platform/build.gradle build check publish --info \
+          gradle build check publish --info \
           --no-daemon --console plain \
           -PsourceMaven=https://repo.maven.apache.org/maven2/ \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/.github/workflows/pr-cli.yaml
+++ b/.github/workflows/pr-cli.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
           gradle-home-cache-excludes: |
             caches/modules-2/files-2.1/dev.galasa/**
@@ -193,7 +193,7 @@ jobs:
         working-directory: ./modules/cli
         run : |
           set -o pipefail
-          gradle -b build.gradle installJarsIntoTemplates --info \
+          gradle installJarsIntoTemplates --info \
           --no-daemon --console plain \
           -PsourceMaven=/home/runner/.m2/repository \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
@@ -258,7 +258,7 @@ jobs:
         working-directory: ./modules/cli
         run : |
           set -o pipefail
-          gradle -b build.gradle publish --info --warning-mode all \
+          gradle publish --info --warning-mode all \
           --no-daemon --console plain \
           -PsourceMaven=/home/runner/.m2/repository \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/.github/workflows/pr-docs.yaml
+++ b/.github/workflows/pr-docs.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
           gradle-home-cache-excludes: |
             caches/modules-2/files-2.1/dev.galasa/**
@@ -133,7 +133,7 @@ jobs:
         working-directory: ./docs
         run : |
           set -o pipefail
-          gradle -b build.gradle publish --info --warning-mode all \
+          gradle publish --info --warning-mode all \
           --no-daemon --console plain \
           -PsourceMaven=/home/runner/.m2/repository \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/.github/workflows/pr-extensions.yaml
+++ b/.github/workflows/pr-extensions.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           gradle-home-cache-excludes: |
             caches/modules-2/files-2.1/dev.galasa/**
 
@@ -146,9 +146,9 @@ jobs:
           run-id: ${{ inputs.artifact-id }}
 
       - name: Build Extensions source code with gradle
-        working-directory: modules/extensions
+        working-directory: modules/extensions/galasa-extensions-parent
         run: |
-          gradle -b galasa-extensions-parent/build.gradle check publish --info \
+          gradle check publish --info \
           --no-daemon --console plain \
           -PsourceMaven=${{ github.workspace }}/modules/artifacts \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/.github/workflows/pr-framework.yaml
+++ b/.github/workflows/pr-framework.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
           # gradle-home-cache-excludes: |
           #   caches/modules-2/files-2.1/dev.galasa/**
@@ -170,9 +170,9 @@ jobs:
           docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/openapi2beans:main generate --yaml var/workspace/${{ env.YAML_LOCATION }} --output var/workspace/${{ env.OUTPUT_LOCATION }} --package ${{ env.PACKAGE }}
 
       - name: Build Framework source code
-        working-directory: modules/framework
+        working-directory: modules/framework/galasa-parent
         run: |
-          gradle -b galasa-parent/build.gradle check publish --info \
+          gradle check publish --info \
           --no-daemon --console plain \
           -Dorg.gradle.jvmargs=-Xmx5120M \
           -PsourceMaven=${{ github.workspace }}/modules/artifacts \

--- a/.github/workflows/pr-gradle.yaml
+++ b/.github/workflows/pr-gradle.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           gradle-home-cache-excludes: |
             caches/modules-2/files-2.1/dev.galasa/**
 

--- a/.github/workflows/pr-ivts.yaml
+++ b/.github/workflows/pr-ivts.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           gradle-home-cache-excludes: |
             caches/modules-2/files-2.1/dev.galasa/**
             

--- a/.github/workflows/pr-managers.yaml
+++ b/.github/workflows/pr-managers.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           gradle-home-cache-excludes: |
             caches/modules-2/files-2.1/dev.galasa/**
 
@@ -146,10 +146,10 @@ jobs:
           run-id: ${{ inputs.artifact-id }}
       
       - name: Build Managers source code
-        working-directory: modules/managers
+        working-directory: modules/managers/galasa-managers-parent
         run: |
           set -o pipefail
-          gradle -b galasa-managers-parent/build.gradle check publish --info \
+          gradle check publish --info \
           --no-daemon --console plain \
           -Dorg.gradle.jvmargs=-Xmx4096M \
           -PsourceMaven=${{ github.workspace }}/modules/artifacts \

--- a/.github/workflows/pr-platform.yaml
+++ b/.github/workflows/pr-platform.yaml
@@ -46,14 +46,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           gradle-home-cache-excludes: |
             caches/modules-2/files-2.1/dev.galasa/**
 
       - name: Build Platform
-        working-directory: modules/platform
+        working-directory: modules/platform/dev.galasa.platform
         run: |
-          gradle -b dev.galasa.platform/build.gradle build check publish --info \
+          gradle build check publish --info \
           --no-daemon --console plain \
           -PsourceMaven=https://repo.maven.apache.org/maven2/ \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/modules/extensions/galasa-extensions-parent/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'biz.aQute.bnd.builder' version '5.3.0' apply false
+    id 'biz.aQute.bnd.builder' version '7.1.0' apply false
     id 'dev.galasa.githash' version '0.44.0' apply false
     id 'maven-publish'
     id 'signing'

--- a/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -6,12 +6,12 @@ plugins {
 
 group = 'dev.galasa'
 
-sourceCompatibility = 11
-targetCompatibility = 11
-
 java {
     withJavadocJar()
     withSourcesJar()
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
     
 tasks.withType(Javadoc) {

--- a/modules/framework/build-locally.sh
+++ b/modules/framework/build-locally.sh
@@ -455,7 +455,7 @@ fi
 # Over-rode SOURCE_MAVEN if you want to build from a different maven repo...
 if [[ -z ${SOURCE_MAVEN} ]]; then
     m2=${USER}/.m2/repository
-    export SOURCE_MAVEN=file://$m2
+    export SOURCE_MAVEN=file:///$m2
     # export SOURCE_MAVEN=https://development.galasa.dev/main/maven-repo/obr/
     info "SOURCE_MAVEN repo defaulting to ${SOURCE_MAVEN}."
     info "Set this environment variable if you want to over-ride this value."

--- a/modules/framework/galasa-parent/build.gradle
+++ b/modules/framework/galasa-parent/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'biz.aQute.bnd.builder' version '5.3.0' apply false
+    id 'biz.aQute.bnd.builder' version '7.1.0' apply false
     id 'dev.galasa.githash' version '0.44.0' apply false
     id 'jacoco'
     id 'maven-publish'

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -6,12 +6,12 @@ plugins {
 
 group = 'dev.galasa'
 
-sourceCompatibility = 11
-targetCompatibility = 11
-
 java {
     withJavadocJar()
     withSourcesJar()
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
 
 tasks.withType(Javadoc) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.launcher/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.launcher/build.gradle
@@ -9,6 +9,12 @@ dependencies {
     implementation project(':dev.galasa.framework')
 }
 
+test {
+    // Exclude the LauncherTest.java class
+    // As it has no runnable Tests currently, this causes an error in Gradle 9.0.0.
+    exclude '**/LauncherTest.class'
+}
+
 // Note: These values are consumed by the parent build process
 // They indicate which packages of functionality this OSGi bundle should be delivered inside,
 // or referenced from.

--- a/modules/ivts/compilation-tests/isolated/build.gradle
+++ b/modules/ivts/compilation-tests/isolated/build.gradle
@@ -4,7 +4,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'biz.aQute.bnd.builder' version '6.4.0'
+    id 'biz.aQute.bnd.builder' version '7.1.0'
 }
 
 // This section tells gradle where it should look for any dependencies

--- a/modules/ivts/compilation-tests/mvp/build.gradle
+++ b/modules/ivts/compilation-tests/mvp/build.gradle
@@ -4,7 +4,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'biz.aQute.bnd.builder' version '6.4.0'
+    id 'biz.aQute.bnd.builder' version '7.1.0'
 }
 
 // This section tells gradle where it should look for any dependencies

--- a/modules/ivts/galasa-ivts-parent/buildSrc/build.gradle
+++ b/modules/ivts/galasa-ivts-parent/buildSrc/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'biz.aQute.bnd.builder:biz.aQute.bnd.builder.gradle.plugin:6.4.0'
+    implementation 'biz.aQute.bnd.builder:biz.aQute.bnd.builder.gradle.plugin:7.1.0'
 
     implementation 'dev.galasa.tests:dev.galasa.tests.gradle.plugin:'+version
     implementation 'dev.galasa.obr:dev.galasa.obr.gradle.plugin:'+version

--- a/modules/managers/galasa-managers-parent/build.gradle
+++ b/modules/managers/galasa-managers-parent/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'biz.aQute.bnd.builder' version '5.3.0' apply false
+    id 'biz.aQute.bnd.builder' version '7.1.0' apply false
     id 'jacoco'
     id 'maven-publish'
     id 'signing'

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -6,12 +6,12 @@ plugins {
 
 group = 'dev.galasa'
 
-sourceCompatibility = 11
-targetCompatibility = 11
-
 java {
     withJavadocJar()
     withSourcesJar()
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
     
 tasks.withType(Javadoc) {

--- a/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:5.3.1' // Platform uses 3.1.0
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'commons-io:commons-io'
+    // Required to add a JUnit Platform to the test classpath.
+    // junit-jupiter is a platform artifact, it doesn't pull the runtime engine.
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 test {

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/build.gradle
@@ -10,6 +10,13 @@ dependencies {
     implementation 'com.google.code.gson:gson'
 }
 
+test {
+    // Exclude test source with no runnable Tests, as this causes an error in Gradle 9.0.0.
+    exclude '**/TestRseapiZosBatchImpl.class'
+    exclude '**/TestRseapiZosBatchJobImpl.class'
+    exclude '**/TestRseapiZosBatchManagerImpl.class'
+}
+
 // Note: These values are consumed by the parent build process
 // They indicate which packages of functionality this OSGi bundle should be delivered inside,
 // or referenced from.

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/build.gradle
@@ -10,6 +10,13 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3'
 }
 
+test {
+    // Exclude test source with no runnable Tests, as this causes an error in Gradle 9.0.0.
+    exclude '**/TestZosmfZosBatchImpl.class'
+    exclude '**/TestZosmfZosBatchJobImpl.class'
+    exclude '**/TestZosmfZosBatchManagerImpl.class'
+}
+
 // Note: These values are consumed by the parent build process
 // They indicate which packages of functionality this OSGi bundle should be delivered inside,
 // or referenced from.

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.oeconsol.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.oeconsol.manager/build.gradle
@@ -9,6 +9,14 @@ dependencies {
     implementation project(':galasa-managers-zos-parent:dev.galasa.zosunixcommand.ssh.manager')
 }
 
+test {
+    // Exclude test source with no runnable Tests, as this causes an error in Gradle 9.0.0.
+    exclude '**/TestOeconsolPath.class'
+    exclude '**/TestOeconsolZosConsoleCommandImpl.class'
+    exclude '**/TestOeconsolZosConsoleImpl.class'
+    exclude '**/TestOeconsolZosConsoleManagerImpl.class'
+}
+
 // Note: These values are consumed by the parent build process
 // They indicate which packages of functionality this OSGi bundle should be delivered inside,
 // or referenced from.

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.zosmf.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.zosmf.manager/build.gradle
@@ -9,6 +9,13 @@ dependencies {
     implementation 'com.google.code.gson:gson'
 }
 
+test {
+    // Exclude test source with no runnable Tests, as this causes an error in Gradle 9.0.0.
+    exclude '**/TestZosmfZosConsoleManagerImpl.class'
+    exclude '**/TestZosmfZosConsoleImpl.class'
+    exclude '**/TestZosmfZosConsoleCommandImpl.class'
+}
+
 // Note: These values are consumed by the parent build process
 // They indicate which packages of functionality this OSGi bundle should be delivered inside,
 // or referenced from.

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.rseapi.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.rseapi.manager/build.gradle
@@ -12,6 +12,17 @@ dependencies {
     implementation 'commons-io:commons-io'
 }
 
+test {
+    // Exclude test source with no runnable Tests, as this causes an error in Gradle 9.0.0.
+    exclude '**/TestRseapiZosDatasetAttributesListdsi.class'
+    exclude '**/TestRseapiZosDatasetImpl.class'
+    exclude '**/TestRseapiZosFileHandlerImpl.class'
+    exclude '**/TestRseapiZosFileManagerImpl.class'
+    exclude '**/TestRseapiZosUnixCommand.class'
+    exclude '**/TestRseapiZosUNIXFileImpl.class'
+    exclude '**/TestRseapiZosVSAMDatasetImpl.class'
+}
+
 // Note: These values are consumed by the parent build process
 // They indicate which packages of functionality this OSGi bundle should be delivered inside,
 // or referenced from.

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.zosmf.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.zosmf.manager/build.gradle
@@ -11,6 +11,17 @@ dependencies {
     implementation 'commons-io:commons-io'
 }
 
+test {
+    // Exclude test source with no runnable Tests, as this causes an error in Gradle 9.0.0.
+    exclude '**/TestZosmfZosDatasetAttributesListdsi.class'
+    exclude '**/TestZosmfZosDatasetImpl.class'
+    exclude '**/TestZosmfZosFileHandlerImpl.class'
+    exclude '**/TestZosmfZosFileManagerImpl.class'
+    exclude '**/TestZosmfZosUNIXFileImpl.class'
+    exclude '**/TestZosmfZosVSAMDatasetImpl.class'
+    exclude '**/ZosUNIXCommandManagerImpl.class'
+}
+
 // Note: These values are consumed by the parent build process
 // They indicate which packages of functionality this OSGi bundle should be delivered inside,
 // or referenced from.

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -27,12 +27,12 @@ dependencies {
     // api platform('org.junit:junit-bom:?')
 
     constraints {
-        api 'biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0'
-        api 'biz.aQute.bnd:biz.aQute.bnd.embedded-repo:5.3.0'
-        api 'biz.aQute.bnd:biz.aQute.bndlib:5.3.0'
-        api 'biz.aQute.bnd:biz.aQute.repository:5.3.0'
-        api 'biz.aQute.bnd:biz.aQute.resolve:5.3.0'
-        api 'biz.aQute.bnd.builder:biz.aQute.bnd.builder.gradle.plugin:5.3.0'
+        api 'biz.aQute.bnd:biz.aQute.bnd.gradle:7.1.0'
+        api 'biz.aQute.bnd:biz.aQute.bnd.embedded-repo:7.1.0'
+        api 'biz.aQute.bnd:biz.aQute.bndlib:7.1.0'
+        api 'biz.aQute.bnd:biz.aQute.repository:7.1.0'
+        api 'biz.aQute.bnd:biz.aQute.resolve:7.1.0'
+        api 'biz.aQute.bnd.builder:biz.aQute.bnd.builder.gradle.plugin:7.1.0'
 
         api 'com.auth0:java-jwt:4.4.0' // used by wrapper.
         

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -266,6 +266,8 @@ dependencies {
 
         api 'org.junit.jupiter:junit-jupiter:5.10.2'
 
+        api 'org.junit.platform:junit-platform-launcher:1.10.2'
+
         api 'org.jspecify:jspecify:1.0.0'
 
         api 'org.mockito:mockito-core:3.1.0'


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2369

## Changes

- Uplift Gradle version used in GitHub Actions workflows to 9.0.0 from 8.9.
- Uplift biz.aQute.bnd dependencies to version 7.1.0 as this version of the plugin is compatible with Gradle 9.0.0.
- Remove use of -b flag to point to location of build.gradle file as this has been removed in Gradle 9.
- Replace sourceCompatibility and targetCompatibility with Java toolchains as this is the recommended way to set the Java version and setting sourceCompatibility and targetCompatibility is not supported in Gradle 9.
- Gradle 9 now throws an error if it detects test source files in src/test/java but these files do not have any runnable test cases. This PR introduces an excludes section to the build.gradle files of projects that have test files with no runnable tests to exclude Gradle from parsing them.
- junit-platform-launcher has been added to the SDV Manager as it requires a JUnit runtime (Gradle 9 throws an error now if this is missing).
- Missing slash added in Framework's build-locally.sh as Gradle 9 now throws an error.