### PR TITLE
Iss2471 - Fix bug where stopped runs with `unknown` status are counted as `Active` in `runs get` report

### DIFF
--- a/modules/cli/pkg/runsformatter/detailsFormatter_test.go
+++ b/modules/cli/pkg/runsformatter/detailsFormatter_test.go
@@ -314,7 +314,8 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 	formattableTest7 := createFormattableTestForDetails("cbd-543210", "L111", "Finished", "Failed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", methods, false, "none", "https://127.0.0.1/test-runs/cdb-123", "https://127.0.0.1/api/ras/runs/cdb-123")
 	formattableTest8 := createFormattableTestForDetails("cbd-222", "L222", "Building", "", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", methods, false, "none", "https://127.0.0.1/test-runs/cdb-123", "https://127.0.0.1/api/ras/runs/cdb-123")
 	formattableTest9 := createFormattableTestForDetails("cbd-333", "L333", "Generating", "", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", methods, false, "none", "https://127.0.0.1/test-runs/cdb-123", "https://127.0.0.1/api/ras/runs/cdb-123")
-	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9)
+	formattableTest10 := createFormattableTestForDetails("cbd-567", "L334", "UNKNOWN", "", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", nil, false, "none", "https://127.0.0.1/test-runs/cdb-123", "https://127.0.0.1/api/ras/runs/cdb-123")
+	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9, formattableTest10)
 
 	// When...
 	actualFormattedOutput, err := formatter.FormatRuns(formattableTest)
@@ -517,7 +518,28 @@ func TestDetailsFormatterMultipleRunsDifferentResultsProducesExpectedTotalsCount
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
 			"testCoreIvtTest test finished passed 2023-05-05 06:03:38 2023-05-05 06:03:39 349\n" +
 			"\n" +
-			"Total:9 Passed:2 PassedWithDefects:1 Failed:2 FailedWithDefects:1 EnvFail:1 Active:2\n"
+			"---" +
+			"\n\n" +
+			"name                : L334\n" +
+			"status              : UNKNOWN\n" +
+			"result              : \n" +
+			"submitted-time(UTC) : 2023-05-04 10:55:29\n" +
+			"start-time(UTC)     : 2023-05-05 06:00:14\n" +
+			"end-time(UTC)       : \n" +
+			"duration(ms)        : \n" +
+			"test-name           : dev.galasa.Zos3270LocalJava11Ubuntu\n" +
+			"requestor           : galasa\n" +
+			"user                : galasa\n" +
+			"bundle              : dev.galasa\n" +
+			"group               : none\n" +
+			"tags                : \n" +
+			"run-log             : https://127.0.0.1/ras/runs/cbd-567/runlog\n" +
+			"web-ui-url          : https://127.0.0.1/test-runs/cdb-123\n" +
+			"rest-api-url        : https://127.0.0.1/api/ras/runs/cdb-123\n" +
+			"\n" +
+			"method type status result start-time(UTC) end-time(UTC) duration(ms)\n" +
+			"\n" +
+			"Total:10 Passed:2 PassedWithDefects:1 Failed:2 FailedWithDefects:1 EnvFail:1 UNKNOWN:1 Active:2\n"
 
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
 }
@@ -539,7 +561,8 @@ func TestDetailsFormatterMultipleRunsDoesNotDisplayLostRunsAndProducesExpectedTo
 	formattableTest7 := createFormattableTestForDetails("cbd-543210", "L111", "Finished", "Failed", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "2023-05-05T06:00:15.654565Z", "https://127.0.0.1", methods, false, "none", "https://127.0.0.1/test-runs/cdb-123", "https://127.0.0.1/api/ras/runs/cdb-123")
 	formattableTest8 := createFormattableTestForDetails("cbd-222", "L222", "Building", "", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", methods, true, "none", "https://127.0.0.1/test-runs/cdb-123", "https://127.0.0.1/api/ras/runs/cdb-123")
 	formattableTest9 := createFormattableTestForDetails("cbd-333", "L333", "Generating", "", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", methods, false, "none", "https://127.0.0.1/test-runs/cdb-123", "https://127.0.0.1/api/ras/runs/cdb-123")
-	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9)
+	formattableTest10 := createFormattableTestForDetails("cbd-567", "L334", "UNKNOWN", "", "dev.galasa", "dev.galasa.Zos3270LocalJava11Ubuntu", "galasa", "galasa", "2023-05-04T10:55:29.545323Z", "2023-05-05T06:00:14.496953Z", "", "https://127.0.0.1", nil, false, "none", "https://127.0.0.1/test-runs/cdb-123", "https://127.0.0.1/api/ras/runs/cdb-123")
+	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9, formattableTest10)
 
 	// When...
 	actualFormattedOutput, err := formatter.FormatRuns(formattableTest)
@@ -654,7 +677,28 @@ func TestDetailsFormatterMultipleRunsDoesNotDisplayLostRunsAndProducesExpectedTo
 			"method          type status   result start-time(UTC)     end-time(UTC)       duration(ms)\n" +
 			"testCoreIvtTest test finished passed 2023-05-05 06:03:38 2023-05-05 06:03:39 349\n" +
 			"\n" +
-			"Total:9 PassedWithDefects:1 Failed:2 FailedWithDefects:1 Lost:4 Active:1\n"
+			"---" +
+			"\n\n" +
+			"name                : L334\n" +
+			"status              : UNKNOWN\n" +
+			"result              : \n" +
+			"submitted-time(UTC) : 2023-05-04 10:55:29\n" +
+			"start-time(UTC)     : 2023-05-05 06:00:14\n" +
+			"end-time(UTC)       : \n" +
+			"duration(ms)        : \n" +
+			"test-name           : dev.galasa.Zos3270LocalJava11Ubuntu\n" +
+			"requestor           : galasa\n" +
+			"user                : galasa\n" +
+			"bundle              : dev.galasa\n" +
+			"group               : none\n" +
+			"tags                : \n" +
+			"run-log             : https://127.0.0.1/ras/runs/cbd-567/runlog\n" +
+			"web-ui-url          : https://127.0.0.1/test-runs/cdb-123\n" +
+			"rest-api-url        : https://127.0.0.1/api/ras/runs/cdb-123\n" +
+			"\n" +
+			"method type status result start-time(UTC) end-time(UTC) duration(ms)\n" +
+			"\n" +
+			"Total:10 PassedWithDefects:1 Failed:2 FailedWithDefects:1 Lost:4 UNKNOWN:1 Active:1\n"
 
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
 }

--- a/modules/cli/pkg/runsformatter/runsFormatter.go
+++ b/modules/cli/pkg/runsformatter/runsFormatter.go
@@ -163,17 +163,17 @@ func generateResultTotalsReport(totalResults int, resultsCount map[string]int) s
 }
 
 func accumulateResults(resultCounts map[string]int, run FormattableTest) {
-	runResult := run.Result
-	if len(runResult) > 0 {
-		resultTotal, isPresent := resultCounts[runResult]
-		if isPresent {
-			resultTotal++
-			resultCounts[runResult] = resultTotal
-		}
+	var resultKey string
+
+	if len(run.Result) > 0 {
+		resultKey = run.Result
+	} else if strings.ToUpper(run.Status) == RUN_RESULT_UNKNOWN {
+		resultKey = RUN_RESULT_UNKNOWN
 	} else {
-		resultCounts[RUN_RESULT_ACTIVE]++
+		resultKey = RUN_RESULT_ACTIVE
 	}
 
+	resultCounts[resultKey]++
 }
 
 func initialiseResultMap() map[string]int {

--- a/modules/cli/pkg/runsformatter/summaryFormatter_test.go
+++ b/modules/cli/pkg/runsformatter/summaryFormatter_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	EXAMPLE_URL  = "https://my-api-server.com/"
-	RUN_ID       = "cdb-ba06e2a6-U123"
-	WEB_UI_URL   = EXAMPLE_URL + "test-runs/" + RUN_ID
+	EXAMPLE_URL = "https://my-api-server.com/"
+	RUN_ID      = "cdb-ba06e2a6-U123"
+	WEB_UI_URL  = EXAMPLE_URL + "test-runs/" + RUN_ID
 )
 
 func TestSummaryFormatterNoDataReturnsTotalCountAllZeros(t *testing.T) {
@@ -133,7 +133,8 @@ func TestSummaryFormatterWithMultipleRunsPrintsOnlyFinishedRuns(t *testing.T) {
 	formattableTest7 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C111", "MyTestName6", "Finished", "Failed", "myUserId1", false, "none", tags)
 	formattableTest8 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C222", "MyTestName7", "Finished", "UNKNOWN", "myUserId2", false, "none", tags)
 	formattableTest9 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C333", "MyTestName8", "Finished", "Ignored", "myUserId1", false, "none", tags)
-	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9)
+	formattableTest10 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C567", "MyTestName9", "Running", "", "myUserId1", false, "none", tags)
+	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9, formattableTest10)
 
 	// When...
 	actualFormattedOutput, err := formatter.FormatRuns(formattableTest)
@@ -150,8 +151,9 @@ func TestSummaryFormatterWithMultipleRunsPrintsOnlyFinishedRuns(t *testing.T) {
 			"2023-05-04 10:55:29 C111 myUserId1 Finished Failed              MyTestName6 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
 			"2023-05-04 10:55:29 C222 myUserId2 Finished UNKNOWN             MyTestName7 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
 			"2023-05-04 10:55:29 C333 myUserId1 Finished Ignored             MyTestName8 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
+			"2023-05-04 10:55:29 C567 myUserId1 Running                      MyTestName9 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
 			"\n" +
-			"Total:9 Passed:1 PassedWithDefects:1 Failed:2 EnvFail:2 UNKNOWN:1 Active:1 Ignored:1\n"
+			"Total:10 Passed:1 PassedWithDefects:1 Failed:2 EnvFail:2 UNKNOWN:2 Active:1 Ignored:1\n"
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
 }
 
@@ -169,8 +171,8 @@ func TestSummaryFormatterMultipleRunsWithLostRunsDoesNotDisplayLostRunsAndCounts
 	formattableTest7 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C111", "MyTestName6", "Finished", "Failed", "myUserId1", false, "none", tags)
 	formattableTest8 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C222", "MyTestName7", "Finished", "UNKNOWN", "myUserId2", false, "none", tags)
 	formattableTest9 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C333", "MyTestName8", "Finished", "Ignored", "myUserId1", true, "none", tags)
-	//formattableTest10 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L321", "MyTestName9", "UNKNOWN", "", "myUserId2", true)
-	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9)
+	formattableTest10 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C567", "MyTestName9", "Running", "", "myUserId1", false, "none", tags)
+	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9, formattableTest10)
 
 	// When...
 	actualFormattedOutput, err := formatter.FormatRuns(formattableTest)
@@ -184,8 +186,9 @@ func TestSummaryFormatterMultipleRunsWithLostRunsDoesNotDisplayLostRunsAndCounts
 			"2023-05-04 10:55:29 L789 myUserId2 Finished Passed With Defects MyTestName5 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
 			"2023-05-04 10:55:29 C111 myUserId1 Finished Failed              MyTestName6 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
 			"2023-05-04 10:55:29 C222 myUserId2 Finished UNKNOWN             MyTestName7 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
+			"2023-05-04 10:55:29 C567 myUserId1 Running                      MyTestName9 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
 			"\n" +
-			"Total:9 Passed:1 PassedWithDefects:1 Failed:1 Lost:3 EnvFail:1 UNKNOWN:1 Active:1\n"
+			"Total:10 Passed:1 PassedWithDefects:1 Failed:1 Lost:3 EnvFail:1 UNKNOWN:2 Active:1\n"
 
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
 }
@@ -205,7 +208,8 @@ func TestSummaryFormatterMultipleRunsWithUnknownStatusOfLostRunsDoesNotDisplayLo
 	formattableTest8 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C222", "MyTestName7", "Finished", "UNKNOWN", "myUserId2", false, "none", tags)
 	formattableTest9 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "C333", "MyTestName8", "Finished", "Ignored", "myUserId1", true, "none", tags)
 	formattableTest10 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L321", "MyTestName9", "UNKNOWN", "", "myUserId2", true, "none", tags)
-	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9, formattableTest10)
+	formattableTest11 := createFormattableTestForSummary("2023-05-04T10:55:29.545323Z", "L567", "MyTestNameX", "Running", "", "myUserId2", false, "none", tags)
+	formattableTest = append(formattableTest, formattableTest1, formattableTest2, formattableTest3, formattableTest4, formattableTest5, formattableTest6, formattableTest7, formattableTest8, formattableTest9, formattableTest10, formattableTest11)
 
 	// When...
 	actualFormattedOutput, err := formatter.FormatRuns(formattableTest)
@@ -219,8 +223,9 @@ func TestSummaryFormatterMultipleRunsWithUnknownStatusOfLostRunsDoesNotDisplayLo
 			"2023-05-04 10:55:29 L789 myUserId2 Finished Passed With Defects MyTestName5 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
 			"2023-05-04 10:55:29 C111 myUserId1 Finished Failed              MyTestName6 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
 			"2023-05-04 10:55:29 C222 myUserId2 Finished UNKNOWN             MyTestName7 none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
+			"2023-05-04 10:55:29 L567 myUserId2 Running                      MyTestNameX none       https://my-api-server.com/test-runs/cdb-ba06e2a6-U123\n" +
 			"\n" +
-			"Total:10 Passed:1 PassedWithDefects:1 Failed:1 Lost:4 EnvFail:1 UNKNOWN:1 Active:1\n"
+			"Total:11 Passed:1 PassedWithDefects:1 Failed:1 Lost:4 EnvFail:1 UNKNOWN:2 Active:1\n"
 
 	assert.Equal(t, expectedFormattedOutput, actualFormattedOutput)
 }


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2471

## Changes

- Runs with `UNKNOWN`/`unknown` status will be added to the 'UNKNOWN' category on the `runs get` result report instead of `Active`, as these runs no longer have a Pod, so are not active and should not be reported as such. Reporting them as unknown is more accurate. Active should be for runs still in Building/Generating/Running etc.
- Unit tests updated.