### PR TITLE
Clear the "Hung" interrupt when a test run begins and when its status changes

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
@@ -121,4 +121,9 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
             throws FrameworkException {
         throw new UnsupportedOperationException("Unimplemented method 'getCpsPropertiesAndOverridesUsedByTestRun'");
     }
+
+    @Override
+    public void clearRunInterrupt(String runName) throws DynamicStatusStoreException {
+        throw new UnsupportedOperationException("Unimplemented method 'clearRunInterrupt'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -30,6 +30,7 @@ import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IFramework;
+import dev.galasa.framework.spi.IFrameworkRuns;
 import dev.galasa.framework.spi.IResultArchiveStore;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.IShuttableFramework;
@@ -364,9 +365,13 @@ public class BaseTestRunner {
 
     protected void clearRunHungInterruptIfSet() throws TestRunException {
         try {
-            String interruptReason = this.run.getInterruptReason();
+            String runName = this.run.getName();
+            IFrameworkRuns frameworkRuns = framework.getFrameworkRuns();
+            IRun currentRunInDss = frameworkRuns.getRun(runName);
+            String interruptReason = currentRunInDss.getInterruptReason();
+
             if (interruptReason != null && interruptReason.equals(Result.HUNG)) {
-                this.framework.getFrameworkRuns().clearRunInterrupt(this.run.getName());
+                frameworkRuns.clearRunInterrupt(runName);
             }
         } catch (FrameworkException e) {
             throw new TestRunException("Failed to clear run interrupt", e);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -393,6 +393,20 @@ public class FrameworkRuns implements IFrameworkRuns {
     }
 
     @Override
+    public void clearRunInterrupt(String runName) throws DynamicStatusStoreException {
+        if (isRunInDss(runName)) {
+            logger.info("Clearing interrupt properties for run " + runName);
+            Set<String> propertyKeysToDelete = new HashSet<>();
+            propertyKeysToDelete.add(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.INTERRUPTED_AT));
+            propertyKeysToDelete.add(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.INTERRUPT_REASON));
+
+            this.dss.delete(propertyKeysToDelete);
+
+            logger.info("Cleared interrupt properties for run " + runName);
+        }
+    }
+
+    @Override
     public void markRunFinished(String runName, String result) throws DynamicStatusStoreException {
         if (isRunInDss(runName)) {
             Map<String, String> propertiesToSet = new HashMap<>();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -76,6 +76,8 @@ public class TestRunner extends BaseTestRunner {
         String testClassName = run.getTestClassName();
             
         try {
+            clearRunHungInterruptIfSet();
+
             this.testStructure = createNewTestStructure(run);
 
             String rasRunId = run.getRasRunId();
@@ -89,7 +91,6 @@ public class TestRunner extends BaseTestRunner {
             Class<?> testClass ;
 
             try {
-                
                 String streamName = AbstractManager.nulled(run.getStream());
                 new MavenRepositoryListBuilder(this.mavenRepository, this.cps)
                     .addMavenRepositories(streamName, run.getRepository());
@@ -131,7 +132,6 @@ public class TestRunner extends BaseTestRunner {
                 logger.error("Logic error. A RunType has been added for which the cleanup logic has not been implemented!");
             }
 
-            logger.debug("state changing to started.");
             updateStatus(TestRunLifecycleStatus.STARTED, "started");
 
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
@@ -50,6 +50,14 @@ public interface IFrameworkRuns {
 
     boolean markRunInterrupted(String runName, String interruptReason) throws DynamicStatusStoreException;
 
+    /**
+     * Clears all interrupt-related properties for a run with the given name from the DSS.
+     * 
+     * @param runName the run to remove interrupt properties for
+     * @throws DynamicStatusStoreException if there was an issue accessing the DSS
+     */
+    void clearRunInterrupt(String runName) throws DynamicStatusStoreException;
+
     void markRunFinished(String runName, String result) throws DynamicStatusStoreException;
 
     /**

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
@@ -150,4 +150,13 @@ public class MockFrameworkRuns implements IFrameworkRuns {
             throws FrameworkException {
         throw new UnsupportedOperationException("Unimplemented method 'getCpsPropertiesAndOverridesUsedByTestRun'");
     }
+
+    @Override
+    public void clearRunInterrupt(String runName) throws DynamicStatusStoreException {
+        MockRun run = (MockRun) getRun(runName);
+        if (run != null) {
+            run.setInterruptReason(null);
+            run.setInterruptedAt(null);
+        }
+    }
 }


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2479

## Changes
- Added a new `clearRunInterrupt` method to IFrameworkRuns that clears all interrupt-related properties for a given run from the DSS
- When the test runner begins and whenever it wants to update the status of a test run, it checks if the run has been marked as "Hung" and if so, it will now clear the "Hung" interrupt from the run's DSS properties