### PR TITLE
Iss2409 - Remove Java 11 support

### DIFF
--- a/developer-docs/install-pre-req-tools.md
+++ b/developer-docs/install-pre-req-tools.md
@@ -76,16 +76,16 @@ List the available java releases
 sdk list java
 ```
 
-Install the semeru java 11 release:
+Install the semeru java 17 release:
 ```shell
-sdk install java 11.0.16.1-sem
+sdk install java 17.0.12-sem
 ```
 
 Add this to your `~.zprofile` :
 ```shell
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 sdk version
-export SDKMAN_JAVA_VERSION="11.0.16.1-sem"
+export SDKMAN_JAVA_VERSION="17.0.12-sem"
 sdk default java ${SDKMAN_JAVA_VERSION}
 sdk use java ${SDKMAN_JAVA_VERSION}
 ```

--- a/docs/content/docs/cli-command-reference/cli-prereqs.md
+++ b/docs/content/docs/cli-command-reference/cli-prereqs.md
@@ -8,7 +8,7 @@ The following section explains more about the software prerequisites that you ne
 
 ### Java JDK 
 
-Required. Galasa tests and Managers are written in Java - you need to install a Java version 11 JDK or later to use it. _Note:_ We do not currently support Java 21 or later. After installing, you must set the `JAVA_HOME` environment variable to your Java JDK installation path and check it set successfully by running the command `echo $JAVA_HOME` on Mac or Unix, or `echo %JAVA_HOME%` on Windows (PowerShell). The returned result shows the path to your JDK installation.
+Required. Galasa tests and Managers are written in Java - you need to install Java version 11 JDK to use it. _Note:_ We do not currently support Java 21 or later. After installing, you must set the `JAVA_HOME` environment variable to your Java JDK installation path and check it set successfully by running the command `echo $JAVA_HOME` on Mac or Unix, or `echo %JAVA_HOME%` on Windows (PowerShell). The returned result shows the path to your JDK installation.
 
 
 ### Maven 

--- a/docs/content/docs/cli-command-reference/cli-prereqs.md
+++ b/docs/content/docs/cli-command-reference/cli-prereqs.md
@@ -8,7 +8,7 @@ The following section explains more about the software prerequisites that you ne
 
 ### Java JDK 
 
-Required. Galasa tests and Managers are written in Java - you need to install Java version 11 JDK to use it. _Note:_ We do not currently support Java 21 or later. After installing, you must set the `JAVA_HOME` environment variable to your Java JDK installation path and check it set successfully by running the command `echo $JAVA_HOME` on Mac or Unix, or `echo %JAVA_HOME%` on Windows (PowerShell). The returned result shows the path to your JDK installation.
+Required. Galasa tests and Managers are written in Java - you need to install Java version 17 JDK to use it. _Note:_ We do not currently support Java 21 or later. After installing, you must set the `JAVA_HOME` environment variable to your Java JDK installation path and check it set successfully by running the command `echo $JAVA_HOME` on Mac or Unix, or `echo %JAVA_HOME%` on Windows (PowerShell). The returned result shows the path to your JDK installation.
 
 
 ### Maven 

--- a/docs/content/docs/cli-command-reference/runs-submit-local.md
+++ b/docs/content/docs/cli-command-reference/runs-submit-local.md
@@ -16,7 +16,7 @@ Local runs do not benefit from the features that are provided when running tests
 
 To use the `galasactl runs submit local` command, the `JAVA_HOME` environment variable must be set to reference the JVM in which you want the test to run, as described in the [CLI prerequisites online](./cli-prereqs.md) and [CLI prerequisites offline](./zipped-prerequisites.md) documentation. This is because the local java run-time environment is used to launch the test locally. To check that `JAVA_HOME` is set correctly, the tool checks that `$JAVA_HOME/bin/java` exists in Unix or Mac, and `%JAVA_HOME%\bin\java.exe` exists on Windows.
 
-The level of Java must match the supported level of the Galasa version that is being launched. Use the `galasactl --version` command to find the galasactl tool version. We currently support Java version 11 to version 17 JDK. _Note:_ We do not currently support Java 21 or later.
+The level of Java must match the supported level of the Galasa version that is being launched. Use the `galasactl --version` command to find the galasactl tool version. We currently support Java version 17 JDK. _Note:_ We do not currently support Java 21 or later.
 
 To view the full list of options that are available, see the [galasactl runs submit local](../reference/cli-syntax/galasactl_runs_submit_local.md) command reference.
 

--- a/docs/content/docs/cli-command-reference/zipped-prerequisites.md
+++ b/docs/content/docs/cli-command-reference/zipped-prerequisites.md
@@ -8,7 +8,7 @@ The following section explains more about the software prerequisites that you ne
 
 ### Java JDK 
 
-Required. Galasa tests and Managers are written in Java - you need to install a Java version 11 JDK or later to use it. _Note:_ We do not currently support Java 21 or later. After installing, you must set the `JAVA_HOME` environment variable to your Java JDK installation path and check it set successfully by running the command `echo $JAVA_HOME` on Mac or Unix, or `echo %JAVA_HOME%` on Windows (PowerShell). The returned result shows the path to your JDK installation.
+Required. Galasa tests and Managers are written in Java - you need to install Java version 11 JDK to use it. _Note:_ We do not currently support Java 21 or later. After installing, you must set the `JAVA_HOME` environment variable to your Java JDK installation path and check it set successfully by running the command `echo $JAVA_HOME` on Mac or Unix, or `echo %JAVA_HOME%` on Windows (PowerShell). The returned result shows the path to your JDK installation.
 
 ### Gradle
 

--- a/docs/content/docs/cli-command-reference/zipped-prerequisites.md
+++ b/docs/content/docs/cli-command-reference/zipped-prerequisites.md
@@ -8,7 +8,7 @@ The following section explains more about the software prerequisites that you ne
 
 ### Java JDK 
 
-Required. Galasa tests and Managers are written in Java - you need to install Java version 11 JDK to use it. _Note:_ We do not currently support Java 21 or later. After installing, you must set the `JAVA_HOME` environment variable to your Java JDK installation path and check it set successfully by running the command `echo $JAVA_HOME` on Mac or Unix, or `echo %JAVA_HOME%` on Windows (PowerShell). The returned result shows the path to your JDK installation.
+Required. Galasa tests and Managers are written in Java - you need to install Java version 17 JDK to use it. _Note:_ We do not currently support Java 21 or later. After installing, you must set the `JAVA_HOME` environment variable to your Java JDK installation path and check it set successfully by running the command `echo $JAVA_HOME` on Mac or Unix, or `echo %JAVA_HOME%` on Windows (PowerShell). The returned result shows the path to your JDK installation.
 
 ### Gradle
 

--- a/docs/content/docs/running-simbank-tests/running-simbank-tests-cli-offline.md
+++ b/docs/content/docs/running-simbank-tests/running-simbank-tests-cli-offline.md
@@ -9,7 +9,7 @@ You can explore Galasa further with Galasa Simbank. Galasa Simbank is a simulate
 - A test that uses a provisioned account object to perform the same test as `BasicAccountCreditTest.java` in an improved test design - `ProvisionedAccountCreditTests.java`.
 - A test that exercises the z/OS Batch Manager by simulating the submission of a JCL job to add a number of accounts to the SimBank system - `BatchAccountsOpenTest.java`.
 
-The following sections explain how to run the `SimBankIVT` test class by using the CLI. Make sure that you have installed the Galasa CLI tool and Java version 11 JDK, and have set the JAVA_HOME environment variable, as described in the [CLI prerequisites offline](../cli-command-reference/zipped-prerequisites.md) documentation. 
+The following sections explain how to run the `SimBankIVT` test class by using the CLI. Make sure that you have installed the Galasa CLI tool and Java version 17 JDK, and have set the JAVA_HOME environment variable, as described in the [CLI prerequisites offline](../cli-command-reference/zipped-prerequisites.md) documentation. 
 
 
 ## Updating the overrides and credentials property files

--- a/docs/content/docs/running-simbank-tests/running-simbank-tests-cli.md
+++ b/docs/content/docs/running-simbank-tests/running-simbank-tests-cli.md
@@ -9,7 +9,7 @@ You can explore Galasa further with Galasa Simbank. Galasa Simbank is a simulate
 - A test that uses a provisioned account object to perform the same test as `BasicAccountCreditTest.java` in an improved test design - `ProvisionedAccountCreditTests.java`.
 - A test that exercises the z/OS Batch Manager by simulating the submission of a JCL job to add a number of accounts to the SimBank system - `BatchAccountsOpenTest.java`.
 
-The following sections explain how to run the `SimBankIVT` test class by using the CLI. Make sure that you have installed the Galasa CLI tool and Java version 11 JDK, and have set the JAVA_HOME environment variable, as described in the [CLI prerequisites online](../cli-command-reference/cli-prereqs.md) documentation. 
+The following sections explain how to run the `SimBankIVT` test class by using the CLI. Make sure that you have installed the Galasa CLI tool and Java version 17 JDK, and have set the JAVA_HOME environment variable, as described in the [CLI prerequisites online](../cli-command-reference/cli-prereqs.md) documentation. 
 
 
 ## Updating the overrides and credentials property files

--- a/docs/content/docs/running-simbank-tests/web-app-integration-test.md
+++ b/docs/content/docs/running-simbank-tests/web-app-integration-test.md
@@ -84,7 +84,7 @@ Complete the following steps to build a Docker image called `simbank-webapp` to 
 
 ### Troubleshooting
 
-If the container is not working correctly, for example, compilation and runtime errors are returned, check the version of tomcat in the Dockerfile. You might need to edit the tomcat version to a version that is compatible with Java 17, for example, `FROM tomcat:11-jre17-temurin`.
+If the container is not working correctly, for example, compilation and runtime errors are returned, check the version of tomcat in the Dockerfile. You might need to edit the tomcat version to a version that is compatible with the `javax.servlet.*` API and Java 17, for example, `FROM tomcat:9-jre17-temurin`.
 
 
 ## Walkthrough - WebAppIntegrationTest

--- a/docs/content/docs/running-simbank-tests/web-app-integration-test.md
+++ b/docs/content/docs/running-simbank-tests/web-app-integration-test.md
@@ -84,7 +84,7 @@ Complete the following steps to build a Docker image called `simbank-webapp` to 
 
 ### Troubleshooting
 
-If the container is not working correctly, for example, compilation and runtime errors are returned, check the version of tomcat in the Dockerfile. You might need to edit the tomcat version to a version that is compatible with Java 11, for example, `FROM tomcat:8.5.82-jre11-temurin`.
+If the container is not working correctly, for example, compilation and runtime errors are returned, check the version of tomcat in the Dockerfile. You might need to edit the tomcat version to a version that is compatible with Java 17, for example, `FROM tomcat:11-jre17-temurin`.
 
 
 ## Walkthrough - WebAppIntegrationTest

--- a/modules/buildutils/openapi2beans/JavaChecker/pom.xml
+++ b/modules/buildutils/openapi2beans/JavaChecker/pom.xml
@@ -12,9 +12,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>11</java.version>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<java.version>17</java.version>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 		<unpackBundle>true</unpackBundle>
 	</properties>

--- a/modules/cli/.devcontainer/devcontainer.json
+++ b/modules/cli/.devcontainer/devcontainer.json
@@ -10,10 +10,10 @@
             "version": "1.19.1"
         },
         "ghcr.io/devcontainers/features/java:1": {
-            "version": "11.0.18-sem",
+            "version": "17.0.12-sem",
             "jdkDistro": "sem",
             "installGradle"	: true,
-            "gradleVersion": "6.9.2",
+            "gradleVersion": "9.0.0",
             "installMaven": true,
             "mavenVersion": "3.8.6"
         }

--- a/modules/cli/pkg/embedded/templates/projectCreate/parent-project/pom.xml
+++ b/modules/cli/pkg/embedded/templates/projectCreate/parent-project/pom.xml
@@ -26,9 +26,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>11</java.version>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<java.version>17</java.version>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 		<unpackBundle>true</unpackBundle>
 

--- a/modules/framework/README.md
+++ b/modules/framework/README.md
@@ -46,7 +46,7 @@ After building the framework module locally, the boot.jar will be located in `ga
 
 ### Syntax
 
