### PR TITLE
Iss2446 - Update developer attribution email to Galasa maintainers LF email list

### DIFF
--- a/modules/extensions/galasa-extensions-parent/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/build.gradle
@@ -182,7 +182,7 @@ publishing {
                 developers {
                     developer {
                         name = 'Galasa Developer'
-                        email = 'galasadelivery@ibm.com'
+                        email = 'galasa-maintainers@lists.openmainframeproject.org'
                         organization = 'IBM'
                         organizationUrl = 'https://www.ibm.com'
                     }

--- a/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/extensions/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -88,7 +88,7 @@ publishing {
                 developers {
                     developer {
                         name = 'Galasa Contributors'
-                        email = 'galasadelivery@ibm.com'
+                        email = 'galasa-maintainers@lists.openmainframeproject.org'
                         organization = 'Linux Foundation'
                         organizationUrl = 'https://github.com/galasa-dev'
                     }

--- a/modules/framework/galasa-parent/build.gradle
+++ b/modules/framework/galasa-parent/build.gradle
@@ -322,7 +322,7 @@ publishing {
                 developers {
                     developer {
                         name = 'Galasa Developer'
-                        email = 'galasadelivery@ibm.com'
+                        email = 'galasa-maintainers@lists.openmainframeproject.org'
                         organization = 'IBM'
                         organizationUrl = 'https://www.ibm.com'
                     }

--- a/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/framework/galasa-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -88,7 +88,7 @@ publishing {
                 developers {
                     developer {
                         name = 'Galasa Contributors'
-                        email = 'galasadelivery@ibm.com'
+                        email = 'galasa-maintainers@lists.openmainframeproject.org'
                         organization = 'Linux Foundation'
                         organizationUrl = 'https://github.com/galasa-dev'
                     }

--- a/modules/gradle/build.gradle
+++ b/modules/gradle/build.gradle
@@ -76,7 +76,7 @@ publishing {
                     developers {
                         developer {
                             name = 'Galasa Contributors'
-                            email = 'galasadelivery@ibm.com'
+                            email = 'galasa-maintainers@lists.openmainframeproject.org'
                             organization = 'Linux Foundation'
                             organizationUrl = 'https://github.com/galasa-dev'
                         }

--- a/modules/gradle/dev.galasa.gradle.impl/build.gradle
+++ b/modules/gradle/dev.galasa.gradle.impl/build.gradle
@@ -128,7 +128,7 @@ publishing {
                     developers {
                         developer {
                             name = 'Galasa Contributors'
-                            email = 'galasadelivery@ibm.com'
+                            email = 'galasa-maintainers@lists.openmainframeproject.org'
                             organization = 'Linux Foundation'
                             organizationUrl = 'https://github.com/galasa-dev'
                         }

--- a/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
@@ -78,7 +78,7 @@ publishing {
                     developers {
                         developer {
                             name = 'Galasa Contributors'
-                            email = 'galasadelivery@ibm.com'
+                            email = 'galasa-maintainers@lists.openmainframeproject.org'
                             organization = 'Linux Foundation'
                             organizationUrl = 'https://github.com/galasa-dev'
                         }

--- a/modules/gradle/dev.galasa.plugin.common.test/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.test/build.gradle
@@ -78,7 +78,7 @@ publishing {
                     developers {
                         developer {
                             name = 'Galasa Contributors'
-                            email = 'galasadelivery@ibm.com'
+                            email = 'galasa-maintainers@lists.openmainframeproject.org'
                             organization = 'Linux Foundation'
                             organizationUrl = 'https://github.com/galasa-dev'
                         }

--- a/modules/gradle/dev.galasa.plugin.common/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common/build.gradle
@@ -100,7 +100,7 @@ publishing {
                     developers {
                         developer {
                             name = 'Galasa Contributors'
-                            email = 'galasadelivery@ibm.com'
+                            email = 'galasa-maintainers@lists.openmainframeproject.org'
                             organization = 'Linux Foundation'
                             organizationUrl = 'https://github.com/galasa-dev'
                         }

--- a/modules/managers/galasa-managers-parent/build.gradle
+++ b/modules/managers/galasa-managers-parent/build.gradle
@@ -241,7 +241,7 @@ publishing {
                 developers {
                     developer {
                         name = 'Galasa Developer'
-                        email = 'galasadelivery@ibm.com'
+                        email = 'galasa-maintainers@lists.openmainframeproject.org'
                         organization = 'IBM'
                         organizationUrl = 'https://www.ibm.com'
                     }

--- a/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/modules/managers/galasa-managers-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -90,7 +90,7 @@ publishing {
                 developers {
                     developer {
                         name = 'Galasa Contributors'
-                        email = 'galasadelivery@ibm.com'
+                        email = 'galasa-maintainers@lists.openmainframeproject.org'
                         organization = 'Linux Foundation'
                         organizationUrl = 'https://github.com/galasa-dev'
                     }

--- a/modules/maven/galasa-maven-plugin/pom.xml
+++ b/modules/maven/galasa-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
 	<developers>
 		<developer>
 			<name>Galasa Contributors</name>
-			<email>galasadelivery@ibm.com</email>
+			<email>galasa-maintainers@lists.openmainframeproject.org</email>
 			<organization>Linux Foundation</organization>
 			<organizationUrl>https://github.com/galasa-dev</organizationUrl>
 		</developer>

--- a/modules/obr/dev.galasa.uber.obr/pom.template
+++ b/modules/obr/dev.galasa.uber.obr/pom.template
@@ -23,7 +23,7 @@
     <developers>
         <developer>
             <name>Galasa Contributors</name>
-            <email>galasadelivery@ibm.com</email>
+            <email>galasa-maintainers@lists.openmainframeproject.org</email>
             <organization>Linux Foundation</organization>
             <organizationUrl>https://github.com/galasa-dev</organizationUrl>
         </developer>

--- a/modules/obr/galasa-bom/pom.template
+++ b/modules/obr/galasa-bom/pom.template
@@ -24,7 +24,7 @@
     <developers>
         <developer>
             <name>Galasa Contributors</name>
-            <email>galasadelivery@ibm.com</email>
+            <email>galasa-maintainers@lists.openmainframeproject.org</email>
             <organization>Linux Foundation</organization>
             <organizationUrl>https://github.com/galasa-dev</organizationUrl>
         </developer>

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -341,7 +341,7 @@ publishing {
                 developers {
                     developer {
                         name = 'Galasa Developer'
-                        email = 'galasadelivery@ibm.com'
+                        email = 'galasa-maintainers@lists.openmainframeproject.org'
                         organization = 'IBM'
                         organizationUrl = 'https://www.ibm.com'
                     }

--- a/modules/wrapping/pom.xml
+++ b/modules/wrapping/pom.xml
@@ -28,7 +28,7 @@
 	<developers>
 		<developer>
 			<name>Galasa Contributors</name>
-			<email>galasadelivery@ibm.com</email>
+			<email>galasa-maintainers@lists.openmainframeproject.org</email>
 			<organization>Linux Foundation</organization>
 			<organizationUrl>https://github.com/galasa-dev</organizationUrl>
 		</developer>


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2446

## Changes

- Update email from Galasa team IBM email address to the Galasa maintainers LF email list in pom.xmls and build.gradles.