### PR TITLE
Improve CouchDB query performance for single-value filters

### DIFF
--- a/docs/content/releases/posts/v0.46.0.md
+++ b/docs/content/releases/posts/v0.46.0.md
@@ -7,6 +7,10 @@ links:
 
 # 0.46.0 - Release Highlights
 
+## Deprecated features
+
+- The Galasa Service's `GET /ras/runs` REST API endpoint: The `includeCursor` query parameter has been deprecated as cursor-based pagination is now enabled by default. This query parameter should be removed from requests to this endpoint.
+
 ## Changes affecting tests running locally or on the Galasa Service
 
 - The SSH client library that Galasa uses has been updated to support stronger key algorithms, including `rsa-sha2-256` and `rsa-sha2-512`. See [#2461](https://github.com/galasa-dev/projectmanagement/issues/2461).

--- a/docs/content/releases/posts/v0.46.0.md
+++ b/docs/content/releases/posts/v0.46.0.md
@@ -9,7 +9,7 @@ links:
 
 ## Deprecated features
 
-- The Galasa Service's `GET /ras/runs` REST API endpoint: The `includeCursor` query parameter has been deprecated as cursor-based pagination is now enabled by default. This query parameter should be removed from requests to this endpoint.
+- The `includeCursor` query parameter has been marked as deprecated in the Galasa Service's `GET /ras/runs` REST API endpoint as cursor-based pagination is now enabled by default. This query parameter should be removed from requests to this endpoint.
 
 ## Changes affecting tests running locally or on the Galasa Service
 

--- a/modules/cli/pkg/launcher/remoteLauncher.go
+++ b/modules/cli/pkg/launcher/remoteLauncher.go
@@ -191,7 +191,6 @@ func (launcher *RemoteLauncher) GetRunsBySubmissionId(submissionId string, group
 			var context context.Context = nil
 
 			apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion).
-				IncludeCursor("true").
 				SubmissionId(submissionId).Group(groupId).Sort("from:desc")
 
 			runData, httpResponse, err = apicall.Execute()

--- a/modules/cli/pkg/runs/runsQuery.go
+++ b/modules/cli/pkg/runs/runsQuery.go
@@ -85,7 +85,7 @@ func (query *RunsQuery) GetRunsPageFromRestApi(
 		var httpResponse *http.Response
 		var context context.Context = nil
 
-		apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion).IncludeCursor("true")
+		apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion)
 		if !query.fromTime.IsZero() {
 			apicall = apicall.From(query.fromTime)
 		}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImpl.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImpl.java
