### PR TITLE
Only set a test class' result to 'ignored' if all methods were ignored

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -374,7 +374,7 @@ public class TestClassWrapper {
         try {
             dss.put("run." + runName + "." + DssPropertyKeyRunNameSuffix.METHOD_TOTAL, Integer.toString(this.testMethods.size()));
 
-            Set<Result> testMethodResultsSoFar = new HashSet<>();
+            Set<String> testMethodResultNamesSoFar = new HashSet<>();
             int actualMethod = 0;
             for (TestMethodWrapper testMethod : this.testMethods) {
 
@@ -391,7 +391,7 @@ public class TestClassWrapper {
                 testMethod.invoke(managers, this.testClassObject, this.continueOnTestFailure, this);
                 // Setting the result so far after every @Test 
                 // method happens inside the testMethod class.
-                testMethodResultsSoFar.add(testMethod.getResult());
+                testMethodResultNamesSoFar.add(testMethod.getResult().getName());
                 if (testMethod.fullStop()) {
                     break;
                 }
@@ -399,10 +399,10 @@ public class TestClassWrapper {
 
             // If all of the test methods were ignored, then 'ignored' will be the only result recorded,
             // so mark the entire test class as ignored as well
-            if (testMethodResultsSoFar.size() == 1) {
-                Result result = testMethodResultsSoFar.iterator().next();
-                if (result.isIgnored()) {
-                    setResult(result, managers);
+            if (testMethodResultNamesSoFar.size() == 1) {
+                String resultName = testMethodResultNamesSoFar.iterator().next();
+                if (resultName.equalsIgnoreCase(Result.IGNORED)) {
+                    setResult(Result.ignore("All test methods were ignored"), managers);
                 }
             }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
@@ -195,19 +195,16 @@ public class TestMethodWrapper {
     private void markTestAndLinkedMethodsIgnored(Result ignoredResult, TestClassWrapper testClassWrapper, ITestRunManagers managers) {
         // Mark test method as ignored
         testMethod.setResult(ignoredResult);
-        testClassWrapper.setResult(testMethod.getResult(), managers);
         this.result = ignoredResult;
 
         // Mark any before methods associated with the test method as ignored
         for (GenericMethodWrapper before : this.befores) {
             before.setResult(ignoredResult);
-            testClassWrapper.setResult(before.getResult(), managers);
         }
 
         // Mark any after methods associated with the test method as ignored
         for (GenericMethodWrapper after : this.afters) {
             after.setResult(ignoredResult);
-            testClassWrapper.setResult(after.getResult(), managers);
         }
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/Result.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/Result.java
@@ -17,8 +17,8 @@ public class Result implements IResult {
     public static final String REQUEUED    = "Requeued";
     public static final String CANCELLED   = "Cancelled";
     public static final String HUNG        = "Hung";
+    public static final String IGNORED     = "Ignored";
 
-    private static final String IGNORED     = "Ignored";
     private static final String PASSED      = "Passed";
     private static final String FAILED      = "Failed";
     private static final String ENVFAIL     = "EnvFail";

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestMethodWrapperTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestMethodWrapperTest.java
@@ -137,6 +137,9 @@ public class TestMethodWrapperTest {
         testMethodWrapper.invoke(mockTestRunManagers, mockTestClass, continueOnTestFailure, testClassWrapper);
 
         // Then...
+        // The test class shouldn't have had a result set yet
+        assertThat(testClassWrapper.getResult()).isNull();
+
         assertThat(beforeMethodWrapper.getResult().getName()).isEqualTo("Ignored");
         assertThat(afterMethodWrapper.getResult().getName()).isEqualTo("Ignored");
         assertThat(testMethodWrapper.getResult().getName()).isEqualTo("Ignored");
@@ -182,6 +185,8 @@ public class TestMethodWrapperTest {
 
         // Then...
         String passedResultStr = passedResult.getName();
+
+        assertThat(testClassWrapper.getResult().isPassed()).isTrue();
         assertThat(beforeMethodWrapper.getResult().getName()).isEqualTo(passedResultStr);
         assertThat(afterMethodWrapper.getResult().getName()).isEqualTo(passedResultStr);
         assertThat(testMethodWrapper.getResult().getName()).isEqualTo(passedResultStr);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockTestRunManagers.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockTestRunManagers.java
@@ -44,6 +44,10 @@ public class MockTestRunManagers implements ITestRunManagers {
         this.testMethodResultToReturn = testMethodResultToReturn;
     }
 
+    public void setResultToReturn(Result resultToReturn) {
+        this.resultToReturn = resultToReturn;
+    }
+
     @Override
     public boolean anyReasonTestClassShouldBeIgnored() throws FrameworkException {
         return ignoreTestClass;
@@ -92,7 +96,7 @@ public class MockTestRunManagers implements ITestRunManagers {
     @Override
     public Result endOfTestClass(@NotNull Result result, Throwable currentException) throws FrameworkException {
         calledCountEndOfTestClass +=1;
-        return resultToReturn;
+        return result;
     }
 
     @Override


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2438

## Changes
- When all test methods in a class are ignored, then the test class' result will be set to 'ignored'
- If test methods are allowed to run, then the test class' result will be set to the result of running those test methods
  - If a test method fails, then the test class will be marked as 'failed'
  - If all test methods that ran pass, then the test class will be marked as 'passed'