### PR TITLE
Stop runs in the 'allocated' state from being returned when getting active runs

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
@@ -165,4 +165,9 @@ public class MockIRun implements IRun {
     public Instant getInterruptedAt() {
         throw new UnsupportedOperationException("Unimplemented method 'getInterruptedAt'");
     }
+
+    @Override
+    public Instant getAllocatedTimeout() {
+        throw new UnsupportedOperationException("Unimplemented method 'getAllocatedTimeout'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
@@ -218,4 +218,9 @@ public class MockIRun implements IRun{
     public Instant getInterruptedAt() {
         throw new UnsupportedOperationException("Unimplemented method 'getInterruptedAt'");
     }
+
+    @Override
+    public Instant getAllocatedTimeout() {
+        throw new UnsupportedOperationException("Unimplemented method 'getAllocatedTimeout'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/ISettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/ISettings.java
@@ -51,5 +51,7 @@ public interface ISettings {
     public int getMaxTestPodRetryLimit();
 
     public long getInterruptedTestRunCleanupGracePeriodSeconds();
+
+    public long getAllocatedTestRunTimeoutMinutes();
 }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -32,6 +32,9 @@ public class Settings implements Runnable, ISettings {
     public static final int INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_DEFAULT = 300;
     public static final String INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_PROPERTY_NAME = "interrupted_test_run_cleanup_grace_period_seconds";
 
+    public static final int ALLOCATED_TEST_RUN_TIMEOUT_MINUTES_DEFAULT = 30;
+    public static final String ALLOCATED_TEST_RUN_TIMEOUT_MINUTES_PROPERTY_NAME = "allocated_test_run_timeout_minutes";
+
     private final Log         logger                      = LogFactory.getLog(getClass());
 
     private final K8sController controller;
@@ -66,6 +69,7 @@ public class Settings implements Runnable, ISettings {
 
     private long              kubeLaunchIntervalMillisecs = 1000L;
     private long              interruptedTestRunCleanupGracePeriodSeconds = INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_DEFAULT;
+    private long              allocatedTestRunTimeoutMinutes = ALLOCATED_TEST_RUN_TIMEOUT_MINUTES_DEFAULT;
 
     // Poll loop interval which is looking for queued test runs, so they can be launched in a pod.
     private int               runPollSeconds              = 60;
@@ -200,6 +204,7 @@ public class Settings implements Runnable, ISettings {
         this.engineImage = updateProperty(configMapData, "engine_image", "ghcr.io/galasa-dev/galasa-boot-embedded-amd64", this.engineImage);
         this.kubeLaunchIntervalMillisecs = updateProperty(configMapData, "kube_launch_interval_milliseconds", kubeLaunchIntervalMillisecs, this.kubeLaunchIntervalMillisecs);
         this.interruptedTestRunCleanupGracePeriodSeconds = updateProperty(configMapData, INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_PROPERTY_NAME, INTERRUPTED_RUN_CLEANUP_GRACE_PERIOD_SECS_DEFAULT, this.interruptedTestRunCleanupGracePeriodSeconds);
+        this.allocatedTestRunTimeoutMinutes = updateProperty(configMapData, ALLOCATED_TEST_RUN_TIMEOUT_MINUTES_PROPERTY_NAME, ALLOCATED_TEST_RUN_TIMEOUT_MINUTES_DEFAULT, this.allocatedTestRunTimeoutMinutes);
 
         this.engineMemoryRequestMi = updateProperty(configMapData, "engine_memory_request", engineMemoryRequestMi, this.engineMemoryRequestMi);
         this.engineMemoryLimitMi = updateProperty(configMapData, "engine_memory_limit", engineMemoryLimitMi, this.engineMemoryLimitMi);
@@ -390,5 +395,9 @@ public class Settings implements Runnable, ISettings {
 
     public long getInterruptedTestRunCleanupGracePeriodSeconds() {
         return this.interruptedTestRunCleanupGracePeriodSeconds;
+    }
+
+    public long getAllocatedTestRunTimeoutMinutes() {
+        return this.allocatedTestRunTimeoutMinutes;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -189,11 +189,11 @@ public class TestPodScheduler implements Runnable {
         try {
             // *** First attempt to allocate the run to this controller
             Instant now = timeService.now();
-            Instant expire = now.plus(15, ChronoUnit.MINUTES);
+            Instant allocatedTimeoutTimestamp = now.plus(settings.getAllocatedTestRunTimeoutMinutes(), ChronoUnit.MINUTES);
             HashMap<String, String> props = new HashMap<>();
             props.put("run." + runName + "." + DssPropertyKeyRunNameSuffix.CONTROLLER, settings.getPodName());
             props.put("run." + runName + "." + DssPropertyKeyRunNameSuffix.ALLOCATED, now.toString());
-            props.put("run." + runName + "." + DssPropertyKeyRunNameSuffix.ALLOCATE_TIMEOUT, expire.toString());
+            props.put("run." + runName + "." + DssPropertyKeyRunNameSuffix.ALLOCATE_TIMEOUT, allocatedTimeoutTimestamp.toString());
             if (!this.dss.putSwap("run." + runName + "."+DssPropertyKeyRunNameSuffix.STATUS, "queued", "allocated", props)) {
                 logger.info("run allocated by another controller");
                 return;

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockISettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockISettings.java
@@ -8,6 +8,7 @@ public class MockISettings implements ISettings {
 
     public int maxTestPodRetriesLimit = 2;
     public int interruptedTestRunCleanupGracePeriodSecs = 10;
+    public int allocatedTestRunTimeoutMins = 30;
     public static final String ENGINE_LABEL = "myEngineLabel";
 
     @Override
@@ -98,6 +99,11 @@ public class MockISettings implements ISettings {
     @Override
     public long getInterruptedTestRunCleanupGracePeriodSeconds() {
         return interruptedTestRunCleanupGracePeriodSecs;
+    }
+
+    @Override
+    public long getAllocatedTestRunTimeoutMinutes() {
+        return allocatedTestRunTimeoutMins;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunAllocatedRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunAllocatedRunCleanup.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import dev.galasa.framework.TestRunLifecycleStatus;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IFrameworkRuns;
+import dev.galasa.framework.spi.IResourceManagement;
+import dev.galasa.framework.spi.IRun;
+import dev.galasa.framework.spi.Result;
+import dev.galasa.framework.spi.utils.ITimeService;
+
+public class RunAllocatedRunCleanup implements Runnable {
+
+    private final IResourceManagement resourceManagement;
+    private final IFrameworkRuns      frameworkRuns;
+    private final ITimeService        timeService;
+    private final Log                 logger = LogFactory.getLog(this.getClass());
+
+    protected RunAllocatedRunCleanup(
+        IFrameworkRuns frameworkRuns,
+        IResourceManagement resourceManagement,
+        ITimeService timeService
+    ) throws FrameworkException {
+        this.resourceManagement = resourceManagement;
+        this.frameworkRuns = frameworkRuns;
+        this.timeService = timeService;
+        this.logger.info("Allocated runs cleanup monitor initialised");
+    }
+
+    public void run() {
+        logger.info("Starting search for allocated runs to clean up");
+        try {
+            List<IRun> runs = frameworkRuns.getAllRuns();
+            for (IRun run : runs) {
+                String runName = run.getName();
+                Instant now = timeService.now();
+
+                String status = run.getStatus();
+                if (TestRunLifecycleStatus.ALLOCATED.toString().equals(status)) {
+                    Instant allocatedRunExpiryTime = run.getAllocatedTimeout();
+                    if (allocatedRunExpiryTime != null && now.isAfter(allocatedRunExpiryTime)) {
+                        logger.info("Interrupting run " + runName + " as the run has been in the 'allocated' state for too long");
+                        this.frameworkRuns.markRunInterrupted(runName, Result.HUNG);
+                    }
+                }
+            }
+        } catch (FrameworkException e) {
+            logger.error("Scan of allocated runs failed", e);
+        }
+
+        this.resourceManagement.resourceManagementRunSuccessful();
+        logger.info("Finished search for allocated runs to clean up");
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunResourceManagement.java
@@ -18,6 +18,7 @@ import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IResourceManagement;
 import dev.galasa.framework.spi.IResourceManagementProvider;
 import dev.galasa.framework.spi.ResourceManagerException;
+import dev.galasa.framework.spi.utils.SystemTimeService;
 
 @Component(service = { IResourceManagementProvider.class })
 public class RunResourceManagement implements IResourceManagementProvider {
@@ -63,6 +64,13 @@ public class RunResourceManagement implements IResourceManagementProvider {
             this.resourceManagement.getScheduledExecutorService().scheduleWithFixedDelay(
                     new RunFinishedRuns(this.framework, this.resourceManagement, this.dss, this, cps),
                     this.framework.getRandom().nextInt(20), 20, TimeUnit.SECONDS);
+        } catch (FrameworkException e) {
+            logger.error("Unable to initialise Finished Run monitor", e);
+        }
+        try {
+            this.resourceManagement.getScheduledExecutorService().scheduleWithFixedDelay(
+                    new RunAllocatedRunCleanup(this.framework.getFrameworkRuns(), this.resourceManagement, new SystemTimeService()),
+                    this.framework.getRandom().nextInt(20), 5, TimeUnit.MINUTES);
         } catch (FrameworkException e) {
             logger.error("Unable to initialise Finished Run monitor", e);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/TestRunAllocatedRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/TestRunAllocatedRunCleanup.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import dev.galasa.framework.TestRunLifecycleStatus;
+import dev.galasa.framework.mocks.MockFrameworkRuns;
+import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.mocks.MockTimeService;
+import dev.galasa.framework.resource.management.internal.mocks.MockResourceManagement;
+import dev.galasa.framework.spi.IRun;
+import dev.galasa.framework.spi.Result;
+
+public class TestRunAllocatedRunCleanup {
+
+    private MockRun createMockRun(String runName, TestRunLifecycleStatus status) {
+        MockRun run = new MockRun(
+            "bundle",
+            "class",
+            runName,
+            "teststream",
+            "obr",
+            "repo",
+            "requestor",
+            false
+        );
+        run.setStatus(status.toString());
+        return run;
+    }
+
+    @Test
+    public void testCanCleanUpAllocatedRunThatHasTimedOut() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun timedOutRun = createMockRun("run1", TestRunLifecycleStatus.ALLOCATED);
+        timedOutRun.setAllocatedTimeout(Instant.EPOCH);
+
+        runs.add(timedOutRun);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockResourceManagement mockResourceManagement = new MockResourceManagement();
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+
+        RunAllocatedRunCleanup runCleanup = new RunAllocatedRunCleanup(mockFrameworkRuns, mockResourceManagement, mockTimeService);
+
+        // When...
+        runCleanup.run();
+
+        // Then...
+        // The test run should have been set an interrupt reason
+        assertThat(mockResourceManagement.isSuccessful).isTrue();
+        assertThat(timedOutRun.getInterruptReason()).isEqualTo(Result.HUNG);
+    }
+
+    @Test
+    public void testCanCleanUpMultipleAllocatedRunThatHaveTimedOut() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun timedOutRun1 = createMockRun("run1", TestRunLifecycleStatus.ALLOCATED);
+        MockRun timedOutRun2 = createMockRun("run2", TestRunLifecycleStatus.ALLOCATED);
+        MockRun timedOutRun3 = createMockRun("run3", TestRunLifecycleStatus.ALLOCATED);
+
+        timedOutRun1.setAllocatedTimeout(Instant.EPOCH);
+        timedOutRun2.setAllocatedTimeout(Instant.EPOCH);
+        timedOutRun3.setAllocatedTimeout(Instant.EPOCH);
+
+        runs.add(timedOutRun1);
+        runs.add(timedOutRun2);
+        runs.add(timedOutRun3);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockResourceManagement mockResourceManagement = new MockResourceManagement();
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+
+        RunAllocatedRunCleanup runCleanup = new RunAllocatedRunCleanup(mockFrameworkRuns, mockResourceManagement, mockTimeService);
+
+        // When...
+        runCleanup.run();
+
+        // Then...
+        assertThat(mockResourceManagement.isSuccessful).isTrue();
+        assertThat(timedOutRun1.getInterruptReason()).isEqualTo(Result.HUNG);
+        assertThat(timedOutRun2.getInterruptReason()).isEqualTo(Result.HUNG);
+        assertThat(timedOutRun3.getInterruptReason()).isEqualTo(Result.HUNG);
+    }
+
+    @Test
+    public void testDoesNotCleanUpRunsThatHaveNotTimedOut() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun timedOutRun = createMockRun("run1", TestRunLifecycleStatus.ALLOCATED);
+        MockRun newRun = createMockRun("run2", TestRunLifecycleStatus.ALLOCATED);
+
+        Instant currentTime = Instant.now();
+
+        timedOutRun.setAllocatedTimeout(Instant.EPOCH);
+
+        // This run has an allocated timeout set in the future
+        newRun.setAllocatedTimeout(currentTime.plusSeconds(10));
+
+        runs.add(timedOutRun);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockResourceManagement mockResourceManagement = new MockResourceManagement();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        RunAllocatedRunCleanup runCleanup = new RunAllocatedRunCleanup(mockFrameworkRuns, mockResourceManagement, mockTimeService);
+
+        // When...
+        runCleanup.run();
+
+        // Then...
+        assertThat(mockResourceManagement.isSuccessful).isTrue();
+        assertThat(timedOutRun.getInterruptReason()).isEqualTo(Result.HUNG);
+        
+        // The run that hasn't timed out should not have been interrupted
+        assertThat(newRun.getInterruptReason()).isNull();
+    }
+
+    @Test
+    public void testDoesNotCleanUpRunsThatAreNotInTheAllocatedState() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun run1 = createMockRun("run1", TestRunLifecycleStatus.BUILDING);
+        MockRun run2 = createMockRun("run2", TestRunLifecycleStatus.STARTED);
+
+        Instant currentTime = Instant.now();
+
+        run1.setAllocatedTimeout(Instant.EPOCH);
+        run2.setAllocatedTimeout(currentTime.plusSeconds(10));
+
+        runs.add(run1);
+        runs.add(run2);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockResourceManagement mockResourceManagement = new MockResourceManagement();
+        MockTimeService mockTimeService = new MockTimeService(currentTime);
+
+        RunAllocatedRunCleanup runCleanup = new RunAllocatedRunCleanup(mockFrameworkRuns, mockResourceManagement, mockTimeService);
+
+        // When...
+        runCleanup.run();
+
+        // Then...
+        // None of the runs should have been interrupted
+        assertThat(mockResourceManagement.isSuccessful).isTrue();
+        assertThat(run1.getInterruptReason()).isNull();
+        assertThat(run2.getInterruptReason()).isNull();
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockResourceManagement.java
@@ -12,6 +12,8 @@ import dev.galasa.framework.spi.IResourceManagement;
 
 public class MockResourceManagement implements IResourceManagement {
 
+    public boolean isSuccessful;
+
     @Override
     public ScheduledExecutorService getScheduledExecutorService() {
         throw new UnsupportedOperationException("Unimplemented method 'getScheduledExecutorService'");
@@ -19,7 +21,7 @@ public class MockResourceManagement implements IResourceManagement {
 
     @Override
     public void resourceManagementRunSuccessful() {
-        throw new UnsupportedOperationException("Unimplemented method 'resourceManagementRunSuccessful'");
+        this.isSuccessful = true;
     }
     
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -92,10 +92,6 @@ public class FrameworkRuns implements IFrameworkRuns {
                 continue;
             }
 
-            if ("allocated".equals(run.getStatus())) {
-                continue;
-            }
-
             if (run.isSharedEnvironment()) {
                 continue;
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
@@ -56,6 +56,7 @@ public class RunImpl implements IRun {
     private final String  rasRunId;
     private final String  interruptReason;
     private final Instant interruptedAt;
+    private final Instant allocatedTimeout;
     private List<RunRasAction> rasActions = new ArrayList<>();
     private final Set<String> tags;
 
@@ -94,6 +95,7 @@ public class RunImpl implements IRun {
         gherkin = runProperties.get(prefix + DssPropertyKeyRunNameSuffix.GHERKIN);
         tags = getTagsFromDss(runProperties, prefix);
         interruptedAt = getInterruptedAtTimeFromDss(runProperties, prefix);
+        allocatedTimeout = getAllocatedTimeoutFromDss(runProperties, prefix);
 
         String encodedRasActions = runProperties.get(prefix + DssPropertyKeyRunNameSuffix.RAS_ACTIONS);
         if (encodedRasActions != null) {
@@ -143,12 +145,20 @@ public class RunImpl implements IRun {
     }
 
     private Instant getInterruptedAtTimeFromDss(Map<String, String> runProperties, String prefix) {
-        Instant interruptedAt = null;
-        String interruptedAtStr = runProperties.get(prefix + DssPropertyKeyRunNameSuffix.INTERRUPTED_AT);
-        if (interruptedAtStr != null) {
-            interruptedAt = Instant.parse(interruptedAtStr);
+        return getTimeValueFromDss(runProperties, prefix + DssPropertyKeyRunNameSuffix.INTERRUPTED_AT);
+    }
+
+    private Instant getAllocatedTimeoutFromDss(Map<String, String> runProperties, String prefix) {
+        return getTimeValueFromDss(runProperties, prefix + DssPropertyKeyRunNameSuffix.ALLOCATE_TIMEOUT);
+    }
+
+    private Instant getTimeValueFromDss(Map<String, String> runProperties, String propertyKey) {
+        Instant timeToReturn = null;
+        String timeAsStr = runProperties.get(propertyKey);
+        if (timeAsStr != null) {
+            timeToReturn = Instant.parse(timeAsStr);
         }
-        return interruptedAt;
+        return timeToReturn;
     }
 
     private Set<String> getTagsFromDss(Map<String, String> runProperties, String prefix) {
@@ -309,6 +319,11 @@ public class RunImpl implements IRun {
     @Override
     public Instant getInterruptedAt() {
         return this.interruptedAt;
+    }
+
+    @Override
+    public Instant getAllocatedTimeout() {
+        return allocatedTimeout;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
@@ -55,8 +55,7 @@ public interface IFrameworkRuns {
      * Marks the specified run as finished in the DSS. Only if the state of the test run is as we expect.
      * Other processes may have moved the status of the test run without us knowing.
      * @param runName
-     * @param result
-     * @param currentState The current status of the test run, the status we want to change it from
+     * @param currentStatus The current status of the test run, the status we want to change it from
      * @return True if the test was marked as finished, false if not. For example, someother process marked it as
      * starting or building ahead of us marking it as finished here.
      * @throws DynamicStatusStoreException

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
@@ -62,6 +62,8 @@ public interface IRun {
 
     Instant getInterruptedAt();
 
+    Instant getAllocatedTimeout();
+
     String getRasRunId();
 
     List<RunRasAction> getRasActions();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
@@ -160,4 +160,9 @@ public class MockRun implements IRun {
     public Instant getInterruptedAt() {
         throw new UnsupportedOperationException("Unimplemented method 'getInterruptedAt'");
     }
+
+    @Override
+    public Instant getAllocatedTimeout() {
+        throw new UnsupportedOperationException("Unimplemented method 'getAllocatedTimeout'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
@@ -132,6 +132,10 @@ public class MockFrameworkRuns implements IFrameworkRuns{
 
     @Override
     public boolean markRunInterrupted(String runName, String interruptReason) throws DynamicStatusStoreException {
+        MockRun run = (MockRun) getRun(runName);
+        if (run != null) {
+            run.setInterruptReason(interruptReason);
+        }
         return true;
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
@@ -33,6 +33,7 @@ public class MockRun implements IRun {
     private String status;
     private String interruptReason;
     private Instant interruptedAt;
+    private Instant allocatedTimeout;
     private String result;
     private String runId;
     private List<RunRasAction> rasActions = new ArrayList<>();
@@ -229,6 +230,15 @@ public class MockRun implements IRun {
         }
 
         return testStructure;
+    }
+
+    @Override
+    public Instant getAllocatedTimeout() {
+        return this.allocatedTimeout;
+    }
+
+    public void setAllocatedTimeout(Instant allocatedTimeout) {
+        this.allocatedTimeout = allocatedTimeout;
     }
 
     // ------------- un-implemented methods follow ----------------


### PR DESCRIPTION
## Why?
Related to https://github.com/galasa-dev/projectmanagement/issues/2269

## Changes
Kubernetes pods for test runs in the `allocated` state may not have been scheduled yet so the test runs would not have started, but when the framework was getting the "active" runs, it was including the "allocated" runs as well. This meant that when the resource monitor was checking for runs with no heartbeat, it would find the "allocated" runs and mark them as "hung" before their test pods were even scheduled.

- Stopped runs in the `allocated` state from being returned when the framework looks for active runs
- Added a job to the resource monitor that periodically checks for runs in the `allocated` state that have exceeded the value in their `allocate.timeout` DSS property, interrupting the timed out runs with a reason of 'Hung'
- Fixed a javadoc warning around the `markRunCancelling` method appearing in builds.