### PR TITLE
Add galasactl runs cleanup local command to invoke resource management locally

### DIFF
--- a/docs/content/releases/posts/v0.45.0.md
+++ b/docs/content/releases/posts/v0.45.0.md
@@ -15,3 +15,8 @@ links:
 
 - When a local test run shares a Dynamic Status Store (DSS) with a Galasa service and the run exits while in the 'queued' state, the test run will be interrupted and the DSS record for that run will be cleaned up after a period of time has passed. See [#2395](https://github.com/galasa-dev/projectmanagement/issues/2395).
   - By default, local 'queued' runs are set to time out after 15 minutes but this can be changed by setting the new `framework.resource.management.local.queued.timeout` CPS property to the desired amount of time in seconds.
+
+
+## Changes affecting tests running locally
+
+- If a local test run uses a manager that allocates resources and the test run's JVM exits before cleaning the allocated resources up, you can run the new `galasactl runs cleanup local` command which runs resource management providers (Java classes implementing Galasa's IResourceManagementProvider interface) to clean up resources. [See the new command syntax](../../docs/reference/cli-syntax/galasactl_runs_cleanup_local.md).

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -457,6 +457,35 @@ The run "C1234" can be cancelled using the following command:
 galasactl runs cancel --name C1234
 ```
 
+## runs cleanup local
+
+This command can be used to run a set of resource managment providers within a local JVM to clean up resources that may have been provisioned by local test runs and were not cleaned up properly as part of the test runs' lifecycles. This could be because the test runs' JVM processes exited before the provisioned resources could be discarded.
+
+The `--obr` flag can be supplied multiple times to load additional OBRs that contain resource management provider services that you would like to run. Likewise, the `--remoteMaven` flag can also be supplied multiple times to specify the remote Maven repositories where Galasa can download the provided OBRs from.
+
+To select which resource management providers to run, you can supply a glob pattern to the `--includes-pattern` flag to tell Galasa which providers should be executed. To exclude certain resource management providers, you can supply a glob pattern to the `--excludes-pattern` flag. The `--includes-pattern` and `--excludes-pattern` flags can be supplied multiple times if you wish to supply multiple glob patterns.
+
+The following special characters can be provided within the supplied glob patterns:
+
+- `*` (wildcard) Matches zero or more characters
+- `?` matches exactly one character
+
+For example, the pattern `dev.galasa*` will match any resource management provider that includes `dev.galasa` as its prefix, so a class like `dev.galasa.core.CoreResourceMonitorClass` will be matched.
+
+A pattern like `*MyResourceMonitorClass` will match any resource management provider that ends with `MyResourceMonitorClass`, such as `my.company.monitors.MyResourceMonitorClass`.
+
+The `runs cleanup local` command also supports a set of debug flags, like `--debug` and `--debugPort`, to launch the resource cleanup JVM process in 'debug mode'. This works in the same way as the debugger support for the `runs submit local` command. See [Debugging a single test which runs in the local JVM](#debugging-a-single-test-which-runs-in-the-local-jvm).
+
+A complete list of supported parameters for the `runs cleanup local` command is available [here](./docs/generated/galasactl_runs_cleanup_local.md)
+
+### Examples
+
+The following command provides an OBR `my.company.group/my.company.group.obr/0.0.1/obr` to load resource management provider bundles from and an extra remote Maven repository `https://my-company/maven-repo` where the OBR can be downloaded from. The command then supplies an includes pattern which will match any Java classes that start with `my.company.` in their fully qualified class names and an excludes pattern to exclude any classes that end with `MyUnwantedCleanupProviderClass`:
+
+```
+galasactl runs cleanup local --obr my.company.group/my.company.group.obr/0.0.1/obr --remoteMaven https://my-company/maven-repo --includes-pattern "my.company.*" --excludes-pattern "*MyUnwantedCleanupProviderClass" --log -
+```
+
 ## monitors set
 
 This command can be used to update a monitor in the Galasa service. The name of the monitor to be enabled must be provided using the `--name` flag.

--- a/modules/cli/docs/generated/errors-list.md
+++ b/modules/cli/docs/generated/errors-list.md
@@ -247,6 +247,7 @@ The `galasactl` tool can generate the following errors:
 - GAL1245E: Failed to delete stream {}. Unexpected http status code {} received from the server. Error details from the server are: '{}'
 - GAL1246E: Failed to delete stream {}. Unexpected http status code {} received from the server. Error details from the server are not in the json format.
 - GAL1247E: Error cancelling runs with group name '{}'. Reason: '{}'
+- GAL1248E: Unsupported glob pattern character provided. Only alphanumeric (A-Z, a-z, 0-9), '.', '?', and '*' characters can be provided in the '--includes-pattern' and '--excludes-pattern' flags.
 - GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '{}', and 'pre-release' repository is '{}'
 - GAL2501I: Downloaded {} artifacts to folder '{}'
 

--- a/modules/cli/docs/generated/galasactl_runs.md
+++ b/modules/cli/docs/generated/galasactl_runs.md
@@ -26,6 +26,7 @@ Assembles, submits and monitors test runs in Galasa Ecosystem
 
 * [galasactl](galasactl.md)	 - CLI for Galasa
 * [galasactl runs cancel](galasactl_runs_cancel.md)	 - cancel an active run in the ecosystem
+* [galasactl runs cleanup](galasactl_runs_cleanup.md)	 - Run resource cleanup jobs for resources provisioned by Galasa
 * [galasactl runs delete](galasactl_runs_delete.md)	 - Delete a named test run.
 * [galasactl runs download](galasactl_runs_download.md)	 - Download the artifacts of a test run which ran.
 * [galasactl runs get](galasactl_runs_get.md)	 - Get the details of a test runname which ran or is running.

--- a/modules/cli/docs/generated/galasactl_runs_cleanup.md
+++ b/modules/cli/docs/generated/galasactl_runs_cleanup.md
@@ -1,0 +1,29 @@
+## galasactl runs cleanup
+
+Run resource cleanup jobs for resources provisioned by Galasa
+
+### Synopsis
+
+The parent command for operations to run cleanup jobs for resources provisioned by Galasa
+
+### Options
+
+```
+  -h, --help   Displays the options for the 'runs cleanup' command.
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+```
+
+### SEE ALSO
+
+* [galasactl runs](galasactl_runs.md)	 - Manage test runs in the ecosystem
+* [galasactl runs cleanup local](galasactl_runs_cleanup_local.md)	 - Runs resource cleanup providers once for resources provisioned by Galasa
+

--- a/modules/cli/docs/generated/galasactl_runs_cleanup_local.md
+++ b/modules/cli/docs/generated/galasactl_runs_cleanup_local.md
@@ -1,0 +1,47 @@
+## galasactl runs cleanup local
+
+Runs resource cleanup providers once for resources provisioned by Galasa
+
+### Synopsis
+
+Runs resource cleanup providers loaded from provided OBRs for resources provisioned by Galasa as part of local test runs. The loaded providers are only run once and do not run as a daemon process. The providers that are loaded are determined by the patterns provided in the '--includes-pattern' and '--excludes-pattern' flags. By default, all cleanup providers in the provided OBRs will be loaded and none will be excluded.
+Supported glob patterns include the following special characters:
+'*' (wildcard) Matches zero or more characters.
+'?' matches exactly one character
+For example, the pattern 'dev.galasa*' will match any monitor that includes 'dev.galasa' as its prefix, so a provider like 'dev.galasa.core.CoreResourceMonitorClass' will be matched.
+
+```
+galasactl runs cleanup local [flags]
+```
+
+### Options
+
+```
+      --excludes-pattern strings   The glob pattern(s) representing the resource cleanup providers that should not be loaded. Supported glob patterns include the following special characters:
+                                   '*' (wildcard) Matches zero or more characters.
+                                   '?' matches exactly one character
+                                   For example, the pattern '*MyResourceCleanupClass' will match any provider that ends with 'MyResourceCleanupClass' such as 'my.company.resources.MyResourceCleanupClass' and so that provider will not be loaded.
+  -h, --help                       Displays the options for the 'runs cleanup local' command.
+      --includes-pattern strings   The glob pattern(s) representing the resource cleanup providers that should be loaded. Supported glob patterns include the following special characters:
+                                   '*' (wildcard) Matches zero or more characters.
+                                   '?' matches exactly one character
+                                   For example, the pattern 'dev.galasa*' will match any provider that includes 'dev.galasa' as its prefix, so a provider like 'dev.galasa.core.CoreResourceCleanupClass' will be matched. (default [*])
+      --localMaven string          The url of a local maven repository are where galasa bundles can be loaded from on your local file system. Defaults to your home .m2/repository file. Please note that this should be in a URL form e.g. 'file:///Users/myuserid/.m2/repository', or 'file://C:/Users/myuserid/.m2/repository'
+      --obr strings                The maven coordinates of the obr bundle(s) which refer to your resource cleanup bundles. The format of this parameter is 'mvn:${OBR_GROUP_ID}/${OBR_ARTIFACT_ID}/${OBR_VERSION}/obr' Multiple instances of this flag can be used to describe multiple obr bundles.
+      --remoteMaven strings        the urls of the remote maven repositories where galasa bundles can be loaded from. Defaults to maven central. (default [https://repo.maven.apache.org/maven2])
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+```
+
+### SEE ALSO
+
+* [galasactl runs cleanup](galasactl_runs_cleanup.md)	 - Run resource cleanup jobs for resources provisioned by Galasa
+

--- a/modules/cli/docs/generated/galasactl_runs_cleanup_local.md
+++ b/modules/cli/docs/generated/galasactl_runs_cleanup_local.md
@@ -17,10 +17,14 @@ galasactl runs cleanup local [flags]
 ### Options
 
 ```
+      --debug                      When set (or true) the debugger pauses on startup and tries to connect to a Java debugger. The connection is established using the --debugMode and --debugPort values.
+      --debugMode string           The mode to use when the --debug option causes the resource management provider to connect to a Java debugger. Valid values are 'listen' or 'attach'. 'listen' means the JVM will pause on startup, waiting for the Java debugger to connect to the debug port (see the --debugPort option). 'attach' means the JVM will pause on startup, trying to attach to a java debugger which is listening on the debug port. The default value is 'listen' but can be overridden by the 'galasactl.jvm.local.launch.debug.mode' property in the bootstrap file, which in turn can be overridden by this explicit parameter on the galasactl command.
+      --debugPort uint32           The port to use when the --debug option causes the resource cleanup provider to connect to a java debugger. The default value used is 2970 which can be overridden by the 'galasactl.jvm.local.launch.debug.port' property in the bootstrap file, which in turn can be overridden by this explicit parameter on the galasactl command.
       --excludes-pattern strings   The glob pattern(s) representing the resource cleanup providers that should not be loaded. Supported glob patterns include the following special characters:
                                    '*' (wildcard) Matches zero or more characters.
                                    '?' matches exactly one character
                                    For example, the pattern '*MyResourceCleanupClass' will match any provider that ends with 'MyResourceCleanupClass' such as 'my.company.resources.MyResourceCleanupClass' and so that provider will not be loaded.
+      --galasaVersion string       the version of galasa you want to use. This should match the version of the galasa obr you built your resource cleanup providers against. (default "0.45.0")
   -h, --help                       Displays the options for the 'runs cleanup local' command.
       --includes-pattern strings   The glob pattern(s) representing the resource cleanup providers that should be loaded. Supported glob patterns include the following special characters:
                                    '*' (wildcard) Matches zero or more characters.
@@ -29,6 +33,7 @@ galasactl runs cleanup local [flags]
       --localMaven string          The url of a local maven repository are where galasa bundles can be loaded from on your local file system. Defaults to your home .m2/repository file. Please note that this should be in a URL form e.g. 'file:///Users/myuserid/.m2/repository', or 'file://C:/Users/myuserid/.m2/repository'
       --obr strings                The maven coordinates of the obr bundle(s) which refer to your resource cleanup bundles. The format of this parameter is 'mvn:${OBR_GROUP_ID}/${OBR_ARTIFACT_ID}/${OBR_VERSION}/obr' Multiple instances of this flag can be used to describe multiple obr bundles.
       --remoteMaven strings        the urls of the remote maven repositories where galasa bundles can be loaded from. Defaults to maven central. (default [https://repo.maven.apache.org/maven2])
+      --trace                      Enables trace-level logging
 ```
 
 ### Options inherited from parent commands