-To run Galasa Boot, you must have Java 11 or above installed.
+To run Galasa Boot, you must have Java 17 installed.
 
 ```
 java -jar /path/to/galasa/galasa-boot-{version}.jar [OPTIONS]

--- a/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -577,17 +577,17 @@ public class Launcher {
     public void validateJavaLevel(Environment env) throws LauncherException{
         String version = env.getProperty("java.version");
         logger.trace("Checking version of Java, found: " + version);
-        if(version == null || version.isEmpty()){
+        if (version == null || version.isEmpty()){
             logger.error("Unable to determine Java version - will exit");
             throw new LauncherException("Unable to determine Java version - will exit");
         }
 
-        if(version.startsWith("17") || version.startsWith("11")){
+        if (version.startsWith("17")){
             logger.trace("Java version " + version + " validated");
             return;
         }
 
-        String msg = "Galasa requires Java 11 or 17, we found: " + version + ". Correct your classpath to a supported version of java and re-try.";
+        String msg = "Galasa requires Java 17, we found: " + version + ". Correct your classpath to a supported version of java and re-try.";
         logger.error(msg);
         throw new LauncherException(msg);
     }

--- a/modules/maven/galasa-maven-plugin/pom.xml
+++ b/modules/maven/galasa-maven-plugin/pom.xml
@@ -204,8 +204,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/modules/wrapping/pom.xml
+++ b/modules/wrapping/pom.xml
@@ -114,8 +114,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2409

## Changes
 
- External docs now state that Galasa only runs on Java 17
- Developer-facing docs now tell developers to install Java 17 Semeru
- CLI dev container installs Java 17 Semeru
- Maven compiler source and target updated to Java 17
- Galasa Launcher now validates that the user's Java version is 17