### PR TITLE
Start drafting release notes for 0.44.0

### DIFF
--- a/docs/content/releases/posts/v0.44.0.md
+++ b/docs/content/releases/posts/v0.44.0.md
@@ -1,0 +1,23 @@
+---
+slug: v0.44.0
+date: 2025-09-04
+links:
+  - v0.44.0 GitHub release: https://github.com/galasa-dev/galasa/releases/tag/v0.44.0
+---
+
+# 0.44.0 - Release Highlights
+
+## Changes affecting the Galasa Service
+
+- The Galasa service Helm chart's `eventStreamsSecretName` value is now optional and a value is no longer provided by default.
+    - If no secret name is given, the Galasa service's Kafka extension will not be loaded.
+    - If a secret name is given, the Helm chart will attempt to load the Kubernetes secret with the given name and pass it through to be used by the Galasa service's Kafka extension.
+    - If a secret name is given but no such secret exists in the Kubernetes namespace, then the Galasa service will fail to be installed or upgraded.
+
+## Changes affecting tests running locally or on the Galasa Service
+
+- The 3270 manager's `ITerminal` interface has a new `toJsonString()` method that allows tests to convert the current 3270 terminal screen into JSON format.
+
+## Other changes
+
+## Galasa Web UI changes


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/projectmanagement/issues/2390 and https://github.com/galasa-dev/projectmanagement/issues/2353

## Changes
- Added initial draft release notes for 0.44.0 which should continue to be filled out as more changes are delivered ahead of the 0.44.0 release (these are **not** the final release notes for 0.44.0)