### PR TITLE
Remove all mention of the old zos3270.terminal.output CPS property since it does not exist

### DIFF
--- a/docs/content/docs/cli-command-reference/viewing-test-results-cli.md
+++ b/docs/content/docs/cli-command-reference/viewing-test-results-cli.md
@@ -14,15 +14,9 @@ You can view the results of your test runs in the `run.log` file by completing t
 
 ## Viewing 3270 terminal interactions
 
-To view 3270 terminal screens and recorded web requests and responses that are generated from running tests you need to first update the `3270.terminal.output` property in the `cps.properties` file on your local machine. To do this, complete the following steps: 
+3270 terminal screens, and recorded web requests and responses for test runs are stored as .png files in the _ras > results > artifacts > zos3270 > images_ folder.
 
-1. Navigate to your ``.galasa`` directory 
-1. Open the _cps.properties_ file, for example in VS Code.
-1. Edit the _zos3270.terminal.output_ property to include ``.png`` files as well as `json` by adding the value `png` to the property. For example, ```zos3270.terminal.output=json,png```.
-
-3270 terminal screens, and recorded web requests and responses for test runs are now stored as .png files in the _ras > results > artifacts > zos3270 > images_ folder.
-
-You can then view the terminal interactions from your test runs in the `images` folder in the `zos3270` directory by completing the following steps:
+You can view the terminal interactions from your test runs in the `images` folder in the `zos3270` directory by completing the following steps:
 
 1. Navigate to your ``.galasa`` directory 
 1. Open the _images_ folder by selecting _ras > results > artifacts > zos3270 > images_

--- a/docs/content/docs/faqs/index.md
+++ b/docs/content/docs/faqs/index.md
@@ -5,28 +5,6 @@ title: "Frequently asked questions"
 Use the following sections to scan for questions and problems that have been raised previously, and how these have been answered and resolved.
 
 
-## How can I generate screenshot output when running my tests locally?
-
-You can generate screenshot output by setting the `zos3270.terminal.output` property in your `cps.properties` file or your `overrides.properties` file. For example, to generate screenshot output in json and png format, set the property to `zos3270.terminal.output=json,png`. 
-
-If you used the `galasactl local init` command to initialise your environment, the following setting should be in the `cps.properties` file already, so you can un-comment the line `zos3270.terminal.output=json,png` by removing the hash symbol (`#`), as shown in the following example:
-
-```properties
-#-------------------------------------------------------------------------
-# zos3270.terminal.output
-#
-# Controls which output format(s) any 3270 traffic uses when creating artifact files
-# in the Result Archive Store (RAS).
-#
-# Supported values are 'json' or 'png' or both.
-# 
-# Default for a locally-launched JVM test is both.
-#
-# Example:
-zos3270.terminal.output=json,png
-```
-
-
 ## What function can I use to clear a CICS screen in a 3270 terminal?
 
 If your terminal object is of type `ITerminal` you can use the `terminal.clear().waitForKeyboard()` method in your test code. 

--- a/docs/content/docs/managers/zos-managers/zos3270terminal-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos3270terminal-manager.md
@@ -15,7 +15,7 @@ The `ConfidentialTextFiltering` service enables confidential information such as
 
 Examples of using colour support and screen sizing are available in the [Code snippets and examples](#code-snippets-and-examples) section.
 
-When running a Galasa test with the Galasa CLI, terminal images are logged to the run log and PNG representations of the terminal screens can also be saved to the Result Archive Store (RAS) as the outputs are now controlled by the `zos3270.terminal.output` CPS property.
+When running a Galasa test with the Galasa CLI, terminal images are logged to the run log and PNG representations of the terminal screens are saved to the Result Archive Store (RAS).
 
 The zos3270Terminal Manager supports [Gherkin keywords](https://github.com/galasa-dev/cli/blob/main/gherkin-docs.md#3270-terminal-manipulation-steps){target="_blank"}. 
 
@@ -133,18 +133,6 @@ The following properties are used to configure the Zos3270Terminal Manager:
 | Description: | Allows for a custom 3270 device name to be requested when connecting to a server. Device names are case-insensitive 7-bit US ASCII strings that must not exceed 8 characters. |
 | Required:  | No |
 | Examples: | `zos3270.image.IMAGE_A.device.name=IYCQTC57` |
-
-
-### Select 3270 terminal outputs
-
-| Property: | 3270TerminalOutput CPS Property |
-| --------------------------------------- | :------------------------------------- |
-| Name: | zos3270.terminal.output |
-| Description: | Experimental: Selects the representations of 3270 terminal screens to be saved to the RAS |
-| Required:  | No |
-| Default value: |  JSON  |
-| Valid values: | JSON, PNG  |
-| Examples: | `zos3270.terminal.output=json,png` |
 
 
 ## Annotations provided by the Manager

--- a/modules/cli/pkg/launcher/jvmLauncher.go
+++ b/modules/cli/pkg/launcher/jvmLauncher.go
@@ -425,20 +425,8 @@ func addStandardOverrideProperties(
 
 	overrideRasStoreProperty(galasaHome, overrides)
 	overrideLocalRunIdPrefixProperty(overrides)
-	override3270TerminalOutputFormat(overrides)
 
 	return overrides
-}
-
-func override3270TerminalOutputFormat(overrides map[string]interface{}) {
-	// Force the launched runs to use the "L" prefix in their runids.
-	const OVERRIDE_PROPERTY_3270_TERMINAL_OUTPUT_FORMAT = "zos3270.terminal.output"
-
-	// Only set this property if it's not already set by the user, or in the users' override file.
-	_, isPropAlreadySet := overrides[OVERRIDE_PROPERTY_3270_TERMINAL_OUTPUT_FORMAT]
-	if !isPropAlreadySet {
-		overrides[OVERRIDE_PROPERTY_3270_TERMINAL_OUTPUT_FORMAT] = "json,png"
-	}
 }
 
 func overrideLocalRunIdPrefixProperty(overrides map[string]interface{}) {

--- a/modules/cli/pkg/launcher/jvmLauncher_test.go
+++ b/modules/cli/pkg/launcher/jvmLauncher_test.go
@@ -384,19 +384,6 @@ func TestJvmLauncherSetsRASStoreOverride(t *testing.T) {
 	assert.Contains(t, overridesGotBack, "framework.resultarchive.store")
 }
 
-func TestJvmLauncherSets3270TerminalOutputFormatProperty(t *testing.T) {
-	overrides := make(map[string]interface{})
-	fs := files.NewMockFileSystem()
-	env := utils.NewMockEnv()
-	galasaHome, _ := utils.NewGalasaHome(fs, env, "")
-
-	overridesGotBack := addStandardOverrideProperties(galasaHome, overrides)
-
-	assert.Contains(t, overridesGotBack, "zos3270.terminal.output")
-	assert.Contains(t, overridesGotBack["zos3270.terminal.output"], "png")
-	assert.Contains(t, overridesGotBack["zos3270.terminal.output"], "json")
-}
-
 func TestCanCreateTempPropsFile(t *testing.T) {
 	overrides := make(map[string]interface{})
 	fs := files.NewMockFileSystem()


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2449

## Changes
- Removed all remaining mentions of the `zos3270.terminal.output` property as it was removed several releases ago in favour of client-side PNG rendering in the Galasa CLI tool