### PR TITLE
Downgrading biz.aQute.bnd plugins back down to 6.4.0

### DIFF
--- a/modules/extensions/galasa-extensions-parent/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'biz.aQute.bnd.builder' version '7.1.0' apply false
+    id 'biz.aQute.bnd.builder' version '5.3.0' apply false
     id 'dev.galasa.githash' version '0.44.0' apply false
     id 'maven-publish'
     id 'signing'

--- a/modules/framework/galasa-parent/build.gradle
+++ b/modules/framework/galasa-parent/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'biz.aQute.bnd.builder' version '7.1.0' apply false
+    id 'biz.aQute.bnd.builder' version '5.3.0' apply false
     id 'dev.galasa.githash' version '0.44.0' apply false
     id 'jacoco'
     id 'maven-publish'

--- a/modules/ivts/compilation-tests/isolated/build.gradle
+++ b/modules/ivts/compilation-tests/isolated/build.gradle
@@ -4,7 +4,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'biz.aQute.bnd.builder' version '7.1.0'
+    id 'biz.aQute.bnd.builder' version '5.3.0'
 }
 
 // This section tells gradle where it should look for any dependencies

--- a/modules/ivts/compilation-tests/mvp/build.gradle
+++ b/modules/ivts/compilation-tests/mvp/build.gradle
@@ -4,7 +4,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'biz.aQute.bnd.builder' version '7.1.0'
+    id 'biz.aQute.bnd.builder' version '5.3.0'
 }
 
 // This section tells gradle where it should look for any dependencies

--- a/modules/ivts/galasa-ivts-parent/buildSrc/build.gradle
+++ b/modules/ivts/galasa-ivts-parent/buildSrc/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'biz.aQute.bnd.builder:biz.aQute.bnd.builder.gradle.plugin:7.1.0'
+    implementation 'biz.aQute.bnd.builder:biz.aQute.bnd.builder.gradle.plugin:5.3.0'
 
     implementation 'dev.galasa.tests:dev.galasa.tests.gradle.plugin:'+version
     implementation 'dev.galasa.obr:dev.galasa.obr.gradle.plugin:'+version

--- a/modules/managers/galasa-managers-parent/build.gradle
+++ b/modules/managers/galasa-managers-parent/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'biz.aQute.bnd.builder' version '7.1.0' apply false
+    id 'biz.aQute.bnd.builder' version '5.3.0' apply false
     id 'jacoco'
     id 'maven-publish'
     id 'signing'

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -27,12 +27,12 @@ dependencies {
     // api platform('org.junit:junit-bom:?')
 
     constraints {
-        api 'biz.aQute.bnd:biz.aQute.bnd.gradle:7.1.0'
-        api 'biz.aQute.bnd:biz.aQute.bnd.embedded-repo:7.1.0'
-        api 'biz.aQute.bnd:biz.aQute.bndlib:7.1.0'
-        api 'biz.aQute.bnd:biz.aQute.repository:7.1.0'
-        api 'biz.aQute.bnd:biz.aQute.resolve:7.1.0'
-        api 'biz.aQute.bnd.builder:biz.aQute.bnd.builder.gradle.plugin:7.1.0'
+        api 'biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0'
+        api 'biz.aQute.bnd:biz.aQute.bnd.embedded-repo:5.3.0'
+        api 'biz.aQute.bnd:biz.aQute.bndlib:5.3.0'
+        api 'biz.aQute.bnd:biz.aQute.repository:5.3.0'
+        api 'biz.aQute.bnd:biz.aQute.resolve:5.3.0'
+        api 'biz.aQute.bnd.builder:biz.aQute.bnd.builder.gradle.plugin:5.3.0'
 
         api 'com.auth0:java-jwt:4.4.0' // used by wrapper.
         


### PR DESCRIPTION
## Why?

PR #405 included changes to uplift the Gradle version used in our builds to 9.0. I upgraded the version of the biz.aQute.bnd plugins to 7.1.0 (latest version) as Gradle 9 removes the Conventions API but the bnd plugins of under version 7 still call it, so this causes errors. Reading the 7.1.0 release notes in more detail, it mentions "All Bnd artifacts are built to run on Java 17 or later." (https://github.com/bndtools/bnd/wiki/Changes-in-7.1.0#backward-compatibility). I am concerned that upgrading to 7.1.0 will break Galasa users who still use Java 11, which our website says we still support.

Therefore I'm downgrading the bnd plugins back to 6.4.0 so still newer than 5.3.0 but does not break backwards compatibility. Also 6.4.0 was used in a few locations so this means a consistent version throughout.