--- a/modules/cli/pkg/cmd/commandCollection.go
+++ b/modules/cli/pkg/cmd/commandCollection.go
@@ -56,6 +56,8 @@ const (
 	COMMAND_NAME_RUNS_SUBMIT_LOCAL        = "runs submit local"
 	COMMAND_NAME_RUNS_RESET               = "runs reset"
 	COMMAND_NAME_RUNS_CANCEL              = "runs cancel"
+	COMMAND_NAME_RUNS_CLEANUP             = "runs cleanup"
+	COMMAND_NAME_RUNS_CLEANUP_LOCAL       = "runs cleanup local"
 	COMMAND_NAME_RUNS_DELETE              = "runs delete"
 	COMMAND_NAME_RESOURCES                = "resources"
 	COMMAND_NAME_RESOURCES_APPLY          = "resources apply"
@@ -336,6 +338,8 @@ func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, root
 	var runsResetCommand spi.GalasaCommand
 	var runsCancelCommand spi.GalasaCommand
 	var runsDeleteCommand spi.GalasaCommand
+	var runsCleanupCommand spi.GalasaCommand
+	var runsCleanupLocalCommand spi.GalasaCommand
 
 	runsCommand, err = NewRunsCmd(rootCommand, commsFlagSet)
 	if err == nil {
@@ -361,6 +365,12 @@ func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, root
 				}
 			}
 		}
+		if err == nil {
+			runsCleanupCommand, err = NewRunsCleanupCmd(runsCommand)
+			if err == nil {
+				runsCleanupLocalCommand, err = NewRunsCleanupLocalCommand(factory, runsCleanupCommand, rootCommand)
+			}
+		}
 	}
 
 	if err == nil {
@@ -373,6 +383,8 @@ func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, root
 		commands.commandMap[runsResetCommand.Name()] = runsResetCommand
 		commands.commandMap[runsCancelCommand.Name()] = runsCancelCommand
 		commands.commandMap[runsDeleteCommand.Name()] = runsDeleteCommand
+		commands.commandMap[runsCleanupCommand.Name()] = runsCleanupCommand
+		commands.commandMap[runsCleanupLocalCommand.Name()] = runsCleanupLocalCommand
 	}
 
 	return err
@@ -455,6 +467,9 @@ func (commands *commandCollectionImpl) addMonitorsCommands(factory spi.Factory, 
 
 	if err == nil {
 		monitorsGetCommand, err = NewMonitorsGetCommand(factory, monitorsCommand, commsFlagSet)
+	}
+
+	if err == nil {
 		monitorsSetCommand, err = NewMonitorsSetCommand(factory, monitorsCommand, commsFlagSet)
 	}
 

--- a/modules/cli/pkg/cmd/commandCollection.go
+++ b/modules/cli/pkg/cmd/commandCollection.go
@@ -368,7 +368,7 @@ func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, root
 		if err == nil {
 			runsCleanupCommand, err = NewRunsCleanupCmd(runsCommand)
 			if err == nil {
-				runsCleanupLocalCommand, err = NewRunsCleanupLocalCommand(factory, runsCleanupCommand, rootCommand)
+				runsCleanupLocalCommand, err = NewRunsCleanupLocalCommand(factory, runsCleanupCommand, commsFlagSet)
 			}
 		}
 	}

--- a/modules/cli/pkg/cmd/runsCleanup.go
+++ b/modules/cli/pkg/cmd/runsCleanup.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/spf13/cobra"
+)
+
+type RunsCleanupCmdValues struct {
+}
+
+type RunsCleanupCommand struct {
+    cobraCommand *cobra.Command
+    values       *RunsCleanupCmdValues
+}
+
+// ------------------------------------------------------------------------------------------------
+// Constructors
+// ------------------------------------------------------------------------------------------------
+
+func NewRunsCleanupCmd(runsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+    cmd := new(RunsCleanupCommand)
+    err := cmd.init(runsCommand)
+    return cmd, err
+}
+
+// ------------------------------------------------------------------------------------------------
+// Public functions
+// ------------------------------------------------------------------------------------------------
+
+func (cmd *RunsCleanupCommand) Name() string {
+    return COMMAND_NAME_RUNS_CLEANUP
+}
+
+func (cmd *RunsCleanupCommand) CobraCommand() *cobra.Command {
+    return cmd.cobraCommand
+}
+
+func (cmd *RunsCleanupCommand) Values() any {
+    return cmd.values
+}
+
+// ------------------------------------------------------------------------------------------------
+// Private functions
+// ------------------------------------------------------------------------------------------------
+
+func (cmd *RunsCleanupCommand) init(runsCommand spi.GalasaCommand) error {
+
+    var err error
+
+    cmd.values = &RunsCleanupCmdValues{}
+    cmd.cobraCommand, err = cmd.createCobraCommand(runsCommand)
+
+    return err
+}
+
+func (cmd *RunsCleanupCommand) createCobraCommand(runsCommand spi.GalasaCommand) (*cobra.Command, error) {
+
+    var err error
+
+    runsCleanupCobraCmd := &cobra.Command{
+        Use:   "cleanup",
+        Short: "Run resource cleanup jobs for resources provisioned by Galasa",
+        Long:  "The parent command for operations to run cleanup jobs for resources provisioned by Galasa",
+    }
+
+    runsCommand.CobraCommand().AddCommand(runsCleanupCobraCmd)
+
+    return runsCleanupCobraCmd, err
+}
+

--- a/modules/cli/pkg/cmd/runsCleanupLocal.go
+++ b/modules/cli/pkg/cmd/runsCleanupLocal.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"log"
+
+	"github.com/galasa-dev/cli/pkg/launcher"
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type RunsCleanupLocalCmdValues struct {
+	runsCleanupLocalCmdParams  *launcher.RunsCleanupLocalCmdParameters
+}
+
+type RunsCleanupLocalCommand struct {
+	values *RunsCleanupLocalCmdValues
+    cobraCommand *cobra.Command
+}
+
+// ------------------------------------------------------------------------------------------------
+// Constructors methods
+// ------------------------------------------------------------------------------------------------
+func NewRunsCleanupLocalCommand(
+    factory spi.Factory,
+    runsCleanupCommand spi.GalasaCommand,
+	rootCmd spi.GalasaCommand,
+) (spi.GalasaCommand, error) {
+
+    cmd := new(RunsCleanupLocalCommand)
+
+    err := cmd.init(factory, runsCleanupCommand, rootCmd)
+    return cmd, err
+}
+
+// ------------------------------------------------------------------------------------------------
+// Public methods
+// ------------------------------------------------------------------------------------------------
+func (cmd *RunsCleanupLocalCommand) Name() string {
+    return COMMAND_NAME_RUNS_CLEANUP_LOCAL
+}
+
+func (cmd *RunsCleanupLocalCommand) CobraCommand() *cobra.Command {
+    return cmd.cobraCommand
+}
+
+func (cmd *RunsCleanupLocalCommand) Values() interface{} {
+	return cmd.values
+}
+
+// ------------------------------------------------------------------------------------------------
+// Private methods
+// ------------------------------------------------------------------------------------------------
+func (cmd *RunsCleanupLocalCommand) init(factory spi.Factory, runsCleanupCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) error {
+    var err error
+
+	cmd.values = &RunsCleanupLocalCmdValues{
+		runsCleanupLocalCmdParams:  &launcher.RunsCleanupLocalCmdParameters{},
+	}
+
+    cmd.cobraCommand, err = cmd.createCobraCmd(factory, runsCleanupCommand, rootCmd)
+
+    return err
+}
+
+func (cmd *RunsCleanupLocalCommand) createCobraCmd(
+    factory spi.Factory,
+    runsCleanupCommand spi.GalasaCommand,
+	rootCmd spi.GalasaCommand,
+) (*cobra.Command, error) {
+
+    var err error
+
+    runsCleanupLocalCobraCmd := &cobra.Command{
+        Use:     "local",
+        Short:   "Runs resource cleanup providers once for resources provisioned by Galasa",
+        Long:    "Runs resource cleanup providers loaded from provided OBRs for resources provisioned by Galasa as part of local test runs. The loaded providers are only run once and do not run as a daemon process. "+
+			"The providers that are loaded are determined by the patterns provided in the '--includes-pattern' and '--excludes-pattern' flags. By default, all cleanup providers in the provided OBRs will be loaded and none will be excluded.\n"+
+			"Supported glob patterns include the following special characters:\n"+
+			"'*' (wildcard) Matches zero or more characters.\n"+
+			"'?' matches exactly one character\n"+
+			"For example, the pattern 'dev.galasa*' will match any monitor that includes 'dev.galasa' as its prefix, so a provider like 'dev.galasa.core.CoreResourceMonitorClass' will be matched.",
+        Aliases: []string{COMMAND_NAME_RUNS_CLEANUP_LOCAL},
+        RunE: func(cobraCommand *cobra.Command, args []string) error {
+			return cmd.executeRunsCleanupLocal(factory, runsCleanupCommand.Values().(*RunsCleanupCmdValues), rootCmd.Values().(*RootCmdValues))
+        },
+    }
+
+	runsCleanupLocalCobraCmd.Flags().StringSliceVar(&cmd.values.runsCleanupLocalCmdParams.RemoteMavenRepos, "remoteMaven",
+		[]string{"https://repo.maven.apache.org/maven2"},
+		"the urls of the remote maven repositories where galasa bundles can be loaded from. "+
+			"Defaults to maven central.")
+
+	runsCleanupLocalCobraCmd.Flags().StringVar(&cmd.values.runsCleanupLocalCmdParams.LocalMaven, "localMaven", "",
+		"The url of a local maven repository are where galasa bundles can be loaded from on your local file system. Defaults to your home .m2/repository file. Please note that this should be in a URL form e.g. 'file:///Users/myuserid/.m2/repository', or 'file://C:/Users/myuserid/.m2/repository'")
+
+	runsCleanupLocalCobraCmd.Flags().StringSliceVar(&cmd.values.runsCleanupLocalCmdParams.Obrs, "obr", make([]string, 0),
+		"The maven coordinates of the obr bundle(s) which refer to your resource cleanup bundles. "+
+			"The format of this parameter is 'mvn:${OBR_GROUP_ID}/${OBR_ARTIFACT_ID}/${OBR_VERSION}/obr' "+
+			"Multiple instances of this flag can be used to describe multiple obr bundles.")
+
+	runsCleanupLocalCobraCmd.Flags().StringSliceVar(&cmd.values.runsCleanupLocalCmdParams.IncludesPatterns, "includes-pattern", []string{"*"},
+		"The glob pattern(s) representing the resource cleanup providers that should be loaded. "+
+			"Supported glob patterns include the following special characters:\n"+
+			"'*' (wildcard) Matches zero or more characters.\n"+
+			"'?' matches exactly one character\n"+
+			"For example, the pattern 'dev.galasa*' will match any provider that includes 'dev.galasa' as its prefix, so a provider like 'dev.galasa.core.CoreResourceCleanupClass' will be matched.")
+
+	runsCleanupLocalCobraCmd.Flags().StringSliceVar(&cmd.values.runsCleanupLocalCmdParams.ExcludesPatterns, "excludes-pattern", make([]string, 0),
+		"The glob pattern(s) representing the resource cleanup providers that should not be loaded. "+
+			"Supported glob patterns include the following special characters:\n"+
+			"'*' (wildcard) Matches zero or more characters.\n"+
+			"'?' matches exactly one character\n"+
+			"For example, the pattern '*MyResourceCleanupClass' will match any provider that ends with 'MyResourceCleanupClass' such as 'my.company.resources.MyResourceCleanupClass' and so that provider will not be loaded.")
+
+	runsCleanupLocalCobraCmd.MarkFlagRequired("obr")
+
+    runsCleanupCommand.CobraCommand().AddCommand(runsCleanupLocalCobraCmd)
+
+    return runsCleanupLocalCobraCmd, err
+}
+
+func (cmd *RunsCleanupLocalCommand) executeRunsCleanupLocal(
+    factory spi.Factory,
+    runsCleanupCmdValues *RunsCleanupCmdValues,
+    rootCmdValues *RootCmdValues,
+) error {
+
+    var err error
+    // Operations on the file system will all be relative to the current folder.
+    fileSystem := factory.GetFileSystem()
+
+	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	if err == nil {
+		rootCmdValues.isCapturingLogs = true
+	
+		log.Println("Galasa CLI - Run resource cleanup for local runs")
+	}
+
+    return err
+}

