### PR TITLE
Iss2523 - Remove httpclient and httpmine from MVP zip

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/build.gradle
@@ -7,8 +7,6 @@ description = 'HTTP Manager'
 dependencies {
     api             'dev.galasa:dev.galasa.wrapping.httpclient-osgi'
     implementation  project (':galasa-managers-common-parent:dev.galasa.common')
-    implementation  'org.apache.httpcomponents:httpcore-osgi'
-    implementation  'org.apache.httpcomponents:httpmime'
     implementation  'commons-io:commons-io'
     implementation  'com.google.code.gson:gson'
     implementation  'jakarta.xml.bind:jakarta.xml.bind-api'

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -339,8 +339,8 @@ external:
 
   - group: org.apache.httpcomponents
     artifact: httpclient
-    mvp: true
-    isolated: true
+    mvp: false
+    isolated: false
 
   - group: org.apache.httpcomponents
     artifact: httpcore-osgi
@@ -357,8 +357,8 @@ external:
 
   - group: org.apache.httpcomponents
     artifact: httpmime
-    mvp: true
-    isolated: true
+    mvp: false
+    isolated: false
 
   - group: org.apache.logging.log4j
     artifact: log4j-api


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2523

## Changes

- [x] Update the release.yaml to have mvp: false for httpclient and httpmime to remove these two from the MVP zip.
- [x] Update HTTP Manager (as its provided in the MVP) to depend only on dev.galasa.wrapping.httpclient-osgi and not httpclient and httpmime as they are provided in the wrapper.

