### PR TITLE
mcobbett fix dss get tool

### DIFF
--- a/tools/dss-get.sh
+++ b/tools/dss-get.sh
@@ -90,7 +90,7 @@ if [[ "$pod" == "" ]]; then
     pod=$(kubectl get pods | grep etcd | cut -f1 -d' ')
 fi
 
-kubectl -it exec techcobweb-galasa-1-etcd-0  -- etcdctl get dss --prefix=true > "$BASEDIR/etcd-temp.values"
+kubectl -it "${pod}"  -- etcdctl get dss --prefix=true > "$BASEDIR/etcd-temp.values"
 done=0
 while [[ "$done" == "0" ]]; do
     IFS= read -r key

--- a/tools/dss-get.sh
+++ b/tools/dss-get.sh
@@ -90,7 +90,7 @@ if [[ "$pod" == "" ]]; then
     pod=$(kubectl get pods | grep etcd | cut -f1 -d' ')
 fi
 
-kubectl -it "${pod}"  -- etcdctl get dss --prefix=true > "$BASEDIR/etcd-temp.values"
+kubectl exec -it "${pod}" -- etcdctl get dss --prefix=true > "$BASEDIR/etcd-temp.values"
 done=0
 while [[ "$done" == "0" ]]; do
     IFS= read -r key


### PR DESCRIPTION
# Why ?

The script tool we can use to get values from dss.sh wasn't finished properly. It was merged incorrectly, so half the changes were left behind. 

- Pod variable wasn't used 
- Corrected syntax of kubectl command

