### PR TITLE
rest docs - remove the server box which does nothing

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -71,7 +71,11 @@ task importOpenApiDefinition(type: Copy) {
     into "content/docs/reference/rest-api"
     include ("dev.galasa.framework.api.openapi-${version}.yaml")
     rename ("dev.galasa.framework.api.openapi-${version}.yaml", "openapi.yaml")
-    
+
+    // When we do the copy, remove the two lines in the output which contain the server 
+    // definition. The static docs don't have the 'try it...' functionality of the UI enabled.
+    filter { line -> line.replaceAll('.*API_SERVER_URL.*', '') }
+    filter { line -> line.replaceAll('^servers:$', '') }
     dependsOn downloadRawDependencies
 }
 


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
The REST documentation has a bad-looking servers box which does nothing:
<img width="1192" height="415" alt="image" src="https://github.com/user-attachments/assets/cf2fde92-b390-488b-b7c7-0fa58071fae3" />

This change makes it look like this:
<img width="1089" height="503" alt="image" src="https://github.com/user-attachments/assets/19ad329e-a29a-4d33-ac75-0cf6eec3ab02" />

- Added a filter when the openapi.yaml file is copied into the docs folder for use, which strips out the server feature. It's not too pretty, but it's quick and works.
