### PR TITLE
Iss2312 - Pass max gRPC message size from Helm chart into ETCD client creation

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     //  implementation('org.apache.logging.log4j:log4j-slf4j-impl:2.17.1')
     implementation('org.checkerframework:checker-qual')
     implementation('org.slf4j:slf4j-api:2.0.17')
+
+    testImplementation(testFixtures(project(':dev.galasa.extensions.common')))
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStore.java
@@ -84,8 +84,8 @@ public class Etcd3DynamicStatusStore extends Etcd3Store implements IDynamicStatu
      * 
      * @param dssUri - http:// uri for th etcd cluster.
      */
-    public Etcd3DynamicStatusStore(URI dssUri) {
-        super(dssUri);
+    public Etcd3DynamicStatusStore(URI dssUri, int maxgRPCMessageSize) {
+        super(dssUri, maxgRPCMessageSize);
         this.watchClient = client.getWatchClient();
         this.leaseClient = client.getLeaseClient();
     }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStoreRegistration.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStoreRegistration.java
@@ -30,8 +30,8 @@ import dev.galasa.framework.spi.SystemEnvironment;
 @Component(service = { IDynamicStatusStoreRegistration.class })
 public class Etcd3DynamicStatusStoreRegistration implements IDynamicStatusStoreRegistration {
 
-    private static final String MAX_GRPC_MESSAGE_SIZE_ENV_VAR = "MAX_GRPC_MESSAGE_SIZE";
-    private static final int DEFAULT_MAX_GRPC_MESSAGE_SIZE = 4194304;
+    public static final String MAX_GRPC_MESSAGE_SIZE_ENV_VAR = "MAX_GRPC_MESSAGE_SIZE";
+    public static final int DEFAULT_MAX_GRPC_MESSAGE_SIZE = 4194304;
 
     private final Log logger = LogFactory.getLog(Etcd3DynamicStatusStoreRegistration.class);
 

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStoreRegistration.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStoreRegistration.java
@@ -66,7 +66,7 @@ public class Etcd3DynamicStatusStoreRegistration implements IDynamicStatusStoreR
         if (isEtcdUri(dss)) {
             try {
                 URI uri = new URI(dss.toString().substring(5));
-                setMaxgRPCMessageSizeFromEnvironmentOrDefault(MAX_GRPC_MESSAGE_SIZE_ENV_VAR, DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+                setMaxgRPCMessageSizeFromEnvironmentOrDefault();
                 frameworkInitialisation.registerDynamicStatusStore(new Etcd3DynamicStatusStore(uri, this.maxgRPCMessageSize));
             } catch (URISyntaxException e) {
                 throw new DynamicStatusStoreException("Could not create URI", e);
@@ -84,8 +84,8 @@ public class Etcd3DynamicStatusStoreRegistration implements IDynamicStatusStoreR
         return "etcd".equals(uri.getScheme());
     }
 
-    private void setMaxgRPCMessageSizeFromEnvironmentOrDefault(String envVar, int defaultValue) {
-        String value = this.env.getenv(envVar);
+    private void setMaxgRPCMessageSizeFromEnvironmentOrDefault() {
+        String value = this.env.getenv(MAX_GRPC_MESSAGE_SIZE_ENV_VAR);
         if (value != null && !value.isBlank()) {
             try {
                 int parsed = Integer.parseInt(value.trim());
@@ -94,7 +94,7 @@ public class Etcd3DynamicStatusStoreRegistration implements IDynamicStatusStoreR
                 }
             } catch (IllegalArgumentException e) {
                 logger.warn("Invalid value was set in the environment for maximum gRPC message size in bytes," +
-                " setting to default value " + defaultValue);
+                " setting to default value " + DEFAULT_MAX_GRPC_MESSAGE_SIZE);
             }
         }
     }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStoreRegistration.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3DynamicStatusStoreRegistration.java
@@ -10,11 +10,16 @@ import java.net.URISyntaxException;
 
 import javax.validation.constraints.NotNull;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.osgi.service.component.annotations.Component;
 
 import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.Environment;
 import dev.galasa.framework.spi.IDynamicStatusStoreRegistration;
 import dev.galasa.framework.spi.IFrameworkInitialisation;
+import dev.galasa.framework.spi.SystemEnvironment;
 
 /**
  * This Class is a small OSGI bean that registers the DSS store as a ETCD
@@ -24,6 +29,23 @@ import dev.galasa.framework.spi.IFrameworkInitialisation;
  */
 @Component(service = { IDynamicStatusStoreRegistration.class })
 public class Etcd3DynamicStatusStoreRegistration implements IDynamicStatusStoreRegistration {
+
+    private static final String MAX_GRPC_MESSAGE_SIZE_ENV_VAR = "MAX_GRPC_MESSAGE_SIZE";
+    private static final int DEFAULT_MAX_GRPC_MESSAGE_SIZE = 4194304;
+
+    private final Log logger = LogFactory.getLog(Etcd3DynamicStatusStoreRegistration.class);
+
+    private Environment env;
+
+    private int maxgRPCMessageSize = DEFAULT_MAX_GRPC_MESSAGE_SIZE;
+
+    public Etcd3DynamicStatusStoreRegistration(){
+        this(new SystemEnvironment());
+    }
+
+    public Etcd3DynamicStatusStoreRegistration(Environment env) {
+        this.env = env;
+    }
 
     /**
      * This intialise method is a overide that registers the correct store to the
@@ -44,7 +66,8 @@ public class Etcd3DynamicStatusStoreRegistration implements IDynamicStatusStoreR
         if (isEtcdUri(dss)) {
             try {
                 URI uri = new URI(dss.toString().substring(5));
-                frameworkInitialisation.registerDynamicStatusStore(new Etcd3DynamicStatusStore(uri));
+                setMaxgRPCMessageSizeFromEnvironmentOrDefault(MAX_GRPC_MESSAGE_SIZE_ENV_VAR, DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+                frameworkInitialisation.registerDynamicStatusStore(new Etcd3DynamicStatusStore(uri, this.maxgRPCMessageSize));
             } catch (URISyntaxException e) {
                 throw new DynamicStatusStoreException("Could not create URI", e);
             }
@@ -59,5 +82,27 @@ public class Etcd3DynamicStatusStoreRegistration implements IDynamicStatusStoreR
      */
     public static boolean isEtcdUri(URI uri) {
         return "etcd".equals(uri.getScheme());
+    }
+
+    private void setMaxgRPCMessageSizeFromEnvironmentOrDefault(String envVar, int defaultValue) {
+        String value = this.env.getenv(envVar);
+        if (value != null && !value.isBlank()) {
+            try {
+                int parsed = Integer.parseInt(value.trim());
+                if (parsed >= 0) {
+                    this.maxgRPCMessageSize = parsed;
+                }
+            } catch (IllegalArgumentException e) {
+                logger.warn("Invalid value was set in the environment for maximum gRPC message size in bytes," +
+                " setting to default value " + defaultValue);
+            }
+        }
+    }
+
+    /*
+     * This method exists for unit testing purposes.
+     */
+    public int getMaxgRPCMessageSize() {
+        return this.maxgRPCMessageSize;
     }
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3Store.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3Store.java
@@ -39,6 +39,8 @@ import io.vertx.core.file.FileSystemOptions;
  */
 public abstract class Etcd3Store {
 
+    private static final int DEFAULT_MAX_GRPC_MESSAGE_SIZE = 4194304;
+
     protected final Client client;
     protected final KV kvClient;
 
@@ -47,10 +49,15 @@ public abstract class Etcd3Store {
         this.kvClient = client.getKVClient();
     }
 
-    public Etcd3Store(URI etcdUri) {
+    public Etcd3Store(URI etcdUri, int maxgRPCMessageSize) {
         this(Client.builder()
             .vertx(createVertx())
-            .endpoints(etcdUri).build());
+            .endpoints(etcdUri)
+            .maxInboundMessageSize(maxgRPCMessageSize).build());
+    }
+
+    public Etcd3Store(URI etcdUri) {
+        this(etcdUri, DEFAULT_MAX_GRPC_MESSAGE_SIZE);
     }
 
     /**

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3Store.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3Store.java
@@ -7,6 +7,8 @@ package dev.galasa.cps.etcd.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import static dev.galasa.cps.etcd.internal.Etcd3DynamicStatusStoreRegistration.DEFAULT_MAX_GRPC_MESSAGE_SIZE;
+
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -38,8 +40,6 @@ import io.vertx.core.file.FileSystemOptions;
  * and deleting properties.
  */
 public abstract class Etcd3Store {
-
-    private static final int DEFAULT_MAX_GRPC_MESSAGE_SIZE = 4194304;
 
     protected final Client client;
     protected final KV kvClient;

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3DynamicStatusStoreRegistrationTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3DynamicStatusStoreRegistrationTest.java
@@ -7,6 +7,9 @@ package dev.galasa.etcd.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static dev.galasa.cps.etcd.internal.Etcd3DynamicStatusStoreRegistration.DEFAULT_MAX_GRPC_MESSAGE_SIZE;
+import static dev.galasa.cps.etcd.internal.Etcd3DynamicStatusStoreRegistration.MAX_GRPC_MESSAGE_SIZE_ENV_VAR;
+
 import java.net.URI;
 
 import org.junit.Test;
@@ -16,9 +19,6 @@ import dev.galasa.extensions.common.mocks.MockEnvironment;
 import dev.galasa.extensions.common.mocks.MockFrameworkInitialisation;
 
 public class Etcd3DynamicStatusStoreRegistrationTest {
-
-    private static final String MAX_GRPC_MESSAGE_SIZE_ENV_VAR = "MAX_GRPC_MESSAGE_SIZE";
-    private static final int DEFAULT_MAX_GRPC_MESSAGE_SIZE = 4194304;
 
     @Test
     public void testCanCreateARegistrationOK() {

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3DynamicStatusStoreRegistrationTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3DynamicStatusStoreRegistrationTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.etcd.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+import dev.galasa.cps.etcd.internal.Etcd3DynamicStatusStoreRegistration;
+import dev.galasa.extensions.common.mocks.MockEnvironment;
+import dev.galasa.extensions.common.mocks.MockFrameworkInitialisation;
+
+public class Etcd3DynamicStatusStoreRegistrationTest {
+
+    private static final String MAX_GRPC_MESSAGE_SIZE_ENV_VAR = "MAX_GRPC_MESSAGE_SIZE";
+    private static final int DEFAULT_MAX_GRPC_MESSAGE_SIZE = 4194304;
+
+    @Test
+    public void testCanCreateARegistrationOK() {
+        new Etcd3DynamicStatusStoreRegistration();
+    }
+
+    @Test
+    public void testWhenRemoteRunCanInitialiseARegistrationOK() throws Exception {
+        // Given...
+        Etcd3DynamicStatusStoreRegistration registration = new Etcd3DynamicStatusStoreRegistration();
+
+        URI cps = new URI("etcd://my.server/api");
+        URI dss = new URI("etcd://my.server/api");
+        MockFrameworkInitialisation mockFrameworkInit = new MockFrameworkInitialisation(cps, dss);
+
+        // When...
+        registration.initialise(mockFrameworkInit);
+
+        // Then...
+        assertThat(mockFrameworkInit.getDynamicStatusStoreUri()).isEqualTo(dss);
+    }
+
+    @Test
+    public void testCanInitialiseARegistrationWithValidMaxgRPCMessageSizeFromEnvironmentOK() throws Exception {
+        // Given...
+        MockEnvironment mockEnvironment = new MockEnvironment();
+        String validValue = Integer.toString(Integer.MAX_VALUE);
+        mockEnvironment.setenv(MAX_GRPC_MESSAGE_SIZE_ENV_VAR, validValue);
+
+        Etcd3DynamicStatusStoreRegistration registration = new Etcd3DynamicStatusStoreRegistration(mockEnvironment);
+
+        URI cps = new URI("etcd://my.server/api");
+        URI dss = new URI("etcd://my.server/api");
+        MockFrameworkInitialisation mockFrameworkInit = new MockFrameworkInitialisation(cps, dss);
+
+        // When...
+        registration.initialise(mockFrameworkInit);
+
+        // Then...
+        // We should have been able to initialise the registration OK, and the env var should have been used.
+        assertThat(registration.getMaxgRPCMessageSize()).isEqualTo(Integer.parseInt(validValue));
+    }
+
+    @Test
+    public void testCanInitialiseARegistrationWithNullMaxgRPCMessageSizeFromEnvironmentOK() throws Exception {
+        // Given...
+        MockEnvironment mockEnvironment = new MockEnvironment();
+        mockEnvironment.setenv(MAX_GRPC_MESSAGE_SIZE_ENV_VAR, null);
+
+        Etcd3DynamicStatusStoreRegistration registration = new Etcd3DynamicStatusStoreRegistration(mockEnvironment);
+
+        URI cps = new URI("etcd://my.server/api");
+        URI dss = new URI("etcd://my.server/api");
+        MockFrameworkInitialisation mockFrameworkInit = new MockFrameworkInitialisation(cps, dss);
+
+        // When...
+        registration.initialise(mockFrameworkInit);
+
+        // Then...
+        // We should have been able to initialise the registration OK still, and the env var should have been ignored.
+        assertThat(registration.getMaxgRPCMessageSize()).isEqualTo(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+    }
+
+    @Test
+    public void testCanInitialiseARegistrationWithBlankMaxgRPCMessageSizeFromEnvironmentOK() throws Exception {
+        // Given...
+        MockEnvironment mockEnvironment = new MockEnvironment();
+        mockEnvironment.setenv(MAX_GRPC_MESSAGE_SIZE_ENV_VAR, "    ");
+
+        Etcd3DynamicStatusStoreRegistration registration = new Etcd3DynamicStatusStoreRegistration(mockEnvironment);
+
+        URI cps = new URI("etcd://my.server/api");
+        URI dss = new URI("etcd://my.server/api");
+        MockFrameworkInitialisation mockFrameworkInit = new MockFrameworkInitialisation(cps, dss);
+
+        // When...
+        registration.initialise(mockFrameworkInit);
+
+        // Then...
+        // We should have been able to initialise the registration OK still, and the env var should have been ignored.
+        assertThat(registration.getMaxgRPCMessageSize()).isEqualTo(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+    }
+
+    @Test
+    public void testCanInitialiseARegistrationWithNegativeMaxgRPCMessageSizeFromEnvironmentOK() throws Exception {
+        // Given...
+        MockEnvironment mockEnvironment = new MockEnvironment();
+        String invalidNegativeValue = Integer.toString(-1);
+        mockEnvironment.setenv(MAX_GRPC_MESSAGE_SIZE_ENV_VAR, invalidNegativeValue);
+
+        Etcd3DynamicStatusStoreRegistration registration = new Etcd3DynamicStatusStoreRegistration(mockEnvironment);
+
+        URI cps = new URI("etcd://my.server/api");
+        URI dss = new URI("etcd://my.server/api");
+        MockFrameworkInitialisation mockFrameworkInit = new MockFrameworkInitialisation(cps, dss);
+
+        // When...
+        registration.initialise(mockFrameworkInit);
+
+        // Then...
+        // We should have been able to initialise the registration OK still, and the env var should have been ignored.
+        assertThat(registration.getMaxgRPCMessageSize()).isEqualTo(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+    }
+
+    @Test
+    public void testCanInitialiseARegistrationWithInvalidMaxgRPCMessageSizeFromEnvironmentOK() throws Exception {
+        // Given...
+        MockEnvironment mockEnvironment = new MockEnvironment();
+        String invalidValue = "2147483648"; // This is an invalid integer as bigger than 2147483647.
+        mockEnvironment.setenv(MAX_GRPC_MESSAGE_SIZE_ENV_VAR, invalidValue);
+
+        Etcd3DynamicStatusStoreRegistration registration = new Etcd3DynamicStatusStoreRegistration(mockEnvironment);
+
+        URI cps = new URI("etcd://my.server/api");
+        URI dss = new URI("etcd://my.server/api");
+        MockFrameworkInitialisation mockFrameworkInit = new MockFrameworkInitialisation(cps, dss);
+
+        // When...
+        registration.initialise(mockFrameworkInit);
+
+        // Then...
+        // We should have been able to initialise the registration OK still, and the env var should have been ignored.
+        assertThat(registration.getMaxgRPCMessageSize()).isEqualTo(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+    }
+
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3DynamicStatusStoreTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3DynamicStatusStoreTest.java
@@ -5,6 +5,7 @@
  */
 package dev.galasa.etcd.internal;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,4 +87,55 @@ public class Etcd3DynamicStatusStoreTest {
         assertThat(thenOperations).hasSize(2);
         assertThat(thenOperations).hasOnlyElementsOfType(PutOp.class);
     }
+
+    @Test
+    public void testCreateAnEtcd3DynamicStatusStoreWithDefaultgRPCMessageSizeIsOK() throws Exception {
+        // Given...
+        URI uri = new URI("http://mydss.com");
+        int defaultMaxgRPCMessageSize = 4194304;
+
+        // When...
+        new Etcd3DynamicStatusStore(uri, defaultMaxgRPCMessageSize);
+
+        // Then...
+        // We should have been able to create a DSS okay.
+    }
+
+    @Test
+    public void testCreateAnEtcd3DynamicStatusStoreWithIntegerMaxValueIsOK() throws Exception {
+        // Given...
+        URI uri = new URI("http://mydss.com");
+
+        // When...
+        new Etcd3DynamicStatusStore(uri, Integer.MAX_VALUE);
+
+        // Then...
+        // We should have been able to create a DSS okay.
+    }
+
+    @Test
+    public void testCreateAnEtcd3DynamicStatusStoreWithZeroValueIsOK() throws Exception {
+        // Given...
+        URI uri = new URI("http://mydss.com");
+
+        // When...
+        new Etcd3DynamicStatusStore(uri, 0);
+
+        // Then...
+        // We should have been able to create a DSS okay.
+    }
+
+    @Test
+    public void testCreateAnEtcd3DynamicStatusStoreWithNegativeValueThrowsException() throws Exception {
+        // Given...
+        URI uri = new URI("http://mydss.com");
+
+        // When...
+        Exception thrown = catchThrowableOfType(() -> new Etcd3DynamicStatusStore(uri, -1), Exception.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("negative max");
+    }
+
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/test/force/codecoverage/Etcd3DssTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/test/force/codecoverage/Etcd3DssTest.java
@@ -75,11 +75,13 @@ public class Etcd3DssTest {
     @Mock
     KV                      mockKvCLient;
 
+    private static final int DEFAULT_MAX_GRPC_MESSAGE_SIZE = 4194304;
+
     /**
      * Creates a dss for the etcd and injects the mock above.
      */
     @InjectMocks
-    Etcd3DynamicStatusStore mockDss = new Etcd3DynamicStatusStore(createDssUri());
+    Etcd3DynamicStatusStore mockDss = new Etcd3DynamicStatusStore(createDssUri(), DEFAULT_MAX_GRPC_MESSAGE_SIZE);
 
     /**
      * This test method tests the put method for a simple example.

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/test/force/codecoverage/Etcd3DssTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/test/force/codecoverage/Etcd3DssTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import static dev.galasa.cps.etcd.internal.Etcd3DynamicStatusStoreRegistration.DEFAULT_MAX_GRPC_MESSAGE_SIZE;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -74,8 +76,6 @@ public class Etcd3DssTest {
      */
     @Mock
     KV                      mockKvCLient;
-
-    private static final int DEFAULT_MAX_GRPC_MESSAGE_SIZE = 4194304;
 
     /**
      * Creates a dss for the etcd and injects the mock above.

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/src/testFixtures/java/dev/galasa/extensions/common/mocks/MockFrameworkInitialisation.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common/src/testFixtures/java/dev/galasa/extensions/common/mocks/MockFrameworkInitialisation.java
@@ -35,15 +35,22 @@ public class MockFrameworkInitialisation implements IFrameworkInitialisation {
     
     protected URI authStoreUri;
     protected URI cpsBootstrapUri;
+    protected URI dssUri;
 
     private List<IAuthStore> registeredAuthStores = new ArrayList<IAuthStore>();
     private List<IConfigurationPropertyStore> registeredConfigPropertyStores = new ArrayList<IConfigurationPropertyStore>();
     private List<IEventsService> registeredEventsServices = new ArrayList<IEventsService>();
+    private List<IDynamicStatusStore> registeredDynamicStatusStores = new ArrayList<IDynamicStatusStore>();
 
     public MockFrameworkInitialisation() {}
 
     public MockFrameworkInitialisation(URI cpsBootstrapUri) {
         this.cpsBootstrapUri = cpsBootstrapUri;
+    }
+
+    public MockFrameworkInitialisation(URI cpsBootstrapUri, URI dssUri) {
+        this.cpsBootstrapUri = cpsBootstrapUri;
+        this.dssUri = dssUri;
     }
 
     public void setAuthStoreUri(URI authStoreUri) {
@@ -79,9 +86,31 @@ public class MockFrameworkInitialisation implements IFrameworkInitialisation {
     }
 
     @Override
-    public URI getDynamicStatusStoreUri() {
-        throw new UnsupportedOperationException("Unimplemented method 'getDynamicStatusStoreUri'");
+    public void registerDynamicStatusStore(@NotNull IDynamicStatusStore dynamicStatusStore)
+            throws DynamicStatusStoreException {
+        registeredDynamicStatusStores.add(dynamicStatusStore);
     }
+
+    @Override
+    public URI getDynamicStatusStoreUri() {
+        return dssUri;
+    }
+
+    @Override
+    public @NotNull IFramework getFramework() {
+        return new MockFramework();
+    }
+
+    @Override
+    public void registerEventsService(@NotNull IEventsService eventsService) throws EventsException {
+        registeredEventsServices.add(eventsService);
+    }
+
+    public List<IEventsService> getRegisteredEventsServices() {
+        return registeredEventsServices;
+    }
+
+    // UNIMPLEMENTED METHODS BELOW
 
     @Override
     public URI getCredentialsStoreUri() {
@@ -91,12 +120,6 @@ public class MockFrameworkInitialisation implements IFrameworkInitialisation {
     @Override
     public @NotNull List<URI> getResultArchiveStoreUris() {
         throw new UnsupportedOperationException("Unimplemented method 'getResultArchiveStoreUris'");
-    }
-
-    @Override
-    public void registerDynamicStatusStore(@NotNull IDynamicStatusStore dynamicStatusStore)
-            throws DynamicStatusStoreException {
-        throw new UnsupportedOperationException("Unimplemented method 'registerDynamicStatusStore'");
     }
 
     @Override
@@ -120,20 +143,6 @@ public class MockFrameworkInitialisation implements IFrameworkInitialisation {
     @Override
     public void registerCredentialsStore(@NotNull ICredentialsStore credentialsStore) throws CredentialsException {
         throw new UnsupportedOperationException("Unimplemented method 'registerCredentialsStore'");
-    }
-
-    @Override
-    public @NotNull IFramework getFramework() {
-        return new MockFramework();
-    }
-
-    @Override
-    public void registerEventsService(@NotNull IEventsService eventsService) throws EventsException {
-        registeredEventsServices.add(eventsService);
-    }
-
-    public List<IEventsService> getRegisteredEventsServices() {
-        return registeredEventsServices;
     }
 
     @Override


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2312

## Changes

- Environment variable `MAX_GRPC_MESSAGE_SIZE` if passed in from Helm chart is used to create the ETCD Client for DSS with `maxInboundMessageSize()`
- If it is not provided in the environment, it is set to the default value 4Mib
- Validation of the environment variable in case of letters/whitespace/negative numbers being passed in
- Unit tests to ensure ETCD registration and store can be set up okay with this new parameter, and to test the defaulting logic for if not provided/invalid value is provided