@@ -46,7 +46,7 @@ public class CouchdbValidatorImpl implements CouchdbValidator {
     private static final String TEST_NAMES_VIEW_FUNCTION       = "function (doc) { emit(doc.testName, 1); }";
     private static final String BUNDLE_TESTNAMES_VIEW_FUNCTION = "function (doc) { emit(doc.bundle + '/' + doc.testName, 1); }";
     private static final String RUN_NAMES_VIEW_FUNCTION        = "function (doc) { emit(doc.runName, 1); }";
-    private static final String GROUP_VIEW_FUNCTION            = "function (doc) { if (doc.group !== undefined && doc.group !== null) { emit(doc.group, doc); } }";
+    private static final String GROUP_VIEW_FUNCTION            = "function (doc) { if (doc.group !== undefined && doc.group !== null) { emit(doc.group, 1); } }";
     private static final String COUNT_REDUCE                   = "_count";
     
     private final GalasaGson                         gson               = new GalasaGson();

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbRasQueryBuilderTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbRasQueryBuilderTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.ras.couchdb.internal;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import dev.galasa.framework.TestRunLifecycleStatus;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaBundle;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaQueuedFrom;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaQueuedTo;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaRequestor;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaResult;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaRunName;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaStatus;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaTags;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaTestName;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaUser;
+
+public class CouchdbRasQueryBuilderTest {
+
+    @Test
+    public void testCanBuildQueryWithNoSearchCriteria() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery();
+
+        // Then...
+        assertThat(query).isNotNull();
+        assertThat(query.has("$and")).isTrue();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).isEmpty();
+    }
+
+    @Test
+    public void testCanBuildQueryWithSingleRunName() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaRunName runNameCriteria = new RasSearchCriteriaRunName("L10");
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(runNameCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        assertThat(query.has("$and")).isTrue();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        assertThat(condition.has("runName")).isTrue();
+        assertThat(condition.get("runName").getAsString()).isEqualTo("L10");
+    }
+
+    @Test
+    public void testCanBuildQueryWithMultipleRunNames() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaRunName runNameCriteria = new RasSearchCriteriaRunName("L10", "L20", "L30");
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(runNameCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        JsonArray inArray = condition.getAsJsonObject("runName").getAsJsonArray("$in");
+        assertThat(inArray).hasSize(3);
+        assertThat(inArray.get(0).getAsString()).isEqualTo("L10");
+        assertThat(inArray.get(1).getAsString()).isEqualTo("L20");
+        assertThat(inArray.get(2).getAsString()).isEqualTo("L30");
+    }
+
+    @Test
+    public void testCanBuildQueryWithMultipleTags() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaTags tagsCriteria = new RasSearchCriteriaTags("tag1", "tag2", "tag3");
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(tagsCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        JsonArray inArray = condition.getAsJsonObject("tags").getAsJsonArray("$in");
+        assertThat(inArray).hasSize(3);
+        assertThat(inArray.get(0).getAsString()).isEqualTo("tag1");
+        assertThat(inArray.get(1).getAsString()).isEqualTo("tag2");
+        assertThat(inArray.get(2).getAsString()).isEqualTo("tag3");
+    }
+
+    @Test
+    public void testCanBuildQueryWithQueuedFromCriteria() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        Instant fromTime = Instant.parse("2024-01-01T10:00:00Z");
+        RasSearchCriteriaQueuedFrom queuedFromCriteria = new RasSearchCriteriaQueuedFrom(fromTime);
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(queuedFromCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        assertThat(condition.has("queued")).isTrue();
+        JsonObject queuedCondition = condition.getAsJsonObject("queued");
+        assertThat(queuedCondition.has("$gte")).isTrue();
+        assertThat(queuedCondition.get("$gte").getAsString()).isEqualTo(fromTime.toString());
+    }
+
+    @Test
+    public void testCanBuildQueryWithQueuedToCriteria() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        Instant toTime = Instant.parse("2024-12-31T23:59:59Z");
+        RasSearchCriteriaQueuedTo queuedToCriteria = new RasSearchCriteriaQueuedTo(toTime);
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(queuedToCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        assertThat(condition.has("queued")).isTrue();
+        JsonObject queuedCondition = condition.getAsJsonObject("queued");
+        assertThat(queuedCondition.has("$lt")).isTrue();
+        assertThat(queuedCondition.get("$lt").getAsString()).isEqualTo(toTime.toString());
+    }
+
+    @Test
+    public void testCanBuildQueryWithQueuedFromAndToCriteria() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        Instant fromTime = Instant.parse("2024-01-01T00:00:00Z");
+        Instant toTime = Instant.parse("2024-12-31T23:59:59Z");
+        RasSearchCriteriaQueuedFrom queuedFromCriteria = new RasSearchCriteriaQueuedFrom(fromTime);
+        RasSearchCriteriaQueuedTo queuedToCriteria = new RasSearchCriteriaQueuedTo(toTime);
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(queuedFromCriteria, queuedToCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(2);
+
+        // Check first condition (queued from)
+        JsonObject fromCondition = andArray.get(0).getAsJsonObject();
+        assertThat(fromCondition.getAsJsonObject("queued").get("$gte").getAsString()).isEqualTo(fromTime.toString());
+
+        // Check second condition (queued to)
+        JsonObject toCondition = andArray.get(1).getAsJsonObject();
+        assertThat(toCondition.getAsJsonObject("queued").get("$lt").getAsString()).isEqualTo(toTime.toString());
+    }
+
+    @Test
+    public void testCanBuildQueryWithUserCriteriaOnly() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaUser userCriteria = new RasSearchCriteriaUser("alice");
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(userCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        // When only user is provided, it should create an $or condition matching either user or requestor
+        JsonObject orWrapper = andArray.get(0).getAsJsonObject();
+        assertThat(orWrapper.has("$or")).isTrue();
+        JsonArray orArray = orWrapper.getAsJsonArray("$or");
+        assertThat(orArray).hasSize(2);
+
+        // Check user condition
+        JsonObject userCondition = orArray.get(0).getAsJsonObject();
+        assertThat(userCondition.has("user")).isTrue();
+        assertThat(userCondition.get("user").getAsString()).isEqualTo("alice");
+
+        // Check requestor condition (should also match alice)
+        JsonObject requestorCondition = orArray.get(1).getAsJsonObject();
+        assertThat(requestorCondition.has("requestor")).isTrue();
+        assertThat(requestorCondition.get("requestor").getAsString()).isEqualTo("alice");
+    }
+
+    @Test
+    public void testCanBuildQueryWithRequestorCriteriaOnly() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaRequestor requestorCriteria = new RasSearchCriteriaRequestor("bob");
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(requestorCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        // When only requestor is provided, it should create a strict match on requestor
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        assertThat(condition.has("requestor")).isTrue();
+        assertThat(condition.get("requestor").getAsString()).isEqualTo("bob");
+    }
+
+    @Test
+    public void testCanBuildQueryWithBothUserAndRequestorCriteria() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaUser userCriteria = new RasSearchCriteriaUser("alice");
+        RasSearchCriteriaRequestor requestorCriteria = new RasSearchCriteriaRequestor("bob");
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(userCriteria, requestorCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(2);
+
+        // When both are provided, it should create strict matches on both
+        JsonObject userCondition = andArray.get(0).getAsJsonObject();
+        assertThat(userCondition.has("user")).isTrue();
+        assertThat(userCondition.get("user").getAsString()).isEqualTo("alice");
+
+        JsonObject requestorCondition = andArray.get(1).getAsJsonObject();
+        assertThat(requestorCondition.has("requestor")).isTrue();
+        assertThat(requestorCondition.get("requestor").getAsString()).isEqualTo("bob");
+    }
+
+    @Test
+    public void testCanBuildQueryWithTestNameCriteria() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaTestName testNameCriteria = new RasSearchCriteriaTestName("dev.galasa.test.MyTest");
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(testNameCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        assertThat(condition.has("testName")).isTrue();
+        assertThat(condition.get("testName").getAsString()).isEqualTo("dev.galasa.test.MyTest");
+    }
+
+    @Test
+    public void testCanBuildQueryWithBundleCriteria() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaBundle bundleCriteria = new RasSearchCriteriaBundle("dev.galasa.test");
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(bundleCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        assertThat(condition.has("bundle")).isTrue();
+        assertThat(condition.get("bundle").getAsString()).isEqualTo("dev.galasa.test");
+    }
+
+    @Test
+    public void testCanBuildQueryWithResultCriteria() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaResult resultCriteria = new RasSearchCriteriaResult("Passed");
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(resultCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        assertThat(condition.has("result")).isTrue();
+        assertThat(condition.get("result").getAsString()).isEqualTo("Passed");
+    }
+
+    @Test
+    public void testCanBuildQueryWithStatusCriteria() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        List<TestRunLifecycleStatus> statuses = Arrays.asList(TestRunLifecycleStatus.FINISHED);
+        RasSearchCriteriaStatus statusCriteria = new RasSearchCriteriaStatus(statuses);
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(statusCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        assertThat(condition.has("status")).isTrue();
+        assertThat(condition.get("status").getAsString()).isEqualTo("finished");
+    }
+
+    @Test
+    public void testCanBuildQueryWithMultipleCriteria() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        Instant fromTime = Instant.parse("2024-01-01T00:00:00Z");
+        RasSearchCriteriaQueuedFrom queuedFromCriteria = new RasSearchCriteriaQueuedFrom(fromTime);
+        RasSearchCriteriaRunName runNameCriteria = new RasSearchCriteriaRunName("L10", "L20");
+        RasSearchCriteriaTestName testNameCriteria = new RasSearchCriteriaTestName("dev.galasa.test.MyTest");
+        RasSearchCriteriaResult resultCriteria = new RasSearchCriteriaResult("Passed");
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(queuedFromCriteria, runNameCriteria, testNameCriteria, resultCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(4);
+
+        // Verify queued from condition
+        JsonObject queuedCondition = andArray.get(0).getAsJsonObject();
+        assertThat(queuedCondition.has("queued")).isTrue();
+
+        // Verify runName condition
+        JsonObject runNameCondition = andArray.get(1).getAsJsonObject();
+        assertThat(runNameCondition.has("runName")).isTrue();
+        JsonArray inArray = runNameCondition.getAsJsonObject("runName").getAsJsonArray("$in");
+        assertThat(inArray).hasSize(2);
+        assertThat(inArray.get(0).getAsString()).isEqualTo("L10");
+        assertThat(inArray.get(1).getAsString()).isEqualTo("L20");
+
+        // Verify testName condition
+        JsonObject testNameCondition = andArray.get(2).getAsJsonObject();
+        assertThat(testNameCondition.has("testName")).isTrue();
+        assertThat(testNameCondition.get("testName").getAsString()).isEqualTo("dev.galasa.test.MyTest");
+
+        // Verify result condition
+        JsonObject resultCondition = andArray.get(3).getAsJsonObject();
+        assertThat(resultCondition.has("result")).isTrue();
+        assertThat(resultCondition.get("result").getAsString()).isEqualTo("Passed");
+    }
+
+    @Test
+    public void testCanBuildQueryWithEmptyStringArrayFiltersOutEmptyStrings() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaRunName runNameCriteria = new RasSearchCriteriaRunName("L10", "", "L20", null);
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(runNameCriteria);
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+        assertThat(andArray).hasSize(1);
+
+        JsonObject condition = andArray.get(0).getAsJsonObject();
+        JsonArray inArray = condition.getAsJsonObject("runName").getAsJsonArray("$in");
+
+        // Should only contain non-null, non-empty strings
+        assertThat(inArray).hasSize(2);
+        assertThat(inArray.get(0).getAsString()).isEqualTo("L10");
+        assertThat(inArray.get(1).getAsString()).isEqualTo("L20");
+    }
+
+    @Test
+    public void testCanBuildComplexQueryWithAllCriteriaTypes() throws Exception {
+        // Given...
+        CouchdbRasQueryBuilder builder = new CouchdbRasQueryBuilder();
+        RasSearchCriteriaRunName runNameCriteria = new RasSearchCriteriaRunName("L10");
+        RasSearchCriteriaTestName testNameCriteria = new RasSearchCriteriaTestName("dev.galasa.test.MyTest");
+        RasSearchCriteriaBundle bundleCriteria = new RasSearchCriteriaBundle("dev.galasa.test");
+        RasSearchCriteriaResult resultCriteria = new RasSearchCriteriaResult("Passed");
+        List<TestRunLifecycleStatus> statuses = Arrays.asList(TestRunLifecycleStatus.FINISHED);
+        RasSearchCriteriaStatus statusCriteria = new RasSearchCriteriaStatus(statuses);
+        RasSearchCriteriaUser userCriteria = new RasSearchCriteriaUser("alice");
+        RasSearchCriteriaRequestor requestorCriteria = new RasSearchCriteriaRequestor("bob");
+        Instant fromTime = Instant.parse("2024-01-01T00:00:00Z");
+        Instant toTime = Instant.parse("2024-12-31T23:59:59Z");
+        RasSearchCriteriaQueuedFrom queuedFromCriteria = new RasSearchCriteriaQueuedFrom(fromTime);
+        RasSearchCriteriaQueuedTo queuedToCriteria = new RasSearchCriteriaQueuedTo(toTime);
+
+        // When...
+        JsonObject query = builder.buildGetRunsQuery(
+            runNameCriteria,
+            testNameCriteria,
+            bundleCriteria,
+            resultCriteria,
+            statusCriteria,
+            userCriteria,
+            requestorCriteria,
+            queuedFromCriteria,
+            queuedToCriteria
+        );
+
+        // Then...
+        assertThat(query).isNotNull();
+        JsonArray andArray = query.getAsJsonArray("$and");
+
+        // Should have: queuedFrom, queuedTo, runName, testName, bundle, result, status, user, requestor = 9 conditions
+        assertThat(andArray).hasSize(9);
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
@@ -324,6 +324,18 @@ public class CouchdbValidatorImplTest {
         interactions.add( new CheckIndexPOSTInteraction("submissionId"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
         interactions.add( new CheckIndexPOSTInteraction("tags"));
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("requestor", "queued"));
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("user", "requestor", "queued"));
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("result", "queued"));
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("status", "queued"));
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("group", "result"));
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("group", "status"));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1616,6 +1616,19 @@ paths:
           schema:
             type: string
           example: my-zos-tests
+
+        # Temporary feature flag to enable cursor-based pagination
+        - name: includeCursor
+          in: query
+          deprecated: true
+          description: |
+            Deprecated: Cursor-based pagination is enabled by default as of 0.46.0, so this query parameter is no longer used.
+
+            A boolean flag to enable cursor-based pagination and return the next page cursor
+            in the response. If omitted, it will default to false.
+          schema:
+            type: string
+          example: 'true'
         - name: cursor
           in: query
           description: |

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1554,16 +1554,6 @@ paths:
           schema:
             type: string
           example: dev.galasa.inttests.simbank.local.mvp.SimBankLocalJava11UbuntuMvp
-        - name: page
-          in: query
-          description: |
-            Deprecated (since 0.37.0) - Use the 'cursor' query parameter instead.
-            Causes a specific page in the available results to be returned.
-            The first page is page 1.
-            If omitted, then page 1 is returned.
-          schema:
-            type: integer
-          example: 2
         - name: size
           in: query
           description: |
@@ -1626,16 +1616,6 @@ paths:
           schema:
             type: string
           example: my-zos-tests
-        
-        # Temporary feature flag to enable cursor-based pagination
-        - name: includeCursor
-          in: query
-          description: |
-            A boolean flag to enable cursor-based pagination and return the next page cursor
-            in the response. If omitted, it will default to false.
-          schema:
-            type: string
-          example: 'true'
         - name: cursor
           in: query
           description: |
@@ -3564,11 +3544,7 @@ components:
     RunResults:
       type: object
       properties:
-        pageNumber:
-          type: integer
         pageSize:
-          type: integer
-        numPages:
           type: integer
         amountOfRuns:
           type: integer

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
@@ -28,8 +28,18 @@ import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 public class RasQueryParameters {
 
-	public static final int DEFAULT_PAGE_NUMBER = 1;
 	public static final int DEFAULT_NUMBER_RECORDS_PER_PAGE = 100;
+
+    public static final Set<String> SUPPORTED_SORT_KEYS = Set.of(
+        "from",
+        "to",
+        "testclass",
+        "result",
+        "requestor",
+        "resultnames",
+        "runname"
+    );
+
     private final Map<String, Boolean> sortDirectionMap = new HashMap<String,Boolean>(){{
         put("asc",true);
         put("ascending",true);
@@ -67,11 +77,6 @@ public class RasQueryParameters {
 	}
 
 
-
-    public int getPageNumber() throws InternalServletException {
-        int pageNumber = generalQueryParams.getSingleInt("page", DEFAULT_PAGE_NUMBER);
-        return pageNumber;
-    }
 
     public int getPageSize() throws InternalServletException {
         return generalQueryParams.getSingleInt("size", DEFAULT_NUMBER_RECORDS_PER_PAGE);
@@ -119,10 +124,6 @@ public class RasQueryParameters {
 
     public String getPageCursor() throws InternalServletException {
         return generalQueryParams.getSingleString("cursor", null);
-    }
-
-    public boolean getIncludeCursor() throws InternalServletException {
-        return generalQueryParams.getSingleBoolean("includeCursor", false);
     }
 
     public RasSortField getSortValue() throws InternalServletException {
@@ -213,7 +214,10 @@ public class RasQueryParameters {
     private RasSortField getValidatedSortValue(String sortValue) throws InternalServletException {
         String[] sortValueParts = sortValue.split(":");
 
-        if (sortValueParts.length != 2 || !sortDirectionMap.containsKey(sortValueParts[1].toLowerCase())) {
+        if (sortValueParts.length != 2
+            || !SUPPORTED_SORT_KEYS.contains(sortValueParts[0].toLowerCase())
+            || !sortDirectionMap.containsKey(sortValueParts[1].toLowerCase())
+        ) {
             ServletError error = new ServletError(GAL5011_SORT_VALUE_NOT_RECOGNIZED, sortValue);
             throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/UserQueryContext.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/UserQueryContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.ras.internal.common;
+
+public class UserQueryContext {
+	private final String matchedRequestor;
+	private final String matchedUser;
+	private final boolean shouldReturnEmptyResultsPage;
+
+	public UserQueryContext(String matchedRequestor, String matchedUser, boolean shouldReturnEmptyResultsPage) {
+		this.matchedRequestor = matchedRequestor;
+		this.matchedUser = matchedUser;
+		this.shouldReturnEmptyResultsPage = shouldReturnEmptyResultsPage;
+	}
+
+	public String getMatchedRequestor() {
+		return matchedRequestor;
+	}
+
+	public String getMatchedUser() {
+		return matchedUser;
+	}
+
+	public boolean shouldReturnEmptyResultsPage() {
+		return shouldReturnEmptyResultsPage;
+	}
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
@@ -68,6 +68,9 @@ public class RunQueryRoute extends RunsRoute {
 			"to", "endTime",
 			"testclass", "testName");
 
+	// No longer used, but keep it for now to avoid breaking existing clients
+	public static final String QUERY_PARAMETER_INCLUDECURSOR = "includecursor";
+
 	public static final String QUERY_PARAMETER_SORT = "sort";
 	public static final String QUERY_PARAMETER_RESULT = "result";
 	public static final String QUERY_PARAMETER_STATUS = "status";
@@ -80,7 +83,6 @@ public class RunQueryRoute extends RunsRoute {
 	public static final String QUERY_PARAMETER_SIZE = "size";
 	public static final String QUERY_PARAMETER_GROUP = "group";
 	public static final String QUERY_PARAMETER_SUBMISSION_ID = "submissionId";
-	public static final String QUERY_PARAMETER_INCLUDECURSOR = "includecursor";
 	public static final String QUERY_PARAMETER_CURSOR = "cursor";
 	public static final String QUERY_PARAMETER_RUNNAME = "runname";
 	public static final String QUERY_PARAMETER_RUNID = "runid";

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
@@ -5,8 +5,6 @@
  */
 package dev.galasa.framework.api.ras.internal.routes;
 
-import org.apache.commons.collections4.ListUtils;
-
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -22,6 +20,7 @@ import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.api.ras.internal.common.RasDetailsQueryParams;
 import dev.galasa.framework.api.ras.internal.common.RasQueryParameters;
 import dev.galasa.framework.api.ras.internal.common.RunResultUtility;
+import dev.galasa.framework.api.ras.internal.common.UserQueryContext;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IResultArchiveStoreDirectoryService;
@@ -78,7 +77,6 @@ public class RunQueryRoute extends RunsRoute {
 	public static final String QUERY_PARAMETER_FROM = "from";
 	public static final String QUERY_PARAMETER_TO = "to";
 	public static final String QUERY_PARAMETER_TESTNAME = "testname";
-	public static final String QUERY_PARAMETER_PAGE = "page";
 	public static final String QUERY_PARAMETER_SIZE = "size";
 	public static final String QUERY_PARAMETER_GROUP = "group";
 	public static final String QUERY_PARAMETER_SUBMISSION_ID = "submissionId";
@@ -92,14 +90,13 @@ public class RunQueryRoute extends RunsRoute {
 	public static final SupportedQueryParameterNames SUPPORTED_QUERY_PARAMETER_NAMES = new SupportedQueryParameterNames(
 			QUERY_PARAMETER_SORT, QUERY_PARAMETER_RESULT, QUERY_PARAMETER_STATUS,
 			QUERY_PARAMETER_BUNDLE, QUERY_PARAMETER_DETAIL, QUERY_PARAMETER_REQUESTOR, QUERY_PARAMETER_USER,
-			QUERY_PARAMETER_FROM, QUERY_PARAMETER_TO, QUERY_PARAMETER_TESTNAME, QUERY_PARAMETER_PAGE,
+			QUERY_PARAMETER_FROM, QUERY_PARAMETER_TO, QUERY_PARAMETER_TESTNAME,
 			QUERY_PARAMETER_SIZE, QUERY_PARAMETER_GROUP, QUERY_PARAMETER_SUBMISSION_ID,
 			QUERY_PARAMETER_INCLUDECURSOR, QUERY_PARAMETER_CURSOR, QUERY_PARAMETER_RUNNAME,
 			QUERY_PARAMETER_RUNID, QUERY_PARAMETER_TAGS);
 
 	private static final GalasaGson gson = new GalasaGson();
 
-	private final Environment env;
 	private final RunResultUtility runResultUtility;
 
 	public RunQueryRoute(ResponseBuilder responseBuilder, IFramework framework, Environment env) throws RBACException {
@@ -111,7 +108,6 @@ public class RunQueryRoute extends RunsRoute {
 		 */
 		super(responseBuilder, path, framework);
 
-		this.env = env;
 		this.runResultUtility = new RunResultUtility(env);
 	}
 
@@ -138,14 +134,6 @@ public class RunQueryRoute extends RunsRoute {
 	private String retrieveResults(RasQueryParameters queryParams, boolean isMethodDetailsExcluded)
 			throws InternalServletException {
 
-		int pageNum = queryParams.getPageNumber();
-		int pageSize = queryParams.getPageSize();
-
-		boolean includeCursor = queryParams.getIncludeCursor();
-		String pageCursor = queryParams.getPageCursor();
-
-		List<RasRunResult> runs = new ArrayList<>();
-
 		/*
 		 * Get list of Run Ids from the URL -
 		 * If a Run ID parameter list is present in the URL then only return that run /
@@ -156,82 +144,24 @@ public class RunQueryRoute extends RunsRoute {
 
 		// Default to sorting in descending order based on the "queued time" of runs
 		RasSortField sortValue = queryParams.getSortValue("from:desc");
-
-		RasRunResultPage runsPage = null;
 		String responseJson = null;
-
 		try {
-			if (runIds != null && runIds.size() > 0) {
-				runs = getRunsByIds(runIds, isMethodDetailsExcluded);
+			if (runIds != null && !runIds.isEmpty()) {
+				responseJson = getRunsJsonByRunIds(runIds, isMethodDetailsExcluded, queryParams, sortValue);
 			} else {
-
-				String requestor  = queryParams.getRequestor();
-				String user = queryParams.getUser();
-
-				String matchedRequestor = null;
-				String matchedUser = null;
-
-				boolean queryingRequestor = requestor != null && !requestor.isEmpty();
-				boolean queryingUser = user != null && !user.isEmpty();
-
-				// If querying by requestor and user, search for runs that match both the requestor and user.
-				if (queryingRequestor && queryingUser) {
-					matchedRequestor = findMatchingRequestor(requestor);
-					matchedUser = findMatchingRequestor(user);
-
-					// We weren't able to match against both a known requestor and user,
-					// so there should be no runs for the given requestor/user combination.
-					if (matchedRequestor == null || matchedUser == null) {
-						runsPage = new RasRunResultPage(new ArrayList<>());
-					}
-				} 
-				
-				// If querying by requestor, search for runs that match that requestor.
-				else if (queryingRequestor) {
-					matchedRequestor = findMatchingRequestor(requestor);
-
-					// We weren't able to match against a known requestor,
-					// so there should be no runs for the given requestor.
-					if (matchedRequestor == null) {
-						runsPage = new RasRunResultPage(new ArrayList<>());
-					}
+				UserQueryContext userQueryContext = matchRequestorAndUser(
+					queryParams.getRequestor(),
+					queryParams.getUser()
+				);
+	
+				// Return empty results page if no matching requestor/user was found
+				if (userQueryContext.shouldReturnEmptyResultsPage()) {
+					RasRunResultPage emptyPage = new RasRunResultPage(new ArrayList<>());
+					responseJson = buildResponseBody(emptyPage, queryParams.getPageSize(), isMethodDetailsExcluded);
+				} else {
+					// Handle criteria-based queries
+					responseJson = getRunsJsonByCriteria(queryParams, userQueryContext, isMethodDetailsExcluded, sortValue);
 				}
-
-				// If querying by user, search for runs that match that user OR requestor.
-				else if (queryingUser) {
-					matchedUser = findMatchingRequestor(user);
-
-					// We weren't able to match against either a known user or requestor,
-					// so there should be no runs for the given user.
-					if (matchedUser == null) {
-						runsPage = new RasRunResultPage(new ArrayList<>());
-					}
-				}
-
-				if (runsPage == null) {
-					List<IRasSearchCriteria> criteria = getCriteria(queryParams, matchedRequestor, matchedUser);
-
-					// Story https://github.com/galasa-dev/projectmanagement/issues/1978 will
-					// replace the old page-based pagination with the new cursor-based pagination
-					if (includeCursor || pageCursor != null) {
-						String runName = queryParams.getRunName();
-						if (runName != null) {
-							runsPage = new RasRunResultPage(getRunsByRunName(runName));
-						} else {
-							runsPage = getRunsPage(pageCursor, pageSize, formatSortField(sortValue), criteria);
-						}
-					} else {
-						runs = getRuns(criteria, isMethodDetailsExcluded);
-					}
-				}
-
-			}
-
-			if (runsPage == null) {
-				runs = sortResults(runs, queryParams, sortValue);
-				responseJson = buildResponseBody(runs, pageNum, pageSize);
-			} else {
-				responseJson = buildResponseBody(runsPage, pageSize, isMethodDetailsExcluded);
 			}
 		} catch (ResultArchiveStoreException e) {
 			ServletError error = new ServletError(GAL5003_ERROR_RETRIEVING_RUNS);
@@ -352,33 +282,6 @@ public class RunQueryRoute extends RunsRoute {
 		return critList;
 	}
 
-	private String buildResponseBody(List<RasRunResult> runs, int pageNum, int pageSize)
-			throws InternalServletException {
-
-		// Splits up the pages based on the page size
-		List<List<RasRunResult>> paginatedResults = ListUtils.partition(runs, pageSize);
-
-		// Building the object to be returned by the API and splitting
-		JsonObject runsPage = null;
-		try {
-			if ((pageNum == 1) && paginatedResults.isEmpty()) {
-				// No results at all, so return one page saying that.
-				runsPage = pageToJson(runs, runs.size(), 1, pageSize, 1);
-			} else {
-				runsPage = pageToJson(
-						paginatedResults.get(pageNum - 1),
-						runs.size(),
-						pageNum,
-						pageSize,
-						paginatedResults.size());
-			}
-		} catch (IndexOutOfBoundsException e) {
-			ServletError error = new ServletError(GAL5004_ERROR_RETRIEVING_PAGE);
-			throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST, e);
-		}
-		return gson.toJson(runsPage);
-	}
-
 	private String findMatchingRequestor(String loginId) throws InternalServletException {
 		String matchedRequestor = null;
 
@@ -401,53 +304,21 @@ public class RunQueryRoute extends RunsRoute {
 		return matchedRequestor;
 	}
 
-	private String buildResponseBody(RasRunResultPage runsPage, int pageSize, boolean isMethodDetailsExcluded)
-			throws ResultArchiveStoreException {
+	private String buildResponseBody(List<RasRunResult> runs, int pageSize, String nextPageCursor) {
+        JsonObject pageJson = new JsonObject();
 
-		// Building the object to be returned by the API and splitting
-		JsonObject pageJson = new JsonObject();
+        JsonElement tree = gson.toJsonTree(runs);
+        pageJson.addProperty("pageSize", pageSize);
+        pageJson.addProperty("amountOfRuns", runs.size());
+        pageJson.addProperty("nextCursor", nextPageCursor);
+        pageJson.add("runs", tree);
 
-		List<RasRunResult> runs = convertRunsToRunResults(runsPage.getRuns(), isMethodDetailsExcluded);
-		JsonElement tree = gson.toJsonTree(runs);
-		pageJson.addProperty("pageSize", pageSize);
-		pageJson.addProperty("amountOfRuns", runs.size());
-		pageJson.addProperty("nextCursor", runsPage.getNextCursor());
-		pageJson.add("runs", tree);
-
-		return gson.toJson(pageJson);
+        return gson.toJson(pageJson);
 	}
 
-	private JsonObject pageToJson(List<RasRunResult> resultsInPage, int totalRuns, int pageNum, int pageSize,
-			int numPages) {
-		JsonObject obj = new JsonObject();
-
-		obj.addProperty("pageNum", pageNum);
-		obj.addProperty("pageSize", pageSize);
-		obj.addProperty("numPages", numPages);
-		obj.addProperty("amountOfRuns", totalRuns);
-
-		JsonElement tree = gson.toJsonTree(resultsInPage);
-
-		obj.add("runs", tree);
-		return obj;
-	}
-
-	private List<RasRunResult> getRuns(List<IRasSearchCriteria> critList, boolean isMethodDetailsExcluded)
-			throws ResultArchiveStoreException, InternalServletException {
-
-		IRasSearchCriteria[] criteria = new IRasSearchCriteria[critList.size()];
-
-		critList.toArray(criteria);
-		// Collect all the runs from all the RAS stores into a single list
-		List<IRunResult> runs = new ArrayList<>();
-		for (IResultArchiveStoreDirectoryService directoryService : getFramework().getResultArchiveStore()
-				.getDirectoryServices()) {
-			runs.addAll(directoryService.getRuns(criteria));
-		}
-
-		List<RasRunResult> runResults = convertRunsToRunResults(runs, isMethodDetailsExcluded);
-
-		return runResults;
+	private String buildResponseBody(RasRunResultPage runsPage, int pageSize, boolean isMethodDetailsExcluded) throws ResultArchiveStoreException {
+        List<RasRunResult> runs = convertRunsToRunResults(runsPage.getRuns(), isMethodDetailsExcluded);
+        return buildResponseBody(runs, pageSize, runsPage.getNextCursor());
 	}
 
 	private RasRunResultPage getRunsPage(String pageCursor, int maxResults, RasSortField primarySort,
@@ -494,6 +365,83 @@ public class RunQueryRoute extends RunsRoute {
 			runResults.add(runResultUtility.toRunResult(run, isMethodDetailsExcluded));
 		}
 		return runResults;
+	}
+
+	private String getRunsJsonByRunIds(List<String> runIds, boolean isMethodDetailsExcluded,
+			RasQueryParameters queryParams, RasSortField sortValue)
+			throws InternalServletException, ResultArchiveStoreException {
+		List<RasRunResult> runs = sortResults(getRunsByIds(runIds, isMethodDetailsExcluded), queryParams, sortValue);
+		return buildResponseBody(runs, queryParams.getPageSize(), null);
+	}
+
+	private UserQueryContext matchRequestorAndUser(String requestor, String user)
+			throws InternalServletException {
+		boolean isQueryingRequestor = (requestor != null && !requestor.isEmpty());
+		boolean isQueryingUser = (user != null && !user.isEmpty());
+
+		String matchedRequestor = null;
+		String matchedUser = null;
+		boolean shouldReturnEmptyResultsPage = false;
+
+		// If querying by requestor and user, search for runs that match both the requestor and user.
+		if (isQueryingRequestor && isQueryingUser) {
+			matchedRequestor = findMatchingRequestor(requestor);
+			matchedUser = findMatchingRequestor(user);
+
+			// We weren't able to match against both a known requestor and user,
+			// so there should be no runs for the given requestor/user combination.
+			if (matchedRequestor == null || matchedUser == null) {
+				shouldReturnEmptyResultsPage = true;
+			}
+		}
+		// If querying by requestor, search for runs that match that requestor.
+		else if (isQueryingRequestor) {
+			matchedRequestor = findMatchingRequestor(requestor);
+
+			// We weren't able to match against a known requestor,
+			// so there should be no runs for the given requestor.
+			if (matchedRequestor == null) {
+				shouldReturnEmptyResultsPage = true;
+			}
+		}
+		// If querying by user, search for runs that match that user OR requestor.
+		else if (isQueryingUser) {
+			matchedUser = findMatchingRequestor(user);
+
+			// We weren't able to match against either a known user or requestor,
+			// so there should be no runs for the given user.
+			if (matchedUser == null) {
+				shouldReturnEmptyResultsPage = true;
+			}
+		}
+
+		return new UserQueryContext(matchedRequestor, matchedUser, shouldReturnEmptyResultsPage);
+	}
+
+	private String getRunsJsonByCriteria(RasQueryParameters queryParams,
+			UserQueryContext userQueryContext, boolean isMethodDetailsExcluded,
+			RasSortField sortValue)
+			throws InternalServletException, ResultArchiveStoreException {
+		
+		String runName = queryParams.getRunName();
+		int pageSize = queryParams.getPageSize();
+		String pageCursor = queryParams.getPageCursor();
+
+		String responseJson = null;
+
+		// Handle runName as a special case
+		if (runName != null) {
+			List<RasRunResult> runs = convertRunsToRunResults(getRunsByRunName(runName), isMethodDetailsExcluded);
+			runs = sortResults(runs, queryParams, sortValue);
+			responseJson = buildResponseBody(runs, pageSize, null);
+		} else {
+			// Handle general criteria-based queries
+			List<IRasSearchCriteria> criteria = getCriteria(queryParams, userQueryContext.getMatchedRequestor(), userQueryContext.getMatchedUser());
+			RasRunResultPage runsPage = getRunsPage(pageCursor, pageSize, formatSortField(sortValue), criteria);
+			responseJson = buildResponseBody(runsPage, pageSize, isMethodDetailsExcluded);
+		}
+
+		return responseJson;
 	}
 
 	class SortByQueuedTime implements Comparator<RasRunResult> {


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2505

## Changes
- [x] Removed the deprecated page-based pagination from the `/ras/runs` endpoint to take advantage of cursor-based pagination performance enhancements by default

- [x] Deprecated the `includeCursor` query parameter as it is no longer needed

- [x] Updated the CouchDB query builder code to use equality comparisons for single-value fields instead of using the `$in` operator for all comparisons.
  - Multi-valued fields will still work as they did before

For example, when querying `/ras/runs?group=my-group&result=failed`, the previous CouchDB query would look like this:
```json
{
  "selector": {
    "$and": [
      {
        "group": {
          "$in": [
            "my-group"
          ]
        }
      },
      {
        "result": {
          "$in": [
            "Failed"
          ]
        }
      }
    ]
  }
}
```

Now, it looks like this:
```json
{
  "selector": {
    "$and": [
      {
        "group": "my-group"
      },
      {
        "result": "Failed"
      }
    ]
  }
}
```

- [x] Added new indexes with multiple fields to improve performance for queries that use the following fields:
  - [x] requestor and from/to
  - [x] requestor, user, and from/to
  - [x] result and from/to
  - [x] status and from/to
  - [x] group and result
  - [x] group and status

- [x] Stopped emitting entire documents in the group view to save disk space (the recommendation is to use `include_docs=true` in view queries to get documents back, which is what we already do)