### PR TITLE
Make user priority settable via the REST API and CLI

### DIFF
--- a/docs/content/releases/posts/v0.46.0.md
+++ b/docs/content/releases/posts/v0.46.0.md
@@ -11,3 +11,8 @@ links:
 
 - The SSH client library that Galasa uses has been updated to support stronger key algorithms, including `rsa-sha2-256` and `rsa-sha2-512`. See [#2461](https://github.com/galasa-dev/projectmanagement/issues/2461).
   - **Galasa managers that use the IP network manager, like the zOS TSO Command SSH and zOS UNIX Command SSH managers, no longer support the RSA/SHA1 signature algorithm when connecting to a server via SSH. If you are using RSA/SHA1, you should upgrade your servers to use a stronger algorithm.**
+
+## Changes affecting the Galasa Service
+
+- Users now have a `priority` modifier associated with them that can affect the order in which tests submitted by users are scheduled. Tests submitted by users with higher priority modifiers can be scheduled before tests that were submitted by users with lower priority modifiers. See [#2176](https://github.com/galasa-dev/projectmanagement/issues/2176).
+  - User priorities can be updated using the new `--priority` flag in the `galasactl users set` command. [See the command reference](../../docs/reference/cli-syntax/galasactl_users_set.md).

--- a/modules/buildutils/openapi2beans/JavaChecker/src/test/java/dev/galasa/openapi2beans/example/TestBeanToTestArraysWithVariousPrimitiveTypes.java
+++ b/modules/buildutils/openapi2beans/JavaChecker/src/test/java/dev/galasa/openapi2beans/example/TestBeanToTestArraysWithVariousPrimitiveTypes.java
@@ -21,7 +21,7 @@ public class TestBeanToTestArraysWithVariousPrimitiveTypes {
         BeanToTestArraysWithVariousPrimitiveTypes beanUnderTest = new BeanToTestArraysWithVariousPrimitiveTypes();
         beanUnderTest.setAStringArray(new String[]{"randString0", "randString1"});
         beanUnderTest.setABooleanArray(new boolean[]{true, false});
-        beanUnderTest.setAnIntArray(new int[]{2,3});
+        beanUnderTest.setAnIntArray(new Integer[]{2,3});
         beanUnderTest.setANumberArray(new double[]{1.23, 4.56});
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String serialisedForm = gson.toJson(beanUnderTest);

--- a/modules/buildutils/openapi2beans/JavaChecker/src/test/java/dev/galasa/openapi2beans/example/TestBeanWithMixOfArrayAndPrimitiveProperties.java
+++ b/modules/buildutils/openapi2beans/JavaChecker/src/test/java/dev/galasa/openapi2beans/example/TestBeanWithMixOfArrayAndPrimitiveProperties.java
@@ -24,7 +24,7 @@ public class TestBeanWithMixOfArrayAndPrimitiveProperties {
         beanUnderTest.setAStringVariable("hello");
         beanUnderTest.setAnIntVariable(11);
         beanUnderTest.setAnArrayVariable(new String[]{"string0", "string1"});
-        beanUnderTest.setAnIntArray(new int[]{1, 2});
+        beanUnderTest.setAnIntArray(new Integer[]{1, 2});
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String serialisedForm = gson.toJson(beanUnderTest);
         assertThat(serialisedForm).contains("\"aStringVariable\": \"hello\"");

--- a/modules/buildutils/openapi2beans/pkg/generator/JavaStructures.go
+++ b/modules/buildutils/openapi2beans/pkg/generator/JavaStructures.go
@@ -192,18 +192,18 @@ func isDataMemberLessThanComparison(dataMember *DataMember, comparisonMember *Da
 		default:
 			less = true
 		}
-	case strings.Contains(memberType, "int"):
+	case strings.Contains(memberType, "Integer"):
 		switch comparisonMember.MemberType {
 		case "boolean":
 			less = false
-		case "int":
+		case "Integer":
 			less = dataMember.Name > comparisonMember.Name
 		default:
 			less = true
 		}
 	case strings.Contains(memberType, "double"):
 		switch comparisonMemberType := comparisonMember.MemberType; {
-		case strings.Contains(comparisonMemberType, "boolean"), strings.Contains(comparisonMemberType, "int"):
+		case strings.Contains(comparisonMemberType, "boolean"), strings.Contains(comparisonMemberType, "Integer"):
 			less = false
 		case strings.Contains(comparisonMemberType, "double"):
 			less = dataMember.Name > comparisonMember.Name
@@ -212,7 +212,7 @@ func isDataMemberLessThanComparison(dataMember *DataMember, comparisonMember *Da
 		}
 	case strings.Contains(memberType, "String"):
 		switch comparisonMemberType := comparisonMember.MemberType; {
-		case strings.Contains(comparisonMemberType, "boolean"), strings.Contains(comparisonMemberType, "int"), strings.Contains(comparisonMemberType, "double"):
+		case strings.Contains(comparisonMemberType, "boolean"), strings.Contains(comparisonMemberType, "Integer"), strings.Contains(comparisonMemberType, "double"):
 			less = false
 		case strings.Contains(comparisonMemberType, "String"):
 			less = dataMember.Name > comparisonMember.Name

--- a/modules/buildutils/openapi2beans/pkg/generator/schema2package.go
+++ b/modules/buildutils/openapi2beans/pkg/generator/schema2package.go
@@ -70,7 +70,7 @@ func propertyToJavaType(property *Property) string {
 		if property.typeName == "string" {
 			javaType = "String"
 		} else if property.typeName == "integer" {
-			javaType = "int"
+			javaType = "Integer"
 		} else if property.typeName == "number" {
 			javaType = "double"
 		} else if property.typeName == "" {

--- a/modules/buildutils/openapi2beans/pkg/generator/yaml2java_test.go
+++ b/modules/buildutils/openapi2beans/pkg/generator/yaml2java_test.go
@@ -277,11 +277,11 @@ components:
 	intGetter := `public String getMyStringVar() {
         return this.myStringVar;
     }`
-	intSetter := `public void setMyIntVar(int myIntVar) {
+	intSetter := `public void setMyIntVar(Integer myIntVar) {
         this.myIntVar = myIntVar;
     }`
 	intVarCreation := `// a test integer
-    private int myIntVar;`
+    private Integer myIntVar;`
 	assert.Contains(t, generatedClassFile, intGetter)
 	assert.Contains(t, generatedClassFile, intSetter)
 	assert.Contains(t, generatedClassFile, intVarCreation)
@@ -335,14 +335,14 @@ components:
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)
-	getter = `public int getMyIntVar() {
+	getter = `public Integer getMyIntVar() {
         return this.myIntVar;
     }`
-	setter = `public void setMyIntVar(int myIntVar) {
+	setter = `public void setMyIntVar(Integer myIntVar) {
         this.myIntVar = myIntVar;
     }`
 	varCreation = `// a test integer
-    private int myIntVar;`
+    private Integer myIntVar;`
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)
@@ -458,18 +458,18 @@ components:
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)
-	getter = `public int getMyIntVar() {
+	getter = `public Integer getMyIntVar() {
         return this.myIntVar;
     }`
-	setter = `public void setMyIntVar(int myIntVar) {
+	setter = `public void setMyIntVar(Integer myIntVar) {
         this.myIntVar = myIntVar;
     }`
 	varCreation = `// a test integer
-    private int myIntVar;`
+    private Integer myIntVar;`
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)
-	assert.Contains(t, generatedClassFile, `    public MyBeanName(int myIntVar, String myStringVar) {
+	assert.Contains(t, generatedClassFile, `    public MyBeanName(Integer myIntVar, String myStringVar) {
         this.myIntVar = myIntVar;
         this.myStringVar = myStringVar;
     }`)
@@ -518,14 +518,14 @@ components:
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)
-	getter = `public int getMyIntVar() {
+	getter = `public Integer getMyIntVar() {
         return this.myIntVar;
     }`
-	setter = `public void setMyIntVar(int myIntVar) {
+	setter = `public void setMyIntVar(Integer myIntVar) {
         this.myIntVar = myIntVar;
     }`
 	varCreation = `// a test integer
-    private int myIntVar;`
+    private Integer myIntVar;`
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -858,6 +858,11 @@ An administrator can change the role of a user:
 > galasactl users set --login-id user.one@mydomain.com --role tester
 ```
 
+An administrator can also change the priority of a user:
+```
+> galasactl users set --login-id user.one@mydomain.com --priority 100
+```
+
 ## Reference Material
 
 ### Syntax

--- a/modules/cli/docs/generated/galasactl_users_set.md
+++ b/modules/cli/docs/generated/galasactl_users_set.md
@@ -15,7 +15,7 @@ galasactl users set [flags]
 ```
   -h, --help              Displays the options for the 'users set' command.
       --login-id string   A mandatory field indicating the login ID of a user.
-      --priority int      An optional field indicating the new priority of the specified user.
+      --priority int      An optional field indicating the new priority of the specified user. The higher the number, the higher the priority.
       --role string       An optional field indicating the new role of the specified user.
 ```
 

--- a/modules/cli/docs/generated/galasactl_users_set.md
+++ b/modules/cli/docs/generated/galasactl_users_set.md
@@ -15,6 +15,7 @@ galasactl users set [flags]
 ```
   -h, --help              Displays the options for the 'users set' command.
       --login-id string   A mandatory field indicating the login ID of a user.
+      --priority int      An optional field indicating the new priority of the specified user.
       --role string       An optional field indicating the new role of the specified user.
 ```
 

--- a/modules/cli/pkg/cmd/usersSet.go
+++ b/modules/cli/pkg/cmd/usersSet.go
@@ -110,7 +110,7 @@ func addRoleFlag(cmd *cobra.Command, userSetCmdValues *UsersSetCmdValues) {
 
 func addPriorityFlag(cmd *cobra.Command, userSetCmdValues *UsersSetCmdValues) {
 	flagName := "priority"
-	description := "An optional field indicating the new priority of the specified user."
+	description := "An optional field indicating the new priority of the specified user. The higher the number, the higher the priority."
 	cmd.Flags().IntVar(&userSetCmdValues.priority, flagName, 0, description)
 }
 

--- a/modules/cli/pkg/cmd/usersSet.go
+++ b/modules/cli/pkg/cmd/usersSet.go
@@ -149,7 +149,9 @@ func (cmd *UsersSetCommand) executeUsersSet(
 			if err == nil {
 				byteReader := factory.GetByteReader()
 
-				// if the user did not explicitly pass --priority, treat it as "empty"
+				// If the user did not explicitly pass --priority, treat it as "empty"
+				// We can't use 0 as the "empty" value because 0 is a valid value and
+				// we want to allow users to set priority to 0.
 				if !cmd.cobraCommand.Flags().Changed("priority") {
 					cmd.values.priority = users.DEFAULT_EMPTY_PRIORITY
 				}

--- a/modules/cli/pkg/cmd/usersSet.go
+++ b/modules/cli/pkg/cmd/usersSet.go
@@ -128,7 +128,7 @@ func (cmd *UsersSetCommand) executeUsersSet(
 	if err == nil {
 		commsFlagSetValues.isCapturingLogs = true
 	
-		log.Println("Galasa CLI - Sets properties on an existibg user in the ecosystem")
+		log.Println("Galasa CLI - Sets properties on an existing user in the ecosystem")
 	
 		// Get the ability to query environment variables.
 		env := factory.GetEnvironment()
@@ -147,8 +147,6 @@ func (cmd *UsersSetCommand) executeUsersSet(
 			)
 
 			if err == nil {
-	
-				var console = factory.GetStdOutConsole()				
 				byteReader := factory.GetByteReader()
 
 				// if the user did not explicitly pass --priority, treat it as "empty"
@@ -163,7 +161,6 @@ func (cmd *UsersSetCommand) executeUsersSet(
 						cmd.values.role,
 						cmd.values.priority,
 						apiClient,
-						console,
 						byteReader,
 					)
 				}

--- a/modules/cli/pkg/users/usersSet_test.go
+++ b/modules/cli/pkg/users/usersSet_test.go
@@ -16,6 +16,431 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSetUnknownUserReturnsError(t *testing.T) {
+	//Given...
+	loginId := "test-user"
+	getNamedUsersInteraction := utils.NewHttpInteraction("/users", http.MethodGet)
+	getNamedUsersInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		actualLoginId := req.URL.Query().Get("loginId")
+		assert.Equal(t, loginId, actualLoginId)
+
+		body := `[]`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	interactions := []utils.HttpInteraction{
+		getNamedUsersInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiClient := api.InitialiseAPI(server.Server.URL)
+
+	mockByteReader := utils.NewMockByteReader()
+
+	//When
+	err := SetUsers(loginId, "2", 100, apiClient, mockByteReader)
+
+	//Then
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "User with login id test-user is not known on the Galasa service")
+}
+
+func TestSetUnknownRoleReturnsError(t *testing.T) {
+	//Given...
+	loginId := "test-user"
+	getNamedUsersInteraction := utils.NewHttpInteraction("/users", http.MethodGet)
+	getNamedUsersInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		actualLoginId := req.URL.Query().Get("loginId")
+		assert.Equal(t, loginId, actualLoginId)
+
+		body := `
+			[{
+				"url": "http://localhost:8080/users/d2055afbc0ae6e513fa9b23c1a000d9f",
+				"login-id": "test-user",
+				"role" : "2",
+				"id": "usernumber201",
+				"clients": [
+					{
+						"last-login": "2024-10-28T14:54:49.546029Z",
+						"client-name": "web-ui"
+					}
+				],
+				"synthetic" : {
+					"role": {
+						"metadata" : {
+							"name" : "admin"
+						}
+					}
+				}
+			}]
+		`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	getRolesInteraction := utils.NewHttpInteraction("/rbac/roles", http.MethodGet)
+	getRolesInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		body := `[]`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	interactions := []utils.HttpInteraction{
+		getNamedUsersInteraction,
+		getRolesInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiClient := api.InitialiseAPI(server.Server.URL)
+
+	mockByteReader := utils.NewMockByteReader()
+
+	//When
+	err := SetUsers(loginId, "2", 100, apiClient, mockByteReader)
+
+	//Then
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "Role name 2 is not known on the Galasa service")
+}
+
+func TestSetUserRoleAndPriorityGoodPath(t *testing.T) {
+	//Given...
+	loginId := "test-user"
+	getNamedUsersInteraction := utils.NewHttpInteraction("/users", http.MethodGet)
+	getNamedUsersInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		actualLoginId := req.URL.Query().Get("loginId")
+		assert.Equal(t, loginId, actualLoginId)
+
+		body := `
+			[{
+				"url": "http://localhost:8080/users/d2055afbc0ae6e513fa9b23c1a000d9f",
+				"login-id": "test-user",
+				"role" : "2",
+				"id": "usernumber201",
+				"clients": [
+					{
+						"last-login": "2024-10-28T14:54:49.546029Z",
+						"client-name": "web-ui"
+					}
+				],
+				"synthetic" : {
+					"role": {
+						"metadata" : {
+							"name" : "admin"
+						}
+					}
+				}
+			}]
+		`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	getRolesInteraction := utils.NewHttpInteraction("/rbac/roles", http.MethodGet)
+	getRolesInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		body := `
+			[{
+				"kind": "GalasaRole",
+				"apiVersion": "galasa-dev/v1alpha1",
+				"metadata": {
+					"url": "http://myhost.com:8080/rbac/roles/2",
+					"name": "admin",
+					"id": "2",
+					"description": "Administrator access"
+				},
+				"data": {
+					"actions": []
+				}
+			}]
+		`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	putNamedUsersInteraction := utils.NewHttpInteraction("/users/usernumber201", http.MethodPut)
+	putNamedUsersInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		loginId := req.URL.Query().Get("login-id")
+		assert.NotNil(t, loginId)
+		var userUpdateData galasaapi.UserUpdateData
+
+		// We expect the code to send an update user structure with the role of 2 inside.
+		err := json.NewDecoder(req.Body).Decode(&userUpdateData)
+		assert.Nil(t, err)
+		assert.Equal(t, *userUpdateData.Role, "2")
+		assert.Equal(t, *userUpdateData.Priority, int32(100))
+
+		body := `
+			{
+				"url": "http://localhost:8080/users/d2055afbc0ae6e513fa9b23c1a000d9f",
+				"login-id": "test-user",
+				"role" : "2",
+				"id": "usernumber201",
+				"clients": [
+					{
+						"last-login": "2024-10-28T14:54:49.546029Z",
+						"client-name": "web-ui"
+					}
+				],
+				"synthetic" : {
+					"role": {
+						"metadata" : {
+							"name" : "admin"
+						}
+					}
+				}
+			}    
+		`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	interactions := []utils.HttpInteraction{
+		getNamedUsersInteraction,
+		getRolesInteraction,
+		putNamedUsersInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiClient := api.InitialiseAPI(server.Server.URL)
+
+	mockByteReader := utils.NewMockByteReader()
+
+	//When
+	err := SetUsers(loginId, "2", 100, apiClient, mockByteReader)
+
+	//Then
+	assert.Nil(t, err)
+}
+
+func TestSetUserPriorityGoodPath(t *testing.T) {
+	//Given...
+	loginId := "test-user"
+	getNamedUsersInteraction := utils.NewHttpInteraction("/users", http.MethodGet)
+	getNamedUsersInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		actualLoginId := req.URL.Query().Get("loginId")
+		assert.Equal(t, loginId, actualLoginId)
+
+		body := `
+			[{
+				"url": "http://localhost:8080/users/d2055afbc0ae6e513fa9b23c1a000d9f",
+				"login-id": "test-user",
+				"role" : "2",
+				"id": "usernumber201",
+				"clients": [
+					{
+						"last-login": "2024-10-28T14:54:49.546029Z",
+						"client-name": "web-ui"
+					}
+				],
+				"synthetic" : {
+					"role": {
+						"metadata" : {
+							"name" : "admin"
+						}
+					}
+				}
+			}]
+		`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	putNamedUsersInteraction := utils.NewHttpInteraction("/users/usernumber201", http.MethodPut)
+	putNamedUsersInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		loginId := req.URL.Query().Get("login-id")
+		assert.NotNil(t, loginId)
+		var userUpdateData galasaapi.UserUpdateData
+
+		// We expect the code to send an update user structure with the role of 2 inside.
+		err := json.NewDecoder(req.Body).Decode(&userUpdateData)
+		assert.Nil(t, err)
+		assert.Nil(t, userUpdateData.Role)
+		assert.Equal(t, *userUpdateData.Priority, int32(100))
+
+		body := `
+			{
+				"url": "http://localhost:8080/users/d2055afbc0ae6e513fa9b23c1a000d9f",
+				"login-id": "test-user",
+				"role" : "2",
+				"id": "usernumber201",
+				"clients": [
+					{
+						"last-login": "2024-10-28T14:54:49.546029Z",
+						"client-name": "web-ui"
+					}
+				],
+				"synthetic" : {
+					"role": {
+						"metadata" : {
+							"name" : "admin"
+						}
+					}
+				}
+			}    
+		`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	interactions := []utils.HttpInteraction{
+		getNamedUsersInteraction,
+		putNamedUsersInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiClient := api.InitialiseAPI(server.Server.URL)
+
+	mockByteReader := utils.NewMockByteReader()
+
+	//When
+	err := SetUsers(loginId, "", 100, apiClient, mockByteReader)
+
+	//Then
+	assert.Nil(t, err)
+}
+
+func TestSetUserRoleGoodPath(t *testing.T) {
+	//Given...
+	loginId := "test-user"
+	getNamedUsersInteraction := utils.NewHttpInteraction("/users", http.MethodGet)
+	getNamedUsersInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		actualLoginId := req.URL.Query().Get("loginId")
+		assert.Equal(t, loginId, actualLoginId)
+
+		body := `
+			[{
+				"url": "http://localhost:8080/users/d2055afbc0ae6e513fa9b23c1a000d9f",
+				"login-id": "test-user",
+				"role" : "2",
+				"id": "usernumber201",
+				"clients": [
+					{
+						"last-login": "2024-10-28T14:54:49.546029Z",
+						"client-name": "web-ui"
+					}
+				],
+				"synthetic" : {
+					"role": {
+						"metadata" : {
+							"name" : "admin"
+						}
+					}
+				}
+			}]
+		`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	getRolesInteraction := utils.NewHttpInteraction("/rbac/roles", http.MethodGet)
+	getRolesInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		body := `
+			[{
+				"kind": "GalasaRole",
+				"apiVersion": "galasa-dev/v1alpha1",
+				"metadata": {
+					"url": "http://myhost.com:8080/rbac/roles/2",
+					"name": "admin",
+					"id": "2",
+					"description": "Administrator access"
+				},
+				"data": {
+					"actions": []
+				}
+			}]
+		`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	putNamedUsersInteraction := utils.NewHttpInteraction("/users/usernumber201", http.MethodPut)
+	putNamedUsersInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		loginId := req.URL.Query().Get("login-id")
+		assert.NotNil(t, loginId)
+		var userUpdateData galasaapi.UserUpdateData
+
+		// We expect the code to send an update user structure with the role of 2 inside.
+		err := json.NewDecoder(req.Body).Decode(&userUpdateData)
+		assert.Nil(t, err)
+		assert.Equal(t, *userUpdateData.Role, "2")
+		assert.Nil(t, userUpdateData.Priority)
+
+		body := `
+			{
+				"url": "http://localhost:8080/users/d2055afbc0ae6e513fa9b23c1a000d9f",
+				"login-id": "test-user",
+				"role" : "2",
+				"id": "usernumber201",
+				"clients": [
+					{
+						"last-login": "2024-10-28T14:54:49.546029Z",
+						"client-name": "web-ui"
+					}
+				],
+				"synthetic" : {
+					"role": {
+						"metadata" : {
+							"name" : "admin"
+						}
+					}
+				}
+			}    
+		`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	interactions := []utils.HttpInteraction{
+		getNamedUsersInteraction,
+		getRolesInteraction,
+		putNamedUsersInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiClient := api.InitialiseAPI(server.Server.URL)
+
+	mockByteReader := utils.NewMockByteReader()
+
+	//When
+	err := SetUsers(loginId, "2", DEFAULT_EMPTY_PRIORITY, apiClient, mockByteReader)
+
+	//Then
+	assert.Nil(t, err)
+}
+
 func TestSendUpdateOfUserGoodPath(t *testing.T) {
 	//Given...
 	getNamedUsersInteraction := utils.NewHttpInteraction("/users/usernumber201", http.MethodPut)

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/UserImpl.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/UserImpl.java
@@ -53,6 +53,7 @@ public class UserImpl implements IUser {
         this.userDocBean = new UserDoc( user.getLoginId() , trustedClients, user.getRoleId());
         this.userDocBean.setVersion( user.getVersion() );
         this.userDocBean.setUserNumber( user.getUserNumber() );
+        this.userDocBean.setPriority(user.getPriority());
     }
 
     public String toJson( GalasaGson gson) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -163,6 +163,7 @@ public enum ServletErrorMessage {
 
 
     // RBAC APIs...
+    GAL5119_USER_CANNOT_UPDATE_OWN_PRIORITY           (5119, "E: A user is not allowed to update their own priority. Ask a Galasa service administrator to change your priority instead."),
     GAL5120_INVALID_ACTION_NAME_PROVIDED              (5120, "E: Invalid action name provided."),
     GAL5121_INVALID_ROLE_ID_PROVIDED                  (5121, "E: Invalid role id provided."),
     GAL5122_ACTION_NAMED_NOT_FOUND                    (5122, "E: Action with that name not found."),

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -3073,7 +3073,7 @@ components:
           type: integer
           description: |-
             A numeric priority modifier that the user has in the system.
-            Used to determine the priority the user has when performing certain actions.
+            This value is used to determine the priority the user has when the system schedules tests.
         clients:
           type: array
           description: The list of client activities, containing client names and last login times.
@@ -3097,6 +3097,11 @@ components:
             The role that the user has in the system. This is not generally a readable name. 
             It must be less than 128 characters and a consist of alphanumeric characters, '-' (hyphen) or '_' (underscore)
           type: string
+        priority:
+          description: |-
+            A numeric priority modifier that the user has in the system.
+            This value is used to determine the priority the user has when the system schedules tests.
+          type: integer
           
     RBACRole:
       type: object

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/internal/routes/UserRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/internal/routes/UserRoute.java
@@ -167,6 +167,14 @@ public class UserRoute extends AbstractUsersRoute {
             }
         }
 
+        Integer desiredPriority = updatePayload.getpriority();
+        if (desiredPriority != null && desiredPriority != user.getPriority()) {
+            validateUserIsNotUpdatingTheirOwnPriority(requestingUserLoginId, user);
+
+            user.setPriority(desiredPriority);
+            isStoreUpdateRequired = true;
+        }
+
         if (isStoreUpdateRequired) {
             authStoreService.updateUser(user);
             rbacService.invalidateUser(user.getLoginId());
@@ -192,6 +200,17 @@ public class UserRoute extends AbstractUsersRoute {
         String loginIdBeingUpdated = userRecordBeingUpdated.getLoginId();
         if (requestingUserLoginId.equals(loginIdBeingUpdated)) {
             ServletError msg = new ServletError(GAL5413_USER_CANNOT_UPDATE_OWN_USER_ROLE);
+            throw new InternalServletException(msg, HttpStatus.SC_FORBIDDEN);
+        }
+    }
+
+    void validateUserIsNotUpdatingTheirOwnPriority(
+        String requestingUserLoginId, 
+        IUser userRecordBeingUpdated
+    ) throws InternalServletException {
+        String loginIdBeingUpdated = userRecordBeingUpdated.getLoginId();
+        if (requestingUserLoginId.equals(loginIdBeingUpdated)) {
+            ServletError msg = new ServletError(GAL5119_USER_CANNOT_UPDATE_OWN_PRIORITY);
             throw new InternalServletException(msg, HttpStatus.SC_FORBIDDEN);
         }
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/test/java/dev/galasa/framework/api/users/internal/routes/UserRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/test/java/dev/galasa/framework/api/users/internal/routes/UserRouteTest.java
@@ -345,6 +345,9 @@ public class UserRouteTest extends BaseServletTest {
         UserUpdateData putData = new UserUpdateData();
         String desiredUpdatedRoleId = "2";
         putData.setrole(desiredUpdatedRoleId);
+
+        int desiredPriority = 100;
+        putData.setpriority(desiredPriority);
         GalasaGsonBuilder builder = new GalasaGsonBuilder();
         Gson gson = builder.getGson();
         String jsonPayload = gson.toJson(putData);
@@ -371,6 +374,7 @@ public class UserRouteTest extends BaseServletTest {
         IUser updatedUserFromStore = authStoreService.getUser(userNumber);
         assertThat(updatedUserFromStore).isNotNull();
         assertThat(updatedUserFromStore.getRoleId()).isEqualTo(desiredUpdatedRoleId);
+        assertThat(updatedUserFromStore.getPriority()).isEqualTo(desiredPriority);
 
         // Now check a few things about the payload which was returned. 
         // It should contain the rendered json of the updated user record.
@@ -382,6 +386,7 @@ public class UserRouteTest extends BaseServletTest {
         assertThat(userGotBackInPayload.getLoginId()).isEqualTo("user-1");
         assertThat(userGotBackInPayload.getid()).isEqualTo("user-1-number");
         assertThat(userGotBackInPayload.getrole()).isEqualTo(desiredUpdatedRoleId);
+        assertThat(userGotBackInPayload.getpriority()).isEqualTo(desiredPriority);
     } 
 
     @Test
@@ -719,5 +724,124 @@ public class UserRouteTest extends BaseServletTest {
         assertThat(servletResponse.getStatus()).isEqualTo(403);
         ServletOutputStream outStream = servletResponse.getOutputStream();
         checkErrorStructure(outStream.toString(), 5414, "GAL5414", "not allowed to update the role of the Galasa service owner.");
+    }
+
+    @Test
+    public void testUpdateOwnUserPriorityReturnsForbiddenError() throws Exception {
+        // Given...
+        MockEnvironment env = new MockEnvironment();
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        MockAuthStoreService authStoreService = new MockAuthStoreService(mockTimeService);
+
+        MockDexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://my-issuer");
+
+        String baseUrl = "http://my.server/api";
+        String userNumber = "user-1-number";
+
+        env.setenv(EnvironmentVariables.GALASA_USERNAME_CLAIMS, "preferred_username");
+        env.setenv(EnvironmentVariables.GALASA_EXTERNAL_API_URL,baseUrl);
+        MockRBACService rbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+        AuthService authService = new AuthService(authStoreService, mockDexGrpcClient,rbacService);
+        MockUsersServlet servlet = new MockUsersServlet(authService, env, rbacService);
+
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/" + userNumber, headerMap);
+        mockRequest.setMethod(HttpMethod.PUT.toString());
+        mockRequest.setContentType("application/json");
+
+        // Now set up some value data.
+        UserUpdateData putData = new UserUpdateData();
+        int desiredPriority = 2;
+        putData.setpriority(desiredPriority);
+        GalasaGsonBuilder builder = new GalasaGsonBuilder();
+        Gson gson = builder.getGson();
+        String jsonPayload = gson.toJson(putData);
+        mockRequest.setPayload(jsonPayload);
+
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        
+        MockUser mockUser1 = createMockUser(JWT_USERNAME, "user-1-number", "web-ui");
+
+        int originalPriority = 1;
+        mockUser1.setPriority(originalPriority);
+        authStoreService.addUser(mockUser1);
+
+        // When...
+        servlet.init();
+        servlet.doPut(mockRequest, servletResponse);
+
+        assertThat(servletResponse.getStatus()).isEqualTo(403);
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+        checkErrorStructure(outStream.toString(), 5119, "GAL5119", "A user is not allowed to update their own priority.");
+    }
+
+    @Test
+    public void testUpdateUserRoleOnlyDoesNotAffectExistingPriority() throws Exception {
+        // Given...
+        MockEnvironment env = new MockEnvironment();
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        MockAuthStoreService authStoreService = new MockAuthStoreService(mockTimeService);
+
+        MockDexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://my-issuer");
+
+        String baseUrl = "http://my.server/api";
+        String userNumber = "user-1-number";
+
+        env.setenv(EnvironmentVariables.GALASA_USERNAME_CLAIMS, "preferred_username");
+        env.setenv(EnvironmentVariables.GALASA_EXTERNAL_API_URL,baseUrl);
+        MockRBACService rbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+        AuthService authService = new AuthService(authStoreService, mockDexGrpcClient,rbacService);
+        MockUsersServlet servlet = new MockUsersServlet(authService, env, rbacService);
+
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/" + userNumber, headerMap);
+        mockRequest.setMethod(HttpMethod.PUT.toString());
+        mockRequest.setContentType("application/json");
+
+        // Now set up some value data.
+        UserUpdateData putData = new UserUpdateData();
+        String desiredUpdatedRoleId = "2";
+        putData.setrole(desiredUpdatedRoleId);
+        GalasaGsonBuilder builder = new GalasaGsonBuilder();
+        Gson gson = builder.getGson();
+        String jsonPayload = gson.toJson(putData);
+        mockRequest.setPayload(jsonPayload);
+
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+
+        IInternalUser owner = new InternalUser("user-1", "dexId");
+        authStoreService.storeToken("some-client-id", "test-token", owner);
+
+        MockUser mockUser1 = createMockUser("user-1", "user-1-number", "web-ui");
+
+        String originalRole = "1";
+        mockUser1.setRoleId(originalRole);
+
+        int originalPriority = 50;
+        mockUser1.setPriority(originalPriority);
+
+        authStoreService.addUser(mockUser1);
+
+        // When...
+        servlet.init();
+        servlet.doPut(mockRequest, servletResponse);
+
+        assertThat(servletResponse.getStatus()).isEqualTo(200);
+
+        // Check that the user has been updated in the auth Store.
+        IUser updatedUserFromStore = authStoreService.getUser(userNumber);
+        assertThat(updatedUserFromStore).isNotNull();
+        assertThat(updatedUserFromStore.getRoleId()).isEqualTo(desiredUpdatedRoleId);
+        assertThat(updatedUserFromStore.getPriority()).isEqualTo(originalPriority);
+
+        // Now check a few things about the payload which was returned. 
+        // It should contain the rendered json of the updated user record.
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+        String payloadGotBack = outStream.toString();
+        UserData userGotBackInPayload = gson.fromJson(payloadGotBack, UserData.class);
+
+        assertThat(userGotBackInPayload).isNotNull();
+        assertThat(userGotBackInPayload.getLoginId()).isEqualTo("user-1");
+        assertThat(userGotBackInPayload.getid()).isEqualTo("user-1-number");
+        assertThat(userGotBackInPayload.getrole()).isEqualTo(desiredUpdatedRoleId);
+        assertThat(userGotBackInPayload.getpriority()).isEqualTo(originalPriority);
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/FilledMockRBACService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/FilledMockRBACService.java
@@ -65,9 +65,11 @@ public class FilledMockRBACService {
         List<String> actionIDsList = actions.stream().map(action -> action.getId()).collect(Collectors.toList());
 
         MockRole role1 = new MockRole("role1","2","role1 description",actionIDsList,true);
+        MockRole ownerRole = new MockRole("owner","0","owner description",actionIDsList,true);
         
         List<Role> roles = new ArrayList<Role>();
         roles.add(role1);
+        roles.add(ownerRole);
 
         user.setRoleId(role1.getId());
 


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2176

This PR makes the `priority` field in user records settable via the `PUT /users/{user-number}` endpoint and using the Galasa CLI tool's `galasactl users set --login-id <user-to-update> --priority <new-priority-number>`.

## Changes
- Updated the openapi2beans generator tool to use the Java `Integer` wrapper instead of the primitive `int` when generating Java beans that are used when parsing JSON payloads from requests.
  - This means that if a JSON payload omits an optional integer field, that field will be correctly parsed as `null` rather than a `0`. For example, If I wanted to update a user's role only and the user had a role "tester" and priority 100, by not including a priority value in the JSON, the server would have changed the user's priority from 100 to 0.
- Added an optional `priority` field to the JSON payload for `PUT /users/{user-number}`
  - Note: Users with the `owner` role are the only users that can update their own priority. This can be changed if needed.
- Added a `--priority` flag to the `galasactl users set` command