### PR TITLE
Add support for managing test tags as GalasaTag resources using YAML, add missing permissions checks to tags and streams endpoints

### DIFF
--- a/docs/content/docs/ecosystem/ecosystem-manage-resources.md
+++ b/docs/content/docs/ecosystem/ecosystem-manage-resources.md
@@ -214,6 +214,55 @@ where:
 
 You can save the file with a `.yaml` or `.yml` file extension.
 
+## Test Tags as GalasaTag resources
+
+Test tags stored in a Galasa service can be retrieved in YAML format using the `galasactl tags get --format yaml` command. See [the command reference](../reference/cli-syntax/galasactl_tags_get.md) for more details on the `galasactl tags get` command.
+
+If more than one tag is returned, each tag is separated in the file by three dashes, `---`, as shown in the following example: 
+
+```yaml
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaTag
+metadata:
+  name: my-tag
+  description: an example test tag
+data:
+  priority: 5
+---
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaTag
+metadata:
+  name: my-second-tag
+  description: another example test tag
+data:
+  priority: 123
+```
+
+You can update the values in a YAML file and then create, update, or apply those updates by using the galasactl command line tool, as described in the [Creating and updating resources using a YAML file](#creating-and-updating-resources-using-a-yaml-file) section. 
+
+The YAML format for a GalasaTag resource is as follows:
+
+```yaml
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaTag
+metadata:
+  name: <tag-name>
+  description: <tag-description>
+data:
+  priority: <tag-priority>
+```
+
+where:
+
+- `apiVersion` is the version of the API that you are using
+- `tag-name` is the name of the tag that you want to create or update
+- `tag-description` is an optional field that allows you to supply a description associated with the tag being created or updated
+- `tag-priority` is an optional field that allows you to associate a priority modifier with the tag being created or updated. This priority modifier is used to determine the order in which tests with this tag are scheduled on the Galasa service. Tests with tags that hold higher priority values will be scheduled before tests that hold lower priority values.
+
+You can define multiple tags in the same YAML file by separating them using three dashes, `---`, as shown in the first example.
+
+You can save the file with a `.yaml` or `.yml` file extension.
+
 
 ## Creating and updating resources using a YAML file
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -205,6 +205,8 @@ public enum ServletErrorMessage {
     GAL5444_INVALID_TAG_DESCRIPTION_PROVIDED          (5444, "E: Invalid tag description provided. The description should not only contain spaces or tabs. When provided, it must contain characters in the Latin-1 character set. Check your request payload and try again."),
     GAL5445_ERROR_TAG_ALREADY_EXISTS                  (5445, "E: Error occurred when trying to create a tag with the given name. A tag with the provided name already exists. Check your request payload and try again."),
     GAL5446_ERROR_SETTING_TAG                         (5446, "E: Internal server error occurred when trying to set the tag with the given name. Report the problem to your Galasa service administrator"),
+    GAL5447_MISSING_REQUIRED_TAG_FIELD                (5447, "E: Invalid GalasaTag provided. The required field ''{0}'' was missing from the request payload. Check your request payload and try again."),
+    GAL5448_INVALID_TAG_PRIORITY_PROVIDED             (5448, "E: Invalid tag priority provided. The tag priority must be a whole number. Check your request payload and try again."),
     ;
 
     // >>>
@@ -213,7 +215,7 @@ public enum ServletErrorMessage {
     // >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
     // >>>       If you do use this number for a new error template, please incriment this value.
     // >>>
-    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5447;
+    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5449;
 
 
     private String template ;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/GalasaResourceType.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/GalasaResourceType.java
@@ -8,7 +8,8 @@ package dev.galasa.framework.api.common.resources;
 public enum GalasaResourceType {
     GALASA_PROPERTY("GalasaProperty"),
     GALASA_SECRET("GalasaSecret"),
-    GALASA_STREAM("GalasaStream");
+    GALASA_STREAM("GalasaStream"),
+    GALASA_TAG("GalasaTag");
 
     private String name;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/TagValidator.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/TagValidator.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.framework.api.tags.internal.common;
+package dev.galasa.framework.api.common.resources;
 
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -3066,6 +3066,7 @@ components:
             anyOf:
               - $ref: '#/components/schemas/GalasaProperty'
               - $ref: '#/components/schemas/GalasaSecret'
+              - $ref: '#/components/schemas/GalasaTag'
               - $ref: '#/components/schemas/Stream'
     SecretRequest:
       type: object

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/ResourcesServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/ResourcesServlet.java
@@ -20,14 +20,12 @@ import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.SystemEnvironment;
 import dev.galasa.framework.api.common.resources.CPSFacade;
 import dev.galasa.framework.api.resources.routes.ResourcesRoute;
-import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IFramework;
-import dev.galasa.framework.spi.creds.CredentialsException;
 import dev.galasa.framework.spi.creds.ICredentialsService;
-import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.streams.IStreamsService;
-import dev.galasa.framework.spi.streams.StreamsException;
+import dev.galasa.framework.spi.tags.ITagsService;
 import dev.galasa.framework.spi.utils.ITimeService;
 import dev.galasa.framework.spi.utils.SystemTimeService;
 /*
@@ -74,9 +72,18 @@ public class ResourcesServlet extends BaseServlet {
 			ICredentialsService credsService = framework.getCredentialsService();
 			RBACService rbacService = framework.getRBACService();
 			IStreamsService streamsService = framework.getStreamsService();
+			ITagsService tagsService = framework.getTagsService();
 
-            addRoute(new ResourcesRoute(getResponseBuilder(), cpsFacade, credsService, timeService, rbacService,streamsService));
-        } catch (ConfigurationPropertyStoreException | CredentialsException | RBACException | StreamsException e) {
+            addRoute(new ResourcesRoute(
+				getResponseBuilder(),
+				cpsFacade,
+				credsService,
+				timeService,
+				rbacService,
+				streamsService,
+				tagsService
+			));
+        } catch (FrameworkException e) {
             logger.error("Failed to initialise the Resources servlet", e);
             throw new ServletException("Failed to initialise the Resources servlet", e);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/processors/GalasaTagProcessor.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/processors/GalasaTagProcessor.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.resources.processors;
+
+import static dev.galasa.framework.api.common.ServletErrorMessage.*;
+import static dev.galasa.framework.api.common.resources.ResourceAction.*;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+
+import com.google.gson.JsonObject;
+
+import dev.galasa.framework.api.beans.generated.GalasaTag;
+import dev.galasa.framework.api.beans.generated.GalasaTagdata;
+import dev.galasa.framework.api.beans.generated.GalasaTagmetadata;
+import dev.galasa.framework.api.common.InternalServletException;
+import dev.galasa.framework.api.common.RBACValidator;
+import dev.galasa.framework.api.common.ServletError;
+import dev.galasa.framework.api.common.resources.ResourceAction;
+import dev.galasa.framework.api.resources.validators.GalasaTagValidator;
+import dev.galasa.framework.spi.rbac.BuiltInAction;
+import dev.galasa.framework.spi.tags.ITagsService;
+import dev.galasa.framework.spi.tags.Tag;
+import dev.galasa.framework.spi.tags.TagsException;
+
+public class GalasaTagProcessor extends AbstractGalasaResourceProcessor implements IGalasaResourceProcessor {
+
+    private ITagsService tagsService;
+    private final Log logger = LogFactory.getLog(getClass());
+
+    public GalasaTagProcessor(ITagsService tagsService, RBACValidator rbacValidator) {
+        super(rbacValidator);
+        this.tagsService = tagsService;
+    }
+
+    @Override
+    public List<String> processResource(JsonObject resourceJson, ResourceAction action, String username)
+            throws InternalServletException {
+
+        logger.info("Processing GalasaTag resource");
+        List<String> errors = checkGalasaTagJsonStructure(resourceJson, action);
+
+        if (errors.isEmpty()) {
+            GalasaTag galasaTag = gson.fromJson(resourceJson, GalasaTag.class);
+            String tagName = galasaTag.getmetadata().getname();
+
+            if (action == DELETE) {
+                deleteTag(tagName);
+            } else {
+                try {
+                    Tag existingTag = tagsService.getTagByName(tagName);
+                    if (action == CREATE && existingTag != null) {
+                        ServletError error = new ServletError(GAL5445_ERROR_TAG_ALREADY_EXISTS);
+                        throw new InternalServletException(error, HttpServletResponse.SC_CONFLICT);
+                    } else if (action == UPDATE && existingTag == null) {
+                        ServletError error = new ServletError(GAL5441_ERROR_TAG_NOT_FOUND);
+                        throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
+                    }
+
+                    setTag(galasaTag);
+                } catch (TagsException e) {
+                    ServletError error = new ServletError(GAL5446_ERROR_SETTING_TAG);
+                    throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                }
+            }
+
+            logger.info("Processed GalasaTag resource OK");
+        }
+
+        return errors;
+    }
+
+    private void setTag(GalasaTag galasaTag) throws InternalServletException {
+        try {
+            Tag tag = transformGalasaTagToTag(galasaTag);
+            logger.info("Setting tag in CPS store");
+            tagsService.setTag(tag);
+            logger.info("Set tag in CPS store OK");
+        } catch (TagsException e) {
+            ServletError error = new ServletError(GAL5446_ERROR_SETTING_TAG);
+            throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void deleteTag(String tagName) throws InternalServletException {
+        try {
+            logger.info("Deleting tag from CPS store");
+            tagsService.deleteTag(tagName);
+            logger.info("Deleted tag from CPS store OK");
+        } catch (TagsException e) {
+            ServletError error = new ServletError(GAL5442_ERROR_DELETING_TAG);
+            throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private List<String> checkGalasaTagJsonStructure(JsonObject tagJson, ResourceAction action) throws InternalServletException {
+        GalasaTagValidator validator = new GalasaTagValidator(action);
+        return checkGalasaResourceJsonStructure(validator, tagJson);
+    }
+
+    @Override
+    public void validateActionPermissions(ResourceAction action, String username) throws InternalServletException {
+        BuiltInAction requestedAction = getResourceActionAsBuiltInAction(action, BuiltInAction.CPS_PROPERTIES_SET, BuiltInAction.CPS_PROPERTIES_DELETE);
+        rbacValidator.validateActionPermitted(requestedAction, username);
+    }
+
+    private Tag transformGalasaTagToTag(GalasaTag galasaTag) {
+        GalasaTagmetadata metadata = galasaTag.getmetadata();
+        GalasaTagdata data = galasaTag.getdata();
+
+        Tag tag = new Tag(metadata.getname());
+        
+        String description = metadata.getdescription();
+        if (description != null) {
+            tag.setDescription(description);
+        }
+
+        Integer priority = data.getpriority();
+        if (priority != null) {
+            tag.setPriority(priority);
+        }
+        return tag;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
@@ -34,11 +34,13 @@ import dev.galasa.framework.api.common.resources.ResourceNameValidator;
 import dev.galasa.framework.api.resources.processors.GalasaPropertyProcessor;
 import dev.galasa.framework.api.resources.processors.GalasaSecretProcessor;
 import dev.galasa.framework.api.resources.processors.GalasaStreamProcessor;
+import dev.galasa.framework.api.resources.processors.GalasaTagProcessor;
 import dev.galasa.framework.api.resources.processors.IGalasaResourceProcessor;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.creds.ICredentialsService;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.streams.IStreamsService;
+import dev.galasa.framework.spi.tags.ITagsService;
 import dev.galasa.framework.spi.utils.GalasaGson;
 import dev.galasa.framework.spi.utils.ITimeService;
 
@@ -60,13 +62,15 @@ public class ResourcesRoute  extends ProtectedRoute {
         ICredentialsService credentialsService,
         ITimeService timeService,
         RBACService rbacService,
-        IStreamsService streamService
+        IStreamsService streamService,
+        ITagsService tagsService
     ) {
         super(responseBuilder, path, rbacService);
 
         resourceProcessors.put(GALASA_PROPERTY, new GalasaPropertyProcessor(cps, rbacValidator));
         resourceProcessors.put(GALASA_SECRET, new GalasaSecretProcessor(credentialsService, timeService, rbacValidator));
         resourceProcessors.put(GALASA_STREAM, new GalasaStreamProcessor(streamService, rbacValidator));
+        resourceProcessors.put(GALASA_TAG, new GalasaTagProcessor(tagsService, rbacValidator));
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/validators/GalasaTagValidator.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/validators/GalasaTagValidator.java
@@ -56,7 +56,9 @@ public class GalasaTagValidator extends GalasaResourceValidator<JsonObject> {
         if (metadata.has("description")) {
             String description = metadata.get("description").getAsString();
             try {
-                tagValidator.validateDescription(description);
+                if (description != null && !description.isEmpty()) {
+                    tagValidator.validateDescription(description);
+                }
             } catch (InternalServletException e) {
                 validationErrors.add(e.getMessage());
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/validators/GalasaTagValidator.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/validators/GalasaTagValidator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.resources.validators;
+
+import static dev.galasa.framework.api.common.ServletErrorMessage.*;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.gson.JsonObject;
+
+import dev.galasa.framework.api.common.InternalServletException;
+import dev.galasa.framework.api.common.ServletError;
+import dev.galasa.framework.api.common.resources.GalasaResourceValidator;
+import dev.galasa.framework.api.common.resources.ResourceAction;
+import dev.galasa.framework.api.common.resources.TagValidator;
+
+public class GalasaTagValidator extends GalasaResourceValidator<JsonObject> {
+
+    private TagValidator tagValidator = new TagValidator();
+
+    public GalasaTagValidator(ResourceAction action) {
+        super(action);
+    }
+
+    @Override
+    public void validate(JsonObject tagJson) throws InternalServletException {
+        checkResourceHasRequiredFields(tagJson, DEFAULT_API_VERSION);
+        validateTagMetadata(tagJson);
+
+        // Delete operations shouldn't require a 'data' section, just the metadata to identify
+        // the tag to delete
+        if (action != ResourceAction.DELETE) {
+            validateTagData(tagJson);
+        }
+    }
+
+    private void validateTagMetadata(JsonObject tagJson) {
+
+        JsonObject metadata = tagJson.getAsJsonObject("metadata");
+
+        if (!metadata.has("name")) {
+            ServletError error = new ServletError(GAL5447_MISSING_REQUIRED_TAG_FIELD, "name");
+            validationErrors.add(new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST).getMessage());
+        } else {
+            String tagName = metadata.get("name").getAsString();
+            try {
+                tagValidator.validateTagName(tagName);
+            } catch (InternalServletException e) {
+                validationErrors.add(e.getMessage());
+            }
+        }
+
+        if (metadata.has("description")) {
+            String description = metadata.get("description").getAsString();
+            try {
+                tagValidator.validateDescription(description);
+            } catch (InternalServletException e) {
+                validationErrors.add(e.getMessage());
+            }
+        }
+
+    }
+
+    private void validateTagData(JsonObject tagJson) {
+        JsonObject data = tagJson.getAsJsonObject("data");
+
+        if (data.has("priority")) {
+            try {
+                data.get("priority").getAsInt();
+            } catch (NumberFormatException | ClassCastException e) {
+                ServletError error = new ServletError(GAL5448_INVALID_TAG_PRIORITY_PROVIDED);
+                validationErrors.add(new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST).getMessage());
+            }
+        }
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/processors/GalasaTagProcessorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/processors/GalasaTagProcessorTest.java
@@ -182,7 +182,7 @@ public class GalasaTagProcessorTest extends ResourcesServletTest {
 
         JsonObject tagJson = generateTagJson(tagName, description, priority);
 
-        // Check that we have a tag before processing
+        // Check that we have no existing tags before processing
         assertThat(tags).isEmpty();
 
         // When...

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/processors/GalasaTagProcessorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/processors/GalasaTagProcessorTest.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.resources.processors;
+
+import static dev.galasa.framework.api.common.resources.ResourceAction.*;
+import static dev.galasa.framework.spi.rbac.BuiltInAction.GENERAL_API_ACCESS;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+
+import dev.galasa.framework.api.common.InternalServletException;
+import dev.galasa.framework.api.common.RBACValidator;
+import dev.galasa.framework.api.common.resources.GalasaResourceType;
+import dev.galasa.framework.api.common.resources.GalasaResourceValidator;
+import dev.galasa.framework.api.resources.ResourcesServletTest;
+import dev.galasa.framework.mocks.FilledMockRBACService;
+import dev.galasa.framework.mocks.MockRBACService;
+import dev.galasa.framework.mocks.MockTagsService;
+import dev.galasa.framework.spi.rbac.Action;
+import dev.galasa.framework.spi.tags.Tag;
+
+public class GalasaTagProcessorTest extends ResourcesServletTest {
+
+    private JsonObject generateTagJson(
+        String tagName,
+        String description,
+        Integer priority
+    ) {
+        JsonObject tagJson = new JsonObject();
+        tagJson.addProperty("apiVersion", GalasaResourceValidator.DEFAULT_API_VERSION);
+        tagJson.addProperty("kind", GalasaResourceType.GALASA_TAG.toString());
+
+        JsonObject metadata = new JsonObject();
+        if (tagName != null) {
+            metadata.addProperty("name", tagName);
+        }
+
+        if (description != null) {
+            metadata.addProperty("description", description);
+        }
+
+        JsonObject data = new JsonObject();
+
+        if (priority != null) {
+            data.addProperty("priority", priority);
+        }
+
+        tagJson.add("metadata", metadata);
+        tagJson.add("data", data);
+        return tagJson;
+    }
+
+    @Test
+    public void testValidateDeletePermissionsWithMissingPropertiesDeleteReturnsForbidden() throws Exception {
+        // Given...
+        List<Action> permittedActions = List.of(GENERAL_API_ACCESS.getAction());
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME, permittedActions);
+
+        MockTagsService tagService = new MockTagsService();
+        RBACValidator rbacValidator = new RBACValidator(mockRbacService);
+        GalasaTagProcessor tagProcessor = new GalasaTagProcessor(tagService, rbacValidator);
+
+        // When...
+        InternalServletException thrown = catchThrowableOfType(() -> {
+            tagProcessor.validateActionPermissions(DELETE, JWT_USERNAME);
+        }, InternalServletException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        checkErrorStructure(thrown.getMessage(), 5125, "GAL5125E", "CPS_PROPERTIES_DELETE");
+    }
+
+    @Test
+    public void testDeleteTagWithMissingNameReturnsBadRequest() throws Exception {
+        // Given...
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+
+        MockTagsService tagService = new MockTagsService();
+
+        RBACValidator rbacValidator = new RBACValidator(mockRbacService);
+        GalasaTagProcessor tagProcessor = new GalasaTagProcessor(tagService, rbacValidator);
+
+        String description = "This is a test tag";
+        String requestUsername = "myuser";
+
+        JsonObject tagJson = generateTagJson(null, description, null);
+
+        // When...
+        List<String> errors = tagProcessor.processResource(tagJson, DELETE, requestUsername);
+
+        // Then...
+        assertThat(errors).isNotEmpty();
+        assertThat(errors.get(0)).contains("GAL5447E", "The required field 'name' was missing from the request payload");
+    }
+
+    @Test
+    public void testDeleteTagWithInvalidNameReturnsError() throws Exception {
+        // Given...
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+
+        MockTagsService tagService = new MockTagsService();
+
+        RBACValidator rbacValidator = new RBACValidator(mockRbacService);
+        GalasaTagProcessor tagProcessor = new GalasaTagProcessor(tagService, rbacValidator);
+
+        String tagName = "     ";
+        String description = "This is a test tag";
+        Integer priority = 100;
+        String requestUsername = "myuser";
+
+        JsonObject tagJson = generateTagJson(tagName, description, priority);
+
+        // When...
+        List<String> errors = tagProcessor.processResource(tagJson, DELETE, requestUsername);
+
+        // Then...
+        assertThat(errors).isNotEmpty();
+        assertThat(errors.get(0)).contains("GAL5443E", "Invalid tag name provided");
+    }
+
+    @Test
+    public void testCanDeleteTag() throws Exception {
+        // Given...
+        String tagName = "mytag";
+        String description = "This is a test tag";
+        Integer priority = 100;
+        String requestUsername = "myuser";
+
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+
+        Tag tag = new Tag(tagName);
+        tag.setName(tagName);
+        tag.setDescription(description);
+        tag.setPriority(priority);
+
+        Map<String, Tag> tags = new HashMap<>();
+        tags.put(tag.getName(), tag);
+
+        MockTagsService tagService = new MockTagsService(tags);
+
+        RBACValidator rbacValidator = new RBACValidator(mockRbacService);
+        GalasaTagProcessor tagProcessor = new GalasaTagProcessor(tagService, rbacValidator);
+
+        JsonObject tagJson = generateTagJson(tagName, description, priority);
+
+        // Check that we have a tag before processing
+        assertThat(tags).hasSize(1);
+
+        // When...
+        List<String> errors = tagProcessor.processResource(tagJson, DELETE, requestUsername);
+
+        // Then...
+        assertThat(errors).isEmpty();
+        assertThat(tags).isEmpty();
+    }
+
+    @Test
+    public void testCanCreateTag() throws Exception {
+        // Given...
+        String tagName = "mytag";
+        String description = "This is a test tag";
+        Integer priority = 100;
+        String requestUsername = "myuser";
+
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+
+        Map<String, Tag> tags = new HashMap<>();
+
+        MockTagsService tagService = new MockTagsService(tags);
+
+        RBACValidator rbacValidator = new RBACValidator(mockRbacService);
+        GalasaTagProcessor tagProcessor = new GalasaTagProcessor(tagService, rbacValidator);
+
+        JsonObject tagJson = generateTagJson(tagName, description, priority);
+
+        // Check that we have a tag before processing
+        assertThat(tags).isEmpty();
+
+        // When...
+        List<String> errors = tagProcessor.processResource(tagJson, CREATE, requestUsername);
+
+        // Then...
+        assertThat(errors).isEmpty();
+        assertThat(tags).hasSize(1);
+        assertThat(tags.get(tagName).getName()).isEqualTo(tagName);
+        assertThat(tags.get(tagName).getDescription()).isEqualTo(description);
+        assertThat(tags.get(tagName).getPriority()).isEqualTo(priority);
+    }
+
+    @Test
+    public void testCreateExistingTagReturnsError() throws Exception {
+        // Given...
+        String tagName = "mytag";
+        String description = "This is a test tag";
+        Integer priority = 100;
+        String requestUsername = "myuser";
+
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+
+        Tag tag = new Tag(tagName);
+        tag.setName(tagName);
+        tag.setDescription("old description");
+        tag.setPriority(0);
+
+        Map<String, Tag> tags = new HashMap<>();
+        tags.put(tag.getName(), tag);
+
+
+        MockTagsService tagService = new MockTagsService(tags);
+
+        RBACValidator rbacValidator = new RBACValidator(mockRbacService);
+        GalasaTagProcessor tagProcessor = new GalasaTagProcessor(tagService, rbacValidator);
+
+        JsonObject tagJson = generateTagJson(tagName, description, priority);
+
+        // Check that we have a tag before processing
+        assertThat(tags).hasSize(1);
+
+        // When...
+        InternalServletException thrown = catchThrowableOfType(() -> {
+            tagProcessor.processResource(tagJson, CREATE, requestUsername);
+        }, InternalServletException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("GAL5445E", "A tag with the provided name already exists");
+    }
+
+    @Test
+    public void testCanApplyTag() throws Exception {
+        // Given...
+        String tagName = "mytag";
+        String description = "This is a test tag";
+        Integer priority = 100;
+        String requestUsername = "myuser";
+
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+
+        Tag tag = new Tag(tagName);
+        tag.setName(tagName);
+        tag.setDescription("old description");
+        tag.setPriority(0);
+
+        Map<String, Tag> tags = new HashMap<>();
+        tags.put(tag.getName(), tag);
+
+
+        MockTagsService tagService = new MockTagsService(tags);
+
+        RBACValidator rbacValidator = new RBACValidator(mockRbacService);
+        GalasaTagProcessor tagProcessor = new GalasaTagProcessor(tagService, rbacValidator);
+
+        JsonObject tagJson = generateTagJson(tagName, description, priority);
+
+        // Check that we have a tag before processing
+        assertThat(tags).hasSize(1);
+
+        // When...
+        List<String> errors = tagProcessor.processResource(tagJson, APPLY, requestUsername);
+
+        // Then...
+        assertThat(errors).isEmpty();
+        assertThat(tags).hasSize(1);
+        assertThat(tags.get(tagName).getName()).isEqualTo(tagName);
+        assertThat(tags.get(tagName).getDescription()).isEqualTo(description);
+        assertThat(tags.get(tagName).getPriority()).isEqualTo(priority);
+    }
+
+    @Test
+    public void testCanUpdateTag() throws Exception {
+        // Given...
+        String tagName = "mytag";
+        String description = "This is a test tag";
+        Integer priority = 100;
+        String requestUsername = "myuser";
+
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+
+        Tag tag = new Tag(tagName);
+        tag.setName(tagName);
+        tag.setDescription("old description");
+        tag.setPriority(0);
+
+        Map<String, Tag> tags = new HashMap<>();
+        tags.put(tag.getName(), tag);
+
+
+        MockTagsService tagService = new MockTagsService(tags);
+
+        RBACValidator rbacValidator = new RBACValidator(mockRbacService);
+        GalasaTagProcessor tagProcessor = new GalasaTagProcessor(tagService, rbacValidator);
+
+        JsonObject tagJson = generateTagJson(tagName, description, priority);
+
+        // Check that we have a tag before processing
+        assertThat(tags).hasSize(1);
+
+        // When...
+        List<String> errors = tagProcessor.processResource(tagJson, UPDATE, requestUsername);
+
+        // Then...
+        assertThat(errors).isEmpty();
+        assertThat(tags).hasSize(1);
+        assertThat(tags.get(tagName).getName()).isEqualTo(tagName);
+        assertThat(tags.get(tagName).getDescription()).isEqualTo(description);
+        assertThat(tags.get(tagName).getPriority()).isEqualTo(priority);
+    }
+
+    @Test
+    public void testUpdateNonExistentTagReturnsError() throws Exception {
+        // Given...
+        String tagName = "mytag";
+        String description = "This is a test tag";
+        Integer priority = 100;
+        String requestUsername = "myuser";
+
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithTestUser(JWT_USERNAME);
+
+        Map<String, Tag> tags = new HashMap<>();
+
+        MockTagsService tagService = new MockTagsService(tags);
+
+        RBACValidator rbacValidator = new RBACValidator(mockRbacService);
+        GalasaTagProcessor tagProcessor = new GalasaTagProcessor(tagService, rbacValidator);
+
+        JsonObject tagJson = generateTagJson(tagName, description, priority);
+
+        // When...
+        InternalServletException thrown = catchThrowableOfType(() -> {
+            tagProcessor.processResource(tagJson, UPDATE, requestUsername);
+        }, InternalServletException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("GAL5441E", "Failed to find a tag with the given name");
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
@@ -137,7 +137,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         String jsonString = "[{},{},{}]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
@@ -163,7 +163,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         String jsonString = "[{\"kind\":\"GalasaProperty\",\"apiVersion\":\"galasa-dev/v1alpha1\","+namespace+"."+propertyname+":"+value+"}]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
@@ -189,7 +189,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         String jsonString = "[{\"kind\":\"GalasaProperly\",\"apiVersion\":\"v1alpha1\","+namespace+"."+propertyname+":"+value+"}]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
@@ -213,7 +213,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         String jsonString = "[null]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
@@ -238,7 +238,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         JsonArray propertyJson = generatePropertyArrayJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -262,7 +262,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         JsonArray propertyJson = generatePropertyArrayJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -286,7 +286,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         String jsonString = "[null, {\"kind\":\"GalasaProperty\",\"apiVersion\":\"galasa-dev/v1alpha1\","+namespace+"."+propertyname+":"+value+"},"+
             "{\"kind\":\"GalasaProperly\",\"apiVersion\":\"v1alpha1\","+namespace+"."+propertyname+":"+value+"},{}]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
@@ -318,7 +318,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
         jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
@@ -349,7 +349,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
         jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
@@ -382,7 +382,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
         jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
@@ -412,7 +412,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
         jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
@@ -446,7 +446,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         JsonObject requestJson = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -471,7 +471,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -496,7 +496,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -526,7 +526,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
 
         CPSFacade cps = new CPSFacade(mockFramework);
 
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -555,7 +555,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
 
         CPSFacade cps = new CPSFacade(mockFramework);
 
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -580,7 +580,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
         JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -1109,7 +1109,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         CPSFacade cps = new CPSFacade(mockFramework);
 
         RBACService rbacService = mockFramework.getRBACService();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService,null);
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps, null, null, rbacService, null, null);
 
         // When...
         String json = resourcesRoute.getErrorsAsJson(errors);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/validators/GalasaTagValidatorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/validators/GalasaTagValidatorTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.resources.validators;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+
+import dev.galasa.framework.api.common.resources.GalasaResourceType;
+import dev.galasa.framework.api.common.resources.ResourceAction;
+
+public class GalasaTagValidatorTest {
+
+    @Test
+    public void testApplyValidTagHasNoValidationErrors() throws Exception {
+        // Given...
+        ResourceAction action = ResourceAction.APPLY;
+        GalasaTagValidator validator = new GalasaTagValidator(action);
+
+        JsonObject tagJson = new JsonObject();
+        tagJson.addProperty("apiVersion", GalasaStreamValidator.DEFAULT_API_VERSION);
+        tagJson.addProperty("kind", GalasaResourceType.GALASA_TAG.toString());
+
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("name", "my tag");
+        metadata.addProperty("description", "this is a tag description");
+
+        JsonObject data = new JsonObject();
+        int priority = 100;
+        data.addProperty("priority", priority);
+
+        tagJson.add("metadata", metadata);
+        tagJson.add("data", data);
+
+        // When...
+        validator.validate(tagJson);
+
+        // Then...
+        assertThat(validator.getValidationErrors()).isEmpty();
+    }
+
+    @Test
+    public void testApplyTagWithNoDescriptionHasNoValidationErrors() throws Exception {
+        // Given...
+        ResourceAction action = ResourceAction.APPLY;
+        GalasaTagValidator validator = new GalasaTagValidator(action);
+
+        JsonObject tagJson = new JsonObject();
+        tagJson.addProperty("apiVersion", GalasaStreamValidator.DEFAULT_API_VERSION);
+        tagJson.addProperty("kind", GalasaResourceType.GALASA_TAG.toString());
+
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("name", "my tag");
+
+        JsonObject data = new JsonObject();
+        int priority = 100;
+        data.addProperty("priority", priority);
+
+        tagJson.add("metadata", metadata);
+        tagJson.add("data", data);
+
+        // When...
+        validator.validate(tagJson);
+
+        // Then...
+        assertThat(validator.getValidationErrors()).isEmpty();
+    }
+
+    @Test
+    public void testApplyTagWithNoPriorityHasNoValidationErrors() throws Exception {
+        // Given...
+        ResourceAction action = ResourceAction.APPLY;
+        GalasaTagValidator validator = new GalasaTagValidator(action);
+
+        JsonObject tagJson = new JsonObject();
+        tagJson.addProperty("apiVersion", GalasaStreamValidator.DEFAULT_API_VERSION);
+        tagJson.addProperty("kind", GalasaResourceType.GALASA_TAG.toString());
+
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("name", "my tag");
+        metadata.addProperty("description", "this is a tag description");
+
+        JsonObject data = new JsonObject();
+        tagJson.add("metadata", metadata);
+        tagJson.add("data", data);
+
+        // When...
+        validator.validate(tagJson);
+
+        // Then...
+        assertThat(validator.getValidationErrors()).isEmpty();
+    }
+
+    @Test
+    public void testApplyTagWithNoNameHasValidationError() throws Exception {
+        // Given...
+        ResourceAction action = ResourceAction.APPLY;
+        GalasaTagValidator validator = new GalasaTagValidator(action);
+
+        JsonObject tagJson = new JsonObject();
+        tagJson.addProperty("apiVersion", GalasaStreamValidator.DEFAULT_API_VERSION);
+        tagJson.addProperty("kind", GalasaResourceType.GALASA_TAG.toString());
+
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("description", "this is a tag description");
+
+        JsonObject data = new JsonObject();
+        int priority = 100;
+        data.addProperty("priority", priority);
+
+        tagJson.add("metadata", metadata);
+        tagJson.add("data", data);
+
+        // When...
+        validator.validate(tagJson);
+
+        // Then...
+        List<String> validationErrors = validator.getValidationErrors();
+        assertThat(validationErrors).hasSize(1);
+        assertThat(validationErrors.get(0)).contains("GAL5447", "The required field 'name' was missing from the request payload");
+    }
+
+    @Test
+    public void testApplyTagWithInvalidNameHasValidationError() throws Exception {
+        // Given...
+        ResourceAction action = ResourceAction.APPLY;
+        GalasaTagValidator validator = new GalasaTagValidator(action);
+
+        JsonObject tagJson = new JsonObject();
+        tagJson.addProperty("apiVersion", GalasaStreamValidator.DEFAULT_API_VERSION);
+        tagJson.addProperty("kind", GalasaResourceType.GALASA_TAG.toString());
+
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("name", "   ");
+        metadata.addProperty("description", "this is a tag description");
+
+        JsonObject data = new JsonObject();
+        int priority = 100;
+        data.addProperty("priority", priority);
+
+        tagJson.add("metadata", metadata);
+        tagJson.add("data", data);
+
+        // When...
+        validator.validate(tagJson);
+
+        // Then...
+        List<String> validationErrors = validator.getValidationErrors();
+        assertThat(validationErrors).hasSize(1);
+        assertThat(validationErrors.get(0)).contains("GAL5443E", "Invalid tag name provided");
+    }
+
+    @Test
+    public void testApplyTagWithInvalidDescriptionHasValidationError() throws Exception {
+        // Given...
+        ResourceAction action = ResourceAction.APPLY;
+        GalasaTagValidator validator = new GalasaTagValidator(action);
+
+        JsonObject tagJson = new JsonObject();
+        tagJson.addProperty("apiVersion", GalasaStreamValidator.DEFAULT_API_VERSION);
+        tagJson.addProperty("kind", GalasaResourceType.GALASA_TAG.toString());
+
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("name", "my tag");
+        metadata.addProperty("description", "    ");
+
+        JsonObject data = new JsonObject();
+        int priority = 100;
+        data.addProperty("priority", priority);
+
+        tagJson.add("metadata", metadata);
+        tagJson.add("data", data);
+
+        // When...
+        validator.validate(tagJson);
+
+        // Then...
+        List<String> validationErrors = validator.getValidationErrors();
+        assertThat(validationErrors).hasSize(1);
+        assertThat(validationErrors.get(0)).contains("GAL5444E", "Invalid tag description provided");
+    }
+
+    @Test
+    public void testApplyTagWithInvalidPriorityHasValidationError() throws Exception {
+        // Given...
+        ResourceAction action = ResourceAction.APPLY;
+        GalasaTagValidator validator = new GalasaTagValidator(action);
+
+        JsonObject tagJson = new JsonObject();
+        tagJson.addProperty("apiVersion", GalasaStreamValidator.DEFAULT_API_VERSION);
+        tagJson.addProperty("kind", GalasaResourceType.GALASA_TAG.toString());
+
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("name", "my tag");
+        metadata.addProperty("description", "a tag description");
+
+        JsonObject data = new JsonObject();
+        String priority = "not a valid priority!";
+        data.addProperty("priority", priority);
+
+        tagJson.add("metadata", metadata);
+        tagJson.add("data", data);
+
+        // When...
+        validator.validate(tagJson);
+
+        // Then...
+        List<String> validationErrors = validator.getValidationErrors();
+        assertThat(validationErrors).hasSize(1);
+        assertThat(validationErrors.get(0)).contains("GAL5448E", "Invalid tag priority provided");
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/validators/GalasaTagValidatorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/validators/GalasaTagValidatorTest.java
@@ -158,6 +158,35 @@ public class GalasaTagValidatorTest {
     }
 
     @Test
+    public void testApplyTagWithEmptyDescriptionHasNoValidationErrors() throws Exception {
+        // Given...
+        ResourceAction action = ResourceAction.APPLY;
+        GalasaTagValidator validator = new GalasaTagValidator(action);
+
+        JsonObject tagJson = new JsonObject();
+        tagJson.addProperty("apiVersion", GalasaStreamValidator.DEFAULT_API_VERSION);
+        tagJson.addProperty("kind", GalasaResourceType.GALASA_TAG.toString());
+
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("name", "my tag");
+        metadata.addProperty("description", "");
+
+        JsonObject data = new JsonObject();
+        int priority = 100;
+        data.addProperty("priority", priority);
+
+        tagJson.add("metadata", metadata);
+        tagJson.add("data", data);
+
+        // When...
+        validator.validate(tagJson);
+
+        // Then...
+        List<String> validationErrors = validator.getValidationErrors();
+        assertThat(validationErrors).isEmpty();
+    }
+
+    @Test
     public void testApplyTagWithInvalidDescriptionHasValidationError() throws Exception {
         // Given...
         ResourceAction action = ResourceAction.APPLY;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.streams/src/main/java/dev/galasa/framework/api/streams/internal/routes/StreamsByNameRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.streams/src/main/java/dev/galasa/framework/api/streams/internal/routes/StreamsByNameRoute.java
@@ -25,6 +25,7 @@ import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.rbac.BuiltInAction;
 import dev.galasa.framework.spi.rbac.RBACService;
 import dev.galasa.framework.spi.streams.IStream;
 import dev.galasa.framework.spi.streams.IStreamsService;
@@ -75,6 +76,8 @@ public class StreamsByNameRoute extends AbstractStreamsRoute {
     ) throws FrameworkException {
 
         logger.info("handleDeleteRequest() entered");
+        validateActionPermitted(BuiltInAction.CPS_PROPERTIES_DELETE, requestContext.getUsername());
+
         HttpServletRequest request = requestContext.getRequest();
 
         String streamName = getStreamName(pathInfo);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.tags/src/main/java/dev/galasa/framework/api/tags/internal/common/TagCreateRequestValidator.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.tags/src/main/java/dev/galasa/framework/api/tags/internal/common/TagCreateRequestValidator.java
@@ -8,6 +8,7 @@ package dev.galasa.framework.api.tags.internal.common;
 import dev.galasa.framework.api.beans.generated.TagCreateRequest;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.resources.GalasaResourceValidator;
+import dev.galasa.framework.api.common.resources.TagValidator;
 
 public class TagCreateRequestValidator extends GalasaResourceValidator<TagCreateRequest> {
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.tags/src/main/java/dev/galasa/framework/api/tags/internal/common/TagSetRequestValidator.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.tags/src/main/java/dev/galasa/framework/api/tags/internal/common/TagSetRequestValidator.java
@@ -8,6 +8,7 @@ package dev.galasa.framework.api.tags.internal.common;
 import dev.galasa.framework.api.beans.generated.TagSetRequest;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.resources.GalasaResourceValidator;
+import dev.galasa.framework.api.common.resources.TagValidator;
 
 public class TagSetRequestValidator extends GalasaResourceValidator<TagSetRequest> {
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.tags/src/main/java/dev/galasa/framework/api/tags/internal/routes/TagByNameRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.tags/src/main/java/dev/galasa/framework/api/tags/internal/routes/TagByNameRoute.java
@@ -80,6 +80,7 @@ public class TagByNameRoute extends AbstractTagRoute {
 
         logger.info("handleDeleteRequest() entered");
         HttpServletRequest request = requestContext.getRequest();
+        validateActionPermitted(BuiltInAction.CPS_PROPERTIES_DELETE, requestContext.getUsername());
 
         String tagName = getTagNameFromPath(pathInfo);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.tags/src/test/java/dev/galasa/framework/api/tags/internal/routes/TagByNameRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.tags/src/test/java/dev/galasa/framework/api/tags/internal/routes/TagByNameRouteTest.java
@@ -8,9 +8,8 @@ package dev.galasa.framework.api.tags.internal.routes;
 import static org.assertj.core.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Base64;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -123,25 +122,25 @@ public class TagByNameRouteTest extends TagsServletTest {
 
         String tagName = "tag1";
         String description = "My first tag!";
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(description);
         tag1.setPriority(100);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         String tagName2 = "tag2";
         String description2 = "My second tag!";
         Tag tag2 = new Tag(tagName2);
         tag2.setDescription(description2);
         tag2.setPriority(12);
-        tags.add(tag2);
+        tags.put(tag2.getName(), tag2);
 
         String tagName3 = "tag3";
         String description3 = "My third tag!";
         Tag tag3 = new Tag(tagName3);
         tag3.setDescription(description3);
         tag3.setPriority(456);
-        tags.add(tag3);
+        tags.put(tag3.getName(), tag3);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 
@@ -178,18 +177,18 @@ public class TagByNameRouteTest extends TagsServletTest {
 
         String tagName = "tag1";
         String description = "My first tag!";
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(description);
         tag1.setPriority(100);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         String tagName2 = "tag2";
         String description2 = "My second tag!";
         Tag tag2 = new Tag(tagName2);
         tag2.setDescription(description2);
         tag2.setPriority(12);
-        tags.add(tag2);
+        tags.put(tag2.getName(), tag2);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 
@@ -225,18 +224,18 @@ public class TagByNameRouteTest extends TagsServletTest {
 
         String tagName = "tag1";
         String description = "My first tag!";
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(description);
         tag1.setPriority(100);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         String tagName2 = "tag2";
         String description2 = "My second tag!";
         Tag tag2 = new Tag(tagName2);
         tag2.setDescription(description2);
         tag2.setPriority(12);
-        tags.add(tag2);
+        tags.put(tag2.getName(), tag2);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 
@@ -273,11 +272,11 @@ public class TagByNameRouteTest extends TagsServletTest {
         String tagName = "mytag";
         String tagDescription = "my first tag!";
         int tagPriority = 123;
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(tagDescription);
         tag1.setPriority(tagPriority);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 
@@ -322,11 +321,11 @@ public class TagByNameRouteTest extends TagsServletTest {
         String tagName = "mytag";
         String tagDescription = "my first tag!";
         int tagPriority = 123;
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(tagDescription);
         tag1.setPriority(tagPriority);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 
@@ -370,11 +369,11 @@ public class TagByNameRouteTest extends TagsServletTest {
         String tagName = "mytag";
         String tagDescription = "my first tag!";
         int tagPriority = 123;
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(tagDescription);
         tag1.setPriority(tagPriority);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.tags/src/test/java/dev/galasa/framework/api/tags/internal/routes/TagsRouteTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.tags/src/test/java/dev/galasa/framework/api/tags/internal/routes/TagsRouteTest.java
@@ -7,8 +7,7 @@ package dev.galasa.framework.api.tags.internal.routes;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -97,11 +96,11 @@ public class TagsRouteTest extends TagsServletTest {
 
         String tagName = "tag1";
         String description = "My first tag!";
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(description);
         tag1.setPriority(100);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 
@@ -136,28 +135,28 @@ public class TagsRouteTest extends TagsServletTest {
         // Given...
         Map<String, String> headerMap = Map.of("Authorization", "Bearer " + BaseServletTest.DUMMY_JWT);
 
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
 
         String tagName = "tag1";
         String description = "My first tag!";
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(description);
         tag1.setPriority(100);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         String tagName2 = "tag2";
         String description2 = "My second tag!";
         Tag tag2 = new Tag(tagName2);
         tag2.setDescription(description2);
         tag2.setPriority(12);
-        tags.add(tag2);
+        tags.put(tag2.getName(), tag2);
 
         String tagName3 = "tag3";
         String description3 = "My third tag!";
         Tag tag3 = new Tag(tagName3);
         tag3.setDescription(description3);
         tag3.setPriority(456);
-        tags.add(tag3);
+        tags.put(tag3.getName(), tag3);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 
@@ -194,28 +193,28 @@ public class TagsRouteTest extends TagsServletTest {
         // Given...
         Map<String, String> headerMap = Map.of("Authorization", "Bearer " + BaseServletTest.DUMMY_JWT);
 
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
 
         String tagName = "tag1";
         String description = "My first tag!";
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(description);
         tag1.setPriority(100);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         String tagName2 = "tag2";
         String description2 = "My second tag!";
         Tag tag2 = new Tag(tagName2);
         tag2.setDescription(description2);
         tag2.setPriority(12);
-        tags.add(tag2);
+        tags.put(tag2.getName(), tag2);
 
         String tagName3 = "tag3";
         String description3 = "My third tag!";
         Tag tag3 = new Tag(tagName3);
         tag3.setDescription(description3);
         tag3.setPriority(456);
-        tags.add(tag3);
+        tags.put(tag3.getName(), tag3);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 
@@ -252,28 +251,28 @@ public class TagsRouteTest extends TagsServletTest {
         // Given...
         Map<String, String> headerMap = Map.of("Authorization", "Bearer " + BaseServletTest.DUMMY_JWT);
 
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
 
         String tagName = "tag1";
         String description = "My first tag!";
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(description);
         tag1.setPriority(100);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         String tagName2 = "tag2";
         String description2 = "My second tag!";
         Tag tag2 = new Tag(tagName2);
         tag2.setDescription(description2);
         tag2.setPriority(12);
-        tags.add(tag2);
+        tags.put(tag2.getName(), tag2);
 
         String tagName3 = "tag3";
         String description3 = "My third tag!";
         Tag tag3 = new Tag(tagName3);
         tag3.setDescription(description3);
         tag3.setPriority(456);
-        tags.add(tag3);
+        tags.put(tag3.getName(), tag3);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 
@@ -422,7 +421,7 @@ public class TagsRouteTest extends TagsServletTest {
         // Given...
         Map<String, String> headerMap = Map.of("Authorization", "Bearer " + BaseServletTest.DUMMY_JWT);
 
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
 
         String tagName = "tag1";
         String tagDescription = "my first tag!";
@@ -430,7 +429,7 @@ public class TagsRouteTest extends TagsServletTest {
         Tag tag1 = new Tag(tagName);
         tag1.setDescription(tagDescription);
         tag1.setPriority(tagPriority);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         MockTagsService mockTagsService = new MockTagsService(tags);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/scheduling/PrioritySchedulingServiceTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/scheduling/PrioritySchedulingServiceTest.java
@@ -359,14 +359,14 @@ public class PrioritySchedulingServiceTest {
     @Test
     public void testTagPriorityAffectsRunPriorityOrder() throws Exception {
         // Given...
-        List<Tag> tags = new ArrayList<>();
+        Map<String, Tag> tags = new HashMap<>();
         Tag tag1 = new Tag("high-priority-tag");
         tag1.setPriority(200);
-        tags.add(tag1);
+        tags.put(tag1.getName(), tag1);
 
         Tag tag2 = new Tag("another-tag");
         tag2.setPriority(20);
-        tags.add(tag2);
+        tags.put(tag2.getName(), tag2);
 
         Map<String, Tag> tagsMap = new HashMap<>();
         tagsMap.put(tag1.getName(), tag1);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockTagsService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockTagsService.java
@@ -5,8 +5,9 @@
  */
 package dev.galasa.framework.mocks;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import dev.galasa.framework.spi.tags.ITagsService;
 import dev.galasa.framework.spi.tags.Tag;
@@ -14,51 +15,34 @@ import dev.galasa.framework.spi.tags.TagsException;
 
 public class MockTagsService implements ITagsService {
 
-    private List<Tag> tags;
+    private Map<String, Tag> tags;
 
     public MockTagsService() {
-        this(new ArrayList<>());
+        this(new HashMap<>());
     }
 
-    public MockTagsService(List<Tag> tags) {
+    public MockTagsService(Map<String, Tag> tags) {
         this.tags = tags;
     }
 
     @Override
     public List<Tag> getTags() throws TagsException {
-        return tags;
+        return tags.values().stream().toList();
     }
 
     @Override
     public Tag getTagByName(String tagName) throws TagsException {
-        Tag tagToReturn = null;
-        for (Tag tag : tags) {
-            if (tag.getName().equals(tagName)) {
-                tagToReturn = tag;
-                break;
-            }
-        }
-        return tagToReturn;
+        return tags.get(tagName);
     }
 
     @Override
     public void setTag(Tag tag) throws TagsException {
-        tags.remove(tag);
-        tags.add(tag);
+        tags.put(tag.getName(), tag);
     }
 
     @Override
     public void deleteTag(String tagName) throws TagsException {
-        Tag tagToDelete = null;
-        for (Tag tag : tags) {
-            if (tag.getName().equals(tagName)) {
-                tagToDelete = tag;
-                break;
-            }
-        }
-        if (tagToDelete != null) {
-            tags.remove(tagToDelete);
-        }
+        tags.remove(tagName);
     }
-    
+
 }


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2176

## Changes
- [x] Added GalasaTag resource processing logic to allow the `/resources` endpoint to support GalasaTag resources, as well as allow the `galasactl resources` commands to be used to manage tags
- [x] Adds an extra check to make sure users have the CPS_PROPERTIES_DELETE permission before proceeding to delete tags
- [x] Adds a missing check to make sure users have the CPS_PROPERTIES_DELETE permission before proceeding to delete streams