### PR TITLE
Add deprecation notice to the IP network manager and 0.45.0 release notes about dropping support for RSA/SHA1

### DIFF
--- a/docs/content/releases/posts/v0.45.0.md
+++ b/docs/content/releases/posts/v0.45.0.md
@@ -7,6 +7,10 @@ links:
 
 # 0.45.0 - Release Highlights
 
+## Deprecated features
+
+- In a future release, Galasa's IP network manager will no longer support SSH connections using the RSA/SHA1 signature algorithm. If you are using RSA/SHA1 to connect to a server via SSH, you must upgrade your server to use a more secure algorithm to avoid connection failures.
+
 ## Changes affecting tests running locally or on the Galasa Service
 
 - When a local test run shares a Dynamic Status Store (DSS) with a Galasa service and the run exits while in the 'queued' state, the test run will be interrupted and the DSS record for that run will be cleaned up after a period of time has passed. See [#2395](https://github.com/galasa-dev/projectmanagement/issues/2395).

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/src/main/java/dev/galasa/ipnetwork/spi/SSHClient.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/src/main/java/dev/galasa/ipnetwork/spi/SSHClient.java
@@ -75,7 +75,7 @@ public class SSHClient implements ICommandShell {
         // Remove this notice once the SSH client library has been upgraded to drop support for RSA/SHA1
         logger.warn(
             "Deprecation notice: In a future release, Galasa will no longer support SSH connections using the RSA/SHA1 signature algorithm. "+
-            "If you are using RSA/SHA1 to connect to a server via SSH, you must upgrade your server to use a more secure algorithm."
+            "If you are using RSA/SHA1 to connect to a server via SSH, you must upgrade your server to use a more secure algorithm to avoid connection failures."
         );
 
         this.hostname = hostname;

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/src/main/java/dev/galasa/ipnetwork/spi/SSHClient.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/src/main/java/dev/galasa/ipnetwork/spi/SSHClient.java
@@ -72,6 +72,12 @@ public class SSHClient implements ICommandShell {
 
     public SSHClient(String hostname, int port, ICredentials credentials, long defaultTimeoutInMillis) throws SSHException {
 
+        // Remove this notice once the SSH client library has been upgraded to drop support for RSA/SHA1
+        logger.warn(
+            "Deprecation notice: In a future release, Galasa will no longer support SSH connections using the RSA/SHA1 signature algorithm. "+
+            "If you are using RSA/SHA1 to connect to a server via SSH, you must upgrade your server to use a more secure algorithm."
+        );
+
         this.hostname = hostname;
         this.port = port;
         this.defaultTimeout = defaultTimeoutInMillis;


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2461

## Changes
- Added a warning message to the SSHClient constructor to inform users that the RSA/SHA1 algorithm will no longer be supported in a future Galasa release
- Added the above deprecation notice to the 0.45.0 release notes