### PR TITLE
Iss2462 - Remove build of javadoc-site Docker image

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -387,7 +387,7 @@ jobs:
             platform=linux-amd64
 
   build-obr-javadocs:
-    name: Build OBR javadocs using galasabld image and maven
+    name: Build galasa-uber-javadoc using galasabld image and maven
     runs-on: ubuntu-latest
 
     steps:
@@ -514,7 +514,7 @@ jobs:
       #     restore-keys: |
       #         cache-obr-javadoc-
 
-      - name: Build javadoc site using maven
+      - name: Build galasa-uber-javadoc and deploy into temporary location
         working-directory: modules/obr/javadocs
         env:
           GPG_KEYID: ${{ secrets.GPG_KEYID }}
@@ -535,7 +535,7 @@ jobs:
 
       # Note: We publish from a different repository, so the maven comand can't find the javadoc's pom.xml,
       # as we want it to create a new one.
-      - name: Publish the javadoc site using maven, so that the maven bundle contains no dependencies.
+      - name: Publish galasa-uber-javadoc ZIP to local Maven repository
         working-directory: modules/obr
         env:
           GPG_KEYID: ${{ secrets.GPG_KEYID }}
@@ -561,11 +561,11 @@ jobs:
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/modules/obr/settings.xml 2>&1 | tee -a javadocs/build.log
       
-      - name: Upload Javadoc site build log
+      - name: Upload Javadoc build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: javadoc-site-build-log
+          name: javadoc-build-log
           path: modules/obr/javadocs/build.log
           retention-days: 7
 
@@ -584,64 +584,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
           password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
-    
-      - name: Extract metadata for Javadoc site image
-        id: metadata-javadoc-site
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/javadoc-site
-  
-      - name: Build and push Javadoc site image 
-        id: build-javadoc-site
-        uses: docker/build-push-action@v5
-        with:
-          context: modules/obr
-          file: modules/obr/dockerfiles/dockerfile.javadocsite
-          push: true
-          tags: ${{ steps.metadata-javadoc-site.outputs.tags }}
-          labels: ${{ steps.metadata-javadoc-site.outputs.labels }}
-      
-      - name: Recycle javadocsite application in ArgoCD
-        # Skip this job for forks
-        if: ${{ github.repository_owner == 'galasa-dev' }}
-        env:
-          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
-        run: |
-          for i in {1..10}; do
-            docker run \
-            --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} \
-            --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main \
-            app actions run ${{ env.BRANCH }}-maven-repos restart \
-            --kind Deployment \
-            --resource-name javadocsite-${{ env.BRANCH }} \
-            --server argocd.galasa.dev \
-            --grpc-web \
-            && exit 0 || sleep 10
-          done
-
-          echo "ArgoCD still uncontactable after 10 attempts."
-          exit 1
-
-      - name: Wait for javadocsite application health in ArgoCD
-        # Skip this job for forks
-        if: ${{ github.repository_owner == 'galasa-dev' }}
-        env:
-          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
-        run: |
-          for i in {1..10}; do
-            docker run \
-            --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} \
-            --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main \
-            app wait ${{ env.BRANCH }}-maven-repos \
-            --resource apps:Deployment:javadocsite-${{ env.BRANCH }} \
-            --health \
-            --server argocd.galasa.dev \
-            --grpc-web \
-            && exit 0 || sleep 10
-          done
-
-          echo "ArgoCD still uncontactable after 10 attempts."
-          exit 1
 
       - name: Extract metadata for Javadoc Maven repo image
         id: metadata

--- a/.github/workflows/pr-obr.yaml
+++ b/.github/workflows/pr-obr.yaml
@@ -335,7 +335,7 @@ jobs:
           path: modules/obr/repo
 
   build-obr-javadocs:
-    name: Build OBR javadocs using galasabld image and maven
+    name: Build galasa-uber-javadoc using galasabld image and maven
     if: ${{ inputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
@@ -523,7 +523,7 @@ jobs:
           restore-keys: |
             cache-obr-javadoc-
         
-      - name: Build javadoc site using maven
+      - name: Build galasa-uber-javadoc and deploy into temporary location
         working-directory: modules/obr/javadocs
         run: |
           set -o pipefail
@@ -540,7 +540,7 @@ jobs:
 
       # Note: We publish from a different repository, so the maven comand can't find the javadoc's pom.xml,
       # as we want it to create a new one.
-      - name: Publish the javadoc site using maven, so that the maven bundle contains no dependencies.
+      - name: Publish galasa-uber-javadoc ZIP to local Maven repository
         working-directory: modules/obr
         env:
           GALASA_VERSION: ${{ inputs.galasa-version }}
@@ -563,11 +563,11 @@ jobs:
           --batch-mode --errors --fail-at-end \
           2>&1 | tee -a javadocs/build.log
 
-      - name: Upload Javadoc site build log
+      - name: Upload Javadoc build log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: javadoc-site-build-log
+          name: javadoc-build-log
           path: modules/obr/javadocs/build.log
           retention-days: 7
 
@@ -576,14 +576,6 @@ jobs:
         with:
           name: javadoc
           path: modules/obr/javadocs/docker/repo
-      
-      - name: Build Javadoc site image for testing
-        uses: docker/build-push-action@v5
-        with:
-          context: modules/obr
-          file: modules/obr/dockerfiles/dockerfile.javadocsite
-          load: true
-          tags: javadoc-site:test
 
       - name: Build Javadoc Maven repo image for testing
         uses: docker/build-push-action@v5

--- a/modules/obr/dockerfiles/dockerfile.javadocsite
+++ b/modules/obr/dockerfiles/dockerfile.javadocsite
@@ -1,6 +1,0 @@
-FROM ghcr.io/galasa-dev/httpd:alpine
-
-RUN rm -v /usr/local/apache2/htdocs/*
-COPY dockerfiles/httpdconf/httpd.conf /usr/local/apache2/conf/httpd.conf
-
-COPY javadocs/target/site/apidocs/ /usr/local/apache2/htdocs/


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2462

The Galasa javadoc is now built as part of the Github pages docs build. This means there is no longer a need for the site development.galasa.dev/main/javadoc-site which shows the same thing as https://vnext.galasa.dev/docs/reference/javadoc/ so the image ghcr.io/galasa-dev/javadoc-site no longer needs to be built.

## Changes

- Delete the steps in the build that build the javadoc-site image
- Delete the Dockerfile for the image