--- a/modules/cli/pkg/cmd/runsCleanupLocal_test.go
+++ b/modules/cli/pkg/cmd/runsCleanupLocal_test.go
@@ -43,23 +43,6 @@ func TestRunsCleanupLocalHelpFlagSetCorrectly(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestRunsCleanupLocalWithoutObrErrors(t *testing.T) {
-	// Given...
-	factory := utils.NewMockFactory()
-	var args []string = []string{"runs", "cleanup", "local"}
-
-	// When...
-	err := Execute(factory, args)
-
-	// Then...
-	// Check what the user saw was reasonable
-	checkOutput("", "required flag(s) \"obr\" not set", factory, t)
-
-	// Should throw an error asking for flags to be set
-	assert.NotNil(t, err, "err should have been set!")
-	assert.Contains(t, err.Error(), "required flag(s) \"obr\" not set")
-}
-
 func TestRunsCleanupLocalObrFlagReturnsOk(t *testing.T) {
 	// Given...
 	factory := utils.NewMockFactory()

--- a/modules/cli/pkg/cmd/runsCleanupLocal_test.go
+++ b/modules/cli/pkg/cmd/runsCleanupLocal_test.go
@@ -1,0 +1,181 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"testing"
+
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunsCleanupLocalCommandInCommandCollection(t *testing.T) {
+
+	factory := utils.NewMockFactory()
+	commands, _ := NewCommandCollection(factory)
+
+	cmd, err := commands.GetCommand(COMMAND_NAME_RUNS_CLEANUP_LOCAL)
+	assert.Nil(t, err)
+
+	assert.Equal(t, COMMAND_NAME_RUNS_CLEANUP_LOCAL, cmd.Name())
+	assert.NotNil(t, cmd.Values())
+	assert.IsType(t, &RunsCleanupLocalCmdValues{}, cmd.Values())
+	assert.NotNil(t, cmd.CobraCommand())
+}
+
+func TestRunsCleanupLocalHelpFlagSetCorrectly(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+
+	var args []string = []string{"runs", "cleanup", "local", "--help"}
+
+	// When...
+	err := Execute(factory, args)
+
+	// Then...
+
+	// Check what the user saw is reasonable.
+	checkOutput("Displays the options for the 'runs cleanup local' command.", "", factory, t)
+
+	assert.Nil(t, err)
+}
+
+func TestRunsCleanupLocalWithoutObrErrors(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	var args []string = []string{"runs", "cleanup", "local"}
+
+	// When...
+	err := Execute(factory, args)
+
+	// Then...
+	// Check what the user saw was reasonable
+	checkOutput("", "required flag(s) \"obr\" not set", factory, t)
+
+	// Should throw an error asking for flags to be set
+	assert.NotNil(t, err, "err should have been set!")
+	assert.Contains(t, err.Error(), "required flag(s) \"obr\" not set")
+}
+
+func TestRunsCleanupLocalObrFlagReturnsOk(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, cmd := setupTestCommandCollection(COMMAND_NAME_RUNS_CLEANUP_LOCAL, factory, t)
+
+	var args []string = []string{"runs", "cleanup", "local", "--obr", "mvn:a.big.ol.obr"}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw is reasonable.
+	checkOutput("", "", factory, t)
+
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.Obrs, "mvn:a.big.ol.obr")
+}
+
+func TestRunsCleanupLocalMultipleObrAndPatternFlagsReturnsOk(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, cmd := setupTestCommandCollection(COMMAND_NAME_RUNS_CLEANUP_LOCAL, factory, t)
+
+	var args []string = []string{"runs", "cleanup", "local",
+		"--obr", "mvn:a.big.ol.obr",
+		"--obr", "mvn:another.obr",
+		"--includes-pattern", "dev.galasa.*",
+		"--includes-pattern", "my.other.bundles.*",
+		"--excludes-pattern", "*ExcludeMe",
+		"--excludes-pattern", "exclude.these.as.well.*",
+	}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw is reasonable.
+	checkOutput("", "", factory, t)
+
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.Obrs, "mvn:a.big.ol.obr")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.Obrs, "mvn:another.obr")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.IncludesPatterns, "dev.galasa.*")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.IncludesPatterns, "my.other.bundles.*")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.ExcludesPatterns, "*ExcludeMe")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.ExcludesPatterns, "exclude.these.as.well.*")
+}
+
+func TestRunsCleanupLocalLocalMavenFlagReturnsOk(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, cmd := setupTestCommandCollection(COMMAND_NAME_RUNS_CLEANUP_LOCAL, factory, t)
+
+	var args []string = []string{"runs", "cleanup", "local", "--obr", "mvn:a.big.ol.obr", "--localMaven", "maven/repo/location"}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw is reasonable.
+	checkOutput("", "", factory, t)
+
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.Obrs, "mvn:a.big.ol.obr")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.LocalMaven, "maven/repo/location")
+}
+
+func TestRunsCleanupLocalRemoteMavenFlagReturnsOk(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, cmd := setupTestCommandCollection(COMMAND_NAME_RUNS_CLEANUP_LOCAL, factory, t)
+
+	var args []string = []string{"runs", "cleanup", "local", "--obr", "mvn:a.big.ol.obr", "--remoteMaven", "remote.maven.location"}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw is reasonable.
+	checkOutput("", "", factory, t)
+
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.Obrs, "mvn:a.big.ol.obr")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.RemoteMavenRepos, "remote.maven.location")
+}
+
+func TestRunsCleanupLocalAllFlagsWorkTogether(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, cmd := setupTestCommandCollection(COMMAND_NAME_RUNS_CLEANUP_LOCAL, factory, t)
+
+	var args []string = []string{"runs", "cleanup", "local",
+		"--obr", "mvn:a.big.ol.obr",
+		"--localMaven", "local/maven/location",
+		"--remoteMaven", "remote.maven.location",
+		"--includes-pattern", "dev.galasa.*",
+		"--excludes-pattern", "*ignoreme",
+	}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw is reasonable.
+	checkOutput("", "", factory, t)
+
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.Obrs, "mvn:a.big.ol.obr")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.LocalMaven, "local/maven/location")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.RemoteMavenRepos, "remote.maven.location")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.IncludesPatterns, "dev.galasa.*")
+	assert.Contains(t, cmd.Values().(*RunsCleanupLocalCmdValues).runsCleanupLocalCmdParams.ExcludesPatterns, "*ignoreme")
+}
+

