### PR TITLE
galasa-maven-plugin to handle target/classes dependencies

### DIFF
--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildOBRResources.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildOBRResources.java
@@ -129,9 +129,15 @@ public class BuildOBRResources extends AbstractMojo {
                     }
 
                     if (name.endsWith(".jar")) {
-                        processBundle(artifact, newRepository, obrDataModelHelper);
+                        processBundle(artifact, file, newRepository, obrDataModelHelper);
                     } else if (name.endsWith(".obr")) {
                         processObr(artifact, newRepository, obrDataModelHelper);
+                    } else if (file.isDirectory() && name.equals("classes")) {
+                        file = new File(file.getParentFile(), artifact.getArtifactId()+"-"+artifact.getVersion()+".jar"); 
+                        getLog().info("BuildOBRResources: Searching for "+file.getName());
+                        if (file.exists()) {
+                            processBundle(artifact, file, newRepository, obrDataModelHelper);
+                        }
                     }
                 }
             }
@@ -180,13 +186,13 @@ public class BuildOBRResources extends AbstractMojo {
         }
     }
 
-    private void processBundle(DefaultArtifact artifact, RepositoryImpl repository, DataModelHelper obrDataModelHelper)
+    private void processBundle(DefaultArtifact artifact, File file, RepositoryImpl repository, DataModelHelper obrDataModelHelper)
             throws MojoExecutionException {
 
         try {
             getLog().info("BuildOBRResources: Processing artifact " + artifact.getId());
             ResourceImpl newResource = (ResourceImpl) obrDataModelHelper
-                    .createResource(artifact.getFile().toURI().toURL());
+                    .createResource(file.toURI().toURL());
             if (newResource == null) {
                 throw new MojoExecutionException("Problem with jar file. Not an OSGi bundle?");
             }


### PR DESCRIPTION
Fix for https://github.com/galasa-dev/projectmanagement/issues/2483

Sometimes during a test project build, e.g. when javadoc is being generated, Maven generates dependency artifacts for the project before the bundle is built - these artifacts therefore point to the target/classes folder instead of the jar file. These artifacts are then passed to the galasa-maven-plugin, which doesn't know what to do with them....

This change modifies BuildOBRResources to look for the jar file in the parent folder if the artifact is pointing to a "classes" folder, as the jar _should_ exist by this time. If it's not found, we just ignore the dependency artifact, so we're no worse off than before.
