### PR TITLE
Add docs around configuring Log4j when installing the Galasa Helm chart in the galasa.dev docs and update release notes

### DIFF
--- a/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
+++ b/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
@@ -168,6 +168,51 @@ and the value of the `config.yaml` key must be a valid Dex configuration.
 
 For more information on configuring Dex, see the [Dex documentation](https://dexidp.io/docs){target="_blank"}.
 
+### Configuring Logging for the Galasa service (Optional)
+
+The Galasa service generates log messages using Log4j and these messages are sent to each process' standard output stream by default.
+
+If you would like to modify the format of the Galasa service's log messages or configure additional Log4j appenders:
+
+1. Provide a custom set of Log4j2 properties using the `log4j2Properties` value as a multi-line string in the form:
+
+    ```yaml
+    log4j2Properties: |
+      status = error
+      name = Default
+    
+      appender.console.type = Console
+      appender.console.name = stdout
+      appender.console.layout.type = PatternLayout
+      appender.console.layout.pattern = %d{dd/MM/yyyy HH:mm:ss.SSS} %-5p %c{1.} - %m%n
+    
+      rootLogger.level = debug
+      rootLogger.appenderRef.stdout.ref = stdout
+    ```
+
+If you are using Log4j's `JsonTemplateLayout` layout type and would like to use a custom JSON template for your log messages, then you can create a ConfigMap containing the JSON templates that you wish to make available to the Galasa service and supply the name of that ConfigMap in the `log4jJsonTemplatesConfigMapName` value.
+
+The ConfigMap is mounted into the Galasa service pods in the `/log4j-config` directory, so any Log4j properties that need to refer to a template's URI will need a value to be prefixed with `file:/log4j-config`.
+
+For example, if you have a custom JSON template in a file called `MyLayout.json`, then you would take the following steps:
+
+1. Create a ConfigMap by running:
+    ```
+    kubectl create configmap my-json-layout --from-file=/path/to/MyLayout.json
+    ```
+
+2. Set `log4jJsonTemplatesConfigMapName` in the Helm values to:
+    ```yaml
+    log4jJsonTemplatesConfigMapName: "my-json-layout"
+    ```
+
+3. Use the custom layout in the `log4j2Properties` value by adding these properties:
+    ```properties
+    appender.myAppender.layout.type = JsonTemplateLayout
+    appender.myAppender.layout.eventTemplateUri = file:/log4j-config/MyLayout.json
+    ```
+
+Refer to the [Log4j documentation](https://logging.apache.org/log4j/2.x/manual/configuration.html) for available properties.
 
 ## Configure the default user role, and 'owner' of the Galasa service
 

--- a/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
+++ b/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
@@ -198,12 +198,12 @@ For example, if you have a custom JSON template in a file called `MyLayout.json`
 
 1. Create a ConfigMap by running:
     ```
-    kubectl create configmap my-json-layout --from-file=/path/to/MyLayout.json
+    kubectl create configmap my-json-layouts --from-file=/path/to/MyLayout.json
     ```
 
 2. Set `log4jJsonTemplatesConfigMapName` in the Helm values to:
     ```yaml
-    log4jJsonTemplatesConfigMapName: "my-json-layout"
+    log4jJsonTemplatesConfigMapName: "my-json-layouts"
     ```
 
 3. Use the custom layout in the `log4j2Properties` value by adding these properties:

--- a/docs/content/releases/posts/v0.44.0.md
+++ b/docs/content/releases/posts/v0.44.0.md
@@ -19,6 +19,10 @@ links:
   - The `bitnami` images were withdrawn, so the default value in the helm `values.yaml` file was switched to use a different image containing the same tool: `kubectlImage: "rancher/kubectl:v1.33.5"`
   - Previous releases are also effected, so administrators of older installs of the Galasa service will also need to make this change and update their helm install.
 
+- Added `log4j2Properties` and `log4jJsonTemplatesConfigMapName` configuration settings in the Galasa service Helm chart to allow users to configure Log4j in their Galasa service. See the [Installing an Ecosystem using Helm documentation](../../docs/ecosystem/ecosystem-installing-k8s.md#configuring-logging-for-the-galasa-service-optional) for detailed instructions on how to do this.
+
+- Added a configuration setting `couchdb.documentRevisionLimit` in the Galasa Helm chart to control the maximum number of document revisions that should be stored in the CouchDB service. See [#2439](https://github.com/galasa-dev/projectmanagement/issues/2439).
+
 ## Changes affecting tests running locally or on the Galasa Service
 
 - The 3270 manager's `ITerminal` interface has a new `toJsonString()` method that allows tests to convert the current 3270 terminal screen into JSON format.


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2246

## Changes
- Added a section in the docs to install the Galasa Helm chart that goes over configuring Log4j using the new values that were added in https://github.com/galasa-dev/helm/pull/97 and https://github.com/galasa-dev/helm/pull/99
- Updated the 0.44.0 release notes to include the new Helm values that were added in the above PRs and https://github.com/galasa-dev/helm/pull/98