### PR TITLE
Update release notes to highlight the switch away from bitnami kubectl image

### DIFF
--- a/docs/content/releases/posts/v0.44.0.md
+++ b/docs/content/releases/posts/v0.44.0.md
@@ -14,6 +14,11 @@ links:
     - If a secret name is given, the Helm chart will attempt to load the Kubernetes secret with the given name and pass it through to be used by the Galasa service's Kafka extension.
     - If a secret name is given but no such secret exists in the Kubernetes namespace, then the Galasa service will fail to be installed or upgraded.
 
+- The image used by Galasa in init containers, which contains the `kubectl` tool has been replaced.
+  - Previously, the `bitnami/kubectl` image was used by default to make some pods wait for others to start, to avoid an error storm which would happen if all the pods started up at the same time. This enforces an ordering of pods starting up which matches their dependencies.
+  - The `bitnami` images were withdrawn, so the default value in the helm `values.yaml` file was switched to use a different image containing the same tool: `kubectlImage: "rancher/kubectl:v1.33.5"`
+  - Previous releases are also effected, so administrators of older installs of the Galasa service will also need to make this change and update their helm install.
+
 ## Changes affecting tests running locally or on the Galasa Service
 
 - The 3270 manager's `ITerminal` interface has a new `toJsonString()` method that allows tests to convert the current 3270 terminal screen into JSON format.


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
When the bitnami docker image was withdrawn, we need to switch to an alternative.

Document the workaround for what we did in the 0.44.0 release in the release notes.
