### PR TITLE
Use the installed Galasa service name when identifying test pods in Kubernetes

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
@@ -216,7 +216,7 @@ public class K8sController {
         Settings settings
     ) throws FrameworkException {
 
-        runCleanup = new RunPodCleanup(settings, kubeEngineFacade, frameworkRuns);
+        runCleanup = new RunPodCleanup(kubeEngineFacade, frameworkRuns);
         schedulePodCleanup();
 
         podScheduler = new TestPodScheduler(env, dss, cps, settings, kubeEngineFacade, frameworkRuns, timeService);

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunPodCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunPodCleanup.java
@@ -24,12 +24,10 @@ public class RunPodCleanup implements Runnable {
 
     private final IFrameworkRuns runs;
     private final KubernetesEngineFacade kubeApi;
-    private final ISettings settings;
 
-    public RunPodCleanup(ISettings settings, KubernetesEngineFacade kubeApi, IFrameworkRuns runs) {
+    public RunPodCleanup(KubernetesEngineFacade kubeApi, IFrameworkRuns runs) {
         this.runs = runs;
         this.kubeApi = kubeApi;
-        this.settings = settings ;
     }
 
     @Override
@@ -40,7 +38,7 @@ public class RunPodCleanup implements Runnable {
             logger.info("Starting run pod cleanup scan");
     
             try {
-                List<V1Pod> pods = kubeApi.getTestPods(settings.getEngineLabel());
+                List<V1Pod> pods = kubeApi.getTestPods();
                 pods = kubeApi.getTerminatedPods(pods);
     
                 deletePodsForCompletedRuns(pods);
@@ -55,7 +53,7 @@ public class RunPodCleanup implements Runnable {
     void deletePodsForCompletedRuns(List<V1Pod> terminatedPods) throws DynamicStatusStoreException {
         for (V1Pod pod : terminatedPods) {
             Map<String, String> labels = pod.getMetadata().getLabels();
-            String runName = labels.get(TestPodScheduler.GALASA_RUN_POD_LABEL);
+            String runName = labels.get(TestPodKubeLabels.GALASA_RUN.toString());
 
             if (runName != null) {
                 IRun run = runs.getRun(runName);

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodKubeLabels.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodKubeLabels.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.k8s.controller;
+
+/**
+ * An enum of custom labels that are added to the Kubernetes metadata of test pods
+ */
+public enum TestPodKubeLabels {
+
+    /**
+     * Test pods are marked with a kube label of this, with a value holding the test run name. eg: U643
+     */
+    GALASA_RUN("galasa-run"),
+
+    /**
+     * Test pods have this kube label to identify which Galasa service the test pods belong to
+     */
+    GALASA_SERVICE_NAME("galasa-service-name"),
+
+    /**
+     * Test pods have a kube label with a value being the name of the engine controller
+     * the pods were launched using
+     */
+    ENGINE_CONTROLLER("galasa-engine-controller");
+    ;
+
+    private String label;
+
+    private TestPodKubeLabels(String label) {
+        this.label = label;
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -49,8 +49,6 @@ import io.prometheus.client.Counter;
 import dev.galasa.framework.spi.utils.ITimeService;
 
 public class TestPodScheduler implements Runnable {
-    public static final String GALASA_RUN_POD_LABEL = "galasa-run";
-
     private static final String RAS_TOKEN_ENV = "GALASA_RAS_TOKEN";
     private static final String EVENT_TOKEN_ENV = "GALASA_EVENT_STREAMS_TOKEN";
 
@@ -123,7 +121,7 @@ public class TestPodScheduler implements Runnable {
     
                 while (!queuedRuns.isEmpty()) {
                     // *** Check we are not at max engines
-                    List<V1Pod> pods = this.kubeEngineFacade.getTestPods(settings.getEngineLabel());
+                    List<V1Pod> pods = this.kubeEngineFacade.getTestPods();
                     kubeEngineFacade.getActivePods(pods);
     
                     logger.info("Active runs=" + pods.size() + ",max=" + settings.getMaxEngines());
@@ -259,8 +257,10 @@ public class TestPodScheduler implements Runnable {
         V1ObjectMeta metadata = new V1ObjectMeta();
         newPod.setMetadata(metadata);
         metadata.setName(engineName);
-        metadata.putLabelsItem("galasa-engine-controller", this.settings.getEngineLabel());
-        metadata.putLabelsItem(GALASA_RUN_POD_LABEL, runName);
+        metadata.putLabelsItem(TestPodKubeLabels.ENGINE_CONTROLLER.toString(), this.settings.getEngineLabel());
+        metadata.putLabelsItem(TestPodKubeLabels.GALASA_RUN.toString(), runName);
+        metadata.putLabelsItem(TestPodKubeLabels.GALASA_SERVICE_NAME.toString(), kubeEngineFacade.getGalasaServiceInstallName());
+        logger.debug(metadata.toString());
 
         V1PodSpec podSpec = new V1PodSpec();
         newPod.setSpec(podSpec);

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/KubernetesEngineFacadeTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/KubernetesEngineFacadeTest.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 
 import dev.galasa.framework.k8s.controller.api.IKubernetesApiClient;
 import dev.galasa.framework.k8s.controller.api.KubernetesEngineFacade;
-import dev.galasa.framework.k8s.controller.mocks.MockISettings;
 import dev.galasa.framework.k8s.controller.mocks.MockKubernetesApiClient;
 import dev.galasa.framework.k8s.controller.mocks.MockKubernetesPodTestUtils;
 import io.kubernetes.client.openapi.models.V1Pod;
@@ -26,15 +25,16 @@ public class KubernetesEngineFacadeTest {
     @Test
     public void testGetPodsReturnsPodsOk() throws Exception {
         // Given...
+        String galasaServiceInstallName = "myGalasaService";
         List<V1Pod> mockPods = new ArrayList<>();
-        mockPods.add(mockKubeTestUtils.createMockTestPod("RUN1", "running"));
-        mockPods.add(mockKubeTestUtils.createMockTestPod("RUN2", "running"));
+        mockPods.add(mockKubeTestUtils.createMockTestPod("RUN1", galasaServiceInstallName, "running"));
+        mockPods.add(mockKubeTestUtils.createMockTestPod("RUN2", galasaServiceInstallName, "running"));
 
         IKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
-        KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", "myGalasaService");
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", galasaServiceInstallName);
 
         // When...
-        List<V1Pod> pods = facade.getTestPods(MockISettings.ENGINE_LABEL);
+        List<V1Pod> pods = facade.getTestPods();
 
         // Then...
         assertThat(pods).hasSize(2);
@@ -44,13 +44,14 @@ public class KubernetesEngineFacadeTest {
     @Test
     public void testGetActivePodsReturnsPodsOk() throws Exception {
         // Given...
+        String galasaServiceInstallName = "myGalasaService";
         List<V1Pod> mockPods = new ArrayList<>();
-        V1Pod runningPod = mockKubeTestUtils.createMockTestPod("RUN1", "running");
+        V1Pod runningPod = mockKubeTestUtils.createMockTestPod("RUN1", galasaServiceInstallName, "running");
         mockPods.add(runningPod);
-        mockPods.add(mockKubeTestUtils.createMockTestPod("RUN2", "failed"));
+        mockPods.add(mockKubeTestUtils.createMockTestPod("RUN2", galasaServiceInstallName, "failed"));
 
         IKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
-        KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", "myGalasaService");
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", galasaServiceInstallName);
 
         // When...
         List<V1Pod> pods = facade.getActivePods(mockPods);
@@ -63,14 +64,15 @@ public class KubernetesEngineFacadeTest {
     @Test
     public void testGetTerminatedPodsReturnsPodsOk() throws Exception {
         // Given...
+        String galasaServiceInstallName = "myGalasaService";
         List<V1Pod> mockPods = new ArrayList<>();
-        mockPods.add(mockKubeTestUtils.createMockTestPod("RUN1", "running"));
+        mockPods.add(mockKubeTestUtils.createMockTestPod("RUN1", galasaServiceInstallName, "running"));
 
-        V1Pod finishedPod = mockKubeTestUtils.createMockTestPod("RUN2", "failed");
+        V1Pod finishedPod = mockKubeTestUtils.createMockTestPod("RUN2", galasaServiceInstallName, "failed");
         mockPods.add(finishedPod);
 
         IKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
-        KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", "myGalasaService");
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", galasaServiceInstallName);
 
         // When...
         List<V1Pod> pods = facade.getTerminatedPods(mockPods);
@@ -83,20 +85,21 @@ public class KubernetesEngineFacadeTest {
     @Test
     public void testDeletePodRemovesPodOk() throws Exception {
         // Given...
+        String galasaServiceInstallName = "myGalasaService";
         List<V1Pod> mockPods = new ArrayList<>();
-        mockPods.add(mockKubeTestUtils.createMockTestPod("RUN1", "running"));
+        mockPods.add(mockKubeTestUtils.createMockTestPod("RUN1", galasaServiceInstallName, "running"));
 
-        V1Pod podToDelete = mockKubeTestUtils.createMockTestPod("RUN2", "failed");
+        V1Pod podToDelete = mockKubeTestUtils.createMockTestPod("RUN2", galasaServiceInstallName, "failed");
         mockPods.add(podToDelete);
 
         IKubernetesApiClient mockApiClient = new MockKubernetesApiClient(mockPods);
-        KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", "myGalasaService");
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(mockApiClient, "myNamespace", galasaServiceInstallName);
 
         // When...
         facade.deletePod(podToDelete);
 
         // Then...
-        List<V1Pod> remainingPods = facade.getTestPods(MockISettings.ENGINE_LABEL);
+        List<V1Pod> remainingPods = facade.getTestPods();
         assertThat(remainingPods).hasSize(1);
         assertThat(remainingPods).doesNotContain(podToDelete);
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -66,20 +66,31 @@ public class TestPodSchedulerTest {
 
     private void assertPodDetailsAreCorrect(
         V1Pod pod,
+        String expectedGalasaServiceName,
         String expectedRunName,
         String expectedPodName,
         String expectedEncryptionKeysMountPath,
         ISettings settings
     ) {
-        checkPodMetadata(pod, expectedRunName, expectedPodName, settings);
+        checkPodMetadata(pod, expectedGalasaServiceName, expectedRunName, expectedPodName, settings);
         checkPodContainer(pod, expectedEncryptionKeysMountPath, settings);
         checkPodVolumes(pod, settings);
         checkPodSpec(pod, settings);
     }
 
-    private void checkPodMetadata(V1Pod pod, String expectedRunName, String expectedPodName, ISettings settings) {
+    private void checkPodMetadata(
+        V1Pod pod,
+        String expectedGalasaServiceName,
+        String expectedRunName,
+        String expectedPodName,
+        ISettings settings
+    ) {
         V1ObjectMeta expectedMetadata = new V1ObjectMeta()
-            .labels(Map.of("galasa-run", expectedRunName, "galasa-engine-controller", settings.getEngineLabel()))
+            .labels(Map.of(
+                TestPodKubeLabels.GALASA_RUN.toString(), expectedRunName,
+                TestPodKubeLabels.ENGINE_CONTROLLER.toString(), settings.getEngineLabel(),
+                TestPodKubeLabels.GALASA_SERVICE_NAME.toString(), expectedGalasaServiceName
+            ))
             .name(expectedPodName);
 
         // Check the pod's metadata is as expected
@@ -188,7 +199,10 @@ public class TestPodSchedulerTest {
         MockISettings settings = new MockISettings();
         MockCPSStore mockCPS = new MockCPSStore(null);
 
-        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, null, mockFrameworkRuns, new MockTimeService(Instant.now()));;
+        String galasaServiceInstallName = "myGalasaService";
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(null, "mynamespace", galasaServiceInstallName);
+
+        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, facade, mockFrameworkRuns, new MockTimeService(Instant.now()));;
 
         String runName = "run1";
         String podName = settings.getEngineLabel() + "-" + runName;
@@ -199,7 +213,7 @@ public class TestPodSchedulerTest {
 
         // Then...
         String expectedEncryptionKeysMountPath = "/encryption";
-        assertPodDetailsAreCorrect(pod, runName, podName, expectedEncryptionKeysMountPath, settings);
+        assertPodDetailsAreCorrect(pod, galasaServiceInstallName, runName, podName, expectedEncryptionKeysMountPath, settings);
     }
 
     @Test
@@ -218,7 +232,10 @@ public class TestPodSchedulerTest {
         MockISettings settings = new MockISettings();
         MockCPSStore mockCPS = new MockCPSStore(null);
 
-        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, null, mockFrameworkRuns, new MockTimeService(Instant.now()));
+        String galasaServiceInstallName = "myGalasaService";
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(null, "mynamespace", galasaServiceInstallName);
+
+        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, facade, mockFrameworkRuns, new MockTimeService(Instant.now()));
 
         String runName = "run1";
         String podName = settings.getEngineLabel() + "-" + runName;
@@ -253,7 +270,10 @@ public class TestPodSchedulerTest {
 
         MockCPSStore mockCPS = new MockCPSStore(null);
 
-        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, null, mockFrameworkRuns, new MockTimeService(Instant.now()));
+        String galasaServiceInstallName = "myGalasaService";
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(null, "mynamespace", galasaServiceInstallName);
+
+        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, facade, mockFrameworkRuns, new MockTimeService(Instant.now()));
 
         String runName = "run1";
         String podName = settings.getEngineLabel() + "-" + runName;
@@ -288,7 +308,10 @@ public class TestPodSchedulerTest {
 
         MockCPSStore mockCPS = new MockCPSStore(null);
 
-        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, null, mockFrameworkRuns, new MockTimeService(Instant.now()));
+        String galasaServiceInstallName = "myGalasaService";
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(null, "mynamespace", galasaServiceInstallName);
+
+        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, facade, mockFrameworkRuns, new MockTimeService(Instant.now()));
 
         String runName = "run1";
         String podName = settings.getEngineLabel() + "-" + runName;
@@ -322,7 +345,10 @@ public class TestPodSchedulerTest {
         MockISettings settings = new MockISettings();
         MockCPSStore mockCPS = new MockCPSStore(null);
 
-        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, null, mockFrameworkRuns, new MockTimeService(Instant.now()));
+        String galasaServiceInstallName = "myGalasaService";
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(null, "mynamespace", galasaServiceInstallName);
+
+        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, facade, mockFrameworkRuns, new MockTimeService(Instant.now()));
 
         String runName = "run1";
         String podName = settings.getEngineLabel() + "-" + runName;
@@ -358,7 +384,10 @@ public class TestPodSchedulerTest {
         MockISettings settings = new MockISettings();
         MockCPSStore mockCPS = new MockCPSStore(null);
 
-        TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, null, mockFrameworkRuns, new MockTimeService(Instant.now()));
+        String galasaServiceInstallName = "myGalasaService";
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(null, "mynamespace", galasaServiceInstallName);
+
+        TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, facade, mockFrameworkRuns, new MockTimeService(Instant.now()));
 
         // When...
         ArrayList<String> args = podScheduler.createCommandLineArgs(settings, "myRunName", TRACE_IS_ENABLED);

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/interruptedruns/RunInterruptEventCollectorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/interruptedruns/RunInterruptEventCollectorTest.java
@@ -72,16 +72,16 @@ public class RunInterruptEventCollectorTest {
         ITimeService timeService = new MockTimeService(currentTime);
 
         String interruptReason = "cancelled";
+        String galasaServiceInstallName = "myGalasaService";
 
         List<V1Pod> mockPods = new ArrayList<>();
-        mockPods.add(mockKubeTestUtils.createMockTestPod(runName1));
-        mockPods.add(mockKubeTestUtils.createMockTestPod(runName2));
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName1, galasaServiceInstallName));
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName2, galasaServiceInstallName));
 
-        String galasaServiceInstallName = "myGalasaService";
         boolean isReady = true;
         mockPods.addAll(mockKubeTestUtils.createEtcdAndRasPods(galasaServiceInstallName, isReady));
 
-        V1Pod cancelledPod = mockKubeTestUtils.createMockTestPod(runName3);
+        V1Pod cancelledPod = mockKubeTestUtils.createMockTestPod(runName3, galasaServiceInstallName);
         mockPods.add(cancelledPod);
 
         // Create runs associated with the pods
@@ -103,7 +103,7 @@ public class RunInterruptEventCollectorTest {
         List<RunInterruptEvent> events = runPodInterrupt.collectInterruptRunEvents();
 
         // Then...
-        assertThat(kube.getTestPods(MockISettings.ENGINE_LABEL)).hasSize(3);
+        assertThat(kube.getTestPods()).hasSize(3);
         assertThat(mockPods).contains(cancelledPod);
 
         assertThat(events).as("should not have collected any pods to delete as they haven't timed out yet.").hasSize(0);
@@ -116,11 +116,11 @@ public class RunInterruptEventCollectorTest {
 
         // Simulate a situation where the current kubernetes namespace has a pod that may
         // not be a Galasa-related pod, so it doesn't have a "galasa-run" label with a run name.
+        String galasaServiceInstallName = "myGalasaService";
         List<V1Pod> mockPods = new ArrayList<>();
-        V1Pod podWithNoRunName = mockKubeTestUtils.createMockTestPod(null);
+        V1Pod podWithNoRunName = mockKubeTestUtils.createMockTestPod(null, galasaServiceInstallName);
         mockPods.add(podWithNoRunName);
 
-        String galasaServiceInstallName = "myGalasaService";
         boolean isReady = true;
         mockPods.addAll(mockKubeTestUtils.createEtcdAndRasPods(galasaServiceInstallName, isReady));
 
@@ -153,22 +153,22 @@ public class RunInterruptEventCollectorTest {
         String runName3 = "run3";
         String runIdToMarkFinished = "run3-id";
 
+        String galasaServiceInstallName = "myGalasaService";
         String interruptReason = "cancelled";
 
         Instant interruptedAt = Instant.EPOCH;
         ITimeService timeService = new MockTimeService(Instant.now());
 
         List<V1Pod> mockPods = new ArrayList<>();
-        mockPods.add(mockKubeTestUtils.createMockTestPod(runName1));
-        mockPods.add(mockKubeTestUtils.createMockTestPod(runName2));
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName1, galasaServiceInstallName));
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName2, galasaServiceInstallName));
 
-        String galasaServiceInstallName = "myGalasaService";
 
         // Simulate a situation where the etcd and RAS pods are not ready
         boolean isReady = false;
         mockPods.addAll(mockKubeTestUtils.createEtcdAndRasPods(galasaServiceInstallName, isReady));
 
-        V1Pod cancelledPod = mockKubeTestUtils.createMockTestPod(runName3);
+        V1Pod cancelledPod = mockKubeTestUtils.createMockTestPod(runName3, galasaServiceInstallName);
         mockPods.add(cancelledPod);
 
         // Create runs associated with the pods
@@ -187,14 +187,14 @@ public class RunInterruptEventCollectorTest {
         RunInterruptEventCollector runPodInterrupt = new RunInterruptEventCollector(kube, mockFrameworkRuns, settings, timeService);
 
         // Make sure that all 3 test pods exist before processing
-        assertThat(kube.getTestPods(MockISettings.ENGINE_LABEL)).hasSize(3);
+        assertThat(kube.getTestPods()).hasSize(3);
 
         // When...
         List<RunInterruptEvent> events = runPodInterrupt.collectInterruptRunEvents();
 
         // Then...
         // Make sure that all 3 test pods still exist after processing
-        assertThat(kube.getTestPods(MockISettings.ENGINE_LABEL)).hasSize(3);
+        assertThat(kube.getTestPods()).hasSize(3);
 
         // No events should have been added yet
         assertThat(events).isEmpty();

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/interruptedruns/RunInterruptedEventProcessorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/interruptedruns/RunInterruptedEventProcessorTest.java
@@ -18,7 +18,6 @@ import dev.galasa.framework.RunRasActionProcessor;
 import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.k8s.controller.api.IKubernetesApiClient;
 import dev.galasa.framework.k8s.controller.api.KubernetesEngineFacade;
-import dev.galasa.framework.k8s.controller.mocks.MockISettings;
 import dev.galasa.framework.k8s.controller.mocks.MockKubernetesApiClient;
 import dev.galasa.framework.k8s.controller.mocks.MockKubernetesPodTestUtils;
 import dev.galasa.framework.mocks.MockFileSystem;
@@ -243,19 +242,19 @@ public class RunInterruptedEventProcessorTest {
         Instant interruptedAt = Instant.EPOCH;
 
         String interruptReason = "cancelled";
+        String galasaServiceInstallName = "myGalasaService";
 
         // Create 2 pods we won't touch
         List<V1Pod> mockPods = new ArrayList<>();
-        mockPods.add(mockKubeTestUtils.createMockTestPod(runName1));
-        mockPods.add(mockKubeTestUtils.createMockTestPod(runName2));
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName1, galasaServiceInstallName));
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName2, galasaServiceInstallName));
 
         // Create the etcd and couchb pods that makes 4 pods total
-        String galasaServiceInstallName = "myGalasaService";
         boolean isReady = true;
         mockPods.addAll(mockKubeTestUtils.createEtcdAndRasPods(galasaServiceInstallName, isReady));
 
         // Create a pod we can delete to match the run we are cancelling. That makes 5 pods.
-        V1Pod cancelledPod = mockKubeTestUtils.createMockTestPod(runName3);
+        V1Pod cancelledPod = mockKubeTestUtils.createMockTestPod(runName3, galasaServiceInstallName);
         mockPods.add(cancelledPod);
 
         // Create runs associated with the pods
@@ -291,7 +290,7 @@ public class RunInterruptedEventProcessorTest {
         processor.processEvents(events);
 
         // Then...
-        assertThat(kube.getTestPods(MockISettings.ENGINE_LABEL)).as("One of the 3 test engine pods should have been deleted").hasSize(2);
+        assertThat(kube.getTestPods()).as("One of the 3 test engine pods should have been deleted").hasSize(2);
         assertThat(mockPods).doesNotContain(cancelledPod);
 
     }
@@ -306,19 +305,19 @@ public class RunInterruptedEventProcessorTest {
 
         Instant interruptedAt = null;
         String interruptReason = "cancelled";
+        String galasaServiceInstallName = "myGalasaService";
 
         // 2 pods we will leave alone.
         List<V1Pod> mockPods = new ArrayList<>();
-        mockPods.add(mockKubeTestUtils.createMockTestPod(runName1));
-        mockPods.add(mockKubeTestUtils.createMockTestPod(runName2));
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName1, galasaServiceInstallName));
+        mockPods.add(mockKubeTestUtils.createMockTestPod(runName2, galasaServiceInstallName));
 
         // a couchdb and etcd pod
-        String galasaServiceInstallName = "myGalasaService";
         boolean isReady = true;
         mockPods.addAll(mockKubeTestUtils.createEtcdAndRasPods(galasaServiceInstallName, isReady));
 
         // A pod we intend to cancel
-        V1Pod cancelledPod = mockKubeTestUtils.createMockTestPod(runName3);
+        V1Pod cancelledPod = mockKubeTestUtils.createMockTestPod(runName3, galasaServiceInstallName);
         mockPods.add(cancelledPod);
 
         // Create runs associated with the pods
@@ -353,7 +352,7 @@ public class RunInterruptedEventProcessorTest {
         processor.processEvents(events);
 
         // Then...
-        assertThat(kube.getTestPods(MockISettings.ENGINE_LABEL)).hasSize(2);
+        assertThat(kube.getTestPods()).hasSize(2);
         assertThat(mockPods).doesNotContain(cancelledPod);
 
     }
@@ -369,16 +368,16 @@ public class RunInterruptedEventProcessorTest {
 
         Instant interruptedAt = Instant.EPOCH;
         String interruptReason = "cancelled";
+        String galasaServiceInstallName = "myGalasaService";
 
         List<V1Pod> mockPods = new ArrayList<>();
-        V1Pod cancelledPod1 = mockKubeTestUtils.createMockTestPod(runName1);
+        V1Pod cancelledPod1 = mockKubeTestUtils.createMockTestPod(runName1, galasaServiceInstallName);
         mockPods.add(cancelledPod1);
 
-        String galasaServiceInstallName = "myGalasaService";
         boolean isReady = true;
         mockPods.addAll(mockKubeTestUtils.createEtcdAndRasPods(galasaServiceInstallName, isReady));
 
-        V1Pod cancelledPod2 = mockKubeTestUtils.createMockTestPod(runName2);
+        V1Pod cancelledPod2 = mockKubeTestUtils.createMockTestPod(runName2, galasaServiceInstallName);
         mockPods.add(cancelledPod2);
 
         // Create runs associated with the pods
@@ -413,6 +412,6 @@ public class RunInterruptedEventProcessorTest {
         processor.processEvents(events);
 
         // Then...
-        assertThat(kube.getTestPods(MockISettings.ENGINE_LABEL)).isEmpty();
+        assertThat(kube.getTestPods()).isEmpty();
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockKubernetesPodTestUtils.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockKubernetesPodTestUtils.java
@@ -8,8 +8,7 @@ package dev.galasa.framework.k8s.controller.mocks;
 import java.util.ArrayList;
 import java.util.List;
 
-import dev.galasa.framework.k8s.controller.TestPodScheduler;
-import dev.galasa.framework.k8s.controller.api.KubernetesEngineFacade;
+import dev.galasa.framework.k8s.controller.TestPodKubeLabels;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
@@ -44,12 +43,13 @@ public class MockKubernetesPodTestUtils {
         return pod;
     }
 
-    public V1Pod createMockTestPod(String runName, String phase) {
+    public V1Pod createMockTestPod(String runName, String galasaServiceName, String phase) {
         V1Pod mockPod = new V1Pod();
 
         V1ObjectMeta podMetadata = new V1ObjectMeta();
-        podMetadata.putLabelsItem(TestPodScheduler.GALASA_RUN_POD_LABEL, runName);
-        podMetadata.putLabelsItem(KubernetesEngineFacade.ENGINE_CONTROLLER_LABEL_KEY, MockISettings.ENGINE_LABEL);
+        podMetadata.putLabelsItem(TestPodKubeLabels.GALASA_RUN.toString(), runName);
+        podMetadata.putLabelsItem(TestPodKubeLabels.ENGINE_CONTROLLER.toString(), MockISettings.ENGINE_LABEL);
+        podMetadata.putLabelsItem(TestPodKubeLabels.GALASA_SERVICE_NAME.toString(), galasaServiceName);
         podMetadata.setName(runName);
 
         V1PodStatus podStatus = new V1PodStatus();
@@ -60,7 +60,7 @@ public class MockKubernetesPodTestUtils {
         return mockPod;
     }
 
-    public V1Pod createMockTestPod(String runName) {
-        return createMockTestPod(runName, "running");
+    public V1Pod createMockTestPod(String runName, String galasaServiceName) {
+        return createMockTestPod(runName, galasaServiceName, "running");
     }
 }


### PR DESCRIPTION
## Why?
Related to findings as part of https://github.com/galasa-dev/projectmanagement/issues/2397

When multiple Galasa services are installed in the same Kubernetes namespace and multiple test runs are running with the same run name for each deployed service, there is a chance that the engine controller's interrupt logic will delete the wrong test pod. This means that the engine controller can mark a test run as "finished(Cancelled)" but the Kubernetes pod for the run may not have been deleted, so the pod can continue updating its state in the DSS.

## Changes
- Added a "galasa-service-name" label to the Kubernetes metadata for test pods to clearly associate pods with the service they belong to
- Updated the `getTestPod` and `getTestPods` methods to search for pods using the "galasa-service-name" label
  - `getTestPods` previously used the "engine_label" setting to identify pods (which is set in the Helm chart's ConfigMap) but users can easily set a value that is not unique for this, so it now uses the "galasa-service-name" label instead