### PR TITLE
Iss2529 - Uplift assertj-core version to remove High vulnerability

### DIFF
--- a/modules/buildutils/openapi2beans/JavaChecker/pom.xml
+++ b/modules/buildutils/openapi2beans/JavaChecker/pom.xml
@@ -19,25 +19,34 @@
 		<unpackBundle>true</unpackBundle>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.47.0</version>
+				<type>pom</type>
+          		<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.25.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/build.gradle
@@ -13,8 +13,6 @@ dependencies {
     testImplementation(testFixtures(project(':dev.galasa.framework.api.common')))
     testImplementation(testFixtures(project(':dev.galasa.framework')))
     testImplementation 'org.assertj:assertj-core'
-    // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
-    // to use 3.23.1 caused unit test failures. Fixes for this to be completed in a future story.
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.impl/build.gradle
@@ -23,8 +23,6 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpcore'
     implementation 'org.apache.httpcomponents:httpclient'
     testImplementation 'junit:junit'
-    // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
-    // to higher versions caused unit test failures. Fixes for this to be completed in a future story.
 	testImplementation 'org.assertj:assertj-core'
     implementation project(':dev.galasa.plugin.common')
     testImplementation project(':dev.galasa.plugin.common.test')

--- a/modules/gradle/dev.galasa.plugin.common.test/build.gradle
+++ b/modules/gradle/dev.galasa.plugin.common.test/build.gradle
@@ -21,8 +21,6 @@ dependencies {
     implementation 'com.google.code.gson:gson'
     implementation 'commons-codec:commons-codec'
 	implementation 'commons-io:commons-io'
-    // Overriding version 3.16.1 suggested by the Platform - as upgrading the other projects
-    // to higher versions caused unit test failures. Fixes for this to be completed in a future story.
 	implementation 'org.assertj:assertj-core'
     implementation 'org.apache.httpcomponents:httpcore'
     implementation 'org.apache.httpcomponents:httpclient'

--- a/modules/maven/galasa-maven-plugin/pom.xml
+++ b/modules/maven/galasa-maven-plugin/pom.xml
@@ -125,7 +125,6 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.25.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -386,7 +386,7 @@ external:
 
   - group: org.assertj
     artifact: assertj-core
-    version: 3.25.3
+    version: 3.27.7 # Same version as the Platform but here to ensure stability for galasa-bom.
     obr: true
     bom: true
     mvp: true

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -189,9 +189,9 @@ dependencies {
 
         api 'javax.validation:validation-api:2.0.1.Final' // If updating, also update in obr/release.yaml.
 
-        api 'junit:junit:4.13.1'
+        api 'junit:junit:4.13.2'
 
-        api 'net.bytebuddy:byte-buddy:1.15.10'
+        api 'net.bytebuddy:byte-buddy:1.18.3'
 
         api 'net.java.dev.jna:jna:5.12.1' // bnd.bnd only
 
@@ -248,7 +248,7 @@ dependencies {
 
         api 'org.apache.velocity:velocity-engine-core:2.4.1'
 
-        api 'org.assertj:assertj-core:3.25.3'
+        api 'org.assertj:assertj-core:3.27.7'
 
         api 'org.awaitility:awaitility:3.0.0'
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2529

## Changes

- Uplift assertj-core version from 3.25.3 to 3.27.7 to remove High vulnerability
- This uplift requires byte-buddy to also be uplifted from 1.15.10 to 1.18.3 to fix OSGi wiring issues.
- I have removed explicit versions for certain dependencies that matched the version provided by the Platform as they are not needed and it's more to maintain.
- I have provided the dev.galasa.platform in dependencyManagement for the openapi2beans JavaChecker so the explicit dependency versions can be removed.
   - I have added more to the set-version.sh script for this module to ensure the version of dev.galasa.platform gets updated each release.