### PR TITLE
Experiment to find root cause of problem in RunFinishedRuns job

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunFinishedRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunFinishedRuns.java
@@ -76,7 +76,7 @@ public class RunFinishedRuns implements Runnable {
                     this.frameworkRuns.delete(runName);
                 }
             }
-        } catch (FrameworkException e) {
+        } catch (Exception e) {
             logger.error("Scan of runs failed", e);
         }
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2516

## Changes

- Catch any Exception in run() method of RunFinishedRuns to hopefully reveal root cause of problem causing the job to terminate in the resource-monitor.