### PR TITLE
Wait for expected text to appear on the terminal screen before making assertions on the JSON content

### DIFF
--- a/modules/ivts/galasa-ivts-parent/dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos3270/src/main/java/dev/galasa/zos/ivts/zos3270/Zos3270IVT.java
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos3270/src/main/java/dev/galasa/zos/ivts/zos3270/Zos3270IVT.java
@@ -180,7 +180,7 @@ public class Zos3270IVT {
 		assertThat(terminalJsonStr).doesNotContain(expectedText);
 
 		// Run the CGSM transaction to display the good morning panel
-    	terminal.type("CSGM").enter().wfk();
+    	terminal.type("CSGM").enter().wfk().waitForTextInField(expectedText);
 		terminalScreen = terminal.retrieveScreen();
 		terminalJsonStr = terminal.toJsonString();
 


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2415

## Changes
- Added a `waitForTextInField` call to the failing testToJsonStringReturnsCurrentScreenInJsonFormat method to wait for the expected text to appear on the screen before making assertions on the returned JSON output