### PR TITLE
upgrades to python packages as suggested by dependabot

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,6 @@ charset-normalizer==3.4.2
 click==8.2.1
 colorama==0.4.6
 cryptography==45.0.3
-detect_secrets @ git+https://github.com/ibm/detect-secrets.git@cb803c6f7883b631b9aa9c8664b0937a9d358609
 distlib==0.3.9
 filelock==3.18.0
 ghp-import==2.1.0
@@ -44,13 +43,13 @@ pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 PyYAML==6.0.2
 pyyaml_env_tag==1.1
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
-setuptools==75.6.0
+setuptools==78.1.1
 six==1.17.0
 smmap==5.0.2
 tabulate==0.9.0
-urllib3==1.26.20
+urllib3==2.5.0
 verspec==0.1.0
 virtualenv==20.31.2
 watchdog==6.0.0


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
This is a roll-up of 3 PRs that dependabot thought it would be good to upgrade in the docs build process. Testing them all together and delivering as one.

PRs are:
- https://github.com/galasa-dev/galasa/pull/349 
- https://github.com/galasa-dev/galasa/pull/336 
- https://github.com/galasa-dev/galasa/pull/331 
