### PR TITLE
Add the ability to run individual test methods

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2033,7 +2033,7 @@
         "hashed_secret": "c042bdfc4bc5516ec716afe9e85c173b614ff9f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 835,
+        "line_number": 900,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/docs/content/releases/posts/v0.46.0.md
+++ b/docs/content/releases/posts/v0.46.0.md
@@ -22,6 +22,8 @@ links:
   - The user can also be set when submitting tests with the Runs API. [See the REST API reference](../../docs/reference/rest-api/index.html).
   - Runs can now be queried by user in the `galasactl runs get` command with the `--user` flag. This will return any runs where the `user` or `requestor` matches the value passed in with the `--user` flag. [See the command reference](../../docs/reference/cli-syntax/galasactl_runs_get.md).
 
-- Added `galasactl tags` commands to the Galasa CLI tool that can be used to create, read, update, and delete test tags as resources on the Galasa service. [See the command reference for more details](../../docs/reference/cli-syntax/galasactl_tags.md)
+- Added `galasactl tags` commands to the Galasa CLI tool that can be used to create, read, update, and delete test tags as resources on the Galasa service. [See the command reference for more details](../../docs/reference/cli-syntax/galasactl_tags.md).
   - Tags can be assigned a `priority` modifier that can affect the order in which tests submitted to a Galasa service are scheduled. Test submitted with tags that have higher priority modifiers will be scheduled before tests that have no tags or tags with lower priority modifiers. 
   - Tags can also be assigned a `description` which can be used to provide more information about the tag.
+
+- `galasactl runs submit local` commands can now be supplied with one or more `--methods` flags to run a selection of test methods locally from a Galasa test class that is provided with the `--class` flag. [See the command reference for more details](../../docs/reference/cli-syntax/galasactl_runs_submit_local.md).

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -312,14 +312,27 @@ such as cleaning up resources when things fail and arbitrating contention for li
 between competing tests. It should only be used during test development to verify that the test is 
 behaving correctly.
 
-### Example : Run a single test in the local JVM.
+### Example: Run a single test class in the local JVM.
 ```
 galasactl runs submit local --log -
           --obr mvn:dev.galasa.example.banking/dev.galasa.example.banking.obr/0.0.1-SNAPSHOT/obr
           --class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestAccount
 ```
 
-### Example : Run a single Gherkin test in the local JVM.
+### Example: Run a single test method in the local JVM.
+
+To run a single test method within a test class, supply the `--methods` flag into the `galasactl runs submit local` command.
+
+For example, to run the `testCreateAccount` method within the `TestAccount` class, use the following command:
+
+```
+galasactl runs submit local --log -
+          --obr mvn:dev.galasa.example.banking/dev.galasa.example.banking.obr/0.0.1-SNAPSHOT/obr
+          --class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestAccount
+          --methods testCreateAccount
+```
+
+### Example: Run a single Gherkin test in the local JVM.
 ```
 galasactl runs submit local --log -
           --gherkin file:///path/to/gherkin/file.feature

--- a/modules/cli/docs/generated/errors-list.md
+++ b/modules/cli/docs/generated/errors-list.md
@@ -273,6 +273,10 @@ The `galasactl` tool can generate the following errors:
 - GAL1271E: Failed to get tags from the Galasa service. Unexpected http status code {} received from the server. Error details from the server are not in the json format.
 - GAL1272E: Failed to get tags from the Galasa service. Sending the put request to the Galasa service failed. Cause is {}
 - GAL1273E: User '{}' specified with the --user flag does not have permission to launch tests.
+- GAL1274E: Invalid Java method name. Method name should not be blank. Use the --help flag for more information, or refer to the documentation at https://galasa.dev/docs/reference
+- GAL1275E: Invalid Java method name '{}' should start with a letter (a-z, A-Z), not '{}'. Use the --help flag for more information, or refer to the documentation at https://galasa.dev/docs/reference
+- GAL1276E: Invalid Java method name '{}' should not contain the '{}' character. Use the --help flag for more information, or refer to the documentation at https://galasa.dev/docs/reference
+- GAL1277E: Invalid Java method name. Method name '{}' is a reserved Java keyword. Use the --help flag for more information, or refer to the documentation at https://galasa.dev/docs/reference
 - GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '{}', and 'pre-release' repository is '{}'
 - GAL2501I: Downloaded {} artifacts to folder '{}'
 

--- a/modules/cli/docs/generated/galasactl_runs_submit_local.md
+++ b/modules/cli/docs/generated/galasactl_runs_submit_local.md
@@ -21,6 +21,7 @@ galasactl runs submit local [flags]
       --gherkin strings        Gherkin feature file URL. Should start with 'file://'. 
   -h, --help                   Displays the options for the 'runs submit local' command.
       --localMaven string      The url of a local maven repository are where galasa bundles can be loaded from on your local file system. Defaults to your home .m2/repository file. Please note that this should be in a URL form e.g. 'file:///Users/myuserid/.m2/repository', or 'file://C:/Users/myuserid/.m2/repository'
+      --methods strings        Optional. The names of the Java test methods from the test class provided via the --class option that you wish to run. Method names must start with a letter (a-z, A-Z), can contain letters, numbers, and underscores, and must not be a Java reserved keyword. If not specified, all methods in the given class are run. Method names are case sensitive. This option can only be used alongside --class and cannot be used with --gherkin.
       --obr strings            The maven coordinates of the obr bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:${TEST_OBR_GROUP_ID}/${TEST_OBR_ARTIFACT_ID}/${TEST_OBR_VERSION}/obr' Multiple instances of this flag can be used to describe multiple obr bundles.
       --remoteMaven string     the url of the remote maven where galasa bundles can be loaded from. Defaults to maven central. (default "https://repo.maven.apache.org/maven2")
 ```