--- a/modules/cli/pkg/cmd/runsCleanup_test.go
+++ b/modules/cli/pkg/cmd/runsCleanup_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"testing"
+
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandListContainsRunsCleanupCommand(t *testing.T) {
+	/// Given...
+	factory := utils.NewMockFactory()
+	commands, _ := NewCommandCollection(factory)
+
+	// When...
+	command, err := commands.GetCommand(COMMAND_NAME_RUNS_CLEANUP)
+	assert.Nil(t, err)
+
+	// Then...
+	assert.NotNil(t, command)
+	assert.Equal(t, COMMAND_NAME_RUNS_CLEANUP, command.Name())
+	assert.NotNil(t, command.Values())
+	assert.IsType(t, &RunsCleanupCmdValues{}, command.Values())
+}
+
+func TestRunsCleanupHelpFlagSetCorrectly(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+
+	var args []string = []string{"runs", "cleanup", "--help"}
+
+	// When...
+	err := Execute(factory, args)
+
+	// Then...
+	// Check what the user saw is reasonable.
+	checkOutput("Displays the options for the 'runs cleanup' command", "", factory, t)
+
+	assert.Nil(t, err)
+}
+
+func TestRunsCleanupNoCommandsProducesUsageReport(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	var args []string = []string{"runs", "cleanup"}
+
+	// When...
+	err := Execute(factory, args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	checkOutput("Usage:\n  galasactl runs cleanup [command]", "", factory, t)
+}

--- a/modules/cli/pkg/errors/errorMessage.go
+++ b/modules/cli/pkg/errors/errorMessage.go
@@ -458,6 +458,9 @@ var (
 	GALASA_ERROR_UPDATE_MONITOR_SERVER_REPORTED_ERROR    = NewMessageType("GAL1231E: Failed to update a monitor named '%s'. Unexpected http status code %v received from the server. Error details from the server are: '%s'", 1231, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_UPDATE_MONITOR_EXPLANATION_NOT_JSON     = NewMessageType("GAL1232E: Failed to update a monitor named '%s'. Unexpected http status code %v received from the server. Error details from the server are not in the json format.", 1232, STACK_TRACE_NOT_WANTED)
 
+	// Runs cleanup local errors
+	GALASA_ERROR_INVALID_GLOB_PATTERN_PROVIDED = NewMessageType("GAL1248E: Unsupported glob pattern character provided. Only alphanumeric (A-Z, a-z, 0-9), '.', '?', and '*' characters can be provided in the '--includes-pattern' and '--excludes-pattern' flags.", 1248, STACK_TRACE_NOT_WANTED)
+
 	// Warnings...
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'pre-release' repository is '%s'", 2000, STACK_TRACE_WANTED)
 

--- a/modules/cli/pkg/launcher/jvmLauncher.go
+++ b/modules/cli/pkg/launcher/jvmLauncher.go
@@ -109,6 +109,25 @@ type RunsSubmitLocalCmdParameters struct {
 	GherkinURL string
 }
 
+type RunsCleanupLocalCmdParameters struct {
+
+	// A list of OBRs, which we hope one of these contains the tests we want to run.
+	Obrs []string
+
+	// The local maven repo, eg: file:///home/.m2/repository, where we can load the galasa uber-obr
+	LocalMaven string
+
+	// The remote maven repositories, eg: maven central, where we can load the galasa uber-obr
+	// and any other OBRs providing resource cleanup services
+	RemoteMavenRepos []string
+
+	// The list of glob patterns representing the resource cleanup services that we should load
+	IncludesPatterns []string
+
+	// The list of glob patterns representing the resource cleanup services that we should not load
+	ExcludesPatterns []string
+}
+
 const (
 	DEBUG_PORT_DEFAULT uint32 = 2970
 )

--- a/modules/cli/pkg/launcher/jvmLauncherUtils.go
+++ b/modules/cli/pkg/launcher/jvmLauncherUtils.go
@@ -1,0 +1,294 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package launcher
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/galasa-dev/cli/pkg/api"
+	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
+	"github.com/galasa-dev/cli/pkg/props"
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/galasa-dev/cli/pkg/utils"
+)
+
+// -----------------------------------------------------------------------------
+// Local functions that can be used by different types of JVM launchers
+// -----------------------------------------------------------------------------
+
+func getBaseCommandSyntax(
+	bootstrapProperties props.JavaProperties,
+	galasaHome spi.GalasaHome,
+	fileSystem spi.FileSystem,
+	javaHome string,
+	obrs []utils.MavenCoordinates,
+	remoteMavenRepos []string,
+	localMaven string,
+	galasaVersionToRun string,
+	isTraceEnabled bool,
+	isDebugEnabled bool,
+	debugPort uint32,
+	debugMode string,
+	jwt string,
+) (string, []string, error) {
+	var cmd string = ""
+	var args []string = make([]string, 0)
+	var err error
+	var bootJarPath string
+
+	// Gather any variable values we need to.
+	debugMode, err = calculateDebugMode(debugMode, bootstrapProperties)
+	if err == nil {
+		debugPort, err = calculateDebugPort(debugPort, bootstrapProperties)
+		if err == nil {
+			bootJarPath, err = utils.GetGalasaBootJarPath(fileSystem, galasaHome)
+		}
+	}
+
+	if err == nil {
+
+		separator := fileSystem.GetFilePathSeparator()
+
+		// Note: Even in windows, when the java executable is called 'java.exe'
+		// You don't need to add the '.exe' extension it seems.
+		cmd = javaHome + separator + "bin" +
+			separator + "java"
+
+		args = appendArgsDebugOptions(args, isDebugEnabled, debugMode, debugPort)
+
+		args = appendArgsBootstrapJvmLaunchOptions(args, bootstrapProperties)
+
+		// Note: Any -D properties are options for the JVM, so must appear before the -jar parameter.
+		// Parameters after the -jar parameter get passed into the 'main' of the launched java program.
+		args = append(args, "-Dfile.encoding=UTF-8")
+
+		nativeGalasaHomeFolderPath := galasaHome.GetNativeFolderPath()
+		args = append(args, `-DGALASA_HOME="`+nativeGalasaHomeFolderPath+`"`)
+
+		// If there is a jwt, pass it through.
+		if jwt != "" {
+			args = append(args, "-DGALASA_JWT="+jwt)
+		}
+
+		args = append(args, "-jar")
+		args = append(args, bootJarPath)
+
+		// --localmaven file://${M2_PATH}/repository/
+		// Note: URLs always have forward-slashes
+		localMaven, err = defaultLocalMavenIfNotSet(localMaven, fileSystem)
+		args = append(args, "--localmaven")
+		args = append(args, localMaven)
+
+		// --remotemaven $REMOTE_MAVEN
+		for _, repo := range remoteMavenRepos {
+			args = append(args, "--remotemaven")
+			args = append(args, repo)
+		}
+
+		// --bootstrap file:${HOME}/.galasa/bootstrap.properties
+		args = append(args, "--bootstrap")
+		bootstrapPath := "file:///" + galasaHome.GetUrlFolderPath() + "/bootstrap.properties"
+		args = append(args, bootstrapPath)
+
+		for _, obrCoordinate := range obrs {
+			// We are aiming for this:
+			// mvn:${TEST_OBR_GROUP_ID}/${TEST_OBR_ARTIFACT_ID}/${TEST_OBR_VERSION}/obr
+			args = append(args, "--obr")
+			obrMvnPath := "mvn:" + obrCoordinate.GroupId + "/" +
+				obrCoordinate.ArtifactId + "/" + obrCoordinate.Version + "/obr"
+			args = append(args, obrMvnPath)
+		}
+
+		// --obr mvn:dev.galasa/dev.galasa.uber.obr/${OBR_VERSION}/obr
+		args = append(args, "--obr")
+		galasaUberObrPath := "mvn:dev.galasa/dev.galasa.uber.obr/" + galasaVersionToRun + "/obr"
+		args = append(args, galasaUberObrPath)
+
+		if isTraceEnabled {
+			args = append(args, "--trace")
+		}
+	}
+
+	return cmd, args, err
+}
+
+func calculateDebugPort(debugPort uint32, bootstrapProperties props.JavaProperties) (uint32, error) {
+	var err error
+
+	if debugPort == 0 {
+		// Debug port was not set on the command-line.
+
+		// Look in the bootstrap properties for a value.
+		bootstrapPropsValue, isPresent := bootstrapProperties[api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_PORT]
+		if isPresent {
+			// Not specified on command line. Use value in bootstrap property instead.
+			var debugPortU64 uint64
+			debugPortU64, err = strconv.ParseUint(bootstrapPropsValue, 10, 32)
+			if err != nil {
+				err = galasaErrors.NewGalasaError(
+					galasaErrors.GALASA_ERROR_BOOTSTRAP_BAD_DEBUG_PORT_VALUE,
+					bootstrapPropsValue,
+					api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_PORT,
+					strconv.FormatUint(uint64(DEBUG_PORT_DEFAULT), 10),
+				)
+			} else {
+				// Bootstrap property value is good.
+				debugPort = uint32(debugPortU64)
+			}
+		} else {
+			// Not specified on command-linem, nothing in bootstrap property.
+			debugPort = DEBUG_PORT_DEFAULT
+		}
+	}
+	return debugPort, err
+}
+
+func calculateDebugMode(debugMode string, bootstrapProperties props.JavaProperties) (string, error) {
+	var err error
+
+	if debugMode == "" {
+		// The value hasn't been set on the command-line.
+
+		// Look in the bootstrap properties for a value.
+		bootstrapPropsValue, isPresent := bootstrapProperties[api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_MODE]
+		if isPresent {
+			debugMode = bootstrapPropsValue
+			err = checkDebugModeValueIsValid(debugMode, galasaErrors.GALASA_ERROR_BOOTSTRAP_BAD_DEBUG_MODE_VALUE)
+		} else {
+			// Default to 'listen'
+			debugMode = "listen"
+		}
+	}
+
+	if err == nil {
+		err = checkDebugModeValueIsValid(debugMode, galasaErrors.GALASA_ERROR_ARG_BAD_DEBUG_MODE_VALUE)
+	}
+
+	return debugMode, err
+}
+
+func checkDebugModeValueIsValid(debugMode string, errorMessageIfInvalid *galasaErrors.MessageType) error {
+	var err error
+
+	lowerCaseDebugMode := strings.ToLower(debugMode)
+
+	switch lowerCaseDebugMode {
+	case "listen":
+	case "attach":
+		break
+	default:
+		err = galasaErrors.NewGalasaError(errorMessageIfInvalid, debugMode, api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_MODE)
+	}
+
+	return err
+}
+
+// isCPSRemote - decide whether the config store used by tests is remote or not.
+// If it is remote, we are going to have to get a valid JWT to use.
+func isCPSRemote(bootstrapProps props.JavaProperties) bool {
+	isRemote := false
+	configStoreProp := bootstrapProps["framework.config.store"]
+	isRemote = strings.HasPrefix(configStoreProp, "galasacps")
+	return isRemote
+}
+
+// Gets the https URL of the config store, to be used contacting the remote CPS.
+func getCPSRemoteApiServerUrl(bootstrapProps props.JavaProperties) string {
+	configStoreGalasaUrl := bootstrapProps["framework.config.store"]
+	// The configuration has a URL like galasacps://myhost/api
+	// We need to turn it into something like https://myhost/api
+	httpsUrl := strings.Replace(configStoreGalasaUrl, "galasacps", "https", 1)
+	return httpsUrl
+}
+
+func defaultLocalMavenIfNotSet(localMaven string, fileSystem spi.FileSystem) (string, error) {
+	var err error
+	returnMavenPath := ""
+	if localMaven == "" {
+		var userHome string
+		userHome, err = fileSystem.GetUserHomeDirPath()
+		if err == nil {
+			returnMavenPath = "file:///" + strings.ReplaceAll(userHome, "\\", "/") + "/.m2/repository"
+		}
+	} else {
+		returnMavenPath = localMaven
+	}
+	return returnMavenPath, err
+}
+
+func appendArgsDebugOptions(args []string, isDebugEnabled bool, debugMode string, debugPort uint32) []string {
+
+	if isDebugEnabled {
+		var buff strings.Builder
+
+		buff.WriteString("-agentlib:jdwp=transport=dt_socket,address=*:")
+		buff.WriteString(strconv.FormatUint(uint64(debugPort), 10))
+		buff.WriteString(",server=")
+		if debugMode == "listen" {
+			buff.WriteString("y")
+		} else {
+			buff.WriteString("n")
+		}
+		buff.WriteString(",suspend=y")
+
+		args = append(args, buff.String())
+	}
+
+	return args
+}
+
+func appendArgsBootstrapJvmLaunchOptions(args []string, bootstrapProperties props.JavaProperties) []string {
+	// Append all the java launch properties explicitly spelt-out in the boostrap file.
+	// The framework.jvm.local.launch.options bootstrap file property can add parameters to the commmand-line.
+	// For example -Xmx80m and similar parameters.
+	// Use a space-separated list of options and the JVM gets launched with those in front.
+	jvmLaunchOptions, isOptionsPresent := bootstrapProperties[api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_OPTIONS]
+	if isOptionsPresent {
+		// strip off the leading and trailing whitespace.
+		jvmLaunchOptions = strings.Trim(jvmLaunchOptions, " \t\n\r")
+
+		// Split into separate characters
+		launchOptionChars := strings.Split(jvmLaunchOptions, "")
+
+		// Process each character in turn
+		var argBuilder strings.Builder
+		for i, inQuotes := 0, false; i < len(launchOptionChars); i++ {
+			if launchOptionChars[i] == api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_OPTIONS_QUOTE {
+				// Start or end of quoted block. Update flag and discard the quote.
+				inQuotes = !inQuotes
+			} else {
+				if !inQuotes {
+					if (launchOptionChars[i] == api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_OPTIONS_SEPARATOR) {
+						// If we've reached an unquoted space, that marks the end of the argument so
+						// we add what we've built so far to the list of args returned
+						args = append(args, argBuilder.String())
+						argBuilder.Reset()
+					} else {
+						argBuilder.WriteString(launchOptionChars[i])
+					}
+				} else {
+					if i < len(launchOptionChars) - 1 &&
+							launchOptionChars[i] == api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_OPTIONS_ESCAPE &&
+							launchOptionChars[i+1] == api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_OPTIONS_QUOTE {
+						// It's an escaped quote. We include the quote in the argument but discard the escape character.
+						argBuilder.WriteString(api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_OPTIONS_QUOTE)
+						i++
+					} else {
+						argBuilder.WriteString(launchOptionChars[i])
+					}
+				}
+			}
+		}
+
+		// Add the last argument to the list
+		if argBuilder.Len() != 0 {
+			args = append(args, argBuilder.String())
+		}
+	}
+
+	return args
+}

--- a/modules/cli/pkg/launcher/localGalasaBootProcess.go
+++ b/modules/cli/pkg/launcher/localGalasaBootProcess.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package launcher
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/galasa-dev/cli/pkg/spi"
+)
+
+// Represents a local Galasa boot process which gets run.
+type LocalGalasaBootProcess struct {
+	process Process
+	stdout  *JVMOutputProcessor
+	stderr  *bytes.Buffer
+
+	// A go channel. Anything waiting for the process to complete will wait on
+	// this channel. When complete, a string message is placed on this channel to wake
+	// up any waiting threads.
+	reportingChannel chan string
+
+	// A time service. When a significant event occurs, we interrupt it.
+	mainPollLoopSleeper spi.TimedSleeper
+
+	// Something which can create new processes in the operating system
+	processFactory ProcessFactory
+}
+
+// Tell any polling thread that the JVM is complete now.
+func notifyComplete(msg string, reportingChannel chan string, mainPollLoopSleeper spi.TimedSleeper) {
+	reportingChannel <- "DONE"
+	close(reportingChannel)
+
+	mainPollLoopSleeper.Interrupt(msg)
+}
+
+// This method is called by a thread monitoring the state of the JVM.
+// It can receive messages from the JVM launcher go routine.
+// This call never blocks waiting for anything.
+func isJvmCompleted(reportingChannel chan string) bool {
+	isComplete := false
+
+	// The JVM may not be finished. So check the channel where the output monitor tells us
+	// when the JVM is shutting down.
+	select {
+	case msg := <-reportingChannel:
+		log.Printf("Message received from JVM launch thread: %s\n", msg)
+		if msg == "DONE" || msg == "" {
+			isComplete = true
+		}
+
+	default:
+		isComplete = false
+	}
+	return isComplete
+}

--- a/modules/cli/pkg/launcher/localResourceCleanup.go
+++ b/modules/cli/pkg/launcher/localResourceCleanup.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package launcher
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/galasa-dev/cli/pkg/spi"
+)
+
+// A local resource cleanup process which gets run.
+type LocalResourceCleanup struct {
+	LocalGalasaBootProcess
+}
+
+// A structure which tells us all we know about a JVM process we launched.
+func NewLocalResourceCleanup(
+	mainPollLoopSleeper spi.TimedSleeper,
+	fileSystem spi.FileSystem,
+	processFactory ProcessFactory,
+) *LocalResourceCleanup {
+
+	localResourceCleanup := new(LocalResourceCleanup)
+
+	localResourceCleanup.stdout = NewJVMOutputProcessor()
+	localResourceCleanup.stderr = bytes.NewBuffer([]byte{})
+	localResourceCleanup.mainPollLoopSleeper = mainPollLoopSleeper
+	localResourceCleanup.processFactory = processFactory
+
+	localResourceCleanup.reportingChannel = make(chan string, 100)
+
+	return localResourceCleanup
+}
+
+// Launch a resource management run within a JVM.
+func (localResourceCleanup *LocalResourceCleanup) launch(cmd string, args []string) error {
+
+	// Create a new process, so we can track it and all we know about it.
+	localResourceCleanup.process = localResourceCleanup.processFactory.NewProcess()
+
+	// Start the process so it invokes the command.
+	err := localResourceCleanup.process.Start(cmd, args, localResourceCleanup.stdout, localResourceCleanup.stderr)
+	if err != nil {
+		log.Printf("Failed to start the JVM. %s\n", err.Error())
+		log.Printf("Failing command is %s %v\n", cmd, args)
+	} else {
+
+		log.Printf("JVM started. Spawning a go routine to wait for it to complete.\n")
+		go localResourceCleanup.waitForCompletion()
+	}
+	return err
+}
+
+// This method is called by the launching thread as a go routine.
+// The go routine waits for the JVM to complete, then emits
+// a 'DONE' message which can be recieved by the monitoring thread.
+// This call always blocks waiting for the launched JVM to complete and exit.
+func (localResourceCleanup *LocalResourceCleanup) waitForCompletion() error {
+
+	log.Printf("waiting for the JVM to complete within a go routine.\n")
+
+	err := localResourceCleanup.process.Wait()
+	if err != nil {
+		log.Printf("Failed to wait for the JVM to complete. %s\n", err.Error())
+	} else {
+		log.Printf("JVM has completed. Detected by waiting go routine.\n")
+	}
+
+	// Tell any polling thread that the JVM is complete now.
+	msg := "Resource cleanup completed"
+	notifyComplete(msg, localResourceCleanup.reportingChannel, localResourceCleanup.mainPollLoopSleeper)
+
+	return err
+}
+
+// This method is called by a thread monitoring the state of the JVM.
+// It can receive messages from the JVM launcher go routine.
+// This call never blocks waiting for anything.
+func (localResourceCleanup *LocalResourceCleanup) isCompleted() bool {
+	return isJvmCompleted(localResourceCleanup.reportingChannel)
+}

