### PR TITLE
Iss2406 - Simplatform documentation update

### DIFF
--- a/docs/content/docs/running-simbank-tests/simbank-cli.md
+++ b/docs/content/docs/running-simbank-tests/simbank-cli.md
@@ -7,7 +7,7 @@ To start exploring the Galasa Simbank application and to run the sample SimBank 
 
 1. Clone the Galasa `simplatform` repository on your machine by running the following command in a terminal in the directory on your local machine in which you want to clone the repository files:
     ```
-    git clone https://github.com/galasa-dev/simplatform.git
+    git clone https://github.com/galasa-dev/simplatform.git --branch v0.44.0 --single-branch
     ```
 1. Run the `./build-locally.sh` script to build the code.
 1. Run the `./run-locally.sh --server` script to start the simbank server inside a local JVM.

--- a/docs/content/docs/running-simbank-tests/web-app-integration-test.md
+++ b/docs/content/docs/running-simbank-tests/web-app-integration-test.md
@@ -71,7 +71,7 @@ Complete the following steps to build a Docker image called `simbank-webapp` to 
 
 1. If you have not done so already, clone the Galasa `simplatform` repository on your machine by running the following command in the directory on your local machine in which you want to clone the repository files: 
 	```
-	git clone https://github.com/galasa-dev/simplatform.git
+	git clone https://github.com/galasa-dev/simplatform.git --branch v0.44.0 --single-branch
 	```
 2. Build the image and test that the container is working correctly by running the following commands. For the commands to work, the terminal must be running in the same directory as the one that contains the Dockerfile. The Dockerfile is located in the [galasa-simplatform-webapp directory](https://github.com/galasa-dev/simplatform/tree/main/galasa-simplatform-application/galasa-simplatform-webapp) in the Galasa `simplatform` repository.
 	```

--- a/docs/set-version.sh
+++ b/docs/set-version.sh
@@ -229,9 +229,51 @@ function upgrade_running_simbank {
     success "Upgraded version in running-simbank-tests-cli.md."    
 }
 
+function upgrade_simbank_cli {
+    h1 "Upgrading the version in the simbank-cli.md file"
+    
+    source_path=${BASEDIR}/content/docs/running-simbank-tests/simbank-cli.md
+    temp_file=$temp_dir/simbank-cli.md
+    # This lines needs to change:
+    #    git clone https://github.com/galasa-dev/simplatform.git --branch v0.44.0 --single-branch
+    info "Upgrading version in file $source_path"
+
+    cat $source_path \
+    | sed "s/.*git clone https:\/\/github.com\/galasa-dev\/simplatform.git --branch v.* --single-branch/    git clone https:\/\/github.com\/galasa-dev\/simplatform.git --branch v$component_version --single-branch/1" \
+    > $temp_file
+    rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to replace version in file $temp_file" ; exit 1 ; fi
+
+    cp $temp_file $source_path
+    rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to replace master version file with the modified one." ; exit 1 ; fi
+
+    success "Upgraded version in simbank-cli.md."    
+}
+
+function upgrade_web_app {
+    h1 "Upgrading the version in the web-app-integration-test.md file"
+    
+    source_path=${BASEDIR}/content/docs/running-simbank-tests/web-app-integration-test.md
+    temp_file=$temp_dir/web-app-integration-test.md
+    # This lines needs to change:
+    #    git clone https://github.com/galasa-dev/simplatform.git --branch v0.44.0 --single-branch
+    info "Upgrading version in file $source_path"
+
+    cat $source_path \
+    | sed "s/.*git clone https:\/\/github.com\/galasa-dev\/simplatform.git --branch v.* --single-branch/    git clone https:\/\/github.com\/galasa-dev\/simplatform.git --branch v$component_version --single-branch/1" \
+    > $temp_file
+    rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to replace version in file $temp_file" ; exit 1 ; fi
+
+    cp $temp_file $source_path
+    rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to replace master version file with the modified one." ; exit 1 ; fi
+
+    success "Upgraded version in web-app-integration-test.md."    
+}
+
 upgrade_docs_build_gradle
 upgrade_index
 upgrade_installing_cli
 upgrade_ecosystem_installing
 upgrade_running_simbank_offline
 upgrade_running_simbank
+upgrade_simbank_cli
+upgrade_web_app


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2406

## Changes

- Update instructions in the documentation about cloning the Simplatform repo, for users to clone the latest released tag, rather than the `main` development branch. Not only could the main development branch be unstable as its still in development, but also using the released version of galasactl with a newer Simplatform OBR causes OSGi issues.
- As these lines in the docs now refer to the released version, they'll need to be kept up to date, so these have been added to the set-version.sh script.