### PR TITLE
Uplift Java version checker

### DIFF
--- a/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -10,7 +10,7 @@ java {
     withJavadocJar()
     withSourcesJar()
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
     

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -10,7 +10,7 @@ java {
     withJavadocJar()
     withSourcesJar()
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -10,7 +10,7 @@ java {
     withJavadocJar()
     withSourcesJar()
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
     


### PR DESCRIPTION
# Why?

Uplifting the version checker of Java ensures that the process builds for Java's later versions. 

Note: this change was needed in order to build Galasa on my machine for the first time, however not needed from anyone else on the development team hence is worth double checking.