### PR TITLE
Iss2454 - Upgrade grpc-netty-shaded dependency to remove critical vulnerability

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.auth.spi/build.gradle
@@ -45,7 +45,7 @@ protobuf {
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:1.68.0'
+      artifact = 'io.grpc:protoc-gen-grpc-java:1.76.0'
     }
   }
   generateProtoTasks {

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -56,7 +56,7 @@ dependencies {
         api 'com.google.errorprone:error_prone_annotations:2.28.0'
 
         // api 'com.google.protobuf:protobuf-java:4.28.3' - dangerous. Protobuf versions are all explicit elsewhere right now.
-        api 'com.google.protobuf:protobuf-javalite:3.25.5'
+        api 'com.google.protobuf:protobuf-javalite:3.25.8'
         api 'com.google.protobuf:protobuf-java-util:3.25.3'
 
         api 'com.google.guava:guava:33.2.1-jre'

--- a/modules/wrapping/dev.galasa.wrapping.io.grpc.java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.io.grpc.java/pom.xml
@@ -43,7 +43,7 @@
 
 			<!-- 
 			This dependency has a transient dependency of this:
-			com.google.protobuf:protobuf-javalite:jar:3.25.8:compile
+			com.google.protobuf:protobuf-java:jar:3.25.8:compile
 
 			However, we need to depend on it directly or a this causess a NoClassDefFoundError
 			in dev.galasa.framework.auth.spi. We will add an explicit dependency below.

--- a/modules/wrapping/dev.galasa.wrapping.io.grpc.java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.io.grpc.java/pom.xml
@@ -40,25 +40,11 @@
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
 			<version>1.76.0</version>
-
-			<!-- 
-			This dependency has a transient dependency of this:
-			com.google.protobuf:protobuf-java:jar:3.25.8:compile
-
-			However, we need to depend on it directly or a this causess a NoClassDefFoundError
-			in dev.galasa.framework.auth.spi. We will add an explicit dependency below.
-			-->
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.protobuf</groupId>
-					<artifactId>protobuf-java</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!--
 		This dependency is relied upon by io.grpc:grpc-protobuf
-		but we want to explicitly depend on it here.
+		but we need to depend on it directly to avoid OSGi issues.
 		-->
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
@@ -66,38 +52,20 @@
 			<version>3.25.8</version>
 		</dependency>
 
-
-
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf-lite</artifactId>
 			<version>1.76.0</version>
-
-			<!-- 
-			This dependency has a transient dependency of this:
-			com.google.protobuf:protobuf-javalite:jar:3.25.5:compile
-
-			This causes a NoClassDefFoundError in dev.galasa.framework.auth.spi.
-			We will add an explicit dependency on a later version that fixes this.
-			-->
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.protobuf</groupId>
-					<artifactId>protobuf-javalite</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!--
 		This dependency is relied upon by io.grpc:grpc-protobuf-lite
-		but we want to upgrade a transient dependency there.
+		but we need to depend on it directly to avoid OSGi issues.
 		-->
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-javalite</artifactId>
-			<version>3.25.8</version>
 		</dependency>
-
 
 		<dependency>
 			<groupId>io.grpc</groupId>

--- a/modules/wrapping/dev.galasa.wrapping.io.grpc.java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.io.grpc.java/pom.xml
@@ -19,51 +19,51 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-api</artifactId>
-			<version>1.68.0</version>
+			<version>1.76.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-context</artifactId>
-			<version>1.68.0</version>
+			<version>1.76.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-core</artifactId>
-			<version>1.68.0</version>
+			<version>1.76.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
-			<version>1.68.0</version>
+			<version>1.76.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
-			<version>1.68.0</version>
+			<version>1.76.0</version>
 
 			<!-- 
 			This dependency has a transient dependency of this:
-			com.google.protobuf:protobuf-java:jar:3.25.3:compile
+			com.google.protobuf:protobuf-javalite:jar:3.25.8:compile
 
-			Which has a vulnerability. We will add an explicit dependency on 
-			a later version.
+			However, we need to depend on it directly or a this causess a NoClassDefFoundError
+			in dev.galasa.framework.auth.spi. We will add an explicit dependency below.
 			-->
 			<exclusions>
 				<exclusion>
-				<groupId>com.google.protobuf</groupId>
-				<artifactId>protobuf-java</artifactId>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
 
 		<!--
 		This dependency is relied upon by io.grpc:grpc-protobuf
-		but we want to upgrade a transient dependency there.
+		but we want to explicitly depend on it here.
 		-->
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>3.25.5</version>
+			<version>3.25.8</version>
 		</dependency>
 
 
@@ -71,19 +71,19 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf-lite</artifactId>
-			<version>1.68.0</version>
+			<version>1.76.0</version>
 
 			<!-- 
 			This dependency has a transient dependency of this:
-			com.google.protobuf:protobuf-javalite:jar:3.25.3:compile
+			com.google.protobuf:protobuf-javalite:jar:3.25.5:compile
 
-			Which has a vulnerability. We will add an explicit dependency on 
-			a later version.
+			This causes a NoClassDefFoundError in dev.galasa.framework.auth.spi.
+			We will add an explicit dependency on a later version that fixes this.
 			-->
 			<exclusions>
 				<exclusion>
-				<groupId>com.google.protobuf</groupId>
-				<artifactId>protobuf-javalite</artifactId>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-javalite</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -95,18 +95,19 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-javalite</artifactId>
+			<version>3.25.8</version>
 		</dependency>
 
 
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-stub</artifactId>
-			<version>1.68.0</version>
+			<version>1.76.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-util</artifactId>
-			<version>1.68.0</version>
+			<version>1.76.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.perfmark</groupId>


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2454

## Changes

- Bumps the `grpc-netty-shaded` dependency to 1.76.0 from 1.68.0 to remove a critical vulnerability reported to us.
- Also bumps the other `io.grpc` group's dependencies in the wrapper and grpc artifact installed in the auth spi to 1.76.0 for consistency.
- Upgrades the version of `protobuf-javalite` in the platform to align with the new `grpc-protobuf-lite` version.