### PR TITLE
Add MONITORS_SET action and check that users have it before proceeding to update monitors

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.monitors/src/main/java/dev/galasa/framework/api/monitors/internal/routes/MonitorsDetailsRoute.java
@@ -31,6 +31,7 @@ import dev.galasa.framework.api.monitors.internal.IKubernetesApiClient;
 import dev.galasa.framework.api.monitors.internal.MonitorTransform;
 import dev.galasa.framework.api.monitors.internal.UpdateMonitorRequestValidator;
 import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.rbac.BuiltInAction;
 import dev.galasa.framework.spi.rbac.RBACService;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Deployment;
@@ -101,6 +102,7 @@ public class MonitorsDetailsRoute extends ProtectedRoute {
     ) throws FrameworkException, IOException {
 
         logger.info("handlePutRequest() entered");
+        validateActionPermitted(BuiltInAction.MONITORS_SET, requestContext.getUsername());
 
         HttpServletRequest request = requestContext.getRequest();
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/BuiltInAction.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/BuiltInAction.java
@@ -14,6 +14,7 @@ import dev.galasa.framework.internal.rbac.ActionImpl;
 
 public enum BuiltInAction {
     GENERAL_API_ACCESS            (new ActionImpl("GENERAL_API_ACCESS", "General API access", "Able to access the REST API" )),
+    MONITORS_SET                  (new ActionImpl("MONITORS_SET", "Set monitors", "Able to create or edit monitors" )),
     USER_EDIT_OTHER               (new ActionImpl("USER_EDIT_OTHER", "Edit or delete a user other than you", "Edit or delete a user other than you, including role and access tokens")),
     SECRETS_GET_UNREDACTED_VALUES (new ActionImpl("SECRETS_GET_UNREDACTED_VALUES", "Get secret values", "Able to get unredacted secret values")),
     SECRETS_SET                   (new ActionImpl("SECRETS_SET", "Secrets set", "Able to set secrets")),

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestRBACServiceImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestRBACServiceImpl.java
@@ -40,7 +40,7 @@ public class TestRBACServiceImpl {
         assertThat(roleGot.getDescription()).contains("Administrator access");
 
         assertThat(roleGot.getActionIds())
-            .hasSize(10)
+            .hasSize(11)
             .contains("USER_EDIT_OTHER")
             .contains("SECRETS_GET_UNREDACTED_VALUES")
             .contains("GENERAL_API_ACCESS")
@@ -50,7 +50,8 @@ public class TestRBACServiceImpl {
             .contains("SECRETS_DELETE")
             .contains("RUNS_DELETE_OTHER_USERS")
             .contains("TEST_RUN_LAUNCH")
-            .contains("TEST_RUN_SET_USER");
+            .contains("TEST_RUN_SET_USER")
+            .contains("MONITORS_SET");
     }
 
     @Test


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2502

## Changes
- [x] Added `MONITORS_SET` action, which is only given to the "admin" and "owner" roles
- [x]  Added a check into the `handlePutRequest` method for `PUT /monitors/{monitorName}` to make sure the user has the `MONITORS_SET` action
- [x] Added a unit test to make sure that a user without the `MONITORS_SET` action will receive a 403 Forbidden error when trying to update a monitor
- [x] Corrected misspellings of "non-existent" in unit tests