### PR TITLE
Iss2519 - Update links to Javadoc in Galasa Mkdocs site to local paths

### DIFF
--- a/docs/content/docs/faqs/index.md
+++ b/docs/content/docs/faqs/index.md
@@ -16,7 +16,7 @@ If your terminal object is of type `ICicsTerminal` you can use the method `reset
 
 Yes, you can view the [installation verification tests (IVTs)](https://github.com/galasa-dev/managers/tree/main/galasa-managers-parent){target="_blank"} for the Managers in GitHub.
 
-You can find the links to the Javadoc API documentation for all the Galasa Managers on the [overview page](https://javadoc.galasa.dev/){target="_blank"}.
+You can find the links to the Javadoc API documentation for all the Galasa Managers on the [overview page](../reference/javadoc/overview-summary.html){target="_blank"}.
 
 
 ## Can I generate run reports with logs whist running Galasa tests? 
@@ -108,7 +108,7 @@ but with the values customized to match the name and location of your z/OS syste
 
 ## What is the connection between z/OS terminal and application?
 
-The `ITerminal` object allows communication to the remote z/OS system. See the [Javadoc for ITerminal](https://javadoc.galasa.dev/dev/galasa/zos3270/ITerminal.html){target="_blank"} for more information. 
+The `ITerminal` object allows communication to the remote z/OS system. See the [Javadoc for ITerminal](../../docs/reference/javadoc/dev/galasa/zos3270/ITerminal.html){target="_blank"} for more information. 
 
 
 ## Why is my test (which is running on a local LPAR) failing at the Provision Generate phase with the error "Caused by: dev.galasa.zos.ZosManagerException: Insufficent capacity for images in cluster..."?

--- a/docs/content/docs/managers/cics-ts-managers/cics-ts-ceci-manager.md
+++ b/docs/content/docs/managers/cics-ts-managers/cics-ts-ceci-manager.md
@@ -2,7 +2,7 @@
 title: "CICS TS CECI Manager"
 ---
 
-This Manager is at Release level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/cicsts/package-summary.html){target="_blank"}.
+This Manager is at Release level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/cicsts/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/cics-ts-managers/cics-ts-manager.md
+++ b/docs/content/docs/managers/cics-ts-managers/cics-ts-manager.md
@@ -2,7 +2,7 @@
 title: "CICS TS Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/cicsts/package-summary.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/cicsts/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/cloud-managers/docker-manager.md
+++ b/docs/content/docs/managers/cloud-managers/docker-manager.md
@@ -2,7 +2,7 @@
 title: "Docker Manager"
 ---
 
-This Manager is at Release level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/docker/package-summary.html){target="_blank"}.
+This Manager is at Release level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/docker/package-summary.html){target="_blank"}.
 
 
 ## Overview
@@ -39,7 +39,7 @@ The following annotations are available with the Docker Manager.
 | Attribute: `start` |  The `start` attribute indicates whether the Docker Container should be started automatically. If the  test needs to perform some work before the container is started, then `start=false` should be used, after which `IDockerContainer.start()` can be called to start the container. |
 | Attribute: `dockerEngineTag` |  The `dockerEngineTag` will be used in the future so that a container can be run on a specific Docker Engine type. You would not normally need to provide a Docker Engine tag. |
 | Syntax: | <pre lang="java">@DockerContainer(image="library/httpd:latest")<br>public IDockerContainer httpdContainer;<br><br>@DockerContainer(image="privateimage", start=false)<br>public IDockerContainer container1;<br> </pre> |
-| Notes: | The `IDockerContainer` interface gives the test access to the IPv4/6 address and the exposed port numbers of the Docker Container.  The interface also enables the test to execute commands and retrieve the log and transfer files that are sent to  and from the container.<br><br> See [DockerContainer](https://javadoc.galasa.dev/dev/galasa/docker/DockerContainer.html){target="_blank"} and [IDockerContainer](https://javadoc.galasa.dev/dev/galasa/docker/IDockerContainer.html){target="_blank"} to find out more. |
+| Notes: | The `IDockerContainer` interface gives the test access to the IPv4/6 address and the exposed port numbers of the Docker Container.  The interface also enables the test to execute commands and retrieve the log and transfer files that are sent to  and from the container.<br><br> See [DockerContainer](../../reference/javadoc/dev/galasa/docker/DockerContainer.html){target="_blank"} and [IDockerContainer](../../reference/javadoc/dev/galasa/docker/IDockerContainer.html){target="_blank"} to find out more. |
 
 
 ### Docker Container Configuation

--- a/docs/content/docs/managers/cloud-managers/kubernetes-manager.md
+++ b/docs/content/docs/managers/cloud-managers/kubernetes-manager.md
@@ -2,7 +2,7 @@
 title: "Kubernetes Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/kubernetes/package-summary.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/kubernetes/package-summary.html){target="_blank"}.
 
 
 ## Overview
@@ -40,7 +40,7 @@ The following annotations are available with the Kubernetes Manager
 | Description: | The `@KubernetesNamespace` annotation requests the Kubernetes Manager to allocate a namespace on the infrastructure Kubernetes clusters.  The test can request as many namespaces as required so long as they  can be supported simultaneously by the Kubernetes Manager configuration. |
 | Attribute: `kubernetesNamespaceTag` |  The `kubernetesNamespaceTag` identifies the Kubernetes names to other Managers or Shared Environments.  If a test is using multiple  Kubernetes namespace, each separate Kubernetes namespace must have a unique tag.  If more than one Kubernetes namespace use the same tag, they will refer to the  same Kubernetes namespace. |
 | Syntax: | <pre lang="java">@KubernetesNamespace<br>public IKubernetesNamesapce namespace;<br> </pre> |
-| Notes: | The `IKubernetesNamespace` interface gives the test access to create and manage resources on the Kubernetes cluster.  See [KubernetesNamespace](https://javadoc.galasa.dev/dev/galasa/kubernetes/KubernetesNamespace.html){target="_blank"} and [IKubernetesNamespace](https://javadoc.galasa.dev/dev/galasa/kubernetes/IKubernetesNamespace.html){target="_blank"} to find out more. |
+| Notes: | The `IKubernetesNamespace` interface gives the test access to create and manage resources on the Kubernetes cluster.  See [KubernetesNamespace](../../reference/javadoc/dev/galasa/kubernetes/KubernetesNamespace.html){target="_blank"} and [IKubernetesNamespace](../../reference/javadoc/dev/galasa/kubernetes/IKubernetesNamespace.html){target="_blank"} to find out more. |
 
 
 ## Code snippets

--- a/docs/content/docs/managers/cloud-managers/open-stack-manager.md
+++ b/docs/content/docs/managers/cloud-managers/open-stack-manager.md
@@ -2,7 +2,7 @@
 title: "Open Stack Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/openstack/manager/package-summary.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/openstack/manager/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/communications-managers/http-client-manager.md
+++ b/docs/content/docs/managers/communications-managers/http-client-manager.md
@@ -2,7 +2,7 @@
 title: "HTTP Client Manager"
 ---
 
-This Manager is at Release level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/http/package-summary.html){target="_blank"}.
+This Manager is at Release level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/http/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/communications-managers/ipnetwork-manager.md
+++ b/docs/content/docs/managers/communications-managers/ipnetwork-manager.md
@@ -2,7 +2,7 @@
 title: "IP Network Manager"
 ---
 
-This Manager is at Release level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/ipnetwork/package-summary.html){target="_blank"}.
+This Manager is at Release level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/ipnetwork/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/communications-managers/mq-manager.md
+++ b/docs/content/docs/managers/communications-managers/mq-manager.md
@@ -2,7 +2,7 @@
 title: "MQ Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/mq/package-summary.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/mq/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/core-managers/artifact-manager.md
+++ b/docs/content/docs/managers/core-managers/artifact-manager.md
@@ -2,7 +2,7 @@
 title: "Artifact Manager"
 ---
 
-This Manager is at Release level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/artifact/package-summary.html){target="_blank"}.
+This Manager is at Release level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/artifact/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/core-managers/core-manager.md
+++ b/docs/content/docs/managers/core-managers/core-manager.md
@@ -2,7 +2,7 @@
 title: "Core Manager"
 ---
 
-This Manager is at Release level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/core/manager/package-summary.html){target="_blank"}.
+This Manager is at Release level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/core/manager/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/ecosystem-managers/galasa-ecosystem-manager.md
+++ b/docs/content/docs/managers/ecosystem-managers/galasa-ecosystem-manager.md
@@ -2,7 +2,7 @@
 title: "Galasa Ecosystem Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/galasaecosystem/package-summary.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/galasaecosystem/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/ims-tm-managers/ims-tm-manager.md
+++ b/docs/content/docs/managers/ims-tm-managers/ims-tm-manager.md
@@ -2,7 +2,7 @@
 title: "IMS TM Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/imstm/package-summary.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/imstm/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/index.md
+++ b/docs/content/docs/managers/index.md
@@ -2,7 +2,7 @@
 title: "Managers"
 ---
 
-You can find the links to the Javadoc API documentation for all the Galasa Managers on the [overview page](https://javadoc.galasa.dev/){target="_blank"}.
+You can find the links to the Javadoc API documentation for all the Galasa Managers on the [overview page](../reference/javadoc/overview-summary.html){target="_blank"}.
 
 
 ## Managers provided with the current Galasa distribution

--- a/docs/content/docs/managers/test-tool-managers/jmeter-manager.md
+++ b/docs/content/docs/managers/test-tool-managers/jmeter-manager.md
@@ -2,7 +2,7 @@
 title: "JMeter Manager"
 ---
 
-This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/jmeter/package-summary.html){target="_blank"}.
+This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/jmeter/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/test-tool-managers/selenium-manager.md
+++ b/docs/content/docs/managers/test-tool-managers/selenium-manager.md
@@ -2,7 +2,7 @@
 title: "Selenium Manager"
 ---
 
-This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/selenium/package-summary.html){target="_blank"}.
+This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/selenium/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/unix-managers/linux-manager.md
+++ b/docs/content/docs/managers/unix-managers/linux-manager.md
@@ -2,7 +2,7 @@
 title: "Linux Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/linux/package-summary.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/linux/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/workflow-managers/github-manager.md
+++ b/docs/content/docs/managers/workflow-managers/github-manager.md
@@ -2,7 +2,7 @@
 title: "GitHub Manager"
 ---
 
-This Manager is at Release level. You can view the <a href="">[Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/githubissue/package-summary.html){target="_blank"}.
+This Manager is at Release level. You can view the <a href="">[Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/githubissue/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/zos-managers/rse-api-manager.md
+++ b/docs/content/docs/managers/zos-managers/rse-api-manager.md
@@ -2,7 +2,7 @@
 title: "RSE API Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/zosrseapi/package-summary.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zosrseapi/package-summary.html){target="_blank"}.
 
 
 ## Overview
@@ -23,7 +23,7 @@ The following annotations are available with the RSE API Manager
 | Description: | The `@Rseapi` annotation requests the RSE API Manager to provide a RSE API server instance associated with a z/OS image.  The test can request multiple RSE API instances, with the default being associated with the **primary** zOS image. |
 | Attribute: `imageTag` |  The tag of the zOS Image this variable is to be populated with |
 | Syntax: | <pre lang="java">@ZosImage(imageTag="A")<br>public IZosImage zosImageA;<br>@Rseapi(imageTag="A")<br>public IRseapi rseapiA;<br></pre> |
-| Notes: | The `IRseapi` interface has a number of methods to issue requests to the RSE API REST API. See [Rseapi](https://javadoc.galasa.dev/dev/galasa/zosrseapi/Rseapi.html){target="_blank"} and [IRseapi](https://javadoc.galasa.dev/dev/galasa/zosrseapi/IRseapi.html){target="_blank"} to find out more. |
+| Notes: | The `IRseapi` interface has a number of methods to issue requests to the RSE API REST API. See [Rseapi](../../reference/javadoc/dev/galasa/zosrseapi/Rseapi.html){target="_blank"} and [IRseapi](../../reference/javadoc/dev/galasa/zosrseapi/IRseapi.html){target="_blank"} to find out more. |
 
 
 ## Configuration Properties

--- a/docs/content/docs/managers/zos-managers/zos-batch-rse-api-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-batch-rse-api-manager.md
@@ -2,7 +2,7 @@
 title: "z/OS Batch RSE API Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/index.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zosbatch/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/zos-managers/zos-batch-zos-mf-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-batch-zos-mf-manager.md
@@ -2,7 +2,7 @@
 title: "z/OS Batch z/OS MF Manager"
 ---
 
-This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/index.html){target="_blank"}.
+This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zosbatch/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/zos-managers/zos-console-oeconsol-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-console-oeconsol-manager.md
@@ -2,7 +2,7 @@
 title: "zOS Console oeconsol Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/overview-summary.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zosconsole/oeconsol/manager/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/zos-managers/zos-console-zos-mf-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-console-zos-mf-manager.md
@@ -2,7 +2,7 @@
 title: "zOS Console zOS MF Manager"
 ---
 
-This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/overview-summary.html){target="_blank"}.
+This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zosconsole/package-summary.html){target="_blank"}.
 
 ## Overview
 

--- a/docs/content/docs/managers/zos-managers/zos-file-rse-api-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-file-rse-api-manager.md
@@ -2,7 +2,7 @@
 title: "z/OS File RSE API Manager"
 ---
 
-This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/overview-summary.html){target="_blank"}.
+This Manager is at Alpha level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zosfile/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/zos-managers/zos-file-zos-mf-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-file-zos-mf-manager.md
@@ -2,7 +2,7 @@
 title: "zOS File zOS MF Manager"
 ---
 
-This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/overview-summary.html){target="_blank"}.
+This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zosfile/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/zos-managers/zos-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-manager.md
@@ -2,7 +2,7 @@
 title: "z/OS Manager"
 ---
 
-This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/index.html?overview-summary.html){target="_blank"}.
+This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zos/package-summary.html){target="_blank"}.
 
 
 ## Overview
@@ -21,7 +21,7 @@ Additionally, the z/OS Manager provides tests with interfaces to the following z
 
 - `z/OS UNIX Command` which enables tests and Managers to issue and retrieve the responses from z/OS UNIX commands.
 
-You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/zos/package-summary.html){target="_blank"}.
+You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zos/package-summary.html){target="_blank"}.
 
 
 ## Including the Manager in a test
@@ -525,7 +525,7 @@ The following annotations are available with the z/OS Manager
 | Description: | The `@ZosBatch` annotation requests the z/OS Manager to provide a z/OS Batch instance associated with a z/OS image.  The test can request multiple z/OS Batch instances, with the default being associated with the **primary** z/OS image.<br> At test end, the Manager stores the job output with the test results archive and removes jobs from the JES queue. |
 | Attribute: `imageTag` |  The `imageTag` is used to identify the z/OS image. |
 | Syntax: | <pre lang="java">@ZosImage(imageTag="A")<br>public IZosImage zosImageA;<br><br>@ZosBatch(imageTag="A")<br>public IZosBatch zosBatchA;<br></pre> |
-| Notes: | The `IZosBatch` interface has a single method, {@link IZosBatch#submitJob(String, IZosBatchJobname)} to submit a JCL  as a `String` and returns a `IZosBatchJob` instance.<br><br> See [ZosBatch](https://javadoc.galasa.dev/dev/galasa/zosbatch/ZosBatch.html){target="_blank"}, [IZosBatch](https://javadoc.galasa.dev/dev/galasa/zosbatch/IZosBatch.html){target="_blank"} and [IZosBatchJob](https://javadoc.galasa.dev/dev/galasa/zosbatch/IZosBatchJob.html){target="_blank"} to find out more. |
+| Notes: | The `IZosBatch` interface has a single method, {@link IZosBatch#submitJob(String, IZosBatchJobname)} to submit a JCL  as a `String` and returns a `IZosBatchJob` instance.<br><br> See [ZosBatch](../../reference/javadoc/dev/galasa/zosbatch/ZosBatch.html){target="_blank"}, [IZosBatch](../../reference/javadoc/dev/galasa/zosbatch/IZosBatch.html){target="_blank"} and [IZosBatchJob](../../reference/javadoc/dev/galasa/zosbatch/IZosBatchJob.html){target="_blank"} to find out more. |
 
 
 ### z/OS Console
@@ -536,7 +536,7 @@ The following annotations are available with the z/OS Manager
 | Description: | The `@ZosConsole` annotation requests the z/OS Manager to provide a z/OS Console instance associated with a z/OS image.  The test can request multiple z/OS Console instances, with the default being associated with the **primary** z/OS image.<br> |
 | Attribute: `imageTag` |  The tag of the z/OS Image this variable is to be populated with |
 | Syntax: | <pre lang="java">@ZosImage(imageTag="A")<br>public IZosImage zosImageA;<br><br>@ZosConsole(imageTag="A")<br> public IZosConsole zosConsoleA;<br></pre> |
-| Notes: | The `IZosConsole` interface has two methods, {@link IZosConsole#issueCommand(String)} and {@link IZosConsole#issueCommand(String, String)} to issue a command to the z/OS console and returns a `IZosConsoleCommand` instance.<br><br> See [ZosConsole](https://javadoc.galasa.dev/dev/galasa/zosconsole/ZosConsole.html){target="_blank"}, [IZosConsole](https://javadoc.galasa.dev/dev/galasa/zosconsole/IZosConsole.html){target="_blank"} and [IZosConsoleCommand](https://javadoc.galasa.dev/dev/galasa/zosconsole/IZosConsoleCommand.html){target="_blank"} to find out more. |
+| Notes: | The `IZosConsole` interface has two methods, {@link IZosConsole#issueCommand(String)} and {@link IZosConsole#issueCommand(String, String)} to issue a command to the z/OS console and returns a `IZosConsoleCommand` instance.<br><br> See [ZosConsole](../../reference/javadoc/dev/galasa/zosconsole/ZosConsole.html){target="_blank"}, [IZosConsole](../../reference/javadoc/dev/galasa/zosconsole/IZosConsole.html){target="_blank"} and [IZosConsoleCommand](../../reference/javadoc/dev/galasa/zosconsole/IZosConsoleCommand.html){target="_blank"} to find out more. |
 
 
 ### z/OS File
@@ -546,7 +546,7 @@ The following annotations are available with the z/OS Manager
 | Name: | @ZosFileHandler |
 | Description: | The `@ZosFileHandler` annotation requests the z/OS Manager to provide a handler instance to manage data sets and UNIX files on a z/OS image.  A single z/OS File Handler instance can manage multiple z/OS data sets and UNIX files on multiple z/OS images.<br> |
 | Syntax: | <pre lang="java">@ZosFileHandler<br>public IZosFileHandler zosFileHandler;<br></pre> |
-| Notes: | The `IZosFileHandler` interface has three methods supplying file name and z/OS image:<br> {@link IZosFileHandler#newDataset(String, dev.galasa.zos.IZosImage)}<br>  {@link IZosFileHandler#newVSAMDataset(String, dev.galasa.zos.IZosImage)}<br> {@link IZosFileHandler#newUNIXFile(String, dev.galasa.zos.IZosImage)}<br> returning an object representing the type of file requested. This can be an existing file or can be created via a method on the file object.<br><br> See [ZosFileHandler](https://javadoc.galasa.dev/dev/galasa/zosfile/ZosFileHandler.html){target="_blank"}, [IZosFileHandler](https://javadoc.galasa.dev/dev/galasa/zosfile/IZosFileHandler.html){target="_blank"}, [IZosDataset](https://javadoc.galasa.dev/dev/galasa/zosfile/IZosDataset.html){target="_blank"}, [IZosVSAMDataset](https://javadoc.galasa.dev/dev/galasa/zosfile/IZosVSAMDataset.html){target="_blank"} and [IZosUNIXFile](https://javadoc.galasa.dev/dev/galasa/zosfile/IZosUNIXFile.html){target="_blank"} to find out more. |
+| Notes: | The `IZosFileHandler` interface has three methods supplying file name and z/OS image:<br> {@link IZosFileHandler#newDataset(String, dev.galasa.zos.IZosImage)}<br>  {@link IZosFileHandler#newVSAMDataset(String, dev.galasa.zos.IZosImage)}<br> {@link IZosFileHandler#newUNIXFile(String, dev.galasa.zos.IZosImage)}<br> returning an object representing the type of file requested. This can be an existing file or can be created via a method on the file object.<br><br> See [ZosFileHandler](../../reference/javadoc/dev/galasa/zosfile/ZosFileHandler.html){target="_blank"}, [IZosFileHandler](../../reference/javadoc/dev/galasa/zosfile/IZosFileHandler.html){target="_blank"}, [IZosDataset](../../reference/javadoc/dev/galasa/zosfile/IZosDataset.html){target="_blank"}, [IZosVSAMDataset](../../reference/javadoc/dev/galasa/zosfile/IZosVSAMDataset.html){target="_blank"} and [IZosUNIXFile](../../reference/javadoc/dev/galasa/zosfile/IZosUNIXFile.html){target="_blank"} to find out more. |
 
 
 ### z/OS TSO Command
@@ -557,7 +557,7 @@ The following annotations are available with the z/OS Manager
 | Description: | The `@ZosTSOCommand` annotation requests the z/OS Manager to provide a z/OS TSO Command instance associated with a z/OS image.  The test can request multiple z/OS TSO Command instances, with the default being associated with the **primary** z/OS image.<br> |
 | Attribute: `imageTag` |  The tag of the z/OS Image this variable is to be populated with |
 | Syntax: | <pre lang="java">@ZosImage(imageTag="A")<br>public IZosImage zosImageA;<br><br>@ZosTSOCommand(imageTag="A")<br> public IZosTSOCpmmand zosTSOA;<br></pre> |
-| Notes: | The `IZosTSOCommand` interface provides the methods {@link IZosTSOCommand#issueCommand(String)} and {@link IZosTSOCommand#issueCommand(String, long)} to issue a command to z/OS TSO Command and returns a `String`.<br><br> See [IZosTSOCommand](https://javadoc.galasa.dev/dev/galasa/zostsocommand/IZosTSOCommand.html){target="_blank"} to find out more. |
+| Notes: | The `IZosTSOCommand` interface provides the methods {@link IZosTSOCommand#issueCommand(String)} and {@link IZosTSOCommand#issueCommand(String, long)} to issue a command to z/OS TSO Command and returns a `String`.<br><br> See [IZosTSOCommand](../../reference/javadoc/dev/galasa/zostsocommand/IZosTSOCommand.html){target="_blank"} to find out more. |
 
 
 ### z/OS UNIX Command
@@ -568,7 +568,7 @@ The following annotations are available with the z/OS Manager
 | Description: | The `@ZosUNIXCommand` annotation requests the z/OS Manager to provide a z/OS UNIX instance associated with a z/OS image.  The test can request multiple z/OS UNIX Command instances, with the default being associated with the **primary** z/OS image.<br> |
 | Attribute: `imageTag` |  The tag of the z/OS Image this variable is to be populated with |
 | Syntax: | <pre lang="java">@ZosImage(imageTag="A")<br>public IZosImage zosImageA;<br><br>@ZosUNIXCommand(imageTag="A")<br> public IZosUNIXCommand zosUNIXCommandA;<br></pre> |
-| Notes: | The `IZosUNIXCommand` interface provides the methods {@link IZosUNIXCommand#issueCommand(String)} and {@link IZosUNIXCommand#issueCommand(String, long)} to issue a command to z/OS UNIX and returns a [String](https://javadoc.galasa.dev/dev/galasa/zosunixcommand/String.html){target="_blank"} response.<br><br> See [IZosUNIXCommand](https://javadoc.galasa.dev/dev/galasa/zosunixcommand/IZosUNIXCommand.html){target="_blank"} to find out more. |
+| Notes: | The `IZosUNIXCommand` interface provides the methods {@link IZosUNIXCommand#issueCommand(String)} and {@link IZosUNIXCommand#issueCommand(String, long)} to issue a command to z/OS UNIX and returns a String response.<br><br> See [IZosUNIXCommand](../../reference/javadoc/dev/galasa/zosunixcommand/IZosUNIXCommand.html){target="_blank"} to find out more. |
 
 
 ## Code snippets and examples

--- a/docs/content/docs/managers/zos-managers/zos-mf-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-mf-manager.md
@@ -2,7 +2,7 @@
 title: "zOS MF Manager"
 ---
 
-This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/overview-summary.html){target="_blank"}.
+This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zosmf/package-summary.html){target="_blank"}.
 
 
 
@@ -24,7 +24,7 @@ The following annotations are available with the zOS MF Manager
 | Description: | The `@Zosmf` annotation requests the z/OSMF Manager to provide a z/OSMF instance associated with a z/OS image.  The test can request multiple z/OSMF instances, with the default being associated with the **primary** zOS image. |
 | Attribute: `imageTag` |  The tag of the zOS Image this variable is to be populated with |
 | Syntax: | <pre lang="java">@ZosImage(imageTag="A")<br>public IZosImage zosImageA;<br><br>@Zosmf(imageTag="A")<br>public IZosmf zosmfA;<br></pre> |
-| Notes: | The `IZosmf` interface has a number of methods to issue requests to the zOSMF REST API. See [Zosmf](https://javadoc.galasa.dev/dev/galasa/zosmf/Zosmf.html){target="_blank"} and [IZosmf](https://javadoc.galasa.dev/dev/galasa/zosmf/IZosmf.html){target="_blank"} to find out more. |
+| Notes: | The `IZosmf` interface has a number of methods to issue requests to the zOSMF REST API. See [Zosmf](../../reference/javadoc/dev/galasa/zosmf/Zosmf.html){target="_blank"} and [IZosmf](../../reference/javadoc/dev/galasa/zosmf/IZosmf.html){target="_blank"} to find out more. |
 
 
 ## Configuration Properties

--- a/docs/content/docs/managers/zos-managers/zos-program-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-program-manager.md
@@ -15,7 +15,7 @@ The source for the program is stored as a resource, along with the test. The z/O
 
 The Manager retrieves the source from the test bundle, builds and submits the relevant compile and link JCL based on  the programs attributes and CPS properties. The batch job is saved with the test run archive. The  program can be executed in the test by retrieving the library containing the load module by using  the `getLoadLibrary()` method.  
 
-You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/index.html?overview-summary.html){target="_blank"}.
+You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zosprogram/package-summary.html){target="_blank"}.
 
 
 ## Including the Manager in a test
@@ -125,13 +125,13 @@ The following annotations are available with the z/OS Program Manager
 | Description: | The `@ZosProgram` annotation requests the z/OS Program Manager to Compile and Bind a program on a z/OS image.  The test can request multiple z/OS Program instances |
 | Attribute: `name` |  The program name. Required. |
 | Attribute: `location` |  Path to the location of the program source in the Galasa test bundle. This can be either the full path including the file name or the directory containing the source with the name specified in the name attribute with the extension specified in the language attribute. Optional. The default value is "resources". |
-| Attribute: `language` |  The programming language. Required. See [ZosProgram.Language](https://javadoc.galasa.dev/dev/galasa/zosprogram/ZosProgram.Language.html){target="_blank"}. <br><br>  |
+| Attribute: `language` |  The programming language. Required. See [ZosProgram.Language](../../reference/javadoc/dev/galasa/zosprogram/ZosProgram.Language.html){target="_blank"}. <br><br>  |
 | Attribute: `cics` |  Is a CICS program and requires the CICS translator. Optional. The default value is false.|
 | Attribute: `loadlib` |  The load module data set name. Optional. The default value is "".|
 | Attribute: `imageTag` |  The `imageTag` is used to identify the z/OS image. Optional. The default value is "primary".|
 | Attribute: `compile` |  Compile this zOS program. Optional. The default value is true.|
 | Syntax: | <pre lang="java">@ZosImage(imageTag="A")<br>public IZosImage zosImageA;<br><br>@ZosProgram(imageTag="A")<br>public IZosProgram zosProgramA;<br></pre> |
-| Notes: | The `IZosProgram` interface has a number of methods to manage the z/OS Program. See [ZosProgram](https://javadoc.galasa.dev/dev/galasa/zosprogram/ZosProgram.html){target="_blank"} and [IZosProgram](https://javadoc.galasa.dev/dev/galasa/zosprogram/IZosProgram.html){target="_blank"} to find out more. |
+| Notes: | The `IZosProgram` interface has a number of methods to manage the z/OS Program. See [ZosProgram](../../reference/javadoc/dev/galasa/zosprogram/ZosProgram.html){target="_blank"} and [IZosProgram](../../reference/javadoc/dev/galasa/zosprogram/IZosProgram.html){target="_blank"} to find out more. |
 
 
 ## Code snippets and examples

--- a/docs/content/docs/managers/zos-managers/zos-tso-command-ssh-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-tso-command-ssh-manager.md
@@ -2,7 +2,7 @@
 title: "zOS TSO Command SSH Manager"
 ---
 
-This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/overview-summary.html){target="_blank"}.
+This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zostsocommand/package-summary.html){target="_blank"}.
 
 
 ## Overview

--- a/docs/content/docs/managers/zos-managers/zos-unix-command-ssh-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos-unix-command-ssh-manager.md
@@ -2,12 +2,12 @@
 title: "zOS UNIX Command SSH Manager"
 ---
 
-This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/overview-summary.html){target="_blank"}.
+This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zosunixcommand/package-summary.html){target="_blank"}.
 
 
 ## Overview
 
 This Manager is the internal implementation of the z/OS UNIX Command Manager using SSH. <br><br> See the [zOS Manager](./zos-manager.md) for details of the z/OS UNIX annotations and  code snippets.
 
-You can view the [Javadoc  documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/zosunix/package-summary.html){target="_blank"}.
+You can view the [Javadoc  documentation for the Manager](../../reference/javadoc/dev/galasa/zosunixcommand/package-summary.html){target="_blank"}.
 

--- a/docs/content/docs/managers/zos-managers/zos3270terminal-manager.md
+++ b/docs/content/docs/managers/zos-managers/zos3270terminal-manager.md
@@ -2,7 +2,7 @@
 title: "Zos3270Terminal Manager"
 ---
 
-This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](https://javadoc.galasa.dev/dev/galasa/zos3270/package-summary.html){target="_blank"}.
+This Manager is at Beta level. You can view the [Javadoc documentation for the Manager](../../reference/javadoc/dev/galasa/zos3270/package-summary.html){target="_blank"}.
 
 
 ## Overview
@@ -149,7 +149,7 @@ The following annotations are provided by the Zos3270Terminal Manager:
 | Attribute: `imageTag` |  The `imageTag` is used to identify the z/OS image. Optional. The default value is "primary".|
 | Attribute: `autoConnect` |  Allows a user to choose if the terminal automatically connects in the provision start stage. Optional. The default value is true.|
 | Syntax: | <pre lang="java">@ZosImage(imageTag="A")<br>public IZosImage zosImageA;<br><br>@Zos3270Terminal(imageTag="A")<br>public ITerminal zosTerminalA;<br></pre> |
-| Notes: | The `ITerminal` interface has a number of methods to issue commands to the 3270 client. See [ITerminal](https://javadoc.galasa.dev/dev/galasa/zos3270/ITerminal.html){target="_blank"} to find out more. |
+| Notes: | The `ITerminal` interface has a number of methods to issue commands to the 3270 client. See [ITerminal](../../reference/javadoc/dev/galasa/zos3270/ITerminal.html){target="_blank"} to find out more. |
 
 
 ## Code snippets and examples

--- a/docs/content/docs/reference/galasa-javadoc.md
+++ b/docs/content/docs/reference/galasa-javadoc.md
@@ -2,6 +2,6 @@
 title: "Javadoc for the Galasa Managers"
 ---
 
-You can find the links to the Javadoc API documentation for all the Galasa Managers on the [overview page](https://javadoc.galasa.dev/){target="_blank"}.
+You can find the links to the Javadoc API documentation for all the Galasa Managers on the [overview page](./javadoc/overview-summary.html){target="_blank"}.
 
 You can view the [installation verification tests (IVTs)](https://github.com/galasa-dev/managers/tree/main/galasa-managers-parent){target="_blank"} for the Managers in GitHub.


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2519

## Changes

- Updated any links within the Galasa Mkdocs site from `https://javadoc.galasa.dev/*` to `./docs/reference/javadoc/*`
   - The live Mkdocs site will render the same
   - This change will also mean that the links to the Javadoc provided in the static documentation site in the Isolated/MVP zips resolve to local files rather than navigating to the served up Javadoc site which would require internet