### PR TITLE
Bump kubernetes client-java library from 22.0.0 24.0.0

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -119,9 +119,9 @@ dependencies {
 
         api 'io.gsonfire:gson-fire:1.9.0'
 
-        api 'io.kubernetes:client-java:22.0.0'
-        api 'io.kubernetes:client-java-api:22.0.0'
-        api 'io.kubernetes:client-java-proto:22.0.0'
+        api 'io.kubernetes:client-java:24.0.0'
+        api 'io.kubernetes:client-java-api:24.0.0'
+        api 'io.kubernetes:client-java-proto:24.0.0'
 
         api 'io.netty:netty-buffer:4.1.111.Final'
         api 'io.netty:netty-codec:4.1.111.Final'

--- a/modules/wrapping/dev.galasa.wrapping.protobuf-java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.protobuf-java/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>4.28.3</version>
+            <version>4.31.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2423

## Changes
- Bumped the client-java dependencies up to v24.0.0
- Updated protobuf-java up to 4.31.0 to fix an OSGi wiring error when the client-java version was uplifted