--- a/modules/cli/pkg/cmd/runsSubmitLocal.go
+++ b/modules/cli/pkg/cmd/runsSubmitLocal.go
@@ -139,6 +139,12 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 			"The connection is established using the --debugMode and --debugPort values.",
 	)
 
+	runsSubmitLocalCobraCmd.Flags().StringSliceVar(&cmd.values.runsSubmitLocalCmdParams.TestMethods, "methods", make([]string, 0),
+		"Optional. The names of the Java test methods from the test class provided via the --class option that you wish to run."+
+		" Method names must start with a letter (a-z, A-Z), can contain letters, numbers, and underscores, and must not be a Java reserved keyword."+
+		" If not specified, all methods in the given class are run. Method names are case sensitive."+
+		" This option can only be used alongside --class and cannot be used with --gherkin.")
+
 	runs.AddClassFlag(runsSubmitLocalCobraCmd, cmd.values.submitLocalSelectionFlags, false, "test class names."+
 		" The format of each entry is osgi-bundle-name/java-class-name. Java class names are fully qualified. No .class suffix is needed.")
 
@@ -146,6 +152,7 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 
 	runsSubmitLocalCobraCmd.MarkFlagsRequiredTogether("class", "obr")
 	runsSubmitLocalCobraCmd.MarkFlagsOneRequired("class", "gherkin")
+	runsSubmitLocalCobraCmd.MarkFlagsMutuallyExclusive("methods", "gherkin")
 
 	runsSubmitCmd.CobraCommand().AddCommand(runsSubmitLocalCobraCmd)
 

--- a/modules/cli/pkg/cmd/runsSubmitLocal_test.go
+++ b/modules/cli/pkg/cmd/runsSubmitLocal_test.go
@@ -198,6 +198,22 @@ func TestRunsSubmitLocalGalasaVersionFlagReturnsOk(t *testing.T) {
 	assert.Contains(t, cmd.Values().(*RunsSubmitLocalCmdValues).runsSubmitLocalCmdParams.TargetGalasaVersion, "0.1.0")
 }
 
