### PR TITLE
Add priority field to user records

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbUser.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbUser.java
@@ -15,6 +15,7 @@ public class CouchdbUser implements IInternalUser {
     private String loginId;
     private String dexUserId;
     private String roleId;
+    private int priority;
 
     public CouchdbUser(String loginId, String dexUserId) {
         this.loginId = loginId;
@@ -39,5 +40,10 @@ public class CouchdbUser implements IInternalUser {
     @Override
     public String getRoleId() {
         return roleId;
+    }
+
+    @Override
+    public int getPriority() {
+        return priority;
     }
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/UserImpl.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/UserImpl.java
@@ -75,6 +75,16 @@ public class UserImpl implements IUser {
     }
 
     @Override
+    public @NotNull int getPriority() {
+        return this.userDocBean.getPriority();
+    }
+
+    @Override
+    public void setPriority(int newPriority) {
+        this.userDocBean.setPriority(newPriority);
+    }
+
+    @Override
     public String getUserNumber() {
         return this.userDocBean.getUserNumber();
     }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/beans/UserDoc.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/beans/UserDoc.java
@@ -30,6 +30,10 @@ public class UserDoc {
     @SerializedName("activity")
     private List<FrontEndClient> clients;
 
+    @SerializedName("priority")
+    private int priority;
+
+
     public UserDoc() {
         setClients(new ArrayList<FrontEndClient>());
     }
@@ -79,5 +83,12 @@ public class UserDoc {
     public void setClients(List<FrontEndClient> clients) {
         this.clients = clients;
     }
-    
+
+    public int getPriority() {
+        return this.priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestUserImpl.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestUserImpl.java
@@ -97,6 +97,7 @@ public class TestUserImpl {
         private String userNumber;
         private String loginId;
         private String roleId;
+        private int priority;
 
         private List<IFrontEndClient> clients;
 
@@ -146,6 +147,15 @@ public class TestUserImpl {
             this.roleId = newRoleId ;
         }
 
+        @Override
+        public int getPriority() {
+            return this.priority;
+        }
+
+        @Override
+        public void setPriority(int newPriority) {
+            this.priority = newPriority;
+        }
     }
 
     @Test

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/InternalUser.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/InternalUser.java
@@ -12,6 +12,7 @@ public class InternalUser implements IInternalUser {
     private String loginId;
     private String dexUserId;
     private String roleId;
+    private int priority;
 
     public InternalUser(String loginId, String dexUserId) {
         this.loginId = loginId;
@@ -29,5 +30,10 @@ public class InternalUser implements IInternalUser {
     @Override
     public String getRoleId() {
         return roleId;
+    }
+
+    @Override
+    public int getPriority() {
+        return priority;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -3069,6 +3069,11 @@ components:
           description: |- 
             The role that the user has in the system. This is not a readable name, but a numeric.
             It must be less than 128 characters and a consist of alphanumeric characters, '-' (hyphen) or '_' (underscore)
+        priority: 
+          type: integer
+          description: |-
+            A numeric priority modifier that the user has in the system.
+            Used to determine the priority the user has when performing certain actions.
         clients:
           type: array
           description: The list of client activities, containing client names and last login times.

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/internal/routes/BeanTransformer.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/internal/routes/BeanTransformer.java
@@ -55,6 +55,7 @@ public class BeanTransformer {
         userOut.setLoginId(userIn.getLoginId());
         userOut.setid(userIn.getUserNumber());
         userOut.seturl(calculateUrl(userIn.getUserNumber()));
+        userOut.setpriority(userIn.getPriority());
         
         List<FrontEndClient> clientsOutList = new ArrayList<FrontEndClient>();
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/test/java/dev/galasa/framework/api/users/internal/routes/UsersRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/test/java/dev/galasa/framework/api/users/internal/routes/UsersRouteTest.java
@@ -66,10 +66,10 @@ public class UsersRouteTest extends BaseServletTest {
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
         ServletOutputStream outStream = servletResponse.getOutputStream();
 
-        MockUser mockUser1 = createMockUser("user-1", "docid", "web-ui", rbacService.getDefaultRoleId());
+        MockUser mockUser1 = createMockUser("user-1", "docid", "web-ui", rbacService.getDefaultRoleId(), 1);
         authStoreService.addUser(mockUser1);
     
-        MockUser mockUser2 = createMockUser("user-2", "docid-2", "rest-api", rbacService.getDefaultRoleId());
+        MockUser mockUser2 = createMockUser("user-2", "docid-2", "rest-api", rbacService.getDefaultRoleId(), 2);
         authStoreService.addUser(mockUser2);
 
         // When...
@@ -86,7 +86,7 @@ public class UsersRouteTest extends BaseServletTest {
         String gotBackPayload = outStream.toString();
         UserData[] usersGotBack = gson.fromJson(gotBackPayload, UserData[].class);
 
-        // Should be two users returned.
+        // Should have returned one user.
         assertThat(usersGotBack).hasSize(1);
 
         UserData userGotBack = usersGotBack[0];
@@ -95,6 +95,8 @@ public class UsersRouteTest extends BaseServletTest {
             assertThat(userGotBack.getid()).isEqualTo("docid");
             assertThat(userGotBack.geturl()).isEqualTo(baseUrl + "/users/" + userGotBack.getid());
             assertThat(userGotBack.getrole()).isEqualTo( rbacService.getDefaultRoleId() );
+            assertThat(userGotBack.getpriority()).isEqualTo(1);
+
             FrontEndClient[] clients = userGotBack.getclients();
 
             assertThat(clients).hasSize(1);
@@ -134,10 +136,10 @@ public class UsersRouteTest extends BaseServletTest {
         ServletOutputStream outStream = servletResponse.getOutputStream();
 
         
-        MockUser mockUser1 = createMockUser("user-1", "docid", "web-ui", rbacService.getDefaultRoleId());
+        MockUser mockUser1 = createMockUser("user-1", "docid", "web-ui", rbacService.getDefaultRoleId(), 1);
         authStoreService.addUser(mockUser1);
     
-        MockUser mockUser2 = createMockUser("user-2", "docid-2", "rest-api", rbacService.getDefaultRoleId());
+        MockUser mockUser2 = createMockUser("user-2", "docid-2", "rest-api", rbacService.getDefaultRoleId(), 2);
         authStoreService.addUser(mockUser2);
         
 
@@ -164,6 +166,8 @@ public class UsersRouteTest extends BaseServletTest {
             assertThat(userGotBack.getid()).isEqualTo("docid");
             assertThat(userGotBack.geturl()).isEqualTo(baseUrl + "/users/" + userGotBack.getid());
             assertThat(userGotBack.getrole()).isEqualTo( rbacService.getDefaultRoleId() );
+            assertThat(userGotBack.getpriority()).isEqualTo(1);
+
             FrontEndClient[] clients = userGotBack.getclients();
 
             assertThat(clients).hasSize(1);
@@ -187,6 +191,8 @@ public class UsersRouteTest extends BaseServletTest {
             assertThat(userGotBack.getid()).isEqualTo("docid-2");
             assertThat(userGotBack.geturl()).isEqualTo(baseUrl + "/users/" + userGotBack.getid());
             assertThat(userGotBack.getrole()).isEqualTo( rbacService.getDefaultRoleId() );
+            assertThat(userGotBack.getpriority()).isEqualTo(2);
+
             FrontEndClient[] clients = userGotBack.getclients();
 
             assertThat(clients).hasSize(1);
@@ -205,7 +211,13 @@ public class UsersRouteTest extends BaseServletTest {
         }
     }
 
-    private MockUser createMockUser(String loginId, String userNumber, String clientName, String roleId ){
+    private MockUser createMockUser(
+        String loginId,
+        String userNumber,
+        String clientName,
+        String roleId,
+        int priority
+    ) {
 
         MockFrontEndClient newClient = new MockFrontEndClient("web-ui");
         newClient.name = clientName;
@@ -217,6 +229,7 @@ public class UsersRouteTest extends BaseServletTest {
         mockUser.loginId = loginId;
         mockUser.addClient(newClient);
         mockUser.roleId = roleId ;
+        mockUser.setPriority(priority);
 
         return mockUser;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IInternalUser.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IInternalUser.java
@@ -16,4 +16,6 @@ public interface IInternalUser {
     String getLoginId();
 
     String getRoleId();
+
+    int getPriority();
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IUser.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IUser.java
@@ -33,4 +33,7 @@ public interface IUser {
 
     void addClient(IFrontEndClient client);
 
+    int getPriority();
+
+    void setPriority(int newPriority);
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockUser.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockUser.java
@@ -18,6 +18,7 @@ public class MockUser implements IUser {
     public String roleId;
     public String loginId;
     public Collection<IFrontEndClient> clients = new ArrayList<IFrontEndClient>();
+    public int priority;
 
     @Override
     public String getUserNumber() {
@@ -70,4 +71,13 @@ public class MockUser implements IUser {
         this.loginId = loginId;
     }
 
+    @Override
+    public int getPriority() {
+        return priority;
+    }
+
+    @Override
+    public void setPriority(int newPriority) {
+        this.priority = newPriority;
+    }
 };


### PR DESCRIPTION
## Why?
Part of https://github.com/galasa-dev/projectmanagement/issues/2176

## Changes
- This PR adds a `priority` field to user records stored in CouchDB, defaults to 0
  - This `priority` field is returned in API responses to `GET /users` and `GET /users/{userNumber}` calls