--- a/modules/cli/pkg/launcher/resourceCleanupJvmLauncher.go
+++ b/modules/cli/pkg/launcher/resourceCleanupJvmLauncher.go
@@ -6,174 +6,180 @@
 package launcher
 
 import (
-	"log"
-	"time"
+    "log"
+    "time"
 
-	"github.com/galasa-dev/cli/pkg/embedded"
-	"github.com/galasa-dev/cli/pkg/props"
-	"github.com/galasa-dev/cli/pkg/spi"
-	"github.com/galasa-dev/cli/pkg/utils"
+    "github.com/galasa-dev/cli/pkg/embedded"
+    "github.com/galasa-dev/cli/pkg/props"
+    "github.com/galasa-dev/cli/pkg/spi"
+    "github.com/galasa-dev/cli/pkg/utils"
 )
 
 const (
-	// The amount of time in seconds to wait between checking for completion
-	RESOURCE_CLEANUP_COMPLETION_POLL_INTERVAL_SECONDS = 30
+    // The amount of time in seconds to wait between checking for completion
+    RESOURCE_CLEANUP_COMPLETION_POLL_INTERVAL_SECONDS = 30
 )
 
 // ResourceCleanupJvmLauncher launches resource management locally,
-// it is given OBRs containing resource management providers which 
+// it is given OBRs containing resource management providers which
 // need to be executed, and it launches them within a local JVM.
 type ResourceCleanupJvmLauncher struct {
-	// Inherit the properties in the base JVM launcher structure
-	BaseJvmLauncher
+    // Inherit the properties in the base JVM launcher structure
+    BaseJvmLauncher
 
-	// The parameters from the command-line.
-	cmdParams RunsCleanupLocalCmdParameters
+    // The parameters from the command-line.
+    cmdParams RunsCleanupLocalCmdParameters
 }
 
 type RunsCleanupLocalCmdParameters struct {
 
-	// A list of OBRs containing the resource cleanup providers we want to run.
-	Obrs []string
+    // A list of OBRs containing the resource cleanup providers we want to run.
+    Obrs []string
 
-	// The local maven repo, eg: file:///home/.m2/repository, where we can load the galasa uber-obr
-	LocalMaven string
+    // The local maven repo, eg: file:///home/.m2/repository, where we can load the galasa uber-obr
+    LocalMaven string
 
-	// The remote maven repositories, eg: maven central, where we can load the galasa uber-obr
-	// and any other OBRs providing resource cleanup services
-	RemoteMavenRepos []string
+    // The remote maven repositories, eg: maven central, where we can load the galasa uber-obr
+    // and any other OBRs providing resource cleanup services
+    RemoteMavenRepos []string
 
-	// The version of galasa we want to launch. This indicates which uber-obr will be
-	// loaded.
-	TargetGalasaVersion string
+    // The version of galasa we want to launch. This indicates which uber-obr will be
+    // loaded.
+    TargetGalasaVersion string
 
-	// Should the JVM be launched in debug mode ?
-	IsDebugEnabled bool
+    // Should the JVM be launched in debug mode ?
+    IsDebugEnabled bool
 
-	// When launched in debug mode, which port should the JVM use to talk to the Java
-	// debugger ? This port is either listened on, or attached to depending on the
-	// DebugMode field.
-	DebugPort uint32
+    // When launched in debug mode, which port should the JVM use to talk to the Java
+    // debugger ? This port is either listened on, or attached to depending on the
+    // DebugMode field.
+    DebugPort uint32
 
-	// A string indicating whether the JVM should 'attach' to the debug port
-	// to talk to the Java debugger (JDB), or whether it should 'listen' on a port
-	// ready for the JDB to attach to.
-	DebugMode string
+    // A string indicating whether the JVM should 'attach' to the debug port
+    // to talk to the Java debugger (JDB), or whether it should 'listen' on a port
+    // ready for the JDB to attach to.
+    DebugMode string
 
-	// The list of glob patterns representing the resource cleanup services that we should load
-	IncludesPatterns []string
+    // The list of glob patterns representing the resource cleanup services that we should load
+    IncludesPatterns []string
 
-	// The list of glob patterns representing the resource cleanup services that we should not load
-	ExcludesPatterns []string
+    // The list of glob patterns representing the resource cleanup services that we should not load
+    ExcludesPatterns []string
 
-	// Determines whether trace-level logging should be enabled
-	IsTraceEnabled bool
+    // Determines whether trace-level logging should be enabled
+    IsTraceEnabled bool
 }
 
 // -----------------------------------------------------------------------------
 // Constructors
 // -----------------------------------------------------------------------------
 func NewResourceCleanupJVMLauncher(
-	factory spi.Factory,
-	bootstrapProps props.JavaProperties,
-	embeddedFileSystem embedded.ReadOnlyFileSystem,
-	cmdParameters *RunsCleanupLocalCmdParameters,
-	processFactory ProcessFactory,
-	galasaHome spi.GalasaHome,
-	timedSleeper spi.TimedSleeper,
+    factory spi.Factory,
+    bootstrapProps props.JavaProperties,
+    embeddedFileSystem embedded.ReadOnlyFileSystem,
+    cmdParameters *RunsCleanupLocalCmdParameters,
+    processFactory ProcessFactory,
+    galasaHome spi.GalasaHome,
+    timedSleeper spi.TimedSleeper,
 ) (*ResourceCleanupJvmLauncher, error) {
-	var (
-		err      error
-		launcher *ResourceCleanupJvmLauncher = nil
-	)
+    var (
+        err      error
+        launcher *ResourceCleanupJvmLauncher = nil
+    )
 
-	env := factory.GetEnvironment()
-	fileSystem := factory.GetFileSystem()
+    env := factory.GetEnvironment()
+    fileSystem := factory.GetFileSystem()
 
-	javaHome := env.GetEnv("JAVA_HOME")
+    javaHome := env.GetEnv("JAVA_HOME")
 
-	err = utils.ValidateJavaHome(fileSystem, javaHome)
+    err = utils.ValidateJavaHome(fileSystem, javaHome)
 
-	if err == nil {
-		launcher = new(ResourceCleanupJvmLauncher)
-		launcher.factory = factory
-		launcher.javaHome = javaHome
-		launcher.cmdParams = *cmdParameters
-		launcher.env = env
-		launcher.fileSystem = fileSystem
-		launcher.embeddedFileSystem = embeddedFileSystem
-		launcher.processFactory = processFactory
-		launcher.galasaHome = galasaHome
-		launcher.timeService = factory.GetTimeService()
-		launcher.timedSleeper = timedSleeper
-		launcher.bootstrapProps = bootstrapProps
+    if err == nil {
+        launcher = new(ResourceCleanupJvmLauncher)
+        launcher.factory = factory
+        launcher.javaHome = javaHome
+        launcher.cmdParams = *cmdParameters
+        launcher.env = env
+        launcher.fileSystem = fileSystem
+        launcher.embeddedFileSystem = embeddedFileSystem
+        launcher.processFactory = processFactory
+        launcher.galasaHome = galasaHome
+        launcher.timeService = factory.GetTimeService()
+        launcher.timedSleeper = timedSleeper
+        launcher.bootstrapProps = bootstrapProps
 
-		// Make sure the home folder has the boot jar unpacked and ready to invoke.
-		err = utils.InitialiseGalasaHomeFolder(
-			launcher.galasaHome,
-			launcher.fileSystem,
-			launcher.embeddedFileSystem,
-		)
-	}
+        // Make sure the home folder has the boot jar unpacked and ready to invoke.
+        err = utils.InitialiseGalasaHomeFolder(
+            launcher.galasaHome,
+            launcher.fileSystem,
+            launcher.embeddedFileSystem,
+        )
+    }
 
-	return launcher, err
+    return launcher, err
 }
 
 // -----------------------------------------------------------------------------
 // Implementation of the ResourceCleanupLauncher interface
 // -----------------------------------------------------------------------------
 func (launcher *ResourceCleanupJvmLauncher) RunResourceCleanup() error {
-	log.Printf("JvmLauncher: RunResourceCleanup entered")
-	var err error
+    log.Printf("JvmLauncher: RunResourceCleanup entered")
+    var err error
 
-	// We have some OBRs from the command-line
-	var obrs []utils.MavenCoordinates
-	obrs, err = utils.ValidateObrs(launcher.cmdParams.Obrs)
-	if err == nil {
-		var jwt = ""
-		if isCPSRemote(launcher.bootstrapProps) {
-			apiServerUrl := getCPSRemoteApiServerUrl(launcher.bootstrapProps)
-			authenticator := launcher.factory.GetAuthenticator(apiServerUrl, launcher.galasaHome)
-			log.Printf("framework.config.store bootstrap property indicates a remote CPS will be used. So we need a valid JWT.\n")
-			jwt, err = authenticator.GetBearerToken()
-		}
+    err = utils.ValidateJavaClassGlobPatterns(launcher.cmdParams.IncludesPatterns)
+    if err == nil {
+        err = utils.ValidateJavaClassGlobPatterns(launcher.cmdParams.ExcludesPatterns)
+        if err == nil {
+            // We have some OBRs from the command-line
+            var obrs []utils.MavenCoordinates
+            obrs, err = utils.ValidateObrs(launcher.cmdParams.Obrs)
+            if err == nil {
+                var jwt = ""
+                if isCPSRemote(launcher.bootstrapProps) {
+                    apiServerUrl := getCPSRemoteApiServerUrl(launcher.bootstrapProps)
+                    authenticator := launcher.factory.GetAuthenticator(apiServerUrl, launcher.galasaHome)
+                    log.Printf("framework.config.store bootstrap property indicates a remote CPS will be used. So we need a valid JWT.\n")
+                    jwt, err = authenticator.GetBearerToken()
+                }
 
-		if err == nil {
-			var (
-				cmd  string
-				args []string
-			)
-			cmd, args, err = getResourceManagementCommandSyntax(
-				launcher.bootstrapProps,
-				launcher.galasaHome,
-				launcher.fileSystem, launcher.javaHome, obrs,
-				launcher.cmdParams.RemoteMavenRepos, launcher.cmdParams.LocalMaven,
-				launcher.cmdParams.TargetGalasaVersion,
-				launcher.cmdParams.IsTraceEnabled,
-				launcher.cmdParams.IsDebugEnabled,
-				launcher.cmdParams.DebugPort,
-				launcher.cmdParams.DebugMode,
-				launcher.cmdParams.IncludesPatterns,
-				launcher.cmdParams.ExcludesPatterns,
-				jwt,
-			)
+                if err == nil {
+                    var (
+                        cmd  string
+                        args []string
+                    )
+                    cmd, args, err = getResourceManagementCommandSyntax(
+                        launcher.bootstrapProps,
+                        launcher.galasaHome,
+                        launcher.fileSystem, launcher.javaHome, obrs,
+                        launcher.cmdParams.RemoteMavenRepos, launcher.cmdParams.LocalMaven,
+                        launcher.cmdParams.TargetGalasaVersion,
+                        launcher.cmdParams.IsTraceEnabled,
+                        launcher.cmdParams.IsDebugEnabled,
+                        launcher.cmdParams.DebugPort,
+                        launcher.cmdParams.DebugMode,
+                        launcher.cmdParams.IncludesPatterns,
+                        launcher.cmdParams.ExcludesPatterns,
+                        jwt,
+                    )
 
-			if err == nil {
-				log.Printf("Launching command '%s' '%v'\n", cmd, args)
-				localResourceCleanup := NewLocalResourceCleanup(launcher.timedSleeper, launcher.fileSystem, launcher.processFactory)
-				err = localResourceCleanup.launch(cmd, args)
-				if err == nil {
-					pollInterval := time.Second * time.Duration(RESOURCE_CLEANUP_COMPLETION_POLL_INTERVAL_SECONDS)
+                    if err == nil {
+                        log.Printf("Launching command '%s' '%v'\n", cmd, args)
+                        localResourceCleanup := NewLocalResourceCleanup(launcher.timedSleeper, launcher.fileSystem, launcher.processFactory)
+                        err = localResourceCleanup.launch(cmd, args)
+                        if err == nil {
+                            pollInterval := time.Second * time.Duration(RESOURCE_CLEANUP_COMPLETION_POLL_INTERVAL_SECONDS)
 
-					for !localResourceCleanup.isCompleted() {
-						launcher.timedSleeper.Sleep(pollInterval)
-					}
-				}
-			}
-		}
-	}
+                            for !localResourceCleanup.isCompleted() {
+                                launcher.timedSleeper.Sleep(pollInterval)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-	return err
+    return err
 }
 
 // -----------------------------------------------------------------------------
@@ -192,59 +198,59 @@ func (launcher *ResourceCleanupJvmLauncher) RunResourceCleanup() error {
 // --excludes-monitor-pattern "*MyUnwantedCleanupJob"
 // --local-resource-management
 func getResourceManagementCommandSyntax(
-	bootstrapProperties props.JavaProperties,
-	galasaHome spi.GalasaHome,
-	fileSystem spi.FileSystem,
-	javaHome string,
-	obrs []utils.MavenCoordinates,
-	remoteMavenRepos []string,
-	localMaven string,
-	galasaVersionToRun string,
-	isTraceEnabled bool,
-	isDebugEnabled bool,
-	debugPort uint32,
-	debugMode string,
-	includesPatterns []string,
-	excludesPatterns []string,
-	jwt string,
+    bootstrapProperties props.JavaProperties,
+    galasaHome spi.GalasaHome,
+    fileSystem spi.FileSystem,
+    javaHome string,
+    obrs []utils.MavenCoordinates,
+    remoteMavenRepos []string,
+    localMaven string,
+    galasaVersionToRun string,
+    isTraceEnabled bool,
+    isDebugEnabled bool,
+    debugPort uint32,
+    debugMode string,
+    includesPatterns []string,
+    excludesPatterns []string,
+    jwt string,
 ) (string, []string, error) {
 
-	var cmd string = ""
-	var args []string = make([]string, 0)
-	var err error
+    var cmd string = ""
+    var args []string = make([]string, 0)
+    var err error
 
-	cmd, args, err = getBaseCommandSyntax(
-		bootstrapProperties,
-		galasaHome,
-		fileSystem,
-		javaHome,
-		obrs,
-		remoteMavenRepos,
-		localMaven,
-		galasaVersionToRun,
-		isTraceEnabled,
-		isDebugEnabled,
-		debugPort,
-		debugMode,
-		jwt,
-	)
+    cmd, args, err = getBaseCommandSyntax(
+        bootstrapProperties,
+        galasaHome,
+        fileSystem,
+        javaHome,
+        obrs,
+        remoteMavenRepos,
+        localMaven,
+        galasaVersionToRun,
+        isTraceEnabled,
+        isDebugEnabled,
+        debugPort,
+        debugMode,
+        jwt,
+    )
 
-	if err == nil {
+    if err == nil {
 
-		args = append(args, "--local-resource-management")
+        args = append(args, "--local-resource-management")
 
-		// --includes-monitor-pattern $PATTERN
-		for _, pattern := range includesPatterns {
-			args = append(args, "--includes-monitor-pattern")
-			args = append(args, pattern)
-		}
+        // --includes-monitor-pattern $PATTERN
+        for _, pattern := range includesPatterns {
+            args = append(args, "--includes-monitor-pattern")
+            args = append(args, pattern)
+        }
 
-		// --excludes-monitor-pattern $PATTERN
-		for _, pattern := range excludesPatterns {
-			args = append(args, "--excludes-monitor-pattern")
-			args = append(args, pattern)
-		}
-	}
+        // --excludes-monitor-pattern $PATTERN
+        for _, pattern := range excludesPatterns {
+            args = append(args, "--excludes-monitor-pattern")
+            args = append(args, pattern)
+        }
+    }
 
-	return cmd, args, err
+    return cmd, args, err
 }

--- a/modules/cli/pkg/launcher/resourceCleanupJvmLauncher.go
+++ b/modules/cli/pkg/launcher/resourceCleanupJvmLauncher.go
@@ -1,0 +1,250 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package launcher
+
+import (
+	"log"
+	"time"
+
+	"github.com/galasa-dev/cli/pkg/embedded"
+	"github.com/galasa-dev/cli/pkg/props"
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/galasa-dev/cli/pkg/utils"
+)
+
+const (
+	// The amount of time in seconds to wait between checking for completion
+	RESOURCE_CLEANUP_COMPLETION_POLL_INTERVAL_SECONDS = 30
+)
+
+// ResourceCleanupJvmLauncher launches resource management locally,
+// it is given OBRs containing resource management providers which 
+// need to be executed, and it launches them within a local JVM.
+type ResourceCleanupJvmLauncher struct {
+	// Inherit the properties in the base JVM launcher structure
+	BaseJvmLauncher
+
+	// The parameters from the command-line.
+	cmdParams RunsCleanupLocalCmdParameters
+}
+
+type RunsCleanupLocalCmdParameters struct {
+
+	// A list of OBRs containing the resource cleanup providers we want to run.
+	Obrs []string
+
+	// The local maven repo, eg: file:///home/.m2/repository, where we can load the galasa uber-obr
+	LocalMaven string
+
+	// The remote maven repositories, eg: maven central, where we can load the galasa uber-obr
+	// and any other OBRs providing resource cleanup services
+	RemoteMavenRepos []string
+
+	// The version of galasa we want to launch. This indicates which uber-obr will be
+	// loaded.
+	TargetGalasaVersion string
+
+	// Should the JVM be launched in debug mode ?
+	IsDebugEnabled bool
+
+	// When launched in debug mode, which port should the JVM use to talk to the Java
+	// debugger ? This port is either listened on, or attached to depending on the
+	// DebugMode field.
+	DebugPort uint32
+
+	// A string indicating whether the JVM should 'attach' to the debug port
+	// to talk to the Java debugger (JDB), or whether it should 'listen' on a port
+	// ready for the JDB to attach to.
+	DebugMode string
+
+	// The list of glob patterns representing the resource cleanup services that we should load
+	IncludesPatterns []string
+
+	// The list of glob patterns representing the resource cleanup services that we should not load
+	ExcludesPatterns []string
+
+	// Determines whether trace-level logging should be enabled
+	IsTraceEnabled bool
+}
+
+// -----------------------------------------------------------------------------
+// Constructors
+// -----------------------------------------------------------------------------
+func NewResourceCleanupJVMLauncher(
+	factory spi.Factory,
+	bootstrapProps props.JavaProperties,
+	embeddedFileSystem embedded.ReadOnlyFileSystem,
+	cmdParameters *RunsCleanupLocalCmdParameters,
+	processFactory ProcessFactory,
+	galasaHome spi.GalasaHome,
+	timedSleeper spi.TimedSleeper,
+) (*ResourceCleanupJvmLauncher, error) {
+	var (
+		err      error
+		launcher *ResourceCleanupJvmLauncher = nil
+	)
+
+	env := factory.GetEnvironment()
+	fileSystem := factory.GetFileSystem()
+
+	javaHome := env.GetEnv("JAVA_HOME")
+
+	err = utils.ValidateJavaHome(fileSystem, javaHome)
+
+	if err == nil {
+		launcher = new(ResourceCleanupJvmLauncher)
+		launcher.factory = factory
+		launcher.javaHome = javaHome
+		launcher.cmdParams = *cmdParameters
+		launcher.env = env
+		launcher.fileSystem = fileSystem
+		launcher.embeddedFileSystem = embeddedFileSystem
+		launcher.processFactory = processFactory
+		launcher.galasaHome = galasaHome
+		launcher.timeService = factory.GetTimeService()
+		launcher.timedSleeper = timedSleeper
+		launcher.bootstrapProps = bootstrapProps
+
+		// Make sure the home folder has the boot jar unpacked and ready to invoke.
+		err = utils.InitialiseGalasaHomeFolder(
+			launcher.galasaHome,
+			launcher.fileSystem,
+			launcher.embeddedFileSystem,
+		)
+	}
+
+	return launcher, err
+}
+
+// -----------------------------------------------------------------------------
+// Implementation of the ResourceCleanupLauncher interface
+// -----------------------------------------------------------------------------
+func (launcher *ResourceCleanupJvmLauncher) RunResourceCleanup() error {
+	log.Printf("JvmLauncher: RunResourceCleanup entered")
+	var err error
+
+	// We have some OBRs from the command-line
+	var obrs []utils.MavenCoordinates
+	obrs, err = utils.ValidateObrs(launcher.cmdParams.Obrs)
+	if err == nil {
+		var jwt = ""
+		if isCPSRemote(launcher.bootstrapProps) {
+			apiServerUrl := getCPSRemoteApiServerUrl(launcher.bootstrapProps)
+			authenticator := launcher.factory.GetAuthenticator(apiServerUrl, launcher.galasaHome)
+			log.Printf("framework.config.store bootstrap property indicates a remote CPS will be used. So we need a valid JWT.\n")
+			jwt, err = authenticator.GetBearerToken()
+		}
+
+		if err == nil {
+			var (
+				cmd  string
+				args []string
+			)
+			cmd, args, err = getResourceManagementCommandSyntax(
+				launcher.bootstrapProps,
+				launcher.galasaHome,
+				launcher.fileSystem, launcher.javaHome, obrs,
+				launcher.cmdParams.RemoteMavenRepos, launcher.cmdParams.LocalMaven,
+				launcher.cmdParams.TargetGalasaVersion,
+				launcher.cmdParams.IsTraceEnabled,
+				launcher.cmdParams.IsDebugEnabled,
+				launcher.cmdParams.DebugPort,
+				launcher.cmdParams.DebugMode,
+				launcher.cmdParams.IncludesPatterns,
+				launcher.cmdParams.ExcludesPatterns,
+				jwt,
+			)
+
+			if err == nil {
+				log.Printf("Launching command '%s' '%v'\n", cmd, args)
+				localResourceCleanup := NewLocalResourceCleanup(launcher.timedSleeper, launcher.fileSystem, launcher.processFactory)
+				err = localResourceCleanup.launch(cmd, args)
+				if err == nil {
+					pollInterval := time.Second * time.Duration(RESOURCE_CLEANUP_COMPLETION_POLL_INTERVAL_SECONDS)
+
+					for !localResourceCleanup.isCompleted() {
+						launcher.timedSleeper.Sleep(pollInterval)
+					}
+				}
+			}
+		}
+	}
+
+	return err
+}
+
+// -----------------------------------------------------------------------------
+// Local functions
+// -----------------------------------------------------------------------------
+// getResourceManagementCommandSyntax From the parameters we aim to build a command-line incantation that would launch resource management locally
+//
+// For example:
+// java -jar ${BOOT_JAR_PATH} \
+// --localmaven file:${M2_PATH}/repository/ \
+// --remotemaven $REMOTE_MAVEN \
+// --bootstrap file:${HOME}/.galasa/bootstrap.properties \
+// --obr mvn:dev.galasa/dev.galasa.uber.obr/${OBR_VERSION}/obr \
+// --obr mvn:${OBR_GROUP_ID}/${OBR_ARTIFACT_ID}/${OBR_VERSION}/obr \
+// --includes-monitor-pattern "dev.galasa.*"
+// --excludes-monitor-pattern "*MyUnwantedCleanupJob"
+// --local-resource-management
+func getResourceManagementCommandSyntax(
+	bootstrapProperties props.JavaProperties,
+	galasaHome spi.GalasaHome,
+	fileSystem spi.FileSystem,
+	javaHome string,
+	obrs []utils.MavenCoordinates,
+	remoteMavenRepos []string,
+	localMaven string,
+	galasaVersionToRun string,
+	isTraceEnabled bool,
+	isDebugEnabled bool,
+	debugPort uint32,
+	debugMode string,
+	includesPatterns []string,
+	excludesPatterns []string,
+	jwt string,
+) (string, []string, error) {
+
+	var cmd string = ""
+	var args []string = make([]string, 0)
+	var err error
+
+	cmd, args, err = getBaseCommandSyntax(
+		bootstrapProperties,
+		galasaHome,
+		fileSystem,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled,
+		debugPort,
+		debugMode,
+		jwt,
+	)
+
+	if err == nil {
+
+		args = append(args, "--local-resource-management")
+
+		// --includes-monitor-pattern $PATTERN
+		for _, pattern := range includesPatterns {
+			args = append(args, "--includes-monitor-pattern")
+			args = append(args, pattern)
+		}
+
+		// --excludes-monitor-pattern $PATTERN
+		for _, pattern := range excludesPatterns {
+			args = append(args, "--excludes-monitor-pattern")
+			args = append(args, pattern)
+		}
+	}
+
+	return cmd, args, err
+}

--- a/modules/cli/pkg/launcher/resourceCleanupJvmLauncher_test.go
+++ b/modules/cli/pkg/launcher/resourceCleanupJvmLauncher_test.go
@@ -1,0 +1,1007 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package launcher
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/galasa-dev/cli/pkg/api"
+	"github.com/galasa-dev/cli/pkg/files"
+	"github.com/galasa-dev/cli/pkg/props"
+	"github.com/galasa-dev/cli/pkg/spi"
+
+	"github.com/galasa-dev/cli/pkg/embedded"
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func NewMockResourceCleanupLauncherParams() (
+	props.JavaProperties,
+	*utils.MockEnv,
+	spi.FileSystem,
+	embedded.ReadOnlyFileSystem,
+	*RunsCleanupLocalCmdParameters,
+	spi.TimeService,
+	spi.TimedSleeper,
+	ProcessFactory,
+	spi.GalasaHome,
+) {
+	// Given...
+	env := utils.NewMockEnv()
+	env.EnvVars["JAVA_HOME"] = "/java"
+	fs := files.NewMockFileSystem()
+	utils.AddJavaRuntimeToMock(fs, "/java")
+	galasaHome, _ := utils.NewGalasaHome(fs, env, "")
+	jvmLaunchParams := getBasicCleanupJvmLaunchParams()
+	timeService := utils.NewMockTimeService()
+	timedSleeper := utils.NewRealTimedSleeper()
+	mockProcess := NewMockProcess()
+	mockProcessFactory := NewMockProcessFactory(mockProcess)
+
+	bootstrapProps := getBasicBootstrapProperties()
+
+	return bootstrapProps, env, fs, embedded.GetReadOnlyFileSystem(),
+		jvmLaunchParams, timeService, timedSleeper, mockProcessFactory, galasaHome
+}
+
+func TestCanCreateAResourceCleanupJVMLauncher(t *testing.T) {
+
+	env := utils.NewMockEnv()
+	env.EnvVars["JAVA_HOME"] = "/java"
+
+	fs := files.NewMockFileSystem()
+	utils.AddJavaRuntimeToMock(fs, "/java")
+
+	galasaHome, _ := utils.NewGalasaHome(fs, env, "")
+
+	jvmLaunchParams := getBasicCleanupJvmLaunchParams()
+	timeService := utils.NewMockTimeService()
+	timedSleeper := utils.NewRealTimedSleeper()
+
+	mockProcess := NewMockProcess()
+	mockProcessFactory := NewMockProcessFactory(mockProcess)
+
+	bootstrapProps := getBasicBootstrapProperties()
+
+	mockFactory := &utils.MockFactory{
+		Env:         env,
+		FileSystem:  fs,
+		TimeService: timeService,
+	}
+
+	launcher, err := NewResourceCleanupJVMLauncher(
+		mockFactory,
+		bootstrapProps, embedded.GetReadOnlyFileSystem(),
+		jvmLaunchParams, mockProcessFactory, galasaHome, timedSleeper,
+	)
+
+	assert.NoError(t, err, "Constructor should not have failed but it did.")
+	assert.NotNil(t, launcher, "Launcher reference was nil, shouldn't have been.")
+}
+
+func getBasicCleanupJvmLaunchParams() *RunsCleanupLocalCmdParameters {
+	return &RunsCleanupLocalCmdParameters{
+		Obrs:                nil,
+		RemoteMavenRepos: []string{},
+		TargetGalasaVersion: "",
+	}
+}
+
+func TestCantCreateAResourceCleanupJVMLauncherIfJVMHomeNotSet(t *testing.T) {
+
+	env := utils.NewMockEnv()
+
+	fs := files.NewMockFileSystem()
+	utils.AddJavaRuntimeToMock(fs, "/java")
+
+	galasaHome, _ := utils.NewGalasaHome(fs, env, "")
+
+	bootstrapProps := getBasicBootstrapProperties()
+
+	jvmLaunchParams := getBasicCleanupJvmLaunchParams()
+	timeService := utils.NewMockTimeService()
+	timedSleeper := utils.NewRealTimedSleeper()
+
+	mockProcess := NewMockProcess()
+	mockProcessFactory := NewMockProcessFactory(mockProcess)
+
+	mockFactory := &utils.MockFactory{
+		Env:         env,
+		FileSystem:  fs,
+		TimeService: timeService,
+	}
+
+	launcher, err := NewResourceCleanupJVMLauncher(
+		mockFactory,
+		bootstrapProps, embedded.GetReadOnlyFileSystem(),
+		jvmLaunchParams, mockProcessFactory, galasaHome, timedSleeper,
+	)
+
+	assert.Error(t, err, "Constructor should have failed but it did not.")
+	assert.Nil(t, launcher, "Launcher reference was not nil")
+	assert.Contains(t, err.Error(), "GAL1050E")
+}
+
+func TestCanLaunchLocalJVMResourceCleanup(t *testing.T) {
+	// Given...
+	bootstrapProps, env, fs, embeddedReadOnlyFS,
+		jvmLaunchParams, timeService, timedSleeper, mockProcessFactory, galasaHome := NewMockResourceCleanupLauncherParams()
+
+	mockFactory := &utils.MockFactory{
+		Env:         env,
+		FileSystem:  fs,
+		TimeService: timeService,
+	}
+
+	launcher, err := NewResourceCleanupJVMLauncher(
+		mockFactory,
+		bootstrapProps, embeddedReadOnlyFS,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timedSleeper,
+	)
+
+	assert.NoError(t, err, "JVM launcher should have been creatable.")
+	assert.NotNil(t, launcher, "Launcher returned is nil!")
+
+	// When...
+	err = launcher.RunResourceCleanup()
+
+	assert.NoError(t, err, "Launcher should have launched command OK")
+}
+
+func TestBadlyFormedCleanupObrFromProfileInfoCausesError(t *testing.T) {
+
+	// Given...
+	bootstrapProps, env, fs, embeddedReadOnlyFS,
+		jvmLaunchParams, timeService, timedSleeper, mockProcessFactory, galasaHome := NewMockResourceCleanupLauncherParams()
+	
+	jvmLaunchParams.Obrs = append(jvmLaunchParams.Obrs, "notmaven://group/artifact/version/classifier")
+
+	mockFactory := &utils.MockFactory{
+		Env:         env,
+		FileSystem:  fs,
+		TimeService: timeService,
+	}
+
+	launcher, _ := NewResourceCleanupJVMLauncher(
+		mockFactory,
+		bootstrapProps, embeddedReadOnlyFS,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timedSleeper)
+
+	// When...
+	err := launcher.RunResourceCleanup()
+
+	assert.NotNil(t, err)
+	if err != nil {
+		// Expect badly formed OBR
+		assert.Contains(t, err.Error(), "GAL1061E:")
+	}
+}
+
+func getDefaultResourceManagementCommandSyntaxParameters() (
+	props.JavaProperties,
+	spi.Environment,
+	spi.GalasaHome,
+	*files.MockFileSystem,
+	string,
+	[]utils.MavenCoordinates,
+	[]string,
+	string,
+	string,
+	bool,
+	[]string,
+	[]string,
+) {
+	bootstrapProps := getBasicBootstrapProperties()
+	fs := files.NewOverridableMockFileSystem()
+	javaHome := "my_java_home"
+	obrs := make([]utils.MavenCoordinates, 0)
+	obrs = append(
+		obrs,
+		utils.MavenCoordinates{
+			GroupId:    "myGroup",
+			ArtifactId: "myArtifact",
+			Version:    "0.2",
+			Classifier: "myClassifier",
+		},
+	)
+	remoteMavenRepos := []string{"myRemoteMaven"}
+	localMaven := ""
+	galasaVersionToRun := "0.99.0"
+	isTraceEnabled := true
+
+	includesPatterns := []string{"*"}
+	excludesPatterns := []string{"*ExcludeMe"}
+
+	env := utils.NewMockEnv()
+	galasaHome, _ := utils.NewGalasaHome(fs, env, "")
+
+	return bootstrapProps, env, galasaHome, fs, javaHome, obrs,
+		remoteMavenRepos, localMaven, galasaVersionToRun, isTraceEnabled,
+		includesPatterns, excludesPatterns
+}
+
+func TestCleanupCommandSetsIncludesPatterns(t *testing.T) {
+
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		_,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	includesPatterns := []string{"dev.galasa.*", "my.other.bundles.*", "*.more.bundles"}
+	isDebugEnabled := false
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Contains(t, args, "--includes-monitor-pattern")
+	assert.Contains(t, args, "dev.galasa.*")
+	assert.Contains(t, args, "my.other.bundles.*")
+	assert.Contains(t, args, "*.more.bundles")
+}
+
+func TestCleanupCommandSetsExcludesPatterns(t *testing.T) {
+
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		includesPatterns,
+		_ := getDefaultResourceManagementCommandSyntaxParameters()
+
+	excludesPatterns := []string{"dev.galasa.*", "*ExcludeMe", "*.exclude.other.bundles"}
+	isDebugEnabled := false
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Contains(t, args, "--includes-monitor-pattern")
+	assert.Contains(t, args, "dev.galasa.*")
+	assert.Contains(t, args, "*ExcludeMe")
+	assert.Contains(t, args, "*.exclude.other.bundles")
+}
+
+func TestCleanupCommandIncludesTraceWhenTraceIsEnabled(t *testing.T) {
+
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := true
+	isDebugEnabled := false
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Contains(t, args, "--trace")
+}
+
+func TestCleanupCommandDoesNotIncludeTraceWhenTraceIsDisabled(t *testing.T) {
+
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := false
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.NotContains(t, args, "--trace")
+}
+
+func TestCleanupCommandSyntaxContainsJavaHomeUnixSlashes(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		_,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	javaHome := "myJavaHome"
+	fs.SetFilePathSeparator("/")
+	isDebugEnabled := false
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Equal(t, cmd, "myJavaHome/bin/java")
+}
+
+func TestCleanupCommandSyntaxContainsJavaHomeWindowsSlashes(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		_,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	javaHome := "myJavaHome"
+	fs.SetFilePathSeparator("\\")
+	fs.SetExecutableExtension(".exe")
+
+	isDebugEnabled := false
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Equal(t, cmd, "myJavaHome\\bin\\java")
+}
+
+func TestCleanupCommandIncludesGALASA_HOMESystemProperty(t *testing.T) {
+
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := true
+	isDebugEnabled := false
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Contains(t, args, `-DGALASA_HOME="/User/Home/testuser/.galasa"`)
+}
+
+func TestCleeanupCommandAllDashDSystemPropertiesPassedAppearBeforeTheDashJar(t *testing.T) {
+
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := true
+	isDebugEnabled := false
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	// Combine all arguments into a single string.
+	allArgs := strings.Join(args, " ")
+
+	allDashDIndexes := getAllIndexesOfSubstring(allArgs, "-D")
+	allDashJarIndexes := getAllIndexesOfSubstring(allArgs, "-jar")
+
+	assert.Equal(t, 1, len(allDashJarIndexes), "-jar option is found in command launch parameters an unexpected number of times")
+	dashJarIndex := allDashJarIndexes[0]
+	for _, dashDIndex := range allDashDIndexes {
+		assert.Less(t, dashDIndex, dashJarIndex, "A -Dxxx parameter is found after the -jar parameter, so will do nothing. -D parameters should appear before the -jar parameter")
+	}
+}
+
+func TestCleanupCommandIncludesFlagsFromBootstrapProperties(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := false
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Contains(t, args, "-Xmx80m")
+}
+
+func TestCleanupCommandIncludesDefaultDebugPortAndMode(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := true // <<<< Debug is turned on. No overrides to debugPort in either boostrap or explicit command option.
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Contains(t, args, "-agentlib:jdwp=transport=dt_socket,address=*:"+strconv.FormatUint(uint64(DEBUG_PORT_DEFAULT), 10)+",server=y,suspend=y")
+}
+
+func TestCleanupCommandDrawsValidDebugPortFromBootstrap(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := true // <<<< Debug is turned on. No overrides to debugPort in either boostrap or explicit command option.
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	bootstrapProps[api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_PORT] = "345"
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Contains(t, args, "-agentlib:jdwp=transport=dt_socket,address=*:345,server=y,suspend=y")
+}
+
+func TestCleanupCommandDrawsInvalidDebugPortFromBootstrap(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := true // <<<< Debug is turned on. No overrides to debugPort in either boostrap or explicit command option.
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	bootstrapProps[api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_PORT] = "-456"
+
+	_, _, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, err)
+
+	assert.Contains(t, err.Error(), "-456")
+	assert.Contains(t, err.Error(), api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_PORT)
+	assert.Contains(t, err.Error(), "GAL1072E")
+}
+
+func TestCleanupCommandDrawsValidDebugModeFromBootstrap(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := true // <<<< Debug is turned on. No overrides to debugPort in either boostrap or explicit command option.
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	bootstrapProps[api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_MODE] = "attach"
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Contains(
+		t,
+		args,
+		"-agentlib:jdwp=transport=dt_socket,address=*:"+
+			strconv.FormatUint(uint64(DEBUG_PORT_DEFAULT), 10)+
+			",server=n,suspend=y",
+	)
+}
+
+func TestCleanupCommandDrawsInvalidDebugModeFromBootstrap(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := true // <<<< Debug is turned on. No overrides to debugPort in either boostrap or explicit command option.
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	bootstrapProps[api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_MODE] = "shout" //  << Invalid !
+
+	_, _, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, err)
+
+	assert.Contains(t, err.Error(), "shout")
+	assert.Contains(t, err.Error(), api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_MODE)
+	assert.Contains(t, err.Error(), "GAL1070E")
+}
+
+func TestCleanupCommandDrawsValidDebugModeListenFromCommandLine(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := true // <<<< Debug is turned on. No overrides to debugPort in either boostrap or explicit command option.
+	var debugPort uint32 = 0
+	debugMode := "listen"
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Contains(
+		t,
+		args,
+		"-agentlib:jdwp=transport=dt_socket,address=*:"+
+			strconv.FormatUint(uint64(DEBUG_PORT_DEFAULT), 10)+
+			",server=y,suspend=y",
+	)
+}
+
+func TestCleanupCommandDrawsValidDebugModeAttachFromCommandLine(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := true // <<<< Debug is turned on. No overrides to debugPort in either boostrap or explicit command option.
+	var debugPort uint32 = 0
+	debugMode := "attach"
+
+	cmd, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, cmd)
+	assert.NotNil(t, args)
+	assert.Nil(t, err)
+
+	assert.Contains(
+		t,
+		args,
+		"-agentlib:jdwp=transport=dt_socket,address=*:"+
+			strconv.FormatUint(uint64(DEBUG_PORT_DEFAULT), 10)+
+			",server=n,suspend=y",
+	)
+}
+
+func TestCleanupCommandDrawsInvalidDebugModeFromCommandLine(t *testing.T) {
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := true // <<<< Debug is turned on. No overrides to debugPort in either boostrap or explicit command option.
+	var debugPort uint32 = 0
+	debugMode := "invalidMode"
+
+	_, _, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	assert.NotNil(t, err)
+
+	assert.Contains(t, err.Error(), "invalidMode")
+	assert.Contains(t, err.Error(), api.BOOTSTRAP_PROPERTY_NAME_LOCAL_JVM_LAUNCH_DEBUG_MODE)
+	assert.Contains(t, err.Error(), "GAL1071E")
+}
+
+func TestCleanupCommandLocalMavenNotSetDefaults(t *testing.T) {
+	// Given...
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := false // <<<< Debug is turned on. No overrides to debugPort in either boostrap or explicit command option.
+	var debugPort uint32 = 0
+	debugMode := ""
+
+	// When...
+	_, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	// Then...
+	assert.Nil(t, err)
+
+	assert.Contains(t, args, "--localmaven")
+	assert.Contains(t, args, "file:////User/Home/testuser/.m2/repository")
+}
+
+func TestCleanupCommandLocalMavenSet(t *testing.T) {
+	// For...
+	bootstrapProps, _, galasaHome, fs,
+		javaHome,
+		obrs,
+		remoteMavenRepos,
+		_,
+		galasaVersionToRun,
+		_,
+		includesPatterns,
+		excludesPatterns := getDefaultResourceManagementCommandSyntaxParameters()
+
+	isTraceEnabled := false
+	isDebugEnabled := false // <<<< Debug is turned on. No overrides to debugPort in either boostrap or explicit command option.
+	var debugPort uint32 = 0
+	debugMode := ""
+	localMaven := "mavenRepo"
+
+	// When...
+	_, args, err := getResourceManagementCommandSyntax(
+		bootstrapProps,
+		galasaHome,
+		fs, javaHome,
+		obrs,
+		remoteMavenRepos,
+		localMaven,
+		galasaVersionToRun,
+		isTraceEnabled,
+		isDebugEnabled, debugPort, debugMode,
+		includesPatterns,
+		excludesPatterns,
+		BLANK_JWT,
+	)
+
+	// Then...
+	assert.Nil(t, err)
+
+	assert.Contains(t, args, "--localmaven")
+	assert.Contains(t, args, "mavenRepo")
+}
+

--- a/modules/cli/pkg/launcher/resourceCleanupLauncher.go
+++ b/modules/cli/pkg/launcher/resourceCleanupLauncher.go
@@ -1,0 +1,14 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package launcher
+
+// ----------------------------------------------------------------------------------
+// ResourceCleanupLauncher a launcher that kicks off resource cleanup services.
+type ResourceCleanupLauncher interface {
+
+	// RunResourceCleanup launches resource cleanup
+	RunResourceCleanup() error
+}

--- a/modules/cli/pkg/utils/javaClassGlobPattern.go
+++ b/modules/cli/pkg/utils/javaClassGlobPattern.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package utils
+
+import (
+	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
+)
+
+// Checks if the given patterns are all valid glob patterns that are supported by Galasa.
+func ValidateJavaClassGlobPatterns(patternsToValidate []string) error {
+	var err error
+
+	for _, pattern := range patternsToValidate {
+		err = validateJavaClassGlobPattern(pattern)
+		if err != nil {
+			break
+		}
+	}
+	return err
+}
+
+// Checks if an individual glob pattern is a valid glob pattern supported by Galasa.
+//
+// The following characters are currently supported:
+// (a-z, A-Z, 0-9) alphanumeric characters
+// '*' (wildcard) expands to zero or more characters
+// '?' corresponds to exactly one character
+// '.' corresponds to an actual '.' character
+func validateJavaClassGlobPattern(patternToValidate string) error {
+	var err error
+
+	for _, char := range patternToValidate {
+		if !IsCharacterAlphanumeric(char) &&
+				char != '*' &&
+				char != '?' &&
+				char != '.' {
+			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_INVALID_GLOB_PATTERN_PROVIDED)
+			break
+		}
+	}
+
+	return err
+}

--- a/modules/cli/pkg/utils/javaClassGlobPattern_test.go
+++ b/modules/cli/pkg/utils/javaClassGlobPattern_test.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package utils
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestValidateValidJavaClassGlobPatterns(t *testing.T) {
+    // Given...
+    patterns := []string{"dev.galasa.*", "*", "*HelloWorld"}
+
+    // When...
+    err := ValidateJavaClassGlobPatterns(patterns)
+
+    // Then...
+    assert.Nil(t, err, "Validation reported a problem when the patterns were valid.")
+}
+
+func TestValidateInvalidJavaClassGlobPatternsThrowsError(t *testing.T) {
+    // Given...
+    patterns := []string{"this.is.fine", "invalid pattern with spaces", "specialCharacters@$%^&"}
+
+    // When...
+    err := ValidateJavaClassGlobPatterns(patterns)
+
+    // Then...
+    assert.NotNil(t, err, "Validation didn't report a problem when the patterns were invalid.")
+    assert.ErrorContains(t, err, "Unsupported glob pattern character provided")
+}
+


### PR DESCRIPTION
## Why?
Part of https://github.com/galasa-dev/projectmanagement/issues/2484

Note: this PR builds on top of the changes in https://github.com/galasa-dev/galasa/pull/459, so this PR needs to be rebased once the framework changes are delivered.

## Changes
- Added a new `galasactl runs cleanup local` command to allow users to invoke their resource cleanup providers locally
- Refactored common JVM launcher code to avoid duplication
- Added README docs on the new command
- Added release note about the new command