### PR TITLE
Iss1960 - Trigger the Web UI Main build after the OBR has redeployed

### DIFF
--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -885,9 +885,15 @@ jobs:
 
       - name: Triggering simplatform build
         env:
-            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
         run: |
           gh workflow run build.yaml --repo https://github.com/galasa-dev/simplatform --ref ${{ env.BRANCH }}
+
+      - name: Triggering webui build
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/webui --ref ${{ env.BRANCH }}
 
   report-failure:
     # Skip this job for forks


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/1960

## Changes

- Trigger the Web UI main build after the OBR has been rebuilt and redeployed to development.galasa.dev/<branch>/maven-repo/obr so the Web UI rebuilds with the latest Framework changes.
- This should catch problems when if changes to the OpenAPI spec break the WebUI because the required changes have not been made there yet.

I will make a second PR in the automation repo off the back of this removing the manual trigger of the Web UI build during the release process as this will handle that.
