### PR TITLE
Deprecate the callback_url query parameter for GET /auth in favour of base64_callback_url

### DIFF
--- a/docs/content/releases/posts/v0.44.0.md
+++ b/docs/content/releases/posts/v0.44.0.md
@@ -23,6 +23,8 @@ links:
 
 - Added a configuration setting `couchdb.documentRevisionLimit` in the Galasa Helm chart to control the maximum number of document revisions that should be stored in the CouchDB service. See [#2439](https://github.com/galasa-dev/projectmanagement/issues/2439).
 
+- Deprecated the `callback_url` query parameter in the Galasa REST API's `GET /auth` endpoint in favour of a new `base64_callback_url` query parameter, which takes a Base64URL-encoded URL that the API will redirect back to after authenticating. See [#2416](https://github.com/galasa-dev/projectmanagement/issues/2416).
+
 ## Changes affecting tests running locally or on the Galasa Service
 
 - The 3270 manager's `ITerminal` interface has a new `toJsonString()` method that allows tests to convert the current 3270 terminal screen into JSON format.

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/internal/routes/AuthRouteTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -419,6 +420,7 @@ public class AuthRouteTest extends BaseServletTest {
         String clientIp = "123.456.789.010";
         String clientId = "my-client";
         String clientCallbackUrl = "http://my.app";
+        String encodedCallbackUrl = Base64.getUrlEncoder().encodeToString(clientCallbackUrl.getBytes());
 
         MockOidcProvider mockOidcProvider = new MockOidcProvider(redirectLocation);
 
@@ -429,7 +431,7 @@ public class AuthRouteTest extends BaseServletTest {
         servlet.setFramework(mockFramework);
 
         Map<String, String[]> queryParams = Map.of(
-                "client_id", new String[] { clientId }, "callback_url", new String[] { clientCallbackUrl }
+                "client_id", new String[] { clientId }, "base64_callback_url", new String[] { encodedCallbackUrl }
         );
 
         MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, null);
@@ -451,6 +453,8 @@ public class AuthRouteTest extends BaseServletTest {
     public void testAuthGetRequestWithEmptyReturnedLocationHeaderReturnsError() throws Exception {
         // Given...
         String clientIp = "123.456.789.010";
+        String clientCallbackUrl = "http://my.app";
+        String encodedCallbackUrl = Base64.getUrlEncoder().encodeToString(clientCallbackUrl.getBytes());
 
         // No "Location" returned from the issuer, will not be able to redirect anywhere to authenticate
         Map<String, List<String>> headers = new HashMap<>();
@@ -462,7 +466,7 @@ public class AuthRouteTest extends BaseServletTest {
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockOidcProvider);
 
         Map<String, String[]> queryParams = Map.of(
-                "client_id", new String[] { "my-client" }, "callback_url", new String[] { "http://my.app" }
+                "client_id", new String[] { "my-client" }, "base64_callback_url", new String[] { encodedCallbackUrl }
         );
 
         MockHttpServletRequest mockRequest = new MockHttpServletRequest(queryParams, null);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -51,8 +51,9 @@ paths:
         - name: base64_callback_url
           in: query
           description: |
-            A Base64URL-encoded URL to return to once the authentication process is complete.
-            This should be a URL to a client web application.
+            The URL to return to once the authentication process is complete.
+            This must be provided as a Base64URL encoded value and the URL should go to
+            a client web application.
           required: true
           schema:
             type: string

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -44,6 +44,7 @@ paths:
 
             The URL to return to once the authentication process is complete.
             This should be a URL to a client web application.
+          deprecated: true
           required: false
           schema:
             type: string

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -40,7 +40,17 @@ paths:
         - name: callback_url
           in: query
           description: |
+            Deprecated. Use 'base64_callback_url' instead.
+
             The URL to return to once the authentication process is complete.
+            This should be a URL to a client web application.
+          required: false
+          schema:
+            type: string
+        - name: base64_callback_url
+          in: query
+          description: |
+            A Base64URL-encoded URL to return to once the authentication process is complete.
             This should be a URL to a client web application.
           required: true
           schema:


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2416

The `GET /auth` endpoint previously expected a raw URL to be provided in the `callback_url` query parameter. However, if the supplied URL contained its own query parameters, then the Java servlet code would mistakenly parse those query parameters as if they were intended for the `GET /auth` endpoint, which caused issues.

This PR addresses this problem by deprecating the `callback_url` query parameter in favour of the `base64_callback_url` query parameter, which accepts a Base64 URL encoded URL instead.

## Changes
- Deprecated the `callback_url` query parameter for `GET /auth`
- Added a new `base64_callback_url` query parameter for `GET /auth`
- Updated OpenAPI docs and 0.44.0 release notes