### PR TITLE
Add more logging around the engine controller's interrupted run processing

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/api/KubernetesEngineFacade.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/api/KubernetesEngineFacade.java
@@ -72,8 +72,13 @@ public class KubernetesEngineFacade {
 
         // There should only be one pod with this name.
         V1Pod pod = null ;
-        if( !pods.isEmpty() ) {
-            pod = pods.get(0);
+        if (pods != null) {
+            logger.info("Found " + pods.size() + " test pod(s) for run " + runName);
+            if( !pods.isEmpty() ) {
+                pod = pods.get(0);
+            }
+        } else {
+            logger.info("No test pod found for run " + runName);
         }
         return pod;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/interruptedruns/PodDeleter.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/interruptedruns/PodDeleter.java
@@ -1,5 +1,8 @@
 package dev.galasa.framework.k8s.controller.interruptedruns;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import dev.galasa.framework.k8s.controller.K8sControllerException;
 
 import dev.galasa.framework.k8s.controller.api.KubernetesEngineFacade;
@@ -7,6 +10,8 @@ import io.kubernetes.client.openapi.models.V1Pod;
 
 
 public class PodDeleter {
+    private Log logger = LogFactory.getLog(getClass());
+
     private final KubernetesEngineFacade kubeApi;
     
     public PodDeleter(KubernetesEngineFacade kubeApi) {
@@ -17,6 +22,9 @@ public class PodDeleter {
         V1Pod pod = kubeApi.getTestPod(runName);
         if ( pod != null ) {
             kubeApi.deletePod(pod);
+            logger.info("Deleted pod for run " + runName);
+        } else {
+            logger.info("No pod to delete was found for run " + runName);
         }
     }
     

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunImpl.java
@@ -364,6 +364,13 @@ public class RunImpl implements IRun {
             buff.append(" waitUntil: "+waitUntil.toString());
         }
 
+        if (this.interruptedAt == null) {
+            buff.append(" interruptedAt: null");
+        } else {
+            buff.append(" interruptedAt: "+interruptedAt.toString());
+        }
+
+        buff.append(" interruptReason: "+interruptReason);
         buff.append(" requestor: "+requestor);
         buff.append(" stream: "+stream);
         buff.append(" repo: "+repo);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunRasActionProcessor.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RunRasActionProcessor.java
@@ -46,14 +46,24 @@ public class RunRasActionProcessor implements IRunRasActionProcessor {
                         String runStatus = testStructure.getStatus();
                         String desiredRunStatus = rasAction.getDesiredRunStatus();
                         if (!desiredRunStatus.equals(runStatus)) {
+                            String desiredRunResult = rasAction.getDesiredRunResult();
+
+                            logger.info(runName + ": Updating run status in RAS from " + runStatus + " to " + desiredRunStatus);
+                            logger.info(runName + ": Setting result to " + desiredRunResult);
+
                             testStructure.setStatus(desiredRunStatus);
-                            testStructure.setResult(rasAction.getDesiredRunResult());
+                            testStructure.setResult(desiredRunResult);
         
                             rasStore.updateTestStructure(runId, testStructure);
+                            logger.info("Successfully updated RAS record for run " + runName);
                         } else {
                             logger.info("Run already has status '" + desiredRunStatus + "', will not update its RAS record");
                         }
+                    } else {
+                        logger.info("No RAS test structure found for run " + runName + ", skipping RAS actions for this run");
                     }
+                } else {
+                    logger.info("No RAS record ID found for run " + runName + ", skipping RAS actions for this run");
                 }
             } catch (ResultArchiveStoreException ex) {
                 logger.error("Failed to process RAS action", ex);


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2397

## Changes
- Added more log statements around the interrupted run processing logic in the engine controller