### PR TITLE
Stop loading uber OBR bundles containing resource cleanup classes when a test stream is given

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/TestResourceMonitorBundleLoader.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/TestResourceMonitorBundleLoader.java
@@ -106,12 +106,12 @@ public class TestResourceMonitorBundleLoader {
 
         MockResource mockResource1 = createMockBundleWithServiceCapability(BUNDLE_NAME_1);
         MockResource mockResource2 = createMockBundleWithServiceCapability(BUNDLE_NAME_2);
-        mockRepo.addResource(mockResource1);
-        mockRepo.addResource(mockResource2);
 
         boolean IS_RESOLVER_GOING_TO_RESOLVE_TEST_BUNDLE = true;
         Resolver mockResolver = new MockResolver(IS_RESOLVER_GOING_TO_RESOLVE_TEST_BUNDLE);
         MockRepositoryAdmin mockRepositoryAdmin = new MockRepositoryAdmin(mockRepositories, mockResolver);
+        mockRepositoryAdmin.setResourcesToAddToRepositories(List.of(mockResource1, mockResource2));
+
         MockMavenRepository mockMavenRepository = new MockMavenRepository();
 
         String stream = "myStream";

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRepositoryAdmin.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRepositoryAdmin.java
@@ -6,6 +6,7 @@
 package dev.galasa.framework.mocks;
 
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,8 @@ public class MockRepositoryAdmin implements RepositoryAdmin {
 
     private Map<String,Repository> repositoryURLMap = new HashMap<String,Repository>();
 
+    private List<MockResource> resourcesToAddToRepositories = new ArrayList<>();
+
     public MockRepositoryAdmin(List<Repository> repositories, Resolver resolver) {
         for( Repository repo : repositories) {
             String key = repo.getURI().toString();
@@ -40,6 +43,11 @@ public class MockRepositoryAdmin implements RepositoryAdmin {
     @Override
     public Repository addRepository(String repository) throws Exception {
         MockRepository mockRepository = new MockRepository(repository);
+
+        for (MockResource resourceToAdd : resourcesToAddToRepositories) {
+            mockRepository.addResource(resourceToAdd);
+        }
+
         this.repositoryURLMap.put(repository, mockRepository);
         return repositoryURLMap.get(repository);
     }
@@ -55,6 +63,10 @@ public class MockRepositoryAdmin implements RepositoryAdmin {
     @Override
     public Resolver resolver() {
         return resolver;
+    }
+
+    public void setResourcesToAddToRepositories(List<MockResource> resourcesToAddToRepositories) {
+        this.resourcesToAddToRepositories = resourcesToAddToRepositories;
     }
 
     // ----------------- un-implemented methdos follow --------------------


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2511

At the moment, when a user provides a test stream to configure the custom resource monitor, the framework adds the test stream's OBRs to the list of OBRs to look through to find classes implementing the IResourceManagementProvider interface.

The custom resource monitor shouldn't be loading bundles in the uber OBR - those bundles are already loaded in the Galasa service's normal resource monitor pod.

## Changes
- [x] When a test stream is passed to resource management, the framework will now only look through OBRs that are configured into the test stream to find bundles containing IResourceManagementProvider classes
- [x] Switch to using a list of bundles rather than a set in case bundles need to be loaded in a specific order given by the OBR