### PR TITLE
Allow user-supplied public certificates to be passed into Galasa test pods

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -111,7 +111,7 @@
         "hashed_secret": "877704f69026efee10f08e8f95568749f2682203",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 107,
+        "line_number": 85,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -119,7 +119,7 @@
         "hashed_secret": "2feacaec728cefef0f558dfb20a1da6ca2bbde7e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 124,
+        "line_number": 102,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2033,7 +2033,7 @@
         "hashed_secret": "c042bdfc4bc5516ec716afe9e85c173b614ff9f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 842,
+        "line_number": 829,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
+++ b/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
@@ -214,6 +214,25 @@ For example, if you have a custom JSON template in a file called `MyLayout.json`
 
 Refer to the [Log4j documentation](https://logging.apache.org/log4j/2.x/manual/configuration.html) for available properties.
 
+#### Configuring Public Certificates (Optional)
+
+If you are deploying your Galasa service on an internal or corporate network and expect your Galasa tests to connect to servers that use internal certificates, you will need to supply the public certificates so that Galasa can contact those servers successfully.
+
+You can use the `certificatesConfigMapName` value to provide the name of an existing ConfigMap containing the certificates that you wish to inject into the Galasa service pods. To do this, take the following steps:
+
+1. Create a ConfigMap by running:
+    ```
+    kubectl create configmap my-certificates --from-file=/path/to/my/certificate.pem
+    ```
+    where `/path/to/my/certificate.pem` is a file path on your machine to a certificate that you wish to include. You can supply multiple `--from-file` flags if you wish to load multiple certificates into the ConfigMap.
+
+2. Set `certificatesConfigMapName` in the Helm values to the name of the ConfigMap that you created (in this example, the name is `my-certificates`):
+    ```yaml
+    certificatesConfigMapName: "my-certificates"
+    ```
+
+You can then proceed with the installation of the Galasa service and the Helm chart will inject the certificates inside the ConfigMap into the Galasa service pods.
+
 ## Configure the default user role, and 'owner' of the Galasa service
 
 When the Galasa service is first installed, users logging in will be assigned a role as dictated by the `galasaDefaultUserRole` Helm chart property. For example 'tester'.

--- a/docs/content/releases/posts/v0.44.0.md
+++ b/docs/content/releases/posts/v0.44.0.md
@@ -25,6 +25,8 @@ links:
 
 - Deprecated the `callback_url` query parameter in the Galasa REST API's `GET /auth` endpoint in favour of a new `base64_callback_url` query parameter, which takes a Base64URL-encoded URL that the API will redirect back to after authenticating. See [#2416](https://github.com/galasa-dev/projectmanagement/issues/2416).
 
+- Added a configuration setting `certificatesConfigMapName` in the Galasa service Helm chart to allow users to supply public certificates for Galasa service pods to use. See the [Installing an Ecosystem using Helm documentation](../../docs/ecosystem/ecosystem-installing-k8s.md#configuring-public-certificates-optional) for detailed instructions on how to do this.
+
 ## Changes affecting tests running locally or on the Galasa Service
 
 - The 3270 manager's `ITerminal` interface has a new `toJsonString()` method that allows tests to convert the current 3270 terminal screen into JSON format.

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -6,7 +6,6 @@
 package dev.galasa.framework.k8s.controller;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -31,6 +30,7 @@ import dev.galasa.framework.spi.creds.FrameworkEncryptionService;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Affinity;
+import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSource;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1NodeAffinity;
@@ -49,6 +49,9 @@ import io.prometheus.client.Counter;
 import dev.galasa.framework.spi.utils.ITimeService;
 
 public class TestPodScheduler implements Runnable {
+    public static final String CACERTS_FILE_PATH_ENV_VAR = "GALASA_CACERTS_FILE_PATH";
+    public static final String CACERTS_VOLUME_NAME = "galasa-cacerts";
+
     private static final String RAS_TOKEN_ENV = "GALASA_RAS_TOKEN";
     private static final String EVENT_TOKEN_ENV = "GALASA_EVENT_STREAMS_TOKEN";
 
@@ -75,6 +78,10 @@ public class TestPodScheduler implements Runnable {
     // A time service, meaning unit tests can pass in a service which doesn't actually wait, making unit tests run faster.
     private ITimeService timeService ;
 
+    private boolean isUsingUserSuppliedCertificates;
+    private Path cacertsFilePath;
+    private String cacertsConfigMapName;
+
     public TestPodScheduler( 
         Environment env, 
         IDynamicStatusStoreService dss, 
@@ -91,6 +98,13 @@ public class TestPodScheduler implements Runnable {
         this.runs = runs;
         this.dss = dss;
         this.timeService = timeService;
+
+        String cacertsFilePathString = env.getenv(CACERTS_FILE_PATH_ENV_VAR);
+        if (cacertsFilePathString != null && !cacertsFilePathString.isBlank()) {
+            this.isUsingUserSuppliedCertificates = true;
+            this.cacertsFilePath = Path.of(cacertsFilePathString).toAbsolutePath();
+            this.cacertsConfigMapName = this.kubeEngineFacade.getGalasaServiceInstallName() + "-cacerts";
+        }
 
         // *** Create metrics
 
@@ -314,7 +328,6 @@ public class TestPodScheduler implements Runnable {
         return newPod;
     }
 
-
     /*
     * Tolerations are supplied as a string in the form:
     * "node-label1=Operator1:Condition1,node-label2=Operator2:Condition2"
@@ -431,6 +444,17 @@ public class TestPodScheduler implements Runnable {
 
         encryptionKeysVolume.setSecret(encryptionKeysSecretSource);
         volumes.add(encryptionKeysVolume);
+
+        if (this.isUsingUserSuppliedCertificates) {
+            V1Volume cacertsVolume = new V1Volume();
+            cacertsVolume.setName(CACERTS_VOLUME_NAME);
+
+            V1ConfigMapVolumeSource cacertsVolumeSource = new V1ConfigMapVolumeSource();
+            cacertsVolumeSource.setName(this.cacertsConfigMapName);
+
+            cacertsVolume.setConfigMap(cacertsVolumeSource);
+            volumes.add(cacertsVolume);
+        }
         return volumes;
     }
 
@@ -439,7 +463,7 @@ public class TestPodScheduler implements Runnable {
 
         String encryptionKeysMountPath = env.getenv(ENCRYPTION_KEYS_PATH_ENV);
         if (encryptionKeysMountPath != null && !encryptionKeysMountPath.isBlank()) {
-            Path encryptionKeysDirectory = Paths.get(encryptionKeysMountPath).getParent().toAbsolutePath();
+            Path encryptionKeysDirectory = Path.of(encryptionKeysMountPath).getParent().toAbsolutePath();
 
             V1VolumeMount encryptionKeysVolumeMount = new V1VolumeMount();
             encryptionKeysVolumeMount.setName(ENCRYPTION_KEYS_VOLUME_NAME);
@@ -447,6 +471,16 @@ public class TestPodScheduler implements Runnable {
             encryptionKeysVolumeMount.setReadOnly(true);
 
             volumeMounts.add(encryptionKeysVolumeMount);
+        }
+
+        if (this.isUsingUserSuppliedCertificates) {
+            V1VolumeMount cacertsFileVolumeMount = new V1VolumeMount();
+            cacertsFileVolumeMount.setName(CACERTS_VOLUME_NAME);
+            cacertsFileVolumeMount.setMountPath(this.cacertsFilePath.toString());
+            cacertsFileVolumeMount.setSubPath("cacerts");
+            cacertsFileVolumeMount.readOnly(true);
+
+            volumeMounts.add(cacertsFileVolumeMount);
         }
         return volumeMounts;
     }
@@ -473,6 +507,8 @@ public class TestPodScheduler implements Runnable {
         addEnvVarToContainerIfPresent(DSS_ENV_VAR, envs);
         addEnvVarToContainerIfPresent(CREDS_ENV_VAR, envs);
         addEnvVarToContainerIfPresent(EXTRA_BUNDLES_ENV_VAR, envs);
+
+        addEnvVarToContainerIfPresent("JDK_JAVA_OPTIONS", envs);
 
         //
         // envs.add(createSecretEnv("GALASA_SERVER_USER", "galasa-secret",

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -49,6 +49,8 @@ import io.prometheus.client.Counter;
 import dev.galasa.framework.spi.utils.ITimeService;
 
 public class TestPodScheduler implements Runnable {
+    public static final String JAVA_OPTIONS_ENV_VAR = "JDK_JAVA_OPTIONS";
+
     public static final String CACERTS_FILE_PATH_ENV_VAR = "GALASA_CACERTS_FILE_PATH";
     public static final String CACERTS_VOLUME_NAME = "galasa-cacerts";
 
@@ -508,7 +510,7 @@ public class TestPodScheduler implements Runnable {
         addEnvVarToContainerIfPresent(CREDS_ENV_VAR, envs);
         addEnvVarToContainerIfPresent(EXTRA_BUNDLES_ENV_VAR, envs);
 
-        addEnvVarToContainerIfPresent("JDK_JAVA_OPTIONS", envs);
+        addEnvVarToContainerIfPresent(JAVA_OPTIONS_ENV_VAR, envs);
 
         //
         // envs.add(createSecretEnv("GALASA_SERVER_USER", "galasa-secret",

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -671,7 +671,7 @@ public class TestPodSchedulerTest {
         mockEnvironment.setenv(TestPodScheduler.CACERTS_FILE_PATH_ENV_VAR, cacertsMountPath);
 
         String javaOptions = "-Djavax.net.ssl.trustStore=" + cacertsMountPath;
-        mockEnvironment.setenv("JDK_JAVA_OPTIONS", javaOptions);
+        mockEnvironment.setenv(TestPodScheduler.JAVA_OPTIONS_ENV_VAR, javaOptions);
 
         MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
         MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(new ArrayList<>());
@@ -718,7 +718,7 @@ public class TestPodSchedulerTest {
         assertThat(testContainer.getArgs()).contains("-jar", "boot.jar", "--run");
 
         V1EnvVar javaOptionsEnvVar = new V1EnvVar();
-        javaOptionsEnvVar.setName("JDK_JAVA_OPTIONS");
+        javaOptionsEnvVar.setName(TestPodScheduler.JAVA_OPTIONS_ENV_VAR);
         javaOptionsEnvVar.setValue(javaOptions);
         assertThat(testContainer.getEnv()).contains(javaOptionsEnvVar);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -658,4 +658,83 @@ public class TestPodSchedulerTest {
         assertThat(api.podsLaunched).hasSize(0);
         assertThat(mockDss.get("run."+testRunName+"."+DssPropertyKeyRunNameSuffix.STATUS)).isEqualTo("queued");
     }
+
+    @Test
+    public void testCanCreateTestPodWithCustomCertificatesOk() throws Exception {
+        // Given...
+        MockEnvironment mockEnvironment = new MockEnvironment();
+
+        String encryptionKeysMountPath = "/encryption/encryption-keys.yaml";
+        mockEnvironment.setenv(FrameworkEncryptionService.ENCRYPTION_KEYS_PATH_ENV, encryptionKeysMountPath);
+
+        String cacertsMountPath = "/galasa/certificates/cacerts";
+        mockEnvironment.setenv(TestPodScheduler.CACERTS_FILE_PATH_ENV_VAR, cacertsMountPath);
+
+        String javaOptions = "-Djavax.net.ssl.trustStore=" + cacertsMountPath;
+        mockEnvironment.setenv("JDK_JAVA_OPTIONS", javaOptions);
+
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(new ArrayList<>());
+
+        MockISettings settings = new MockISettings();
+        MockCPSStore mockCPS = new MockCPSStore(null);
+
+        String galasaServiceInstallName = "myGalasaService";
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(null, "mynamespace", galasaServiceInstallName);
+
+        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, mockCPS, settings, facade, mockFrameworkRuns, new MockTimeService(Instant.now()));;
+
+        String runName = "run1";
+        String podName = settings.getEngineLabel() + "-" + runName;
+        boolean isTraceEnabled = false;
+
+        // When...
+        V1Pod pod = runPoll.createTestPodDefinition(runName, podName, isTraceEnabled);
+
+        // Then...
+        String expectedEncryptionKeysMountPath = "/encryption";
+        checkPodMetadata(pod, galasaServiceInstallName, runName, podName, settings);
+        checkPodSpec(pod, settings);
+
+        // Check the volumes have been added
+        V1PodSpec actualPodSpec = pod.getSpec();
+        List<V1Volume> actualVolumes = actualPodSpec.getVolumes();
+        assertThat(actualVolumes).hasSize(2);
+
+        V1Volume encryptionKeysVolume = actualVolumes.get(0);
+        assertThat(encryptionKeysVolume.getName()).isEqualTo(TestPodScheduler.ENCRYPTION_KEYS_VOLUME_NAME);
+        assertThat(encryptionKeysVolume.getSecret().getSecretName()).isEqualTo(settings.getEncryptionKeysSecretName());
+
+        V1Volume cacertsVolume = actualVolumes.get(1);
+        assertThat(cacertsVolume.getName()).isEqualTo(TestPodScheduler.CACERTS_VOLUME_NAME);
+        assertThat(cacertsVolume.getConfigMap().getName()).isEqualTo(galasaServiceInstallName + "-cacerts");
+
+        // Check that test container has been added
+        List<V1Container> actualContainers = actualPodSpec.getContainers();
+        assertThat(actualContainers).hasSize(1);
+
+        V1Container testContainer = actualContainers.get(0);
+        assertThat(testContainer.getCommand()).containsExactly("java");
+        assertThat(testContainer.getArgs()).contains("-jar", "boot.jar", "--run");
+
+        V1EnvVar javaOptionsEnvVar = new V1EnvVar();
+        javaOptionsEnvVar.setName("JDK_JAVA_OPTIONS");
+        javaOptionsEnvVar.setValue(javaOptions);
+        assertThat(testContainer.getEnv()).contains(javaOptionsEnvVar);
+
+        // Check that the encryption keys have been mounted to the correct location
+        List<V1VolumeMount> testContainerVolumeMounts = testContainer.getVolumeMounts();
+        assertThat(testContainerVolumeMounts).hasSize(2);
+
+        V1VolumeMount encryptionKeysVolumeMount = testContainerVolumeMounts.get(0);
+        assertThat(encryptionKeysVolumeMount.getName()).isEqualTo(TestPodScheduler.ENCRYPTION_KEYS_VOLUME_NAME);
+        assertThat(encryptionKeysVolumeMount.getMountPath()).isEqualTo(expectedEncryptionKeysMountPath);
+        assertThat(encryptionKeysVolumeMount.getReadOnly()).isTrue();
+
+        V1VolumeMount cacertsVolumeMount = testContainerVolumeMounts.get(1);
+        assertThat(cacertsVolumeMount.getName()).isEqualTo(TestPodScheduler.CACERTS_VOLUME_NAME);
+        assertThat(cacertsVolumeMount.getMountPath()).isEqualTo(cacertsMountPath);
+        assertThat(cacertsVolumeMount.getSubPath()).isEqualTo("cacerts");
+        assertThat(cacertsVolumeMount.getReadOnly()).isTrue();
+    }
 }


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/1825

## Changes
- Updated the code that creates test pod definitions to include a new volume, volume mount, and `JDK_JAVA_OPTIONS` environment variable so that JVMs in test pods can use a cacerts file containing user-supplied public certificates
- Updated release notes and Helm chart installation docs to include instructions on how to supply public certificates into the Helm chart