### PR TITLE
Update v0.44.0 release notes

### DIFF
--- a/docs/content/releases/posts/v0.44.0.md
+++ b/docs/content/releases/posts/v0.44.0.md
@@ -32,6 +32,8 @@ links:
 
 ## Changes affecting tests running locally or on the Galasa Service
 
+- Galasa no longer supports Java 11. Galasa tests must be run with a Java version 17 JDK.
+
 - The 3270 manager's `ITerminal` interface has a new `toJsonString()` method that allows tests to convert the current 3270 terminal screen into JSON format.
 
 - The VTP manager has been removed from the available Galasa managers as the IBM Z Virtual Test Platform offering has been discontinued. See [#2460](https://github.com/galasa-dev/projectmanagement/issues/2460).


### PR DESCRIPTION
## Why?

We forgot to add a release note into the v0.44.0 page stating that Galasa would no longer support Java 11 from that release, so adding this in now. 