### PR TITLE
Iss2477 - Fix links in the documentation that incorrectly refer to the archived 'CLI' repository

### DIFF
--- a/docs/content/docs/cli-command-reference/installing-cli-tool.md
+++ b/docs/content/docs/cli-command-reference/installing-cli-tool.md
@@ -39,7 +39,7 @@ On Mac:
 On Mac or Unix:
 
 1. Find out the architecture of your machine by typing the command `uname -m` into your terminal.
-2. Download the appropriate binary of the Galasa CLI for your machine architecture from the [Galasa CLI repository](https://github.com/galasa-dev/cli/releases){target="_blank"} in GitHub and re-name it to `galasactl`.
+2. Download the appropriate binary of the Galasa CLI for your machine architecture from the [Galasa CLI repository](https://github.com/galasa-dev/galasa/releases){target="_blank"} in GitHub and re-name it to `galasactl`.
 3. Add the Galasa CLI to your PATH to enable you to run CLI commands from anywhere on your file system without having to specify the absolute path. To set the path permanently, you need add the Galasa CLI path to your shell's initialization file. For example, if you downloaded the galasactl executable to a folder called `~/tools` in your home directory, you need to add `~/tools` to the list of directories that your shell searches through when you enter a command. You can do this by adding the line ```export PATH=$PATH:$HOME/tools``` to your shell’s initialization file (for example `~/.bashrc` or `~/.zshrc`). 
 4. Set execute permission on the binary by running the `chmod +x galasactl` command in the directory containing `galasactl`.If you are using a Mac, you can set permission to open the Galasa CLI tool by running the `xattr -dr com.apple.quarantine galasactl` command in the directory containing `galasactl`. 
 

--- a/docs/content/docs/cli-command-reference/runs-submit-local.md
+++ b/docs/content/docs/cli-command-reference/runs-submit-local.md
@@ -72,7 +72,7 @@ where:
 - `--log` specifies that debugging information is directed somewhere, and the `-` means that it is sent to the console (stderr).
 - `--gherkin` specifies the path where the  CLI tool can find the Gherkin file containing the Gherkin tests. The path must be specified in a URL form, ending in a `.feature` extension. For example,`file:///Users/myuserid/gherkin/MyGherkinFile.feature` or `file:///C:/Users/myuserid/gherkin/MyGherkinFile.feature`.
 
-For more information about the Gherkin support currently available, see the [Galasa CLI Gherkin documentation](https://github.com/galasa-dev/cli/blob/main/gherkin-docs.md){target="_blank"}.
+For more information about the Gherkin support currently available, see the [Galasa CLI Gherkin documentation](https://github.com/galasa-dev/galasa/blob/main/modules/cli/gherkin-docs.md){target="_blank"}.
 
 
 ## Overriding the path to the default local Maven repository

--- a/docs/content/docs/managers/zos-managers/zos3270terminal-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos3270terminal-manager.md
@@ -17,7 +17,7 @@ Examples of using colour support and screen sizing are available in the [Code sn
 
 When running a Galasa test with the Galasa CLI, terminal images are logged to the run log and PNG representations of the terminal screens are saved to the Result Archive Store (RAS).
 
-The zos3270Terminal Manager supports [Gherkin keywords](https://github.com/galasa-dev/cli/blob/main/gherkin-docs.md#3270-terminal-manipulation-steps){target="_blank"}. 
+The zos3270Terminal Manager supports [Gherkin keywords](https://github.com/galasa-dev/galasa/blob/main/modules/cli/gherkin-docs.md#3270-terminal-manipulation-steps){target="_blank"}. 
 
 *Note:* The feature for saving PNG representations of the terminal screens to the RAS is available in the current release as experimental code only.
 

--- a/docs/content/docs/upgrading/index.md
+++ b/docs/content/docs/upgrading/index.md
@@ -6,7 +6,7 @@ title: "Upgrading"
 
 You can upgrade your version of Galasa by completing the following steps:
 
-1. Download the appropriate version of the Galasa CLI for your machine architecture from the [Galasa CLI repository](https://github.com/galasa-dev/cli/releases){target="_blank"} in GitHub.
+1. Download the appropriate version of the Galasa CLI for your machine architecture from the [Galasa CLI repository](https://github.com/galasa-dev/galasa/releases){target="_blank"} in GitHub.
 2. Re-name the your existing `galasactl` binary so that you can re-name the Galasa binary that you just downloaded to `galasactl` to replace it. 
 3. Set execute permission on the binary by running the `chmod +x galasactl` command in the directory containing `galasactl`.If you are using a Mac, you can set permission to open the Galasa CLI tool by running the `xattr -dr com.apple.quarantine galasactl` command in the directory containing `galasactl`. 
 

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -2,7 +2,7 @@
 
 The Galasa command line interface (Galasa CLI) is used to interact with a deployed Galasa service or local development environment.
 
-[![Main build](https://github.com/galasa-dev/cli/actions/workflows/build.yml/badge.svg)](https://github.com/galasa-dev/cli/actions/workflows/build.yml)
+[![Main build](https://github.com/galasa-dev/galasa/actions/workflows/pushes.yaml/badge.svg)](https://github.com/galasa-dev/galasa/actions/workflows/pushes.yaml)
 
 ## Environment variables
 
@@ -858,7 +858,7 @@ Built artifacts include:
 
 Browse the following web site and download whichever built binary files you wish:
 
-- Latest (and previous) stable releases: https://github.com/galasa-dev/cli/releases
+- Latest (and previous) stable releases: https://github.com/galasa-dev/galasa/releases
 - Bleeding edge/Unstable : https://development.galasa.dev/main/binary/cli/
 
 ## Docker images containing the command-line tools

--- a/modules/ivts/README.md
+++ b/modules/ivts/README.md
@@ -56,7 +56,7 @@ galasactl runs submit local \
 
 For more information on Test streams, see the [Test streams page](https://galasa.dev/docs/manage-ecosystem/test-streams) on our website.
 
-For more information on running tests locally or remotely with `galasactl`, see our [command-line interface documentation](https://github.com/galasa-dev/cli/blob/main/README.md) on GitHub.
+For more information on running tests locally or remotely with `galasactl`, see our [command-line interface documentation](https://github.com/galasa-dev/galasa/blob/main/modules/cli/README.md) on GitHub.
 
 
 ## How to contribute to this module

--- a/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/README.md
+++ b/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/README.md
@@ -7,7 +7,7 @@ To run the Db2 manager IVT, it requires a Db2 instance to connect to. This can b
 You will need:
 
 - Docker engine (e.g. using [Rancher Desktop](https://rancherdesktop.io) or [colima](https://github.com/abiosoft/colima))
-- [galasactl](https://github.com/galasa-dev/cli/releases)
+- [galasactl](https://github.com/galasa-dev/galasa/releases)
 - Gradle 6.8.2
 
 ### Running on Apple Silicon


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2477