+func TestRunsSubmitLocalWithGherkinAndMethodsFlagsErrors(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, cmd := setupTestCommandCollection(COMMAND_NAME_RUNS_SUBMIT_LOCAL, factory, t)
+
+	var args []string = []string{"runs", "submit", "local", "--gherkin", "my.gherkin.feature", "--methods", "mymethod"}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "if any flags in the group [methods gherkin] are set none of the others can be")
+	assert.Contains(t, cmd.Values().(*RunsSubmitLocalCmdValues).runsSubmitLocalCmdParams.TestMethods, "mymethod")
+}
+
 func TestRunsSubmitLocalLocalMavenFlagReturnsOk(t *testing.T) {
 	// Given...
 	factory := utils.NewMockFactory()

--- a/modules/cli/pkg/errors/errorMessage.go
+++ b/modules/cli/pkg/errors/errorMessage.go
@@ -492,6 +492,12 @@ var (
 	GALASA_ERROR_GET_TAGS_EXPLANATION_NOT_JSON     = NewMessageType("GAL1271E: Failed to get tags from the Galasa service. Unexpected http status code %v received from the server. Error details from the server are not in the json format.", 1271, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_GET_TAGS_REQUEST_FAILED           = NewMessageType("GAL1272E: Failed to get tags from the Galasa service. Sending the put request to the Galasa service failed. Cause is %v", 1272, STACK_TRACE_NOT_WANTED)
 
+	// Java method name validation errors
+	GALASA_ERROR_METHOD_NAME_BLANK                 = NewMessageType("GAL1274E: Invalid Java method name. Method name should not be blank."+SEE_COMMAND_REFERENCE, 1274, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_INVALID_FIRST_CHAR_IN_METHOD_NAME = NewMessageType("GAL1275E: Invalid Java method name '%s' should start with a letter (a-z, A-Z), not '%s'."+SEE_COMMAND_REFERENCE, 1275, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_INVALID_CHAR_IN_METHOD_NAME       = NewMessageType("GAL1276E: Invalid Java method name '%s' should not contain the '%s' character."+SEE_COMMAND_REFERENCE, 1276, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_INVALID_METHOD_RESERVED_WORD      = NewMessageType("GAL1277E: Invalid Java method name. Method name '%s' is a reserved Java keyword."+SEE_COMMAND_REFERENCE, 1277, STACK_TRACE_NOT_WANTED)
+
 	// Warnings...
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'pre-release' repository is '%s'", 2000, STACK_TRACE_WANTED)
 
@@ -509,5 +515,5 @@ var (
 	// >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
 	// >>>       If you do use this number for a new error template, please increment this value.
 	// >>>
-	GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 1274
+	GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 1278
 )

--- a/modules/cli/pkg/launcher/jvmLauncher.go
+++ b/modules/cli/pkg/launcher/jvmLauncher.go
@@ -111,6 +111,9 @@ type RunsSubmitLocalCmdParameters struct {
 
 	// A string containing the url of the gherkin test file to be exceuted
 	GherkinURL string
+
+	// A list of strings containing a selection of test methods to be run.
+	TestMethods []string
 }
 
 const (
@@ -258,6 +261,16 @@ func (launcher *JvmLauncher) SubmitTestRun(
 				}
 
 				if err == nil {
+					// Validate test methods if provided
+					for _, method := range launcher.cmdParams.TestMethods {
+						err = utils.ValidateJavaMethodName(method)
+						if err != nil {
+							break
+						}
+					}
+				}
+
+				if err == nil {
 
 					var jwt = ""
 					if isCPSRemote(launcher.bootstrapProps) {
@@ -279,7 +292,7 @@ func (launcher *JvmLauncher) SubmitTestRun(
 							launcher.bootstrapProps,
 							launcher.galasaHome,
 							launcher.fileSystem, launcher.javaHome, obrs,
-							*testClassToLaunch, launcher.cmdParams.RemoteMaven, launcher.cmdParams.LocalMaven,
+							*testClassToLaunch, launcher.cmdParams.TestMethods, launcher.cmdParams.RemoteMaven, launcher.cmdParams.LocalMaven,
 							launcher.cmdParams.TargetGalasaVersion, overridesFilePath,
 							gherkinURL,
 							isTraceEnabled,
@@ -606,6 +619,7 @@ func getCommandSyntax(
 	javaHome string,
 	testObrs []utils.MavenCoordinates,
 	testLocation TestLocation,
+	testMethods []string,
 	remoteMaven string,
 	localMaven string,
 	galasaVersionToRun string,
@@ -655,6 +669,12 @@ func getCommandSyntax(
 			// --test ${TEST_BUNDLE}/${TEST_JAVA_CLASS}
 			args = append(args, "--test")
 			args = append(args, testLocation.OSGiBundleName+"/"+testLocation.QualifiedJavaClassName)
+
+			// --method ${TEST_METHOD}
+			for _, method := range testMethods {
+				args = append(args, "--methods")
+				args = append(args, method)
+			}
 		}
 	}
 

--- a/modules/cli/pkg/launcher/jvmLauncher.go
+++ b/modules/cli/pkg/launcher/jvmLauncher.go
@@ -670,7 +670,7 @@ func getCommandSyntax(
 			args = append(args, "--test")
 			args = append(args, testLocation.OSGiBundleName+"/"+testLocation.QualifiedJavaClassName)
 
-			// --method ${TEST_METHOD}
+			// --methods ${TEST_METHOD}
 			for _, method := range testMethods {
 				args = append(args, "--methods")
 				args = append(args, method)

--- a/modules/cli/pkg/runs/junitReporter.go
+++ b/modules/cli/pkg/runs/junitReporter.go
@@ -80,7 +80,7 @@ func ReportJunit(
 
 			testSuites.Tests = testSuites.Tests + 1
 			testSuite.Tests = testSuite.Tests + 1
-			if !strings.HasPrefix(method.Result, "Passed") {
+			if !strings.HasPrefix(method.Result, "Passed") && !strings.HasPrefix(method.Result, "Ignored") {
 				testSuites.Failures = testSuites.Failures + 1
 				testSuite.Failures = testSuite.Failures + 1
 

--- a/modules/cli/pkg/utils/javaMethodName.go
+++ b/modules/cli/pkg/utils/javaMethodName.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package utils
+
+import (
+	"unicode"
+
+	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
+)
+
+// ValidateJavaMethodName validates that a string is a valid Java method name.
+// Java method names must:
+// - Start with a letter (a-z, A-Z)
+// - Contain only letters, digits, underscores, or dollar signs
+// - Not be a Java reserved keyword
+// - Not be empty
+func ValidateJavaMethodName(methodName string) error {
+	var err error
+
+	if methodName == "" {
+		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_METHOD_NAME_BLANK)
+	}
+
+	if err == nil {
+		// Check first character - must be a letter only (not underscore or dollar sign)
+		firstChar := rune(methodName[0])
+		if !unicode.IsLetter(firstChar) {
+			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_INVALID_FIRST_CHAR_IN_METHOD_NAME, methodName, string(firstChar))
+		}
+	}
+
+	if err == nil {
+		// Check remaining characters - can include letters, digits, underscore, dollar sign
+		for _, c := range methodName {
+			if !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '_' && c != '$' {
+				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_INVALID_CHAR_IN_METHOD_NAME, methodName, string(c))
+				break
+			}
+		}
+	}
+
+	if err == nil {
+		// Check if the method name is a reserved Java keyword
+		if isJavaReservedWord(methodName) {
+			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_INVALID_METHOD_RESERVED_WORD, methodName)
+		}
+	}
+
+	return err
+}

--- a/modules/cli/pkg/utils/javaMethodName_test.go
+++ b/modules/cli/pkg/utils/javaMethodName_test.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test valid Java method names
+func TestValidateJavaMethodNameWellFormed(t *testing.T) {
+	err := ValidateJavaMethodName("testMethod")
+	assert.Nil(t, err)
+}
+
+func TestValidateJavaMethodNameWithDigits(t *testing.T) {
+	err := ValidateJavaMethodName("testMethod123")
+	assert.Nil(t, err)
+}
+
+func TestValidateJavaMethodNameWithUnderscore(t *testing.T) {
+	err := ValidateJavaMethodName("test_method")
+	assert.Nil(t, err)
+}
+
+func TestValidateJavaMethodNameWithDollarSign(t *testing.T) {
+	err := ValidateJavaMethodName("test$method")
+	assert.Nil(t, err)
+}
+
+func TestValidateJavaMethodNameCamelCase(t *testing.T) {
+	err := ValidateJavaMethodName("testMethodName")
+	assert.Nil(t, err)
+}
+
+func TestValidateJavaMethodNameSingleLetter(t *testing.T) {
+	err := ValidateJavaMethodName("a")
+	assert.Nil(t, err)
+}
+
+func TestValidateJavaMethodNameUpperCase(t *testing.T) {
+	err := ValidateJavaMethodName("TestMethod")
+	assert.Nil(t, err)
+}
+
+// Test invalid Java method names - blank
+func TestValidateJavaMethodNameBlank(t *testing.T) {
+	err := ValidateJavaMethodName("")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1274E")
+	assert.Contains(t, err.Error(), "should not be blank")
+}
+
+// Test invalid Java method names - bad first character
+func TestValidateJavaMethodNameStartsWithDigit(t *testing.T) {
+	err := ValidateJavaMethodName("1testMethod")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1275E")
+	assert.Contains(t, err.Error(), "should start with a letter")
+}
+
+func TestValidateJavaMethodNameStartsWithUnderscore(t *testing.T) {
+	err := ValidateJavaMethodName("_testMethod")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1275E")
+	assert.Contains(t, err.Error(), "should start with a letter")
+}
+
+func TestValidateJavaMethodNameStartsWithDollarSign(t *testing.T) {
+	err := ValidateJavaMethodName("$testMethod")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1275E")
+	assert.Contains(t, err.Error(), "should start with a letter")
+}
+
+// Test invalid Java method names - bad characters
+func TestValidateJavaMethodNameWithSpace(t *testing.T) {
+	err := ValidateJavaMethodName("test method")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1276E")
+	assert.Contains(t, err.Error(), "should not contain")
+}
+
+func TestValidateJavaMethodNameWithDash(t *testing.T) {
+	err := ValidateJavaMethodName("test-method")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1276E")
+	assert.Contains(t, err.Error(), "should not contain")
+}
+
+func TestValidateJavaMethodNameWithDot(t *testing.T) {
+	err := ValidateJavaMethodName("test.method")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1276E")
+	assert.Contains(t, err.Error(), "should not contain")
+}
+
+func TestValidateJavaMethodNameWithSpecialChars(t *testing.T) {
+	err := ValidateJavaMethodName("test@method")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1276E")
+	assert.Contains(t, err.Error(), "should not contain")
+}
+
+func TestValidateJavaMethodNameWithParentheses(t *testing.T) {
+	err := ValidateJavaMethodName("testMethod()")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1276E")
+	assert.Contains(t, err.Error(), "should not contain")
+}
+
+// Test invalid Java method names - reserved keywords
+func TestValidateJavaMethodNameReservedWordClass(t *testing.T) {
+	err := ValidateJavaMethodName("class")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1277E")
+	assert.Contains(t, err.Error(), "reserved Java keyword")
+}
+
+func TestValidateJavaMethodNameReservedWordPublic(t *testing.T) {
+	err := ValidateJavaMethodName("public")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1277E")
+	assert.Contains(t, err.Error(), "reserved Java keyword")
+}
+
+func TestValidateJavaMethodNameReservedWordStatic(t *testing.T) {
+	err := ValidateJavaMethodName("static")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1277E")
+	assert.Contains(t, err.Error(), "reserved Java keyword")
+}
+
+func TestValidateJavaMethodNameReservedWordVoid(t *testing.T) {
+	err := ValidateJavaMethodName("void")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1277E")
+	assert.Contains(t, err.Error(), "reserved Java keyword")
+}
+
+func TestValidateJavaMethodNameReservedWordReturn(t *testing.T) {
+	err := ValidateJavaMethodName("return")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1277E")
+	assert.Contains(t, err.Error(), "reserved Java keyword")
+}
+
+func TestValidateJavaMethodNameReservedWordIf(t *testing.T) {
+	err := ValidateJavaMethodName("if")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1277E")
+	assert.Contains(t, err.Error(), "reserved Java keyword")
+}
+
+// Test edge cases - reserved words as part of method name (should be valid)
+func TestValidateJavaMethodNameContainsReservedWord(t *testing.T) {
+	err := ValidateJavaMethodName("testClassMethod")
+	assert.Nil(t, err, "Method name containing 'class' as substring should be valid")
+}
+
+func TestValidateJavaMethodNameEndsWithReservedWord(t *testing.T) {
+	err := ValidateJavaMethodName("getClass")
+	assert.Nil(t, err, "Method name ending with 'class' should be valid")
+}
+

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/MockIRun.java
@@ -175,4 +175,9 @@ public class MockIRun implements IRun {
     public Instant getAllocatedTimeout() {
         throw new UnsupportedOperationException("Unimplemented method 'getAllocatedTimeout'");
     }
+
+    @Override
+    public List<String> getRequestedTestMethods() {
+        throw new UnsupportedOperationException("Unimplemented method 'getRequestedTestMethods'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIFrameworkRuns.java
@@ -68,11 +68,12 @@ public class MockIFrameworkRuns implements IFrameworkRuns{
     @Override
     public @NotNull IRun submitRun(String type, String requestor, String user, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Set<String> tags, Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId)
-            throws FrameworkException {
-            if (stream.equals("null")){
-                throw new FrameworkException(language);
-            }
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId,
+            List<String> requestedTestMethods
+    ) throws FrameworkException {
+        if (stream.equals("null")){
+            throw new FrameworkException(language);
+        }
         return new MockIRun("runname", type, requestor, user, bundleName + "/" + testName, null, bundleName, testName, groupName, this.mockSubmissionId, tags);
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockIRun.java
@@ -258,4 +258,9 @@ public class MockIRun implements IRun {
     public Instant getAllocatedTimeout() {
         throw new UnsupportedOperationException("Unimplemented method 'getAllocatedTimeout'");
     }
+
+    @Override
+    public List<String> getRequestedTestMethods() {
+        throw new UnsupportedOperationException("Unimplemented method 'getRequestedTestMethods'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/common/GroupRuns.java
@@ -7,6 +7,7 @@ package dev.galasa.framework.api.runs.common;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -27,7 +28,6 @@ import dev.galasa.framework.api.common.EnvironmentVariables;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.ProtectedRoute;
 import dev.galasa.framework.api.common.ResponseBuilder;
-import dev.galasa.framework.api.common.SystemEnvironment;
 import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IRun;
@@ -45,14 +45,12 @@ public class GroupRuns extends ProtectedRoute {
     private IResultArchiveStore rasStore;
     private final GalasaGson gson = new GalasaGson();
     private final ITimeService timeService;
-    private final Environment env;
 
     public GroupRuns(ResponseBuilder responseBuilder, String path, IFramework framework, ITimeService timeService) throws RBACException {
         super(responseBuilder, path, framework.getRBACService());
         this.framework = framework;
         this.rasStore = framework.getResultArchiveStore();
         this.timeService = timeService;
-        this.env = new SystemEnvironment();
     }
 
     protected List<IRun> getRuns(String groupName) throws InternalServletException {
@@ -148,6 +146,7 @@ public class GroupRuns extends ProtectedRoute {
             try {
 
                 String submissionId = UUID.randomUUID().toString();
+                List<String> requestedTestMethods = new ArrayList<>();
 
                 IRun newRun = framework.getFrameworkRuns().submitRun(
                         request.getRequestorType(),
@@ -166,7 +165,9 @@ public class GroupRuns extends ProtectedRoute {
                         senvPhase,
                         request.getSharedEnvironmentRunName(),
                         "java",
-                        submissionId);
+                        submissionId,
+                        requestedTestMethods
+                    );
                         
                 Run serializedRun = setwebUiAndRestApiUrls(newRun, env);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -190,7 +190,7 @@ public class FrameworkRuns implements IFrameworkRuns {
     public @NotNull IRun submitRun(String runType, String requestor, String user, String bundleName,
             @NotNull String testName, String groupName, String mavenRepository, String obr, String stream,
             boolean local, boolean trace, Set<String> tags, Properties overrides, SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName,
-            String language, String submissionId) throws FrameworkException {
+            String language, String submissionId, List<String> requestedTestMethods) throws FrameworkException {
         SubmitRunRequest runRequest = new SubmitRunRequest(
             runType,
             requestor,
@@ -208,7 +208,8 @@ public class FrameworkRuns implements IFrameworkRuns {
             overrides,
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
-            language
+            language,
+            requestedTestMethods
         );
         return submitRun(runRequest);
     }
@@ -232,6 +233,7 @@ public class FrameworkRuns implements IFrameworkRuns {
         boolean trace = runRequest.isTraceEnabled();
         Set<String> tags = runRequest.getTags();
         String runId = generateRasRunId(runName);
+        List<String> requestedTestMethods = runRequest.getRequestedTestMethods();
 
         // *** Set up the otherRunProperties that will go with the Run number
         HashMap<String, String> otherRunProperties = new HashMap<>();
@@ -266,6 +268,11 @@ public class FrameworkRuns implements IFrameworkRuns {
         if (tags != null) {
             String tagsAsString = gson.toJson(tags);
             otherRunProperties.put(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.TAGS) ,tagsAsString);
+        }
+
+        if (requestedTestMethods != null) {
+            String requestedTestMethodsAsString = gson.toJson(requestedTestMethods);
+            otherRunProperties.put(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.TEST_METHODS), requestedTestMethodsAsString);
         }
 
         otherRunProperties.put(getSuffixedRunDssKey(runName, DssPropertyKeyRunNameSuffix.REQUESTOR), requestor);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestMethodWrapper.java
@@ -74,7 +74,7 @@ public class TestMethodWrapper {
                         + TestClassWrapper.LOG_ASTERS);
                 logger.info("Ignoring " + executionMethod.getName() + " due to " + ignoredResult.getReason());
 
-                markTestAndLinkedMethodsIgnored(ignoredResult, testClassWrapper, managers);
+                markTestAndLinkedMethodsIgnored(ignoredResult);
             } else {
 
                 runBeforeMethods(managers, testClassObject, testClassWrapper);
@@ -192,7 +192,7 @@ public class TestMethodWrapper {
         return this.testMethod.getName();
     }
 
-    private void markTestAndLinkedMethodsIgnored(Result ignoredResult, TestClassWrapper testClassWrapper, ITestRunManagers managers) {
+    void markTestAndLinkedMethodsIgnored(Result ignoredResult) {
         // Mark test method as ignored
         testMethod.setResult(ignoredResult);
         this.result = ignoredResult;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -498,7 +498,7 @@ public class TestRunner extends BaseTestRunner {
                 updateStatus(TestRunLifecycleStatus.RUNNING, null);
                 try {
                     logger.info("Running the test class");
-                    testClassWrapper.runMethods(managers, dss, runName);
+                    testClassWrapper.runMethods(managers, dss, runName, run.getRequestedTestMethods());
                 } finally {
                     updateStatus(TestRunLifecycleStatus.RUNDONE, null);
                 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ValidateEcosystem.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ValidateEcosystem.java
@@ -6,6 +6,7 @@
 package dev.galasa.framework;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
@@ -33,7 +34,8 @@ public class ValidateEcosystem {
 
     private Environment env;
 
-    private static final Set<String> NULL_TAGS = null ;
+    private static final Set<String> NULL_TAGS    = null;
+    private static final List<String> NULL_METHODS = null;
 
     public ValidateEcosystem() {
         this(new SystemEnvironment());
@@ -143,7 +145,8 @@ public class ValidateEcosystem {
                 null, 
                 null, 
                 null,
-                submissionId);
+                submissionId,
+                NULL_METHODS);
         
         logger.info("Test CoreManagerIVT submitted as run " + testRun.getName());
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/SubmitRunRequest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/SubmitRunRequest.java
@@ -5,7 +5,9 @@
  */
 package dev.galasa.framework.beans;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -36,6 +38,7 @@ public class SubmitRunRequest {
     private String language = "java";
     private String bundleTest;
     private String gherkinTest;
+    private List<String> requestedTestMethods = new ArrayList<>();
 
     public SubmitRunRequest(
         String runType,
@@ -54,7 +57,8 @@ public class SubmitRunRequest {
         Properties overrides,
         SharedEnvironmentPhase sharedEnvironmentPhase,
         String sharedEnvironmentRunName,
-        String language
+        String language,
+        List<String> requestedTestMethods
     ) throws FrameworkException {
         setTestName(testName);
 
@@ -72,6 +76,11 @@ public class SubmitRunRequest {
         if (tags!=null) {
             this.tags.addAll(tags);
         }
+
+        if (requestedTestMethods != null) {
+            this.requestedTestMethods.addAll(requestedTestMethods);
+        }
+
         this.overrides = overrides;
         this.sharedEnvironmentPhase = sharedEnvironmentPhase;
         this.sharedEnvironmentRunName = sharedEnvironmentRunName;
@@ -231,5 +240,9 @@ public class SubmitRunRequest {
 
     public Set<String> getTags() {
         return this.tags ;
+    }
+
+    public List<String> getRequestedTestMethods() {
+        return this.requestedTestMethods;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/DssPropertyKeyRunNameSuffix.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/DssPropertyKeyRunNameSuffix.java
@@ -42,6 +42,7 @@ public enum DssPropertyKeyRunNameSuffix{
     TEST("test"), 
     TEST_BUNDLE("testbundle"),
     TEST_CLASS("testclass"),
+    TEST_METHODS("testmethods"),
     TRACE("trace"),
     WAIT_UNTIL("wait.until"),
     ;

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkRuns.java
@@ -40,7 +40,8 @@ public interface IFrameworkRuns {
     @NotNull
     IRun submitRun(String type, String requestor, String user, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Set<String> tags, Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId) throws FrameworkException;
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId,
+            List<String> requestedTestMethods) throws FrameworkException;
 
     boolean delete(String runname) throws DynamicStatusStoreException;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRun.java
@@ -34,6 +34,8 @@ public interface IRun {
 
     String getTestClassName();
 
+    List<String> getRequestedTestMethods();
+
     boolean isLocal();
 
     String getGroup();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/utils/GalasaGson.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/utils/GalasaGson.java
@@ -9,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringReader;
+import java.lang.reflect.Type;
 import java.io.Reader;
 
 import org.apache.commons.io.output.StringBuilderWriter;
@@ -46,6 +47,10 @@ public class GalasaGson {
 
     public <T> T fromJson(String json, Class<T> classOfT)  {
         return gson.fromJson(json,  classOfT);   
+    }
+
+    public <T> T fromJson(String json, Type typeOfT)  {
+        return gson.fromJson(json,  typeOfT);   
     }
     
     public <T> T fromJson(InputStreamReader inputStreamReader, Class<T> classOfT) throws IOException  {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
@@ -82,6 +82,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = List.of("testMethod1", "testMethod2", "testMethod3");
 
         Properties overrides = new Properties();
         String override1Key = "override1";
@@ -113,16 +114,19 @@ public class FrameworkRunsTest {
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
             language,
-            submissionId
+            submissionId,
+            requestedTestMethods
         );
 
         // Then...
         assertThat(run).isNotNull();
         assertThat(run.getName()).isEqualTo("U1");
         assertThat(run.getTest()).isEqualTo(bundleName + "/" + testName);
+        assertThat(run.getRequestedTestMethods()).containsExactlyElementsOf(requestedTestMethods);
 
         // Check that the DSS has been populated with the correct run-related properties
         assertThat(mockDss.get("request.prefix.U.lastused")).isEqualTo("1");
+        assertThat(mockDss.get("run.U1.testmethods")).isEqualTo(gson.toJson(requestedTestMethods));
         assertThat(mockDss.get("run.U1."+DssPropertyKeyRunNameSuffix.OBR)).isEqualTo(obr);
         assertThat(mockDss.get("run.U1."+DssPropertyKeyRunNameSuffix.GROUP)).isEqualTo(groupName);
         assertThat(mockDss.get("run.U1."+DssPropertyKeyRunNameSuffix.REQUESTOR)).isEqualTo(requestor);
@@ -164,6 +168,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
         String override1Key = "override1";
@@ -195,7 +200,8 @@ public class FrameworkRunsTest {
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
             language,
-            submissionId
+            submissionId,
+            requestedTestMethods
         );
 
         // Then...
@@ -248,6 +254,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
         String override1Key = "override1";
@@ -280,7 +287,8 @@ public class FrameworkRunsTest {
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
                 language,
-                submissionId
+                submissionId,
+                requestedTestMethods
             );
         }, FrameworkException.class);
 
@@ -312,6 +320,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
 
@@ -338,7 +347,8 @@ public class FrameworkRunsTest {
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
                 language,
-                submissionId
+                submissionId,
+                requestedTestMethods
             );
         }, FrameworkException.class);
 
@@ -370,6 +380,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
 
@@ -396,7 +407,8 @@ public class FrameworkRunsTest {
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
                 language,
-                submissionId
+                submissionId,
+                requestedTestMethods
             );
         }, FrameworkException.class);
 
@@ -429,6 +441,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
 
@@ -453,7 +466,8 @@ public class FrameworkRunsTest {
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
             language,
-            submissionId
+            submissionId,
+            requestedTestMethods
         );
 
         // Then...
@@ -486,6 +500,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
 
@@ -510,7 +525,8 @@ public class FrameworkRunsTest {
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
             language,
-            submissionId
+            submissionId,
+            requestedTestMethods
         );
 
         // Then...
@@ -543,6 +559,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
 
@@ -567,7 +584,8 @@ public class FrameworkRunsTest {
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
             language,
-            submissionId
+            submissionId,
+            requestedTestMethods
         );
 
         // Then...
@@ -619,6 +637,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
 
@@ -640,7 +659,8 @@ public class FrameworkRunsTest {
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
             language,
-            submissionId
+            submissionId,
+            requestedTestMethods
         );
 
         // Then...
@@ -693,6 +713,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
 
@@ -715,7 +736,8 @@ public class FrameworkRunsTest {
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
                 language,
-                submissionId
+                submissionId,
+                requestedTestMethods
             );
         }, FrameworkException.class);
 
@@ -754,6 +776,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
 
@@ -775,7 +798,8 @@ public class FrameworkRunsTest {
             sharedEnvironmentPhase,
             sharedEnvironmentRunName,
             language,
-            submissionId
+            submissionId,
+            requestedTestMethods
         );
 
         // Then...
@@ -819,6 +843,7 @@ public class FrameworkRunsTest {
         boolean local = true;
         boolean trace = true;
         Set<String> tags = null ;
+        List<String> requestedTestMethods = null;
 
         Properties overrides = new Properties();
 
@@ -841,7 +866,8 @@ public class FrameworkRunsTest {
                 sharedEnvironmentPhase,
                 sharedEnvironmentRunName,
                 language,
-                submissionId
+                submissionId,
+                requestedTestMethods
             );
         }, FrameworkException.class);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestRunImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestRunImpl.java
@@ -48,6 +48,26 @@ public class TestRunImpl {
     }
 
     @Test
+    public void testCanCreateARunImplWithRequestedTestMethods() throws Exception  {
+        String name = "U1234";
+        Map<String,String> dssProps = new HashMap<String,String>();
+
+        List<String> requestedTestMethods = new ArrayList<>();
+        requestedTestMethods.add("method1");
+        requestedTestMethods.add("method2");
+
+        GalasaGson gson = new GalasaGson();
+        String testMethodsAsJsonString = gson.toJson(requestedTestMethods);
+        dssProps.put("run.U1234"+".testmethods", testMethodsAsJsonString);
+        IDynamicStatusStoreService dss = new MockDSSStore(dssProps);
+
+        RunImpl run = new RunImpl(name,dss);
+        List<String> testMethodsGotBack = run.getRequestedTestMethods();
+
+        assertThat(testMethodsGotBack).containsExactly("method1","method2");
+    }
+
+    @Test
     public void testCanConvertARunImplToATestStructure() throws Exception  {
         // Given...
         String name = "U1234";

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/MockRun.java
@@ -170,4 +170,9 @@ public class MockRun implements IRun {
     public Instant getAllocatedTimeout() {
         throw new UnsupportedOperationException("Unimplemented method 'getAllocatedTimeout'");
     }
+
+    @Override
+    public List<String> getRequestedTestMethods() {
+        throw new UnsupportedOperationException("Unimplemented method 'getRequestedTestMethods'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
@@ -89,11 +89,12 @@ public class MockFrameworkRuns implements IFrameworkRuns {
     @Override
     public @NotNull IRun submitRun(String type, String requestor, String user, String bundleName, String testName, String groupName,
             String mavenRepository, String obr, String stream, boolean local, boolean trace, Set<String> tags,Properties overrides,
-            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId)
-            throws FrameworkException {
-            if (stream.equals("null")){
-                throw new FrameworkException(language);
-            }
+            SharedEnvironmentPhase sharedEnvironmentPhase, String sharedEnvironmentRunName, String language, String submissionId,
+            List<String> requestedTestMethods
+    ) throws FrameworkException {
+        if (stream.equals("null")){
+            throw new FrameworkException(language);
+        }
 
         throw new FrameworkException("Method not implemented in mock class.");
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
@@ -40,6 +40,7 @@ public class MockRun implements IRun {
     private String runId;
     private List<RunRasAction> rasActions = new ArrayList<>();
     private Set<String> tags = new HashSet<String>();
+    private List<String> requestedTestMethods = new ArrayList<>();
 
     public MockRun(
         String testBundleName,
@@ -307,6 +308,15 @@ public class MockRun implements IRun {
         this.allocatedTimeout = allocatedTimeout;
     }
 
+    @Override
+    public List<String> getRequestedTestMethods() {
+        return this.requestedTestMethods;
+    }
+
+    public void setRequestedTestMethods(List<String> requestedTestMethods) {
+        this.requestedTestMethods = requestedTestMethods;
+    }
+
     // ------------- un-implemented methods follow ----------------
 
     @Override
@@ -335,5 +345,4 @@ public class MockRun implements IRun {
     public Run getSerializedRun() {
         throw new UnsupportedOperationException("Unimplemented method 'getSerializedRun'");
     }
-
 }


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2497

## Changes
- [x] Added a new `--methods` flag to the Galasa boot jar which accepts Galasa test method names that a user wishes to run
- [x] The TestClassWrapper now receives a list of test methods that should be run (which includes befores + afters). As it loops through test methods in a class, any test methods that are not in the list of methods to run will be marked as ignored (including their befores + after methods).
- [x] Added a new `--methods` flag to the `galasactl runs submit local` command which passes a set of flags to the boot jar launch command
- [x] Updated release notes and `galasactl runs submit local` command docs