### PR TITLE
Bump bcel version up to 6.11.0 to remove vulnerability

### DIFF
--- a/modules/framework/galasa-parent/galasa-boot/build.gradle
+++ b/modules/framework/galasa-parent/galasa-boot/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     embedImplementation 'org.apache.felix:org.apache.felix.framework:7.0.5'
     embedImplementation 'org.apache.felix:org.apache.felix.bundlerepository:2.0.10'
     embedImplementation 'commons-cli:commons-cli:1.4'
-    embedImplementation 'commons-io:commons-io:2.16.1'
+    embedImplementation 'commons-io:commons-io:2.20.0'
 
     // This adds the built-in log4j JSON templates to the boot.jar's classpath. These are
     // used when a user supplies a log4j configuration that uses the 'JsonTemplateLayout'

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -58,7 +58,7 @@ external:
 
   - group: commons-io
     artifact: commons-io
-    version: 2.16.1
+    version: 2.20.0
     obr: true
     bom: true
     mvp: true
@@ -285,7 +285,7 @@ external:
 
   - group: org.apache.commons
     artifact: commons-lang3
-    version: 3.18.0
+    version: 3.19.0
     obr: true
     bom: true
     mvp: true

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -85,7 +85,7 @@ dependencies {
 
         api 'commons-collections:commons-collections:3.2.2'
 
-        api 'commons-io:commons-io:2.16.1' // If updating, also update in galasa-boot build.gradle and in obr/release.yaml.
+        api 'commons-io:commons-io:2.20.0' // If updating, also update in galasa-boot build.gradle and in obr/release.yaml.
 
         api 'commons-logging:commons-logging:1.3.4' // If updating, also update in obr/release.yaml.
 
@@ -195,12 +195,12 @@ dependencies {
 
         api 'net.java.dev.jna:jna:5.12.1' // bnd.bnd only
 
-        api 'org.apache.bcel:bcel:6.7.0'
+        api 'org.apache.bcel:bcel:6.11.0'
 
         api 'org.apache.commons:commons-collections4:4.4'
         api 'org.apache.commons:commons-compress:1.28.0'
         api 'org.apache.commons:commons-exec:1.3'
-        api 'org.apache.commons:commons-lang3:3.18.0' // If updating, also update in obr/release.yaml.
+        api 'org.apache.commons:commons-lang3:3.19.0' // If updating, also update in obr/release.yaml.
         
         api 'org.apache.derby:derbyclient:10.14.2.0'
 

--- a/tools/setup-minikube-docker-registry.sh
+++ b/tools/setup-minikube-docker-registry.sh
@@ -216,7 +216,7 @@ function setup_local_registry_for_minikube {
         check_exit_code ${rc} "Failed to start minikube cluster"
     fi
 
-    info" Enabling the minikube registry addons... see https://minikube.sigs.k8s.io/docs/handbook/registry"
+    info "Enabling the minikube registry addons... see https://minikube.sigs.k8s.io/docs/handbook/registry"
     
     minikube addons enable registry
 


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2408

## Changes
- Bumps the bcel dependency up from 6.7.0 to 6.11.0 to remove a reported vulnerability in commons-lang3
  - Also bumped transitive dependencies (commons-io and commons-lang3) up to fix OSGi wiring errors that appeared when bumping bcel up on its own