### PR TITLE
Add galasactl tags delete command

### DIFF
--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -798,6 +798,20 @@ galasactl secrets delete --name SYSTEM1
 
 For a complete list of supported parameters see [here](./docs/generated/galasactl_secrets_delete.md).
 
+## tags delete
+
+This command deletes a tag with the given name from the Galasa service. The name of the tag to be deleted must be provided using the `--name` flag.
+
+### Examples
+
+To delete a tag named `mytag`, run the following command:
+
+```
+galasactl secrets delete --name mytag
+```
+
+For a complete list of supported parameters see [here](./docs/generated/galasactl_tags_delete.md).
+
 ## roles get
 To list the roles which are available on a Galasa service.
 

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -807,7 +807,7 @@ This command deletes a tag with the given name from the Galasa service. The name
 To delete a tag named `mytag`, run the following command:
 
 ```
-galasactl secrets delete --name mytag
+galasactl tags delete --name mytag
 ```
 
 For a complete list of supported parameters see [here](./docs/generated/galasactl_tags_delete.md).

--- a/modules/cli/docs/generated/errors-list.md
+++ b/modules/cli/docs/generated/errors-list.md
@@ -248,6 +248,14 @@ The `galasactl` tool can generate the following errors:
 - GAL1246E: Failed to delete stream {}. Unexpected http status code {} received from the server. Error details from the server are not in the json format.
 - GAL1247E: Error cancelling runs with group name '{}'. Reason: '{}'
 - GAL1248E: Unsupported glob pattern character provided. Only alphanumeric (A-Z, a-z, 0-9), '.', '?', and '*' characters can be provided in the '--includes-pattern' and '--excludes-pattern' flags.
+- GAL1249E: Failed to delete the tag with the given name from the Galasa service
+- GAL1250E: Failed to delete tag {}. Unexpected http status code {} received from the server.
+- GAL1251E: Failed to delete tag {}. Unexpected http status code {} received from the server. Error details from the server could not be read. Cause: {}
+- GAL1252E: Failed to delete tag {}. Unexpected http status code {} received from the server. Error details from the server are not in a valid json format. Cause: '{}'
+- GAL1253E: Failed to delete tag {}. Unexpected http status code {} received from the server. Error details from the server are: '{}'
+- GAL1254E: Failed to delete tag {}. Unexpected http status code {} received from the server. Error details from the server are not in the json format.
+- GAL1255E: Invalid tag name provided. The name provided with the --name flag cannot be empty and must only contain characters in the Latin-1 character set.
+- GAL1256E: No such tag named '{}' exists within the Galasa service.
 - GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '{}', and 'pre-release' repository is '{}'
 - GAL2501I: Downloaded {} artifacts to folder '{}'
 

--- a/modules/cli/docs/generated/galasactl.md
+++ b/modules/cli/docs/generated/galasactl.md
@@ -26,5 +26,6 @@ A tool for controlling Galasa resources using the command-line.
 * [galasactl runs](galasactl_runs.md)	 - Manage test runs in the ecosystem
 * [galasactl secrets](galasactl_secrets.md)	 - Manage secrets stored in the Galasa service's credentials store
 * [galasactl streams](galasactl_streams.md)	 - Manages test streams in a Galasa service
+* [galasactl tags](galasactl_tags.md)	 - Manage tags stored in the Galasa service's configuration property store
 * [galasactl users](galasactl_users.md)	 - Manages users in an ecosystem
 

--- a/modules/cli/docs/generated/galasactl_tags.md
+++ b/modules/cli/docs/generated/galasactl_tags.md
@@ -1,0 +1,29 @@
+## galasactl tags
+
+Manage tags stored in the Galasa service's configuration property store
+
+### Synopsis
+
+The parent command for operations to manipulate tags in the Galasa service's configuration property store
+
+### Options
+
+```
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                                  Displays the options for the 'tags' command.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+```
+
+### Options inherited from parent commands
+
+```
+      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+```
+
+### SEE ALSO
+
+* [galasactl](galasactl.md)	 - CLI for Galasa
+* [galasactl tags delete](galasactl_tags_delete.md)	 - Deletes a tag from the Galasa service
+

--- a/modules/cli/docs/generated/galasactl_tags_delete.md
+++ b/modules/cli/docs/generated/galasactl_tags_delete.md
@@ -1,0 +1,33 @@
+## galasactl tags delete
+
+Deletes a tag from the Galasa service
+
+### Synopsis
+
+Deletes a tag from the Galasa service
+
+```
+galasactl tags delete [flags]
+```
+
+### Options
+
+```
+  -h, --help          Displays the options for the 'tags delete' command.
+      --name string   A mandatory flag that indicates the name of a tag.
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+```
+
+### SEE ALSO
+
+* [galasactl tags](galasactl_tags.md)	 - Manage tags stored in the Galasa service's configuration property store
+

