### PR TITLE
Add priority to tags and include tag priorities in test run scheduling 

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/src/testFixtures/java/dev/galasa/extensions/common/mocks/MockFramework.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/src/testFixtures/java/dev/galasa/extensions/common/mocks/MockFramework.java
@@ -36,6 +36,8 @@ import dev.galasa.framework.spi.creds.ICredentialsService;
 import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.streams.IStreamsService;
+import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.TagsException;
 
 public class MockFramework implements IFramework {
 
@@ -147,6 +149,11 @@ public class MockFramework implements IFramework {
     @Override 
     public @NotNull IStreamsService getStreamsService() {
         throw new UnsupportedOperationException("Unimplemented method 'getStreamsService'");
+    }
+
+    @Override
+    public @NotNull ITagsService getTagsService() throws TagsException {
+        throw new UnsupportedOperationException("Unimplemented method 'getTagsService'");
     }
 
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockFramework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockFramework.java
@@ -29,6 +29,8 @@ import dev.galasa.framework.spi.creds.ICredentialsService;
 import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.streams.IStreamsService;
+import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.TagsException;
 
 import java.net.URL;
 import java.util.HashMap;
@@ -224,6 +226,11 @@ public class MockFramework implements IFramework {
     @Override
     public @NotNull IEventsService getEventsService() {
         throw new UnsupportedOperationException("Unimplemented method 'getEventsService'");
+    }
+
+    @Override
+    public @NotNull ITagsService getTagsService() throws TagsException {
+        throw new UnsupportedOperationException("Unimplemented method 'getTagsService'");
     }
 
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockFramework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockFramework.java
@@ -13,6 +13,8 @@ import dev.galasa.framework.spi.creds.ICredentialsService;
 import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.streams.IStreamsService;
+import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.TagsException;
 
 import java.net.URL;
 import java.util.*;
@@ -124,5 +126,10 @@ public class MockFramework implements IFramework {
     @Override
     public @NotNull IStreamsService getStreamsService() {
         throw new UnsupportedOperationException("Unimplemented method 'getStreamsService'");
+    }
+
+    @Override
+    public @NotNull ITagsService getTagsService() throws TagsException {
+        throw new UnsupportedOperationException("Unimplemented method 'getTagsService'");
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/bnd.bnd
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/bnd.bnd
@@ -10,6 +10,7 @@ Import-Package: com.google.gson,\
                 dev.galasa.framework.spi,\
                 dev.galasa.framework.spi.auth,\
                 dev.galasa.framework.spi.rbac,\
+                dev.galasa.framework.spi.tags,\
                 dev.galasa.framework.spi.utils,\
                 dev.galasa.framework.spi.teststructure,\
                 dev.galasa.framework.k8s.controller,\

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/scheduling/PrioritySchedulingService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/scheduling/PrioritySchedulingService.java
@@ -73,7 +73,11 @@ public class PrioritySchedulingService implements IPrioritySchedulingService {
     @Override
     public List<IRun> getPrioritisedTestRunsToSchedule() throws FrameworkException {
         List<IRun> queuedRuns = getQueuedRemoteRuns();
+
+        // Collect all tags for queued runs from the CPS now so that we don't need to
+        // repeatedly query the CPS when sorting the queued runs.
         Map<String, Tag> queuedRunTags = getAllQueuedRunTagsFromCps(queuedRuns);
+
         queuedRuns.sort(getPriorityComparator(queuedRunTags));
         return queuedRuns;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -30,6 +30,7 @@ import dev.galasa.framework.mocks.MockEnvironment;
 import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
 import dev.galasa.framework.mocks.MockRBACService;
 import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.mocks.MockTagsService;
 import dev.galasa.framework.mocks.MockTimeService;
 import dev.galasa.framework.mocks.MockFrameworkRuns;
 import dev.galasa.framework.spi.DssPropertyKeyRunNameSuffix;
@@ -209,7 +210,8 @@ public class TestPodSchedulerTest {
 
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, settings, facade, mockTimeService, prioritySchedulingService);
 
@@ -246,7 +248,8 @@ public class TestPodSchedulerTest {
 
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, settings, facade, mockTimeService, prioritySchedulingService);
 
@@ -288,7 +291,8 @@ public class TestPodSchedulerTest {
 
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, settings, facade, mockTimeService, prioritySchedulingService);
 
@@ -331,7 +335,8 @@ public class TestPodSchedulerTest {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, settings, facade, mockTimeService, prioritySchedulingService);
 
@@ -373,7 +378,8 @@ public class TestPodSchedulerTest {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, settings, facade, mockTimeService, prioritySchedulingService);
 
@@ -417,7 +423,8 @@ public class TestPodSchedulerTest {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, settings, facade, mockTimeService, prioritySchedulingService);
 
@@ -476,7 +483,8 @@ public class TestPodSchedulerTest {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, settings, kubeEngineFacade, mockTimeService, prioritySchedulingService);
         
@@ -517,7 +525,8 @@ public class TestPodSchedulerTest {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, settings, kubeEngineFacade, mockTimeService, prioritySchedulingService);
         
@@ -564,7 +573,8 @@ public class TestPodSchedulerTest {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, settings, kubeEngineFacade, mockTimeService, prioritySchedulingService);
         
@@ -610,7 +620,8 @@ public class TestPodSchedulerTest {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, settings, kubeEngineFacade, mockTimeService, prioritySchedulingService);
         
@@ -657,7 +668,8 @@ public class TestPodSchedulerTest {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, settings, kubeEngineFacade, mockTimeService, prioritySchedulingService);
         
@@ -709,7 +721,8 @@ public class TestPodSchedulerTest {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, settings, kubeEngineFacade, mockTimeService, prioritySchedulingService);
         
@@ -747,7 +760,8 @@ public class TestPodSchedulerTest {
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, settings, facade, mockTimeService, prioritySchedulingService);
 
@@ -842,7 +856,8 @@ public class TestPodSchedulerTest {
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, settings, kubeEngineFacade, mockTimeService, prioritySchedulingService);
         
@@ -895,7 +910,8 @@ public class TestPodSchedulerTest {
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
         MockTimeService mockTimeService = new MockTimeService(Instant.now());
 
-        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService);
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
 
         TestPodScheduler podScheduler = new TestPodScheduler(mockEnvironment, mockDss, settings, kubeEngineFacade, mockTimeService, prioritySchedulingService);
         

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/scheduling/PrioritySchedulingServiceTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/scheduling/PrioritySchedulingServiceTest.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -20,10 +21,12 @@ import dev.galasa.framework.mocks.MockFrameworkRuns;
 import dev.galasa.framework.mocks.MockIConfigurationPropertyStoreService;
 import dev.galasa.framework.mocks.MockRBACService;
 import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.mocks.MockTagsService;
 import dev.galasa.framework.mocks.MockTimeService;
 import dev.galasa.framework.mocks.MockUser;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.rbac.BuiltInAction;
+import dev.galasa.framework.spi.tags.Tag;
 
 public class PrioritySchedulingServiceTest {
 
@@ -52,8 +55,9 @@ public class PrioritySchedulingServiceTest {
         MockIConfigurationPropertyStoreService mockCps = new MockIConfigurationPropertyStoreService();
         MockTimeService mockTimeService = new MockTimeService(now);
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService();
 
-        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService);
+        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService, mockTagsService);
 
         // When...
         List<IRun> runsGotBack = schedulingService.getPrioritisedTestRunsToSchedule();
@@ -90,8 +94,9 @@ public class PrioritySchedulingServiceTest {
         MockIConfigurationPropertyStoreService mockCps = new MockIConfigurationPropertyStoreService();
         MockTimeService mockTimeService = new MockTimeService(now);
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService();
 
-        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService);
+        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService, mockTagsService);
 
         // When...
         List<IRun> runsGotBack = schedulingService.getPrioritisedTestRunsToSchedule();
@@ -131,8 +136,9 @@ public class PrioritySchedulingServiceTest {
 
         MockTimeService mockTimeService = new MockTimeService(now);
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService();
 
-        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService);
+        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService, mockTagsService);
 
         // When...
         double run1Priority = schedulingService.getQueuedRunTotalPriorityPoints(run1);
@@ -172,8 +178,9 @@ public class PrioritySchedulingServiceTest {
 
         MockTimeService mockTimeService = new MockTimeService(now);
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService();
 
-        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService);
+        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService, mockTagsService);
 
         // When...
         double run1Priority = schedulingService.getQueuedRunTotalPriorityPoints(run1);
@@ -209,8 +216,9 @@ public class PrioritySchedulingServiceTest {
         MockIConfigurationPropertyStoreService mockCps = new MockIConfigurationPropertyStoreService();
         MockTimeService mockTimeService = new MockTimeService(now);
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService();
 
-        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService);
+        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService, mockTagsService);
 
         // When...
         List<IRun> runsGotBack = schedulingService.getPrioritisedTestRunsToSchedule();
@@ -247,8 +255,9 @@ public class PrioritySchedulingServiceTest {
         MockIConfigurationPropertyStoreService mockCps = new MockIConfigurationPropertyStoreService();
         MockTimeService mockTimeService = new MockTimeService(now);
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService();
 
-        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService);
+        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService, mockTagsService);
 
         // When...
         List<IRun> runsGotBack = schedulingService.getPrioritisedTestRunsToSchedule();
@@ -287,8 +296,9 @@ public class PrioritySchedulingServiceTest {
         MockTimeService mockTimeService = new MockTimeService(now);
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService();
 
-        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService);
+        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService, mockTagsService);
 
         // When...
         List<IRun> runsGotBack = schedulingService.getPrioritisedTestRunsToSchedule();
@@ -330,8 +340,9 @@ public class PrioritySchedulingServiceTest {
         MockTimeService mockTimeService = new MockTimeService(now);
 
         MockRBACService mockRBACService = FilledMockRBACService.createTestRBACServiceWithTestUser(user1, BuiltInAction.getActions());
+        MockTagsService mockTagsService = new MockTagsService();
 
-        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService);
+        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService, mockTagsService);
 
         // When...
         List<IRun> runsGotBack = schedulingService.getPrioritisedTestRunsToSchedule();
@@ -341,5 +352,60 @@ public class PrioritySchedulingServiceTest {
         assertThat(runsGotBack.get(0)).isEqualTo(run3);
         assertThat(runsGotBack.get(1)).isEqualTo(run1);
         assertThat(runsGotBack.get(2)).isEqualTo(run2);
+    }
+
+    @Test
+    public void testTagPriorityIsAddedToRunPriorityCalculation() throws Exception {
+        // Given...
+        List<Tag> tags = new ArrayList<>();
+        Tag tag1 = new Tag("high-priority-tag");
+        tag1.setPriority(200);
+        tags.add(tag1);
+
+        Tag tag2 = new Tag("another-tag");
+        tag2.setPriority(20);
+        tags.add(tag2);
+
+        Instant now = Instant.now();
+        List<IRun> runs = new ArrayList<>();
+        MockRun run1 = new MockRun(null, null, "run1", null, null, null, null, false);
+        run1.setQueued(now);
+        run1.setStatus(TestRunLifecycleStatus.QUEUED.toString());
+
+        MockRun run2 = new MockRun(null, null, "run2", null, null, null, null, false);
+        run2.setQueued(now);
+        run2.setStatus(TestRunLifecycleStatus.QUEUED.toString());
+
+        // The only difference here is that run3 has tags with priority values set, so this one should get scheduled first
+        MockRun run3 = new MockRun(null, null, "run3", null, null, null, null, false);
+        run3.setQueued(now);
+        run3.setStatus(TestRunLifecycleStatus.QUEUED.toString());
+        run3.setTags(Set.of("high-priority-tag", "another-tag"));
+
+        runs.add(run1);
+        runs.add(run2);
+        runs.add(run3);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+        MockIConfigurationPropertyStoreService mockCps = new MockIConfigurationPropertyStoreService();
+        MockTimeService mockTimeService = new MockTimeService(now);
+
+        MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService(tags);
+
+        PrioritySchedulingService schedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCps, mockRBACService, mockTimeService, mockTagsService);
+
+        // When...
+        List<IRun> runsGotBack = schedulingService.getPrioritisedTestRunsToSchedule();
+        double run3Priority = schedulingService.getQueuedRunTotalPriorityPoints(run3);
+
+        // Then...
+        assertThat(runsGotBack).hasSize(3);
+        assertThat(runsGotBack.get(0)).isEqualTo(run3);
+        assertThat(runsGotBack.get(1)).isEqualTo(run1);
+        assertThat(runsGotBack.get(2)).isEqualTo(run2);
+
+        // Check that both tag priorities have been added to the run's total priority
+        assertThat(run3Priority).isEqualTo(220);
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/Framework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/Framework.java
@@ -36,6 +36,7 @@ import dev.galasa.framework.internal.rbac.CacheUsers;
 import dev.galasa.framework.internal.rbac.CacheUsersImpl;
 import dev.galasa.framework.internal.rbac.RBACServiceImpl;
 import dev.galasa.framework.internal.streams.StreamsServiceImpl;
+import dev.galasa.framework.internal.tags.TagsService;
 import dev.galasa.framework.spi.creds.CredentialsException;
 import dev.galasa.framework.spi.creds.ICredentialsService;
 import dev.galasa.framework.spi.creds.ICredentialsStore;
@@ -43,6 +44,8 @@ import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.streams.IStreamsService;
 import dev.galasa.framework.spi.streams.StreamsException;
+import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.TagsException;
 
 // I know that the IFramework class isn't strictly necessary, but it does seem to make a
 // difference to whether the OSGi framework can load it or not.
@@ -71,6 +74,7 @@ public class Framework implements IFramework, IShuttableFramework {
     private IAuthStore                         authStore;
     private RBACService                        rbacService;
     private IStreamsService                    streamsService;
+    private ITagsService                       tagsService;
 
     private IConfigurationPropertyStoreService cpsFramework;
     @SuppressWarnings("unused")
@@ -593,4 +597,18 @@ public class Framework implements IFramework, IShuttableFramework {
         return this.streamsService;
     }
 
+    @Override
+    public @NotNull ITagsService getTagsService() throws TagsException {
+
+        if (this.tagsService == null) {
+            try {
+                IConfigurationPropertyStoreService cpsService = getConfigurationPropertyService("tags");
+                this.tagsService = new TagsService(cpsService);
+            } catch (ConfigurationPropertyStoreException e) {
+                throw new TagsException("Failed to initialise Tags service", e);
+            }
+        }
+
+        return this.tagsService;
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/Tag.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/Tag.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.tags;
+
+public class Tag {
+
+    private String name;
+    private String description;
+    private int priority;
+
+    public Tag(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagTransform.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagTransform.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import dev.galasa.framework.spi.tags.Tag;
+
 public class TagTransform {
 
     private final Log logger = LogFactory.getLog(getClass());

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagTransform.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagTransform.java
@@ -30,7 +30,10 @@ public class TagTransform {
     public Map<String, String> getPropertiesFromTag(Tag tag) {
         Map<String, String> properties = new HashMap<>();
         
-        // Encode the tag name into Base64 URL format to ensure safe storage as a property key
+        // Tag names could contain special characters like spaces and dots, so the property keys
+        // need to be able to handle these special characters.
+        // Encode the tag name into Base64 URL format to ensure safe storage as a property key since
+        // Base64 URL encoding uses alphanumeric characters, hyphens (-), and underscores (_) only.
         String tagName = tag.getName();
         String encodedTagName = encodeTagName(tagName);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagTransform.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagTransform.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.tags;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class TagTransform {
+
+    private final Log logger = LogFactory.getLog(getClass());
+
+    private static final String TAG_DESCRIPTION_SUFFIX = "description";
+    private static final String TAG_PRIORITY_SUFFIX    = "priority";
+
+    public Map<String, String> getPropertiesFromTag(Tag tag) {
+        Map<String, String> properties = new HashMap<>();
+
+        String tagName = tag.getName();
+        String description = tag.getDescription();
+        if (description != null) {
+            properties.put(getTagPropertyKey(tagName, TAG_DESCRIPTION_SUFFIX), description);
+        }
+
+        int priority = tag.getPriority();
+        properties.put(getTagPropertyKey(tagName, TAG_PRIORITY_SUFFIX), Integer.toString(priority));
+
+        return properties;
+    }
+
+    public Tag getTagFromProperties(Map<String, String> properties, String tagName) {
+        Tag tag = new Tag(tagName);
+
+        String description = properties.get(TAG_DESCRIPTION_SUFFIX);
+        tag.setDescription(description);
+
+        String priorityString = properties.get(TAG_PRIORITY_SUFFIX);
+        int priority = 0;
+        if (priorityString != null) {
+            try {
+                priority = Integer.parseInt(priorityString);
+            } catch (NumberFormatException e) {
+                logger.warn("Invalid priority value for tag " + tagName + ". Defaulting to " + priority);
+            }
+        }
+        tag.setPriority(priority);
+
+        return tag;
+    }
+
+    private String getTagPropertyKey(String tagName, String suffix) {
+        return tagName + "." + suffix;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagsService.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.tags;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.TagsException;
+
+public class TagsService implements ITagsService {
+
+    private IConfigurationPropertyStoreService cpsService;
+    private TagTransform tagTransform = new TagTransform();
+
+    public TagsService(IConfigurationPropertyStoreService cpsService) {
+        this.cpsService = cpsService;
+    }
+
+    @Override
+    public List<Tag> getTags() throws TagsException {
+        List<Tag> tags = new ArrayList<>();
+        try {
+            Map<String, String> allTagProperties = cpsService.getAllProperties();
+            tags = getTagsFromCpsProperties(allTagProperties);
+
+        } catch (ConfigurationPropertyStoreException e) {
+            throw new TagsException("Failed to get tags from the CPS", e);
+        }
+        return tags;
+    }
+
+    @Override
+    public Tag getTagByName(String tagName) throws TagsException {
+        Tag tag = null;
+        try {
+            Map<String, String> tagProperties = cpsService.getPrefixedProperties(tagName);
+            List<Tag> tags = getTagsFromCpsProperties(tagProperties);
+
+            if (!tags.isEmpty()) {
+                tag = tags.get(0);
+            }
+
+        } catch (ConfigurationPropertyStoreException e) {
+            throw new TagsException("Failed to get tag " + tagName + " from the CPS", e);
+        }
+        return tag;
+    }
+
+    private List<Tag> getTagsFromCpsProperties(Map<String, String> tagProperties) throws ConfigurationPropertyStoreException {
+        List<Tag> tags = new ArrayList<>();
+        Map<String, Map<String, String>> groupedTagProperties = new HashMap<>();
+
+        // Tag properties are returned from the CPS with the format:
+        // TAGNAME.suffix
+        for (Map.Entry<String, String> entry : tagProperties.entrySet()) {
+            String fullKey = entry.getKey();
+            String value = entry.getValue();
+
+            // Get the index of the first dot to separate tag name and suffix
+            int dotIndex = fullKey.indexOf('.');
+            if (dotIndex > 0) {
+                String tagName = fullKey.substring(0, dotIndex);
+                String suffix = fullKey.substring(dotIndex + 1);
+
+                groupedTagProperties
+                    .computeIfAbsent(tagName, k -> new HashMap<>())
+                    .put(suffix, value);
+            }
+        }
+
+        for (Map.Entry<String, Map<String, String>> entry : groupedTagProperties.entrySet()) {
+            String tagName = entry.getKey();
+            Map<String, String> properties = entry.getValue();
+
+            Tag tag = tagTransform.getTagFromProperties(properties, tagName);
+            tags.add(tag);
+        }
+
+        return tags;
+    }
+
+    @Override
+    public void setTag(Tag tag) throws TagsException {
+        try {
+            Map<String, String> properties = tagTransform.getPropertiesFromTag(tag);
+            cpsService.setProperties(properties);
+
+        } catch (ConfigurationPropertyStoreException e) {
+            throw new TagsException("Failed to set tag " + tag.getName() + " in the CPS", e);
+        }
+    }
+
+    @Override
+    public void deleteTag(String tagName) throws TagsException {
+        try {
+            cpsService.deletePrefixedProperties(tagName + ".");
+        } catch (ConfigurationPropertyStoreException e) {
+            throw new TagsException("Failed to delete tag " + tagName + " from the CPS", e);
+        }
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagsService.java
@@ -29,7 +29,8 @@ public class TagsService implements ITagsService {
     public List<Tag> getTags() throws TagsException {
         List<Tag> tags = new ArrayList<>();
         try {
-            Map<String, String> allTagProperties = cpsService.getAllProperties();
+            Map<String, String> allTagProperties = cpsService.getPrefixedProperties("");
+
             tags = getTagsFromCpsProperties(allTagProperties);
 
         } catch (ConfigurationPropertyStoreException e) {
@@ -69,11 +70,11 @@ public class TagsService implements ITagsService {
             // Get the index of the first dot to separate tag name and suffix
             int dotIndex = fullKey.indexOf('.');
             if (dotIndex > 0) {
-                String tagName = fullKey.substring(0, dotIndex);
+                String encodedTagName = fullKey.substring(0, dotIndex);
                 String suffix = fullKey.substring(dotIndex + 1);
 
                 groupedTagProperties
-                    .computeIfAbsent(tagName, k -> new HashMap<>())
+                    .computeIfAbsent(encodedTagName, k -> new HashMap<>())
                     .put(suffix, value);
             }
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/tags/TagsService.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.Tag;
 import dev.galasa.framework.spi.tags.TagsException;
 
 public class TagsService implements ITagsService {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFramework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFramework.java
@@ -19,6 +19,8 @@ import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.streams.IStreamsService;
 import dev.galasa.framework.spi.streams.StreamsException;
+import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.TagsException;
 
 /**
  * <p>
@@ -175,6 +177,9 @@ public interface IFramework {
 
     @NotNull
     IStreamsService getStreamsService() throws StreamsException;
+
+    @NotNull
+    ITagsService getTagsService() throws TagsException;
 
     /**
      * Retrieve the test run name. Will be null for non test runs

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/tags/ITagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/tags/ITagsService.java
@@ -12,6 +12,7 @@ public interface ITagsService {
     /**
      * Get all tags from the CPS.
      * @return List of Tag objects
+     * @throws TagsException if there is an error retrieving the tags
      */
     List<Tag> getTags() throws TagsException;
 
@@ -20,6 +21,7 @@ public interface ITagsService {
      *
      * @param tagName The name of the tag to retrieve
      * @return The Tag object, or null if not found
+     * @throws TagsException if there is an error retrieving the tag
      */
     Tag getTagByName(String tagName) throws TagsException;
 
@@ -27,6 +29,7 @@ public interface ITagsService {
      * Create or update a tag.
      *
      * @param tag The Tag object to set
+     * @throws TagsException if there is an error setting the tag
      */
     void setTag(Tag tag) throws TagsException;
 
@@ -34,6 +37,7 @@ public interface ITagsService {
      * Delete a tag with the given name.
      *
      * @param tagName The name of the tag to delete
+     * @throws TagsException if there is an error deleting the tag
      */
     void deleteTag(String tagName) throws TagsException;
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/tags/ITagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/tags/ITagsService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.tags;
+
+import java.util.List;
+
+import dev.galasa.framework.internal.tags.Tag;
+
+public interface ITagsService {
+
+    /**
+     * Get all tags from the CPS.
+     * @return List of Tag objects
+     */
+    List<Tag> getTags() throws TagsException;
+
+    /**
+     * Get a tag by its name from the CPS.
+     *
+     * @param tagName The name of the tag to retrieve
+     * @return The Tag object, or null if not found
+     */
+    Tag getTagByName(String tagName) throws TagsException;
+
+    /**
+     * Create or update a tag.
+     *
+     * @param tag The Tag object to set
+     */
+    void setTag(Tag tag) throws TagsException;
+
+    /**
+     * Delete a tag with the given name.
+     *
+     * @param tagName The name of the tag to delete
+     */
+    void deleteTag(String tagName) throws TagsException;
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/tags/ITagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/tags/ITagsService.java
@@ -7,8 +7,6 @@ package dev.galasa.framework.spi.tags;
 
 import java.util.List;
 
-import dev.galasa.framework.internal.tags.Tag;
-
 public interface ITagsService {
 
     /**

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/tags/Tag.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/tags/Tag.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.framework.internal.tags;
+package dev.galasa.framework.spi.tags;
 
 public class Tag {
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/tags/TagsException.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/tags/TagsException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.tags;
+
+import dev.galasa.framework.spi.FrameworkErrorDetails;
+import dev.galasa.framework.spi.FrameworkException;
+
+public class TagsException extends FrameworkException {
+    private static final long serialVersionUID = 1L;
+
+    public TagsException() {
+    }
+
+    public TagsException(String message) {
+        super(message);
+    }
+
+    public TagsException(Throwable cause) {
+        super(cause);
+    }
+
+    public TagsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TagsException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public TagsException(FrameworkErrorDetails errorDetails, Throwable cause, boolean enableSuppression,
+        boolean writableStackTrace
+    ) {
+        super(errorDetails,cause,enableSuppression, writableStackTrace);
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/utils/StringValidator.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/utils/StringValidator.java
@@ -23,4 +23,21 @@ public class StringValidator {
         }
         return isValid;
     }
+
+    /**
+     * Checks whether a given string is in valid Latin-1 format (e.g. characters in the range 0 - 255)
+     * 
+     * @param str the string to validate
+     * @return true if the string is in valid Latin-1 format, or false otherwise
+     */
+    public boolean isLatin1(String str) {
+        boolean isValidLatin1 = true;
+        for (char i = 0; i < str.length(); i++) {
+            if (str.charAt(i) > 255) {
+                isValidLatin1 = false;
+                break;
+            }
+        }
+        return isValidLatin1;
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagTransform.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagTransform.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.tags;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+public class TestTagTransform {
+
+    @Test
+    public void testCanConvertTagToProperties() throws Exception {
+        // Given...
+        TagTransform transform = new TagTransform();
+        Tag tag = new Tag("sampleTag");
+        tag.setDescription("This is a sample tag");
+        tag.setPriority(5);
+
+        // When...
+        Map<String, String> properties = transform.getPropertiesFromTag(tag);
+
+        // Then...
+        assertThat(properties).hasSize(2);
+        assertThat(properties).containsEntry("sampleTag.description", "This is a sample tag");
+        assertThat(properties).containsEntry("sampleTag.priority", "5");
+    }
+
+    @Test
+    public void testCanConvertTagToPropertiesWithoutDescription() throws Exception {
+        // Given...
+        TagTransform transform = new TagTransform();
+        Tag tag = new Tag("sampleTag");
+        tag.setPriority(5);
+
+        // When...
+        Map<String, String> properties = transform.getPropertiesFromTag(tag);
+
+        // Then...
+        assertThat(properties).hasSize(1);
+        assertThat(properties).doesNotContainKey("sampleTag.description");
+        assertThat(properties).containsEntry("sampleTag.priority", "5");
+    }
+
+    @Test
+    public void testCanConvertPropertiesToTag() throws Exception {
+        // Given...
+        TagTransform transform = new TagTransform();
+        Map<String, String> properties = Map.of(
+            "description", "This is a sample tag",
+            "priority", "5"
+        );
+
+        // When...
+        Tag tagGotBack = transform.getTagFromProperties(properties, "sampleTag");
+
+        // Then...
+        assertThat(tagGotBack.getName()).isEqualTo("sampleTag");
+        assertThat(tagGotBack.getDescription()).isEqualTo("This is a sample tag");
+        assertThat(tagGotBack.getPriority()).isEqualTo(5);
+    }
+
+    @Test
+    public void testCanConvertPropertiesToTagWithoutDescription() throws Exception {
+        // Given...
+        TagTransform transform = new TagTransform();
+        Map<String, String> properties = Map.of(
+            "priority", "5"
+        );
+
+        // When...
+        Tag tagGotBack = transform.getTagFromProperties(properties, "sampleTag");
+
+        // Then...
+        assertThat(tagGotBack.getName()).isEqualTo("sampleTag");
+        assertThat(tagGotBack.getDescription()).isNull();
+        assertThat(tagGotBack.getPriority()).isEqualTo(5);
+    }
+
+    @Test
+    public void testCanConvertPropertiesToTagWithInvalidPriorityDefaultsToZero() throws Exception {
+        // Given...
+        TagTransform transform = new TagTransform();
+        Map<String, String> properties = Map.of(
+            "description", "This is a sample tag",
+            "priority", "not a valid priority!"
+        );
+
+        // When...
+        Tag tagGotBack = transform.getTagFromProperties(properties, "sampleTag");
+
+        // Then...
+        assertThat(tagGotBack.getName()).isEqualTo("sampleTag");
+        assertThat(tagGotBack.getDescription()).isEqualTo("This is a sample tag");
+        assertThat(tagGotBack.getPriority()).isEqualTo(0);
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagTransform.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagTransform.java
@@ -11,6 +11,8 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import dev.galasa.framework.spi.tags.Tag;
+
 public class TestTagTransform {
 
     @Test

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagTransform.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagTransform.java
@@ -143,4 +143,20 @@ public class TestTagTransform {
         // Then...
         assertThat(tagGotBack).isNull();
     }
+
+    @Test
+    public void testDecodingUnencodedTagNameReturnsNull() throws Exception {
+        // Given...
+        TagTransform transform = new TagTransform();
+        Map<String, String> properties = Map.of(
+            "description", "This is a sample tag",
+            "priority", "not a valid priority!"
+        );
+
+        // When...
+        Tag tagGotBack = transform.getTagFromProperties(properties, "tag1");
+
+        // Then...
+        assertThat(tagGotBack).isNull();
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagsService.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.tags;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.MockIConfigurationPropertyStoreService;
+
+public class TestTagsService {
+
+    @Test
+    public void testCanGetAllTags() throws Exception {
+        // Given...
+        MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
+
+        Map<String, String> propertiesToSet = new HashMap<>();
+        propertiesToSet.put("TAG1.description", "this is a test tag");
+        propertiesToSet.put("TAG1.priority", "100");
+        propertiesToSet.put("TAG2.description", "this is another test tag");
+        propertiesToSet.put("TAG2.priority", "5");
+        propertiesToSet.put("TAG3.description", "new tag");
+        propertiesToSet.put("TAG3.priority", "1");
+
+        mockCpsService.setProperties(propertiesToSet);
+
+        TagsService tagsService = new TagsService(mockCpsService);
+
+        // When...
+        List<Tag> tagsGotBack = tagsService.getTags();
+
+        // Then...
+        assertThat(tagsGotBack).hasSize(3);
+        assertThat(tagsGotBack).extracting(Tag::getName)
+            .containsExactlyInAnyOrder("TAG1", "TAG2", "TAG3");
+        assertThat(tagsGotBack).extracting(Tag::getDescription)
+            .containsExactlyInAnyOrder("this is a test tag", "this is another test tag", "new tag");
+        assertThat(tagsGotBack).extracting(Tag::getPriority)
+            .containsExactlyInAnyOrder(100, 5, 1);
+    }
+
+    @Test
+    public void testCanGetTagByName() throws Exception {
+        // Given...
+        MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
+
+        Map<String, String> propertiesToSet = new HashMap<>();
+        propertiesToSet.put("TAG1.description", "this is a test tag");
+        propertiesToSet.put("TAG1.priority", "100");
+        propertiesToSet.put("TAG2.description", "this is another test tag");
+        propertiesToSet.put("TAG2.priority", "5");
+        propertiesToSet.put("TAG3.description", "new tag");
+        propertiesToSet.put("TAG3.priority", "1");
+
+        mockCpsService.setProperties(propertiesToSet);
+
+        TagsService tagsService = new TagsService(mockCpsService);
+
+        // When...
+        Tag tagGotBack = tagsService.getTagByName("TAG2");
+
+        // Then...
+        assertThat(tagGotBack.getName()).isEqualTo("TAG2");
+        assertThat(tagGotBack.getDescription()).isEqualTo("this is another test tag");
+        assertThat(tagGotBack.getPriority()).isEqualTo(5);
+    }
+
+    @Test
+    public void testGetUnknownTagReturnsNull() throws Exception {
+        // Given...
+        MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
+
+        Map<String, String> propertiesToSet = new HashMap<>();
+        propertiesToSet.put("TAG1.description", "this is a test tag");
+        propertiesToSet.put("TAG1.priority", "100");
+        propertiesToSet.put("TAG2.description", "this is another test tag");
+        propertiesToSet.put("TAG2.priority", "5");
+        propertiesToSet.put("TAG3.description", "new tag");
+        propertiesToSet.put("TAG3.priority", "1");
+
+        mockCpsService.setProperties(propertiesToSet);
+
+        TagsService tagsService = new TagsService(mockCpsService);
+
+        // When...
+        Tag tagGotBack = tagsService.getTagByName("Unknown");
+
+        // Then...
+        assertThat(tagGotBack).isNull();
+    }
+
+    @Test
+    public void testCanDeleteTagByName() throws Exception {
+        // Given...
+        MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
+
+        Map<String, String> propertiesToSet = new HashMap<>();
+        propertiesToSet.put("TAG1.description", "this is a test tag");
+        propertiesToSet.put("TAG1.priority", "100");
+        propertiesToSet.put("TAG2.description", "this is another test tag");
+        propertiesToSet.put("TAG2.priority", "5");
+        propertiesToSet.put("TAG3.description", "new tag");
+        propertiesToSet.put("TAG3.priority", "1");
+
+        mockCpsService.setProperties(propertiesToSet);
+
+        TagsService tagsService = new TagsService(mockCpsService);
+
+        // When...
+        tagsService.deleteTag("TAG2");
+
+        // Then...
+        assertThat(mockCpsService.getAllProperties().keySet()).doesNotContain("TAG2.description", "TAG2.priority");
+    }
+
+    @Test
+    public void testCanCreateTag() throws Exception {
+        // Given...
+        MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
+
+        Map<String, String> propertiesToSet = new HashMap<>();
+        propertiesToSet.put("TAG1.description", "this is a test tag");
+        propertiesToSet.put("TAG1.priority", "100");
+        propertiesToSet.put("TAG2.description", "this is another test tag");
+        propertiesToSet.put("TAG2.priority", "5");
+        propertiesToSet.put("TAG3.description", "new tag");
+        propertiesToSet.put("TAG3.priority", "1");
+
+        mockCpsService.setProperties(propertiesToSet);
+
+        TagsService tagsService = new TagsService(mockCpsService);
+
+        Tag tag = new Tag("NEWTAG");
+        tag.setDescription("Create me!");
+        tag.setPriority(42);
+
+        // When...
+        tagsService.setTag(tag);
+
+        // Then...
+        assertThat(mockCpsService.getAllProperties().keySet()).contains("NEWTAG.description", "NEWTAG.priority");
+        assertThat(mockCpsService.getProperty("NEWTAG", "description")).isEqualTo("Create me!");
+        assertThat(mockCpsService.getProperty("NEWTAG", "priority")).isEqualTo("42");
+    }
+
+    @Test
+    public void testCanUpdateTag() throws Exception {
+        // Given...
+        MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
+
+        Map<String, String> propertiesToSet = new HashMap<>();
+        propertiesToSet.put("TAG1.description", "this is a test tag");
+        propertiesToSet.put("TAG1.priority", "100");
+        propertiesToSet.put("TAG2.description", "this is another test tag");
+        propertiesToSet.put("TAG2.priority", "5");
+        propertiesToSet.put("TAG3.description", "new tag");
+        propertiesToSet.put("TAG3.priority", "1");
+
+        mockCpsService.setProperties(propertiesToSet);
+
+        TagsService tagsService = new TagsService(mockCpsService);
+
+        Tag tag = new Tag("TAG1");
+        tag.setDescription("Updated!");
+        tag.setPriority(42);
+
+        // When...
+        tagsService.setTag(tag);
+
+        // Then...
+        assertThat(mockCpsService.getProperty("TAG1", "description")).isEqualTo("Updated!");
+        assertThat(mockCpsService.getProperty("TAG1", "priority")).isEqualTo("42");
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagsService.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import dev.galasa.framework.mocks.MockIConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.tags.Tag;
 
 public class TestTagsService {
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/tags/TestTagsService.java
@@ -7,9 +7,12 @@ package dev.galasa.framework.internal.tags;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Base64.Encoder;
 
 import org.junit.Test;
 
@@ -23,13 +26,18 @@ public class TestTagsService {
         // Given...
         MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
 
+        Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        String tag1Name = encoder.encodeToString("TAG1".getBytes(StandardCharsets.UTF_8));
+        String tag2Name = encoder.encodeToString("TAG2".getBytes(StandardCharsets.UTF_8));
+        String tag3Name = encoder.encodeToString("TAG3".getBytes(StandardCharsets.UTF_8));
+
         Map<String, String> propertiesToSet = new HashMap<>();
-        propertiesToSet.put("TAG1.description", "this is a test tag");
-        propertiesToSet.put("TAG1.priority", "100");
-        propertiesToSet.put("TAG2.description", "this is another test tag");
-        propertiesToSet.put("TAG2.priority", "5");
-        propertiesToSet.put("TAG3.description", "new tag");
-        propertiesToSet.put("TAG3.priority", "1");
+        propertiesToSet.put(tag1Name + ".description", "this is a test tag");
+        propertiesToSet.put(tag1Name + ".priority", "100");
+        propertiesToSet.put(tag2Name + ".description", "this is another test tag");
+        propertiesToSet.put(tag2Name + ".priority", "5");
+        propertiesToSet.put(tag3Name + ".description", "new tag");
+        propertiesToSet.put(tag3Name + ".priority", "1");
 
         mockCpsService.setProperties(propertiesToSet);
 
@@ -49,17 +57,56 @@ public class TestTagsService {
     }
 
     @Test
+    public void testGetAllTagsSkipsTagWithBadName() throws Exception {
+        // Given...
+        MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
+
+        Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        String tag1Name = encoder.encodeToString("TAG1".getBytes(StandardCharsets.UTF_8));
+        String tag2Name = encoder.encodeToString("TAG2".getBytes(StandardCharsets.UTF_8));
+
+        Map<String, String> propertiesToSet = new HashMap<>();
+        propertiesToSet.put(tag1Name + ".description", "this is a test tag");
+        propertiesToSet.put(tag1Name + ".priority", "100");
+        propertiesToSet.put(tag2Name + ".description", "this is another test tag");
+        propertiesToSet.put(tag2Name + ".priority", "5");
+        propertiesToSet.put("not a valid base64 tag!.description", "new tag");
+        propertiesToSet.put("not a valid base64 tag!.priority", "1");
+
+        mockCpsService.setProperties(propertiesToSet);
+
+        TagsService tagsService = new TagsService(mockCpsService);
+
+        // When...
+        List<Tag> tagsGotBack = tagsService.getTags();
+
+        // Then...
+        assertThat(tagsGotBack).hasSize(2);
+        assertThat(tagsGotBack).extracting(Tag::getName)
+            .containsExactlyInAnyOrder("TAG1", "TAG2");
+        assertThat(tagsGotBack).extracting(Tag::getDescription)
+            .containsExactlyInAnyOrder("this is a test tag", "this is another test tag");
+        assertThat(tagsGotBack).extracting(Tag::getPriority)
+            .containsExactlyInAnyOrder(100, 5);
+    }
+
+    @Test
     public void testCanGetTagByName() throws Exception {
         // Given...
         MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
 
+        Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        String tag1Name = encoder.encodeToString("TAG1".getBytes(StandardCharsets.UTF_8));
+        String tag2Name = encoder.encodeToString("TAG2".getBytes(StandardCharsets.UTF_8));
+        String tag3Name = encoder.encodeToString("TAG3".getBytes(StandardCharsets.UTF_8));
+
         Map<String, String> propertiesToSet = new HashMap<>();
-        propertiesToSet.put("TAG1.description", "this is a test tag");
-        propertiesToSet.put("TAG1.priority", "100");
-        propertiesToSet.put("TAG2.description", "this is another test tag");
-        propertiesToSet.put("TAG2.priority", "5");
-        propertiesToSet.put("TAG3.description", "new tag");
-        propertiesToSet.put("TAG3.priority", "1");
+        propertiesToSet.put(tag1Name + ".description", "this is a test tag");
+        propertiesToSet.put(tag1Name + ".priority", "100");
+        propertiesToSet.put(tag2Name + ".description", "this is another test tag");
+        propertiesToSet.put(tag2Name + ".priority", "5");
+        propertiesToSet.put(tag3Name + ".description", "new tag");
+        propertiesToSet.put(tag3Name + ".priority", "1");
 
         mockCpsService.setProperties(propertiesToSet);
 
@@ -79,13 +126,18 @@ public class TestTagsService {
         // Given...
         MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
 
+        Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        String tag1Name = encoder.encodeToString("TAG1".getBytes(StandardCharsets.UTF_8));
+        String tag2Name = encoder.encodeToString("TAG2".getBytes(StandardCharsets.UTF_8));
+        String tag3Name = encoder.encodeToString("TAG3".getBytes(StandardCharsets.UTF_8));
+
         Map<String, String> propertiesToSet = new HashMap<>();
-        propertiesToSet.put("TAG1.description", "this is a test tag");
-        propertiesToSet.put("TAG1.priority", "100");
-        propertiesToSet.put("TAG2.description", "this is another test tag");
-        propertiesToSet.put("TAG2.priority", "5");
-        propertiesToSet.put("TAG3.description", "new tag");
-        propertiesToSet.put("TAG3.priority", "1");
+        propertiesToSet.put(tag1Name + ".description", "this is a test tag");
+        propertiesToSet.put(tag1Name + ".priority", "100");
+        propertiesToSet.put(tag2Name + ".description", "this is another test tag");
+        propertiesToSet.put(tag2Name + ".priority", "5");
+        propertiesToSet.put(tag3Name + ".description", "new tag");
+        propertiesToSet.put(tag3Name + ".priority", "1");
 
         mockCpsService.setProperties(propertiesToSet);
 
@@ -103,13 +155,18 @@ public class TestTagsService {
         // Given...
         MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
 
+        Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        String tag1Name = encoder.encodeToString("TAG1".getBytes(StandardCharsets.UTF_8));
+        String tag2Name = encoder.encodeToString("TAG2".getBytes(StandardCharsets.UTF_8));
+        String tag3Name = encoder.encodeToString("TAG3".getBytes(StandardCharsets.UTF_8));
+
         Map<String, String> propertiesToSet = new HashMap<>();
-        propertiesToSet.put("TAG1.description", "this is a test tag");
-        propertiesToSet.put("TAG1.priority", "100");
-        propertiesToSet.put("TAG2.description", "this is another test tag");
-        propertiesToSet.put("TAG2.priority", "5");
-        propertiesToSet.put("TAG3.description", "new tag");
-        propertiesToSet.put("TAG3.priority", "1");
+        propertiesToSet.put(tag1Name + ".description", "this is a test tag");
+        propertiesToSet.put(tag1Name + ".priority", "100");
+        propertiesToSet.put(tag2Name + ".description", "this is another test tag");
+        propertiesToSet.put(tag2Name + ".priority", "5");
+        propertiesToSet.put(tag3Name + ".description", "new tag");
+        propertiesToSet.put(tag3Name + ".priority", "1");
 
         mockCpsService.setProperties(propertiesToSet);
 
@@ -119,7 +176,7 @@ public class TestTagsService {
         tagsService.deleteTag("TAG2");
 
         // Then...
-        assertThat(mockCpsService.getAllProperties().keySet()).doesNotContain("TAG2.description", "TAG2.priority");
+        assertThat(mockCpsService.getAllProperties().keySet()).doesNotContain(tag2Name + ".description", tag2Name + ".priority");
     }
 
     @Test
@@ -127,13 +184,18 @@ public class TestTagsService {
         // Given...
         MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
 
+        Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        String tag1Name = encoder.encodeToString("TAG1".getBytes(StandardCharsets.UTF_8));
+        String tag2Name = encoder.encodeToString("TAG2".getBytes(StandardCharsets.UTF_8));
+        String tag3Name = encoder.encodeToString("TAG3".getBytes(StandardCharsets.UTF_8));
+
         Map<String, String> propertiesToSet = new HashMap<>();
-        propertiesToSet.put("TAG1.description", "this is a test tag");
-        propertiesToSet.put("TAG1.priority", "100");
-        propertiesToSet.put("TAG2.description", "this is another test tag");
-        propertiesToSet.put("TAG2.priority", "5");
-        propertiesToSet.put("TAG3.description", "new tag");
-        propertiesToSet.put("TAG3.priority", "1");
+        propertiesToSet.put(tag1Name + ".description", "this is a test tag");
+        propertiesToSet.put(tag1Name + ".priority", "100");
+        propertiesToSet.put(tag2Name + ".description", "this is another test tag");
+        propertiesToSet.put(tag2Name + ".priority", "5");
+        propertiesToSet.put(tag3Name + ".description", "new tag");
+        propertiesToSet.put(tag3Name + ".priority", "1");
 
         mockCpsService.setProperties(propertiesToSet);
 
@@ -147,9 +209,47 @@ public class TestTagsService {
         tagsService.setTag(tag);
 
         // Then...
-        assertThat(mockCpsService.getAllProperties().keySet()).contains("NEWTAG.description", "NEWTAG.priority");
-        assertThat(mockCpsService.getProperty("NEWTAG", "description")).isEqualTo("Create me!");
-        assertThat(mockCpsService.getProperty("NEWTAG", "priority")).isEqualTo("42");
+        String encodedNewTagName = encoder.encodeToString("NEWTAG".getBytes(StandardCharsets.UTF_8));
+        assertThat(mockCpsService.getAllProperties().keySet()).contains(encodedNewTagName + ".description", encodedNewTagName + ".priority");
+        assertThat(mockCpsService.getProperty(encodedNewTagName, "description")).isEqualTo("Create me!");
+        assertThat(mockCpsService.getProperty(encodedNewTagName, "priority")).isEqualTo("42");
+    }
+
+    @Test
+    public void testCanCreateTagWithSpecialCharactersInItsName() throws Exception {
+        // Given...
+        MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
+
+        Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        String tag1Name = encoder.encodeToString("TAG1".getBytes(StandardCharsets.UTF_8));
+        String tag2Name = encoder.encodeToString("TAG2".getBytes(StandardCharsets.UTF_8));
+        String tag3Name = encoder.encodeToString("TAG3".getBytes(StandardCharsets.UTF_8));
+
+        Map<String, String> propertiesToSet = new HashMap<>();
+        propertiesToSet.put(tag1Name + ".description", "this is a test tag");
+        propertiesToSet.put(tag1Name + ".priority", "100");
+        propertiesToSet.put(tag2Name + ".description", "this is another test tag");
+        propertiesToSet.put(tag2Name + ".priority", "5");
+        propertiesToSet.put(tag3Name + ".description", "new tag");
+        propertiesToSet.put(tag3Name + ".priority", "1");
+
+        mockCpsService.setProperties(propertiesToSet);
+
+        TagsService tagsService = new TagsService(mockCpsService);
+
+        String tagName = "this is a new tag!@#$%^&*()_+";
+        Tag tag = new Tag(tagName);
+        tag.setDescription("Create me!");
+        tag.setPriority(42);
+
+        // When...
+        tagsService.setTag(tag);
+
+        // Then...
+        String encodedNewTagName = encoder.encodeToString(tagName.getBytes(StandardCharsets.UTF_8));
+        assertThat(mockCpsService.getAllProperties().keySet()).contains(encodedNewTagName + ".description", encodedNewTagName + ".priority");
+        assertThat(mockCpsService.getProperty(encodedNewTagName, "description")).isEqualTo("Create me!");
+        assertThat(mockCpsService.getProperty(encodedNewTagName, "priority")).isEqualTo("42");
     }
 
     @Test
@@ -157,13 +257,18 @@ public class TestTagsService {
         // Given...
         MockIConfigurationPropertyStoreService mockCpsService = new MockIConfigurationPropertyStoreService();
 
+        Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        String tag1Name = encoder.encodeToString("TAG1".getBytes(StandardCharsets.UTF_8));
+        String tag2Name = encoder.encodeToString("TAG2".getBytes(StandardCharsets.UTF_8));
+        String tag3Name = encoder.encodeToString("TAG3".getBytes(StandardCharsets.UTF_8));
+
         Map<String, String> propertiesToSet = new HashMap<>();
-        propertiesToSet.put("TAG1.description", "this is a test tag");
-        propertiesToSet.put("TAG1.priority", "100");
-        propertiesToSet.put("TAG2.description", "this is another test tag");
-        propertiesToSet.put("TAG2.priority", "5");
-        propertiesToSet.put("TAG3.description", "new tag");
-        propertiesToSet.put("TAG3.priority", "1");
+        propertiesToSet.put(tag1Name + ".description", "this is a test tag");
+        propertiesToSet.put(tag1Name + ".priority", "100");
+        propertiesToSet.put(tag2Name + ".description", "this is another test tag");
+        propertiesToSet.put(tag2Name + ".priority", "5");
+        propertiesToSet.put(tag3Name + ".description", "new tag");
+        propertiesToSet.put(tag3Name + ".priority", "1");
 
         mockCpsService.setProperties(propertiesToSet);
 
@@ -177,7 +282,7 @@ public class TestTagsService {
         tagsService.setTag(tag);
 
         // Then...
-        assertThat(mockCpsService.getProperty("TAG1", "description")).isEqualTo("Updated!");
-        assertThat(mockCpsService.getProperty("TAG1", "priority")).isEqualTo("42");
+        assertThat(mockCpsService.getProperty(tag1Name, "description")).isEqualTo("Updated!");
+        assertThat(mockCpsService.getProperty(tag1Name, "priority")).isEqualTo("42");
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIConfigurationPropertyStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockIConfigurationPropertyStoreService.java
@@ -78,7 +78,7 @@ public class MockIConfigurationPropertyStoreService implements IConfigurationPro
 
     @Override
     public Map<String, String> getAllProperties() throws ConfigurationPropertyStoreException {
-               throw new UnsupportedOperationException("Unimplemented method 'getAllProperties'");
+        return this.properties;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
@@ -215,6 +215,10 @@ public class MockRun implements IRun {
         return this.tags;
     }
 
+    public void setTags(Set<String> tags) {
+        this.tags = tags;
+    }
+
     @Override
     public boolean isTrace() {
         return true;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockShutableFramework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockShutableFramework.java
@@ -32,6 +32,8 @@ import dev.galasa.framework.spi.creds.ICredentialsService;
 import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.streams.IStreamsService;
+import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.TagsException;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -173,6 +175,11 @@ public class MockShutableFramework implements IShuttableFramework {
     @Override
     public @NotNull IStreamsService getStreamsService() {
         throw new UnsupportedOperationException("Unimplemented method 'getStreamsService'");
+    }
+
+    @Override
+    public @NotNull ITagsService getTagsService() throws TagsException {
+        throw new UnsupportedOperationException("Unimplemented method 'getTagsService'");
     }
     
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockTagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockTagsService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.mocks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.Tag;
+import dev.galasa.framework.spi.tags.TagsException;
+
+public class MockTagsService implements ITagsService {
+
+    private List<Tag> tags;
+
+    public MockTagsService() {
+        this(new ArrayList<>());
+    }
+
+    public MockTagsService(List<Tag> tags) {
+        this.tags = tags;
+    }
+
+    @Override
+    public List<Tag> getTags() throws TagsException {
+        return tags;
+    }
+
+    @Override
+    public Tag getTagByName(String tagName) throws TagsException {
+        Tag tagToReturn = null;
+        for (Tag tag : tags) {
+            if (tag.getName().equals(tagName)) {
+                tagToReturn = tag;
+                break;
+            }
+        }
+        return tagToReturn;
+    }
+
+    @Override
+    public void setTag(Tag tag) throws TagsException {
+        tags.remove(tag);
+        tags.add(tag);
+    }
+
+    @Override
+    public void deleteTag(String tagName) throws TagsException {
+        Tag tagToDelete = null;
+        for (Tag tag : tags) {
+            if (tag.getName().equals(tagName)) {
+                tagToDelete = tag;
+                break;
+            }
+        }
+        if (tagToDelete != null) {
+            tags.remove(tagToDelete);
+        }
+    }
+    
+}

--- a/modules/framework/galasa-parent/galasa-testharness/src/main/java/dev/galasa/testharness/TestHarnessFramework.java
+++ b/modules/framework/galasa-parent/galasa-testharness/src/main/java/dev/galasa/testharness/TestHarnessFramework.java
@@ -38,7 +38,8 @@ import dev.galasa.framework.spi.creds.ICredentialsService;
 import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.streams.IStreamsService;
-import dev.galasa.framework.spi.streams.StreamsException;
+import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.TagsException;
 
 public class TestHarnessFramework implements IFramework {
     
@@ -168,6 +169,11 @@ public class TestHarnessFramework implements IFramework {
 
     @Override
     public @NotNull IStreamsService getStreamsService() {
+        throw new Unavailable();
+    }
+
+    @Override
+    public @NotNull ITagsService getTagsService() throws TagsException {
         throw new Unavailable();
     }
 


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2176

This PR adds a tag service that can manipulate tags in the CPS, and allows tags to have priority values associated with them. The priority values associated with tags are then picked up if a queued test run has a tag with a priority value so that test runs with certain tags may be treated with higher priority than other test runs.

## Changes
- [x] Added a new ITagsService with CRUD operations for tags, using the CPS as the underlying storage
- [x] Tags are stored in the CPS with the format `tags.base64EncodedTagName.suffix`. The tag name is Base64 URL encoded so that we can support tags with special characters like spaces and periods.
- [x] Update the PrioritySchedulingService to collect any tags associated with queued test runs in advance before using them in calculating test run priorities