### PR TITLE
Support getting all run results in a single page by setting 'size' to 0 in GET /ras/runs

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1558,6 +1558,8 @@ paths:
           in: query
           description: |
             The number of test results returned within each page.
+            Setting 'size' to 0 will return all matching test results in a single page.
+
             If omitted, the default value is 100.
           schema:
             type: integer

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
@@ -35,6 +35,7 @@ public class RasQueryParameters {
         "to",
         "testclass",
         "result",
+        "results",
         "requestor",
         "resultnames",
         "runname"


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2507

## Changes
- [x] Added support for setting the `size` query parameter to 0 in the `GET /ras/runs` endpoint, which will cause the API server to return all runs that match any given search criteria in a single page