--- a/modules/cli/pkg/cmd/commandCollection.go
+++ b/modules/cli/pkg/cmd/commandCollection.go
@@ -68,6 +68,8 @@ const (
 	COMMAND_NAME_SECRETS_GET              = "secrets get"
 	COMMAND_NAME_SECRETS_SET              = "secrets set"
 	COMMAND_NAME_SECRETS_DELETE           = "secrets delete"
+	COMMAND_NAME_TAGS                     = "tags"
+	COMMAND_NAME_TAGS_DELETE              = "tags delete"
 	COMMAND_NAME_USERS                    = "users"
 	COMMAND_NAME_USERS_GET                = "users get"
 	COMMAND_NAME_USERS_SET                = "users set"
@@ -167,6 +169,10 @@ func (commands *commandCollectionImpl) init(factory spi.Factory) error {
 
 	if err == nil {
 		err = commands.addSecretsCommands(factory, rootCommand, commsFlagSet)
+	}
+
+	if err == nil {
+		err = commands.addTagsCommands(factory, rootCommand, commsFlagSet)
 	}
 
 	if err == nil {
@@ -451,6 +457,26 @@ func (commands *commandCollectionImpl) addSecretsCommands(factory spi.Factory, r
 		commands.commandMap[secretsGetCommand.Name()] = secretsGetCommand
 		commands.commandMap[secretsSetCommand.Name()] = secretsSetCommand
 		commands.commandMap[secretsDeleteCommand.Name()] = secretsDeleteCommand
+	}
+
+	return err
+}
+
+func (commands *commandCollectionImpl) addTagsCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
+
+	var err error
+	var tagsCommand spi.GalasaCommand
+	var tagsDeleteCommand spi.GalasaCommand
+
+	tagsCommand, err = NewTagsCmd(rootCommand, commsFlagSet)
+
+	if err == nil {
+		tagsDeleteCommand, err = NewTagsDeleteCommand(factory, tagsCommand, commsFlagSet)
+	}
+
+	if err == nil {
+		commands.commandMap[tagsCommand.Name()] = tagsCommand
+		commands.commandMap[tagsDeleteCommand.Name()] = tagsDeleteCommand
 	}
 
 	return err

--- a/modules/cli/pkg/cmd/tags.go
+++ b/modules/cli/pkg/cmd/tags.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/spf13/cobra"
+)
+
+type TagsCmdValues struct {
+    name string
+}
+
+type TagsCommand struct {
+    cobraCommand *cobra.Command
+    values       *TagsCmdValues
+}
+
+// ------------------------------------------------------------------------------------------------
+// Constructors
+// ------------------------------------------------------------------------------------------------
+
+func NewTagsCmd(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
+    cmd := new(TagsCommand)
+    err := cmd.init(rootCommand, commsFlagSet)
+    return cmd, err
+}
+
+// ------------------------------------------------------------------------------------------------
+// Public functions
+// ------------------------------------------------------------------------------------------------
+
+func (cmd *TagsCommand) Name() string {
+    return COMMAND_NAME_TAGS
+}
+
+func (cmd *TagsCommand) CobraCommand() *cobra.Command {
+    return cmd.cobraCommand
+}
+
+func (cmd *TagsCommand) Values() interface{} {
+    return cmd.values
+}
+
+// ------------------------------------------------------------------------------------------------
+// Private functions
+// ------------------------------------------------------------------------------------------------
+
+func (cmd *TagsCommand) init(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
+
+    var err error
+
+    cmd.values = &TagsCmdValues{}
+    cmd.cobraCommand, err = cmd.createCobraCommand(rootCommand, commsFlagSet)
+
+    return err
+}
+
+func (cmd *TagsCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (*cobra.Command, error) {
+
+    var err error
+
+    tagsCobraCmd := &cobra.Command{
+        Use:   "tags",
+        Short: "Manage tags stored in the Galasa service's configuration property store",
+        Long:  "The parent command for operations to manipulate tags in the Galasa service's configuration property store",
+    }
+
+    tagsCobraCmd.PersistentFlags().AddFlagSet(commsFlagSet.Flags())
+    rootCommand.CobraCommand().AddCommand(tagsCobraCmd)
+
+    return tagsCobraCmd, err
+}
+
+func addTagNameFlag(cmd *cobra.Command, isMandatory bool, tagsCmdValues *TagsCmdValues) {
+
+	flagName := "name"
+	var description string
+	if isMandatory {
+		description = "A mandatory flag that indicates the name of a tag."
+	} else {
+		description = "An optional flag that indicates the name of a tag."
+	}
+
+	cmd.Flags().StringVar(&tagsCmdValues.name, flagName, "", description)
+
+	if isMandatory {
+		cmd.MarkFlagRequired(flagName)
+	}
+}

--- a/modules/cli/pkg/cmd/tagsDelete.go
+++ b/modules/cli/pkg/cmd/tagsDelete.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"log"
+
+	"github.com/galasa-dev/cli/pkg/api"
+	"github.com/galasa-dev/cli/pkg/tags"
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type TagsDeleteCommand struct {
+    cobraCommand *cobra.Command
+}
+
+// ------------------------------------------------------------------------------------------------
+// Constructors methods
+// ------------------------------------------------------------------------------------------------
+func NewTagsDeleteCommand(
+    factory spi.Factory,
+    tagsDeleteCommand spi.GalasaCommand,
+    commsFlagSet GalasaFlagSet,
+) (spi.GalasaCommand, error) {
+
+    cmd := new(TagsDeleteCommand)
+
+    err := cmd.init(factory, tagsDeleteCommand, commsFlagSet)
+    return cmd, err
+}
+
+// ------------------------------------------------------------------------------------------------
+// Public methods
+// ------------------------------------------------------------------------------------------------
+func (cmd *TagsDeleteCommand) Name() string {
+    return COMMAND_NAME_TAGS_DELETE
+}
+
+func (cmd *TagsDeleteCommand) CobraCommand() *cobra.Command {
+    return cmd.cobraCommand
+}
+
+func (cmd *TagsDeleteCommand) Values() interface{} {
+    return nil
+}
+
+// ------------------------------------------------------------------------------------------------
+// Private methods
+// ------------------------------------------------------------------------------------------------
+func (cmd *TagsDeleteCommand) init(factory spi.Factory, tagsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
+    var err error
+
+    cmd.cobraCommand, err = cmd.createCobraCmd(factory, tagsCommand, commsFlagSet.Values().(*CommsFlagSetValues))
+
+    return err
+}
+
+func (cmd *TagsDeleteCommand) createCobraCmd(
+    factory spi.Factory,
+    tagsCommand spi.GalasaCommand,
+    commsFlagSetValues *CommsFlagSetValues,
+) (*cobra.Command, error) {
+
+    var err error
+
+    tagsCommandValues := tagsCommand.Values().(*TagsCmdValues)
+    tagsDeleteCobraCmd := &cobra.Command{
+        Use:     "delete",
+        Short:   "Deletes a tag from the Galasa service",
+        Long:    "Deletes a tag from the Galasa service",
+        Aliases: []string{COMMAND_NAME_TAGS_DELETE},
+        RunE: func(cobraCommand *cobra.Command, args []string) error {
+			return cmd.executeTagsDelete(factory, tagsCommand.Values().(*TagsCmdValues), commsFlagSetValues)
+        },
+    }
+
+    addTagNameFlag(tagsDeleteCobraCmd, true, tagsCommandValues)
+
+    tagsCommand.CobraCommand().AddCommand(tagsDeleteCobraCmd)
+
+    return tagsDeleteCobraCmd, err
+}
+
+func (cmd *TagsDeleteCommand) executeTagsDelete(
+    factory spi.Factory,
+    tagsCmdValues *TagsCmdValues,
+    commsFlagSetValues *CommsFlagSetValues,
+) error {
+
+    var err error
+    // Operations on the file system will all be relative to the current folder.
+    fileSystem := factory.GetFileSystem()
+
+	err = utils.CaptureLog(fileSystem, commsFlagSetValues.logFileName)
+	if err == nil {
+		commsFlagSetValues.isCapturingLogs = true
+
+		log.Println("Galasa CLI - Delete a tag from the Galasa service")
+
+		env := factory.GetEnvironment()
+
+		var galasaHome spi.GalasaHome
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
+		if err == nil {
+
+			var commsClient api.APICommsClient
+			commsClient, err = api.NewAPICommsClient(
+				commsFlagSetValues.bootstrap,
+				commsFlagSetValues.maxRetries,
+				commsFlagSetValues.retryBackoffSeconds,
+				factory,
+				galasaHome,
+			)
+
+			if err == nil {
+				byteReader := factory.GetByteReader()
+                err = tags.DeleteTag(tagsCmdValues.name, commsClient, byteReader)
+			}
+		}
+	}
+    return err
+}

--- a/modules/cli/pkg/cmd/tagsDelete_test.go
+++ b/modules/cli/pkg/cmd/tagsDelete_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"testing"
+
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagsDeleteCommandInCommandCollectionHasName(t *testing.T) {
+
+	factory := utils.NewMockFactory()
+	commands, _ := NewCommandCollection(factory)
+
+	TagsDeleteCommand, err := commands.GetCommand(COMMAND_NAME_TAGS_DELETE)
+	assert.Nil(t, err)
+
+	assert.Equal(t, COMMAND_NAME_TAGS_DELETE, TagsDeleteCommand.Name())
+	assert.NotNil(t, TagsDeleteCommand.CobraCommand())
+}
+
+func TestTagsDeleteHelpFlagSetCorrectly(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+
+	var args []string = []string{"tags", "delete", "--help"}
+
+	// When...
+	err := Execute(factory, args)
+
+	// Then...
+	// Check what the user saw is reasonable.
+	checkOutput("Displays the options for the 'tags delete' command.", "", factory, t)
+
+	assert.Nil(t, err)
+}
+
+func TestTagsDeleteNamespaceNameFlagsReturnsOk(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, _ := setupTestCommandCollection(COMMAND_NAME_TAGS_DELETE, factory, t)
+
+	var args []string = []string{"tags", "delete", "--name", "mytag"}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw was reasonable
+	checkOutput("", "", factory, t)
+
+	assert.Nil(t, err)
+}
+
+func TestTagsDeleteNamespaceRequiresNameFlag(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, _ := setupTestCommandCollection(COMMAND_NAME_TAGS_DELETE, factory, t)
+
+	var args []string = []string{"tags", "delete"}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "required flag(s) \"name\" not set")
+}

--- a/modules/cli/pkg/cmd/tagsDelete_test.go
+++ b/modules/cli/pkg/cmd/tagsDelete_test.go
@@ -40,7 +40,7 @@ func TestTagsDeleteHelpFlagSetCorrectly(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestTagsDeleteNamespaceNameFlagsReturnsOk(t *testing.T) {
+func TestTagsDeleteNameFlagsReturnsOk(t *testing.T) {
 	// Given...
 	factory := utils.NewMockFactory()
 	commandCollection, _ := setupTestCommandCollection(COMMAND_NAME_TAGS_DELETE, factory, t)
@@ -59,7 +59,7 @@ func TestTagsDeleteNamespaceNameFlagsReturnsOk(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestTagsDeleteNamespaceRequiresNameFlag(t *testing.T) {
+func TestTagsDeleteRequiresNameFlag(t *testing.T) {
 	// Given...
 	factory := utils.NewMockFactory()
 	commandCollection, _ := setupTestCommandCollection(COMMAND_NAME_TAGS_DELETE, factory, t)

--- a/modules/cli/pkg/cmd/tags_test.go
+++ b/modules/cli/pkg/cmd/tags_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"testing"
+
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagsCommandInCommandCollection(t *testing.T) {
+
+	factory := utils.NewMockFactory()
+	commands, _ := NewCommandCollection(factory)
+
+	tagsCommand, err := commands.GetCommand(COMMAND_NAME_TAGS)
+	assert.Nil(t, err)
+
+	assert.NotNil(t, tagsCommand)
+	assert.Equal(t, COMMAND_NAME_TAGS, tagsCommand.Name())
+	assert.NotNil(t, tagsCommand.Values())
+	assert.IsType(t, &TagsCmdValues{}, tagsCommand.Values())
+	assert.NotNil(t, tagsCommand.CobraCommand())
+}
+
+func TestTagsHelpFlagSetCorrectly(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+
+	var args []string = []string{"tags", "--help"}
+
+	// When...
+	err := Execute(factory, args)
+
+	// Then...
+
+	// Check what the user saw is reasonable.
+	checkOutput("Displays the options for the 'tags' command.", "", factory, t)
+
+	assert.Nil(t, err)
+}
+
+func TestTagsNoCommandsProducesUsageReport(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	var args []string = []string{"tags"}
+
+	// When...
+	err := Execute(factory, args)
+
+	// Then...
+	assert.Nil(t, err)
+	// Check what the user saw was reasonable
+	checkOutput("Usage:\n  galasactl tags [command]", "", factory, t)
+}

--- a/modules/cli/pkg/errors/errorMessage.go
+++ b/modules/cli/pkg/errors/errorMessage.go
@@ -463,13 +463,14 @@ var (
 
 	// Tags delete errors
 	GALASA_ERROR_FAILED_TO_DELETE_TAG                = NewMessageType("GAL1249E: Failed to delete the tag with the given name from the Galasa service", 1249, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_DELETE_TAG_NO_RESPONSE_CONTENT      = NewMessageType("GAL1250E: Failed to delete tag %s. Unexpected http status code %v received from the server.", 1250, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_DELETE_TAG_RESPONSE_BODY_UNREADABLE = NewMessageType("GAL1251E: Failed to delete tag %s. Unexpected http status code %v received from the server. Error details from the server could not be read. Cause: %s", 1251, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_DELETE_TAG_UNPARSEABLE_CONTENT      = NewMessageType("GAL1252E: Failed to delete tag %s. Unexpected http status code %v received from the server. Error details from the server are not in a valid json format. Cause: '%s'", 1252, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_DELETE_TAG_SERVER_REPORTED_ERROR    = NewMessageType("GAL1253E: Failed to delete tag %s. Unexpected http status code %v received from the server. Error details from the server are: '%s'", 1253, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_DELETE_TAG_EXPLANATION_NOT_JSON     = NewMessageType("GAL1254E: Failed to delete tag %s. Unexpected http status code %v received from the server. Error details from the server are not in the json format.", 1254, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_INVALID_TAG_NAME                    = NewMessageType("GAL1255E: Invalid tag name provided. The name provided with the --name flag cannot be empty and must only contain characters in the Latin-1 character set.", 1255, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_TAG_NOT_FOUND                       = NewMessageType("GAL1256E: No such tag named '%v' exists within the Galasa service.", 1256, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_NO_RESPONSE_CONTENT      = NewMessageType("GAL1250E: Failed to delete a tag named '%s'. Unexpected http status code %v received from the server.", 1250, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_RESPONSE_BODY_UNREADABLE = NewMessageType("GAL1251E: Failed to delete a tag named '%s'. Unexpected http status code %v received from the server. Error details from the server could not be read. Cause: %s", 1251, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_UNPARSEABLE_CONTENT      = NewMessageType("GAL1252E: Failed to delete a tag named '%s'. Unexpected http status code %v received from the server. Error details from the server are not in a valid json format. Cause: '%s'", 1252, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_SERVER_REPORTED_ERROR    = NewMessageType("GAL1253E: Failed to delete a tag named '%s'. Unexpected http status code %v received from the server. Error details from the server are: '%s'", 1253, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_EXPLANATION_NOT_JSON     = NewMessageType("GAL1254E: Failed to delete a tag named '%s'. Unexpected http status code %v received from the server. Error details from the server are not in the json format.", 1254, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_REQUEST_FAILED           = NewMessageType("GAL1255E: Failed to delete a tag named '%s'. Failed to send a request to the Galasa service. Cause is %v", 1255, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_INVALID_TAG_NAME                    = NewMessageType("GAL1256E: Invalid tag name provided. The name provided with the --name flag cannot be empty and must only contain characters in the Latin-1 character set.", 1256, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_TAG_NOT_FOUND                       = NewMessageType("GAL1257E: No such tag named '%v' exists within the Galasa service.", 1257, STACK_TRACE_NOT_WANTED)
 
 	// Warnings...
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'pre-release' repository is '%s'", 2000, STACK_TRACE_WANTED)
@@ -488,5 +489,5 @@ var (
     // >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
     // >>>       If you do use this number for a new error template, please increment this value.
     // >>>
-    GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 1257;
+    GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 1266;
 )

--- a/modules/cli/pkg/errors/errorMessage.go
+++ b/modules/cli/pkg/errors/errorMessage.go
@@ -461,6 +461,16 @@ var (
 	// Runs cleanup local errors
 	GALASA_ERROR_INVALID_GLOB_PATTERN_PROVIDED = NewMessageType("GAL1248E: Unsupported glob pattern character provided. Only alphanumeric (A-Z, a-z, 0-9), '.', '?', and '*' characters can be provided in the '--includes-pattern' and '--excludes-pattern' flags.", 1248, STACK_TRACE_NOT_WANTED)
 
+	// Tags delete errors
+	GALASA_ERROR_FAILED_TO_DELETE_TAG                = NewMessageType("GAL1249E: Failed to delete the tag with the given name from the Galasa service", 1249, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_NO_RESPONSE_CONTENT      = NewMessageType("GAL1250E: Failed to delete tag %s. Unexpected http status code %v received from the server.", 1250, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_RESPONSE_BODY_UNREADABLE = NewMessageType("GAL1251E: Failed to delete tag %s. Unexpected http status code %v received from the server. Error details from the server could not be read. Cause: %s", 1251, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_UNPARSEABLE_CONTENT      = NewMessageType("GAL1252E: Failed to delete tag %s. Unexpected http status code %v received from the server. Error details from the server are not in a valid json format. Cause: '%s'", 1252, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_SERVER_REPORTED_ERROR    = NewMessageType("GAL1253E: Failed to delete tag %s. Unexpected http status code %v received from the server. Error details from the server are: '%s'", 1253, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_TAG_EXPLANATION_NOT_JSON     = NewMessageType("GAL1254E: Failed to delete tag %s. Unexpected http status code %v received from the server. Error details from the server are not in the json format.", 1254, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_INVALID_TAG_NAME                    = NewMessageType("GAL1255E: Invalid tag name provided. The name provided with the --name flag cannot be empty and must only contain characters in the Latin-1 character set.", 1255, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_TAG_NOT_FOUND                       = NewMessageType("GAL1256E: No such tag named '%v' exists within the Galasa service.", 1256, STACK_TRACE_NOT_WANTED)
+
 	// Warnings...
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'pre-release' repository is '%s'", 2000, STACK_TRACE_WANTED)
 
@@ -471,4 +481,12 @@ var (
 
 	GALASA_INFO_GROUP_RUNS_CANCEL_SUCCESS   = NewMessageType("GAL2505I: The request to cancel runs with group name '%s' has been accepted by the server.\n", 2505, STACK_TRACE_NOT_WANTED)
 	GALASA_INFO_GROUP_RUNS_ALREADY_FINISHED = NewMessageType("GAL2506I: The request to cancel runs with group name '%s' has been handled successfully. However, no recent active (unfinished) test runs were found which are part of that group. Archived test runs may be part of that group, which can be queried separately from the Result Archive Store.\n", 2506, STACK_TRACE_NOT_WANTED)
+
+    // >>>
+    // >>> Note: Please keep this up to date, to save us wondering what to allocate next... 
+    // >>>       otherwise you have to find a 'gap' in the range.
+    // >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
+    // >>>       If you do use this number for a new error template, please increment this value.
+    // >>>
+    GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 1257;
 )

--- a/modules/cli/pkg/errors/errorMessage_test.go
+++ b/modules/cli/pkg/errors/errorMessage_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package errors
+
+import (
+	"regexp"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// This regex pattern matches strings where the start of the string:
+	// - Starts with "GAL"
+	// - Followed by at least one number in the range 0-9
+	// - Followed by "E:"
+	GAL_ERROR_PATTERN = "^GAL[0-9]+E:"
+)
+
+func TestNextMessageNumberToAllocateIsHighestSoFar(t *testing.T) {
+	// Given...
+	errorRegexPattern, _ := regexp.Compile(GAL_ERROR_PATTERN)
+
+	messageCodes := make([]int, 0, len(GALASA_ALL_MESSAGES))
+	for key, value := range GALASA_ALL_MESSAGES {
+		if errorRegexPattern.MatchString(value.Template) {
+			// This is an error message, get the message code
+			messageCodes = append(messageCodes, key)
+		}
+	}
+	highestCodeSoFar := slices.Max(messageCodes)
+
+	// Then
+	assert.Less(t, highestCodeSoFar, GALxxx_NEXT_MESSAGE_NUMBER_TO_USE,
+		"Highest message number in use is higher than the GALxxx_NEXT_MESSAGE_NUMBER_TO_USE marker value. "+
+        "Edit the GALxxx_NEXT_MESSAGE_NUMBER_TO_USE value to be higher than that.")
+}
+

--- a/modules/cli/pkg/tags/tagsDelete.go
+++ b/modules/cli/pkg/tags/tagsDelete.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package tags
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/galasa-dev/cli/pkg/api"
+	"github.com/galasa-dev/cli/pkg/embedded"
+	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/galasa-dev/cli/pkg/utils"
+)
+
+func DeleteTag(tagName string, commsClient api.APICommsClient, byteReader spi.ByteReader) error {
+	var err error
+
+	// We have the tag name but we need the tag ID
+	tag, err := getTagFromRestApi(tagName, commsClient, byteReader)
+
+	if err == nil {
+		err = deleteTagFromRestApi(tag, commsClient, byteReader)
+	}
+	return err
+}
+
+func validateTagName(tagName string) error {
+	var err error
+	log.Println("Validating the provided tag name")
+
+	if tagName == "" || !utils.IsLatin1(tagName) {
+		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_INVALID_TAG_NAME)
+	}
+
+	if err == nil {
+		log.Println("Tag name validated OK")
+	}
+	return err
+}
+
+func getTagFromRestApi(
+	tagName string,
+	commsClient api.APICommsClient,
+	byteReader spi.ByteReader,
+) (galasaapi.GalasaTag, error) {
+	var err error
+	var tagResults []galasaapi.GalasaTag = make([]galasaapi.GalasaTag, 0)
+	var matchingTag galasaapi.GalasaTag
+
+	err = validateTagName(tagName)
+
+	if err == nil {
+		log.Println("getTagFromRestApi - Fetching the tag with the given name from the REST API")
+		tagResults, err = getTagsFromRestApi(tagName, commsClient, byteReader)
+
+		if err == nil {
+			if len(tagResults) > 0 {
+				matchingTag = tagResults[0]
+				log.Printf("getTagFromRestApi - Found the tag with ID %s", *matchingTag.GetMetadata().Id)
+			} else {
+				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_TAG_NOT_FOUND, tagName)
+			}
+		}
+	}
+    return matchingTag, err
+}
+
+func getTagsFromRestApi(
+	tagName string,
+	commsClient api.APICommsClient,
+	byteReader spi.ByteReader,
+) ([]galasaapi.GalasaTag, error) {
+	var err error
+	var restApiVersion string
+	var tagResults []galasaapi.GalasaTag = make([]galasaapi.GalasaTag, 0)
+
+	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
+	if err == nil {
+		err = commsClient.RunAuthenticatedCommandWithRateLimitRetries(func(apiClient *galasaapi.APIClient) error {
+			var err error
+			var httpResponse *http.Response
+			var context context.Context = nil
+
+			apiCall := apiClient.TagsAPIApi.GetTags(context).ClientApiVersion(restApiVersion)
+
+			if tagName != "" {
+				apiCall = apiCall.Name(tagName)
+			}
+
+			tagResults, httpResponse, err = apiCall.Execute()
+
+			if httpResponse != nil {
+				defer httpResponse.Body.Close()
+			}
+
+			if err != nil {
+				if httpResponse == nil {
+					// We never got a response, error sending it or something?
+					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_DELETE_TAG)
+				} else {
+					err = galasaErrors.HttpResponseToGalasaError(
+						httpResponse,
+						tagName,
+						byteReader,
+						galasaErrors.GALASA_ERROR_DELETE_TAG_NO_RESPONSE_CONTENT,
+						galasaErrors.GALASA_ERROR_DELETE_TAG_RESPONSE_BODY_UNREADABLE,
+						galasaErrors.GALASA_ERROR_DELETE_TAG_UNPARSEABLE_CONTENT,
+						galasaErrors.GALASA_ERROR_DELETE_TAG_SERVER_REPORTED_ERROR,
+						galasaErrors.GALASA_ERROR_DELETE_TAG_EXPLANATION_NOT_JSON,
+					)
+				}
+			} else {
+				log.Printf("total tags returned: %v", len(tagResults))
+			}
+			return err
+		})
+	}
+	return tagResults, err
+}
+
+func deleteTagFromRestApi(
+	tag galasaapi.GalasaTag,
+	commsClient api.APICommsClient,
+	byteReader spi.ByteReader,
+) error {
+
+	var context context.Context = nil
+	var resp *http.Response
+
+	tagMetadata := tag.GetMetadata()
+	tagId := *tagMetadata.Id
+	tagName := *tagMetadata.Name
+
+	restApiVersion, err := embedded.GetGalasactlRestApiVersion()
+	if err == nil {
+
+		err = commsClient.RunAuthenticatedCommandWithRateLimitRetries(func(apiClient *galasaapi.APIClient) error {
+			var err error
+			resp, err = apiClient.TagsAPIApi.DeleteTagByName(context, tagId).ClientApiVersion(restApiVersion).Execute()
+
+			if resp != nil {
+				defer resp.Body.Close()
+			}
+
+			if err != nil {
+				if resp == nil {
+					// We never got a response, error sending it or something?
+					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_DELETE_TAG)
+				} else {
+					err = galasaErrors.HttpResponseToGalasaError(
+						resp,
+						*tag.GetMetadata().Name,
+						byteReader,
+						galasaErrors.GALASA_ERROR_DELETE_TAG_NO_RESPONSE_CONTENT,
+						galasaErrors.GALASA_ERROR_DELETE_TAG_RESPONSE_BODY_UNREADABLE,
+						galasaErrors.GALASA_ERROR_DELETE_TAG_UNPARSEABLE_CONTENT,
+						galasaErrors.GALASA_ERROR_DELETE_TAG_SERVER_REPORTED_ERROR,
+						galasaErrors.GALASA_ERROR_DELETE_TAG_EXPLANATION_NOT_JSON,
+					)
+				}
+			}
+
+			if err == nil {
+				log.Printf("Tag with ID '%s' and name '%s', was deleted OK.\n", tagId, tagName)
+			}
+			return err
+		})
+	}
+
+	return err
+}

--- a/modules/cli/pkg/tags/tagsDelete.go
+++ b/modules/cli/pkg/tags/tagsDelete.go
@@ -103,7 +103,7 @@ func getTagsFromRestApi(
 			if err != nil {
 				if httpResponse == nil {
 					// We never got a response, error sending it or something?
-					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_DELETE_TAG)
+					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_DELETE_TAG_REQUEST_FAILED, tagName, err.Error())
 				} else {
 					err = galasaErrors.HttpResponseToGalasaError(
 						httpResponse,

--- a/modules/cli/pkg/tags/tagsDelete_test.go
+++ b/modules/cli/pkg/tags/tagsDelete_test.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package tags
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/galasa-dev/cli/pkg/api"
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func TestDeleteTagWithInvalidNameReturnsError(t *testing.T) {
+	// Given...
+	tagName := ""
+
+	interactions := []utils.HttpInteraction{}
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+    apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+
+	// When...
+	err := DeleteTag(tagName, commsClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "Invalid tag name provided.")
+}
+
+func TestDeleteTagNotFoundOnServiceReturnsError(t *testing.T) {
+	// Given...
+	tagName := "mytag"
+
+	getTagsInteraction := utils.NewHttpInteraction("/tags", http.MethodGet)
+	getTagsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		requestedName := req.URL.Query().Get("name")
+		assert.Equal(t, tagName, requestedName)
+
+		body := `[]`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	interactions := []utils.HttpInteraction{
+		getTagsInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+    apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+
+	// When...
+	err := DeleteTag(tagName, commsClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "No such tag named 'mytag' exists within the Galasa service")
+}
+
+func TestDeleteTagSendsCorrectRequests(t *testing.T) {
+	// Given...
+	tagName := "mytag"
+
+	getTagsInteraction := utils.NewHttpInteraction("/tags", http.MethodGet)
+	getTagsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		requestedName := req.URL.Query().Get("name")
+		assert.Equal(t, tagName, requestedName)
+
+		body := `[{
+			"metadata": {
+				"id": "tag123",
+				"name": "mytag"
+			},
+			"data": {}
+		}]`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	deleteTagInteraction := utils.NewHttpInteraction("/tags/tag123", http.MethodDelete)
+	deleteTagInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusNoContent)
+	}
+
+	interactions := []utils.HttpInteraction{
+		getTagsInteraction,
+		deleteTagInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+    apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+
+	// When...
+	err := DeleteTag(tagName, commsClient, mockByteReader)
+
+	// Then...
+	assert.Nil(t, err)
+}
+
+func TestDeleteTagWithServerFailureDuringGetGivesCorrectMessage(t *testing.T) {
+	// Given...
+	tagName := "mytag"
+
+	getTagsInteraction := utils.NewHttpInteraction("/tags", http.MethodGet)
+	getTagsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+        writer.Header().Set("Content-Type", "application/json")
+        writer.WriteHeader(http.StatusInternalServerError)
+        writer.Write([]byte(`{}`))
+	}
+
+	interactions := []utils.HttpInteraction{
+		getTagsInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+    apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+
+	// When...
+	err := DeleteTag(tagName, commsClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+    assert.ErrorContains(t, err, tagName)
+    assert.ErrorContains(t, err, strconv.Itoa(http.StatusInternalServerError))
+    assert.ErrorContains(t, err, "GAL1253E")
+    assert.ErrorContains(t, err, "Error details from the server are")
+}
+
+func TestDeleteTagWithServerFailureDuringDeleteGivesCorrectMessage(t *testing.T) {
+	// Given...
+	tagName := "mytag"
+
+	getTagsInteraction := utils.NewHttpInteraction("/tags", http.MethodGet)
+	getTagsInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		requestedName := req.URL.Query().Get("name")
+		assert.Equal(t, tagName, requestedName)
+
+		body := `[{
+			"metadata": {
+				"id": "tag123",
+				"name": "mytag"
+			},
+			"data": {}
+		}]`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	deleteTagInteraction := utils.NewHttpInteraction("/tags/tag123", http.MethodDelete)
+	deleteTagInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+        writer.Header().Set("Content-Type", "application/json")
+        writer.WriteHeader(http.StatusInternalServerError)
+        writer.Write([]byte(`{}`))
+	}
+
+	interactions := []utils.HttpInteraction{
+		getTagsInteraction,
+		deleteTagInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+    apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+    commsClient := api.NewMockAPICommsClient(apiServerUrl)
+
+	// When...
+	err := DeleteTag(tagName, commsClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+    assert.ErrorContains(t, err, tagName)
+    assert.ErrorContains(t, err, strconv.Itoa(http.StatusInternalServerError))
+    assert.ErrorContains(t, err, "GAL1253E")
+    assert.ErrorContains(t, err, "Error details from the server are")
+}


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2176

## Changes
- [x] Added `galasactl tags delete --name <tag-name>` command to delete tags
- [x] Added error message unit test to make it easier to figure out what GALxxx error message number can be assigned next when creating new error messages in the CLI