### PR TITLE
Add 'queued' field to group indexes so that the correct indexes are used when sorting by queued time

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImpl.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImpl.java
@@ -104,8 +104,9 @@ public class CouchdbValidatorImpl implements CouchdbValidator {
             checkIndex(httpClient, rasUri, 1, "galasa_run", timeService, "user", "requestor", "queued");
             checkIndex(httpClient, rasUri, 1, "galasa_run", timeService, "result", "queued");
             checkIndex(httpClient, rasUri, 1, "galasa_run", timeService, "status", "queued");
-            checkIndex(httpClient, rasUri, 1, "galasa_run", timeService, "group", "result");
-            checkIndex(httpClient, rasUri, 1, "galasa_run", timeService, "group", "status");
+            checkIndex(httpClient, rasUri, 1, "galasa_run", timeService, "group", "queued");
+            checkIndex(httpClient, rasUri, 1, "galasa_run", timeService, "group", "result", "queued");
+            checkIndex(httpClient, rasUri, 1, "galasa_run", timeService, "group", "status", "queued");
             
             logger.debug("RAS CouchDB at " + rasUri.toString() + " validated");
         } catch (CouchdbException e) {

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
@@ -333,9 +333,11 @@ public class CouchdbValidatorImplTest {
         interactions.add( new CheckDatabaseHasDocumentInteraction());
         interactions.add( new CheckIndexPOSTInteraction("status", "queued"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction("group", "result"));
+        interactions.add( new CheckIndexPOSTInteraction("group", "queued"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction("group", "status"));
+        interactions.add( new CheckIndexPOSTInteraction("group", "result", "queued"));
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("group", "status", "queued"));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2505

## Changes
- [x] By default, the `GET /ras/runs` endpoint sorts by queued time, so when queries are made to CouchDB, the `queued` field will now be added to the indexes that are created on RAS startup in order to avoid CouchDB scanning entire indexes