### PR TITLE
Fix content type used in artifact downloads, add architecture diagrams to developer docs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,16 @@
     }
   ],
   "results": {
+    "developer-docs/cli-architecture.md": [
+      {
+        "hashed_secret": "ec7ae9b5d26766673ddea9d4b4ebdc6129ccb9c3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 128,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "developer-docs/install-pre-req-tools.md": [
       {
         "hashed_secret": "07313f0e320f22cbfa35cfc220508eb3ff457c7e",

--- a/developer-docs/architecture-documentation.md
+++ b/developer-docs/architecture-documentation.md
@@ -1,0 +1,129 @@
+# Galasa Architecture Documentation
+
+This document serves as an index to the architectural documentation for the Galasa framework.
+
+## Overview
+
+Galasa is an open-source test automation framework designed for enterprise-scale testing. It provides a rich ecosystem of components that enable automated testing across various platforms and technologies, including mainframe systems, cloud environments, and more.
+
+## Documentation Index
+
+1. [Architecture Overview](architecture-overview.md) - High-level overview of the Galasa architecture
+2. [Manager Architecture](manager-architecture.md) - Detailed explanation of the manager architecture
+3. [Test Execution Lifecycle](test-execution-lifecycle.md) - How tests are executed in Galasa
+4. [Design Patterns](design-patterns.md) - Key design patterns used in the Galasa codebase
+5. [Storage Services](storage-services.md) - Explanation of Galasa's storage services
+6. [CLI Architecture](cli-architecture.md) - Architecture of the Galasa command-line interface
+
+## Key Architectural Principles
+
+Galasa's architecture is built on several key principles:
+
+1. **Modularity**: Components are designed to be modular and replaceable
+2. **Extensibility**: The framework is designed to be extended with new capabilities
+3. **Separation of Concerns**: Clear separation between different aspects of the system
+4. **Pluggability**: Components can be plugged in and out as needed
+5. **Testability**: The architecture facilitates testing of components
+
+## Architectural Layers
+
+```mermaid
+graph TD
+    User[User/CI System] --> CLI[CLI Layer]
+    CLI --> API[API Layer]
+    API --> Framework[Framework Layer]
+    Framework --> Managers[Manager Layer]
+    Managers --> Resources[Resource Layer]
+    Framework --> Storage[Storage Layer]
+```
+
+### CLI Layer
+The CLI layer provides command-line access to Galasa functionality. It's designed for both interactive use and integration with CI/CD pipelines.
+
+### API Layer
+The API layer provides programmatic access to Galasa services through REST APIs. It enables integration with other systems and tools.
+
+### Framework Layer
+The Framework layer is the core of Galasa. It manages test execution, resource allocation, and provides services to managers and tests.
+
+### Manager Layer
+The Manager layer consists of pluggable components that provide specific functionality for different technologies and platforms.
+
+### Resource Layer
+The Resource layer represents the actual resources that tests interact with, such as mainframes, databases, and cloud services.
+
+### Storage Layer
+The Storage layer provides services for storing configuration, state, and results.
+
+## Component Interactions
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant API
+    participant Framework
+    participant Managers
+    participant Resources
+    
+    User->>CLI: Submit test
+    CLI->>API: POST /runs
+    API->>Framework: Create test run
+    Framework->>Managers: Initialize
+    Managers->>Framework: Register capabilities
+    Framework->>Managers: Provision resources
+    Managers->>Resources: Allocate
+    Resources-->>Managers: Allocated
+    Managers-->>Framework: Resources ready
+    Framework->>Managers: Execute test
+    Managers->>Resources: Interact
+    Resources-->>Managers: Results
+    Managers-->>Framework: Test results
+    Framework-->>API: Run results
+    API-->>CLI: Results
+    CLI-->>User: Display results
+```
+
+## Deployment Architecture
+
+Galasa can be deployed in various configurations:
+
+### Local Development
+```mermaid
+graph TD
+    CLI[CLI] --> LocalFramework[Local Framework]
+    LocalFramework --> FileStorage[File-based Storage]
+```
+
+### Kubernetes Deployment
+```mermaid
+graph TD
+    CLI[CLI] --> API[API Services]
+    API --> Framework[Framework Services]
+    Framework --> Storage[Distributed Storage]
+    Framework --> ResourceManagement[Resource Management]
+    ResourceManagement --> TestControllers[Test Controllers]
+    TestControllers --> TestPods[Test Pods]
+```
+
+## Future Architectural Directions
+
+The Galasa architecture continues to evolve in several directions:
+
+1. **Cloud-Native**: Enhanced support for cloud-native deployment and testing
+2. **Scalability**: Improvements for handling larger test volumes
+3. **Integration**: Better integration with CI/CD pipelines and DevOps tools
+4. **Observability**: Enhanced monitoring and observability
+5. **Security**: Improved security features and compliance
+
+## Contributing to the Architecture
+
+When contributing to Galasa, consider these architectural guidelines:
+
+1. Follow existing design patterns
+2. Maintain separation of concerns
+3. Design for testability
+4. Document architectural decisions
+5. Consider backward compatibility
+
+For more details on contributing, see the [CONTRIBUTING.md](../CONTRIBUTING.md) file.

--- a/developer-docs/architecture-overview.md
+++ b/developer-docs/architecture-overview.md
@@ -1,0 +1,84 @@
+# Galasa Architecture Overview
+
+This document provides a high-level overview of the Galasa architecture, explaining its key components and how they interact.
+
+## Introduction
+
+Galasa is an open-source test automation framework designed for enterprise-scale testing. It provides a rich ecosystem of components that enable automated testing across various platforms and technologies, including mainframe systems, cloud environments, and more.
+
+## Core Architecture Components
+
+The Galasa framework is built with a modular architecture that consists of several key components:
+
+1. **Framework Core**: The central component that manages test execution, resource allocation, and lifecycle management
+2. **Managers**: Pluggable components that provide specific functionality for different technologies and platforms
+3. **Test Runner**: Responsible for executing tests and managing their lifecycle
+4. **Result Archive Store (RAS)**: Stores test results and artifacts
+5. **Configuration Property Store (CPS)**: Manages configuration properties for the framework and tests
+6. **Dynamic Status Store (DSS)**: Maintains dynamic state information during test execution
+7. **CLI**: Command-line interface for interacting with the Galasa ecosystem
+
+## High-Level Architecture Diagram
+
+```mermaid
+graph TD
+    User[User/CI System] --> CLI[Galasa CLI]
+    CLI --> API[Galasa API]
+    API --> Framework[Framework Core]
+    Framework --> TestRunner[Test Runner]
+    TestRunner --> Managers[Managers]
+    Framework --> CPS[Configuration Property Store]
+    Framework --> DSS[Dynamic Status Store]
+    Framework --> RAS[Result Archive Store]
+    Framework --> Auth[Authentication/Authorization]
+    Managers --> Resources[External Resources]
+```
+
+## Key Components in Detail
+
+### Framework Core
+
+The Framework Core is the central component of Galasa. It provides:
+
+- Test lifecycle management
+- Resource allocation and management
+- Service integration
+- Extension points for managers and other components
+
+The Framework implements the `IFramework` interface and provides access to various services like CPS, DSS, RAS, etc.
+
+### Managers
+
+Managers are pluggable components that provide specific functionality for different technologies and platforms. They follow a plugin architecture and are loaded dynamically at runtime. Managers can:
+
+- Provision and manage resources
+- Provide interfaces for test interaction with resources
+- Handle cleanup and resource release
+- Implement test annotations for easy resource declaration
+
+Managers are organized into categories:
+- Core Managers: Essential functionality for all tests
+- Platform Managers: Support for specific platforms (zOS, Linux, Windows, etc.)
+- Technology Managers: Support for specific technologies (CICS, DB2, JMeter, etc.)
+- Cloud Managers: Support for cloud platforms (Kubernetes, Docker, etc.)
+
+### Test Runner
+
+The Test Runner is responsible for:
+- Loading and executing tests
+- Managing the test lifecycle
+- Coordinating with managers for resource provisioning
+- Reporting test results
+
+### Storage Services
+
+Galasa uses several storage services:
+
+- **Configuration Property Store (CPS)**: Manages configuration properties
+- **Dynamic Status Store (DSS)**: Maintains dynamic state information
+- **Result Archive Store (RAS)**: Stores test results and artifacts
+- **Credentials Store**: Securely stores and provides access to credentials
+
+### CLI and API
+
+The CLI provides a command-line interface for interacting with Galasa, while the API provides programmatic access to Galasa services.

--- a/developer-docs/cli-architecture.md
+++ b/developer-docs/cli-architecture.md
@@ -1,0 +1,222 @@
+# Galasa CLI Architecture
+
+This document explains the architecture of the Galasa Command Line Interface (CLI), which provides a user-friendly way to interact with the Galasa ecosystem.
+
+## Overview
+
+The Galasa CLI (`galasactl`) is a command-line tool written in Go that allows users to:
+
+1. Run tests
+2. Manage the Galasa ecosystem
+3. Query test results
+4. Work with test artifacts
+5. Configure Galasa components
+
+## Architecture
+
+```mermaid
+graph TD
+    User[User] --> CLI[CLI]
+    CLI --> Commands[Commands]
+    Commands --> APIClient[API Client]
+    APIClient --> GalasaAPI[Galasa REST API]
+    GalasaAPI --> Framework[Galasa Framework]
+```
+
+### Key Components
+
+1. **Command Structure**: Hierarchical command organization
+2. **API Client**: Go client for the Galasa REST API
+3. **Configuration Management**: Handles CLI configuration
+4. **Output Formatting**: Formats output for different formats (JSON, YAML, text)
+
+## Command Structure
+
+The CLI uses a hierarchical command structure:
+
+```
+galasactl
+├── runs
+│   ├── submit
+│   ├── get
+│   └── cancel
+├── resources
+│   ├── create
+│   ├── get
+│   └── delete
+├── results
+│   ├── get
+│   └── download
+└── ecosystem
+    ├── bootstrap
+    ├── configure
+    └── status
+```
+
+## Implementation
+
+The CLI is implemented using:
+
+- **Cobra**: Go library for creating powerful modern CLI applications
+- **Go HTTP Client**: For API communication
+- **Go Templates**: For output formatting
+- **YAML/JSON Libraries**: For configuration and data handling
+
+```mermaid
+classDiagram
+    class Command {
+        +Run()
+        +PreRun()
+        +PostRun()
+    }
+    
+    class RootCommand {
+        +Execute()
+    }
+    
+    class SubCommand {
+        +Execute()
+    }
+    
+    class APIClient {
+        +Call()
+        +HandleResponse()
+    }
+    
+    Command <|-- RootCommand
+    Command <|-- SubCommand
+    SubCommand --> APIClient
+```
+
+## API Communication
+
+The CLI communicates with the Galasa ecosystem through REST APIs:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant API as Galasa API
+    participant Framework
+    
+    User->>CLI: galasactl runs submit --class MyTest
+    CLI->>API: POST /runs
+    API->>Framework: Submit test
+    Framework-->>API: Run ID
+    API-->>CLI: Run details
+    CLI-->>User: Display run information
+```
+
+## Authentication
+
+The CLI supports multiple authentication methods:
+
+1. **API Key**: Using an API key for authentication
+2. **OAuth**: Using OAuth tokens for authentication
+3. **Basic Auth**: Using username/password for authentication
+
+Authentication flow:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Auth as Auth Service
+    participant API as Galasa API
+    
+    User->>CLI: galasactl login
+    CLI->>Auth: Authenticate
+    Auth-->>CLI: Token
+    CLI->>CLI: Store token
+    
+    User->>CLI: galasactl runs submit
+    CLI->>CLI: Get stored token
+    CLI->>API: Request with token
+    API-->>CLI: Response
+```
+
+## Configuration Management
+
+The CLI manages configuration through:
+
+1. **Global Configuration**: System-wide settings
+2. **User Configuration**: User-specific settings
+3. **Project Configuration**: Project-specific settings
+4. **Environment Variables**: Override settings
+5. **Command-line Flags**: Override settings for a single command
+
+Configuration precedence (highest to lowest):
+- Command-line flags
+- Environment variables
+- Project configuration
+- User configuration
+- Global configuration
+
+## Output Formatting
+
+The CLI supports multiple output formats:
+
+1. **Human-readable**: Default formatted output
+2. **JSON**: Structured JSON output
+3. **YAML**: Structured YAML output
+4. **CSV**: Tabular data for spreadsheets
+
+Example:
+```
+galasactl runs get --output json
+```
+
+## Error Handling
+
+The CLI implements robust error handling:
+
+1. **User Errors**: Clear messages for user mistakes
+2. **System Errors**: Detailed information for system issues
+3. **Network Errors**: Handling API communication failures
+4. **Retry Logic**: For transient failures
+
+## Plugin Architecture
+
+The CLI supports plugins for extensibility:
+
+```mermaid
+graph TD
+    CLI[CLI Core] --> PluginManager[Plugin Manager]
+    PluginManager --> Plugin1[Plugin 1]
+    PluginManager --> Plugin2[Plugin 2]
+    PluginManager --> Plugin3[Plugin 3]
+```
+
+Plugins can:
+1. Add new commands
+2. Extend existing commands
+3. Add new output formats
+4. Integrate with external systems
+
+## Integration with CI/CD
+
+The CLI is designed to integrate with CI/CD pipelines:
+
+1. **Exit Codes**: Standard exit codes for automation
+2. **Machine-readable Output**: JSON/YAML for parsing
+3. **Non-interactive Mode**: For automated execution
+4. **Credentials Management**: Secure handling of credentials
+
+Example Jenkins integration:
+```groovy
+stage('Run Galasa Tests') {
+    steps {
+        sh 'galasactl runs submit --class com.example.TestClass --bootstrap http://galasa:8080/bootstrap'
+    }
+}
+```
+
+## Development Workflow
+
+The CLI development follows these principles:
+
+1. **Modular Design**: Separate concerns for maintainability
+2. **Test-Driven Development**: Comprehensive test coverage
+3. **Continuous Integration**: Automated builds and tests
+4. **Versioning**: Semantic versioning for releases
+5. **Documentation**: Embedded help and external documentation

--- a/developer-docs/design-patterns.md
+++ b/developer-docs/design-patterns.md
@@ -1,0 +1,311 @@
+# Design Patterns in Galasa
+
+This document outlines the key design patterns used in the Galasa framework architecture.
+
+## Service Provider Interface (SPI) Pattern
+
+Galasa makes extensive use of the Service Provider Interface pattern, which separates interface definitions from their implementations.
+
+```mermaid
+classDiagram
+    class IService {
+        <<interface>>
+        +operation()
+    }
+    
+    class ServiceImpl {
+        +operation()
+    }
+    
+    class Client
+    
+    IService <|-- ServiceImpl
+    Client --> IService
+```
+
+Examples in Galasa:
+- `IManager` interface with various manager implementations
+- `IResultArchiveStore` interface with different storage implementations
+- `IConfigurationPropertyStore` interface with different backend implementations
+
+Benefits:
+- Allows for pluggable implementations
+- Enables loose coupling between components
+- Facilitates testing with mock implementations
+
+## Dependency Injection
+
+Galasa uses dependency injection to provide components with their dependencies.
+
+```mermaid
+classDiagram
+    class Framework {
+        +getService()
+    }
+    
+    class Component {
+        -service
+        +Component(IService)
+        +operation()
+    }
+    
+    class IService {
+        <<interface>>
+        +serviceOperation()
+    }
+    
+    Framework --> Component : creates
+    Framework --> IService : provides
+    Component --> IService : uses
+```
+
+Examples in Galasa:
+- Managers are injected with the Framework instance
+- Test classes are injected with manager-provided resources
+- Services are injected with their dependencies
+
+Benefits:
+- Reduces tight coupling between components
+- Makes testing easier through mock dependencies
+- Improves code modularity
+
+## Annotation-Based Configuration
+
+Galasa uses Java annotations extensively for configuration and resource declaration.
+
+```mermaid
+classDiagram
+    class TestClass {
+        +@Annotation field
+        +@Test method()
+    }
+    
+    class AnnotationProcessor {
+        +process(TestClass)
+    }
+    
+    TestClass --> AnnotationProcessor : processed by
+```
+
+Examples in Galasa:
+- `@ZosImage` for declaring zOS image requirements
+- `@HttpClient` for declaring HTTP client requirements
+- `@Test` for marking test methods
+
+Benefits:
+- Declarative programming style
+- Reduced boilerplate code
+- Clear separation of configuration from implementation
+
+## Manager Pattern
+
+Galasa's manager architecture is a specialized form of the Strategy pattern, where each manager provides a specific capability.
+
+```mermaid
+classDiagram
+    class IManager {
+        <<interface>>
+        +initialise()
+        +provisionGenerate()
+        +fillAnnotatedFields()
+    }
+    
+    class AbstractManager {
+        #findAnnotatedFields()
+        #generateAnnotatedFields()
+    }
+    
+    class ConcreteManager1 {
+        +initialise()
+        +provisionGenerate()
+        +fillAnnotatedFields()
+    }
+    
+    class ConcreteManager2 {
+        +initialise()
+        +provisionGenerate()
+        +fillAnnotatedFields()
+    }
+    
+    IManager <|-- AbstractManager
+    AbstractManager <|-- ConcreteManager1
+    AbstractManager <|-- ConcreteManager2
+```
+
+Benefits:
+- Encapsulates specific functionality
+- Allows for composition of capabilities
+- Enables extensibility
+
+## Observer Pattern
+
+Galasa uses the Observer pattern for event notification.
+
+```mermaid
+classDiagram
+    class IEventProducer {
+        +registerListener(IEventListener)
+        +unregisterListener(IEventListener)
+        +fireEvent(Event)
+    }
+    
+    class IEventListener {
+        <<interface>>
+        +processEvent(Event)
+    }
+    
+    class ConcreteListener {
+        +processEvent(Event)
+    }
+    
+    IEventProducer --> IEventListener : notifies
+    IEventListener <|-- ConcreteListener
+```
+
+Examples in Galasa:
+- Framework events for test lifecycle notifications
+- Resource status change notifications
+- Run state change events
+
+Benefits:
+- Loose coupling between event producers and consumers
+- Support for multiple listeners
+- Asynchronous processing
+
+## Factory Pattern
+
+Galasa uses factory patterns to create complex objects.
+
+```mermaid
+classDiagram
+    class Factory {
+        +create() : Product
+    }
+    
+    class Product {
+        <<interface>>
+    }
+    
+    class ConcreteProduct
+    
+    Factory --> Product : creates
+    Product <|-- ConcreteProduct
+```
+
+Examples in Galasa:
+- `GalasaFactory` for creating framework instances
+- Manager factories for creating resources
+- Test runner factories
+
+Benefits:
+- Encapsulates object creation logic
+- Allows for different creation strategies
+- Simplifies client code
+
+## Composite Pattern
+
+Galasa uses the Composite pattern for managing collections of similar objects.
+
+```mermaid
+classDiagram
+    class Component {
+        <<interface>>
+        +operation()
+    }
+    
+    class Leaf {
+        +operation()
+    }
+    
+    class Composite {
+        -children : List~Component~
+        +operation()
+        +add(Component)
+        +remove(Component)
+    }
+    
+    Component <|-- Leaf
+    Component <|-- Composite
+    Composite o-- Component
+```
+
+Examples in Galasa:
+- Multiple Result Archive Stores
+- Manager collections
+- Test class hierarchies
+
+Benefits:
+- Uniform treatment of individual and composite objects
+- Simplified client code
+- Hierarchical structures
+
+## Adapter Pattern
+
+Galasa uses adapters to make incompatible interfaces work together.
+
+```mermaid
+classDiagram
+    class Client
+    
+    class TargetInterface {
+        <<interface>>
+        +targetOperation()
+    }
+    
+    class Adapter {
+        +targetOperation()
+    }
+    
+    class Adaptee {
+        +specificOperation()
+    }
+    
+    Client --> TargetInterface
+    TargetInterface <|-- Adapter
+    Adapter --> Adaptee : adapts
+```
+
+Examples in Galasa:
+- Adapters for different storage backends
+- Protocol adapters in communication managers
+- Legacy system integration
+
+Benefits:
+- Reuse of existing components
+- Gradual migration path
+- Interface compatibility
+
+## Proxy Pattern
+
+Galasa uses proxies to control access to objects.
+
+```mermaid
+classDiagram
+    class Subject {
+        <<interface>>
+        +operation()
+    }
+    
+    class RealSubject {
+        +operation()
+    }
+    
+    class Proxy {
+        -realSubject : RealSubject
+        +operation()
+    }
+    
+    Subject <|-- RealSubject
+    Subject <|-- Proxy
+    Proxy --> RealSubject
+```
+
+Examples in Galasa:
+- Security proxies for credential access
+- Remote proxies for distributed resources
+- Lazy-loading proxies for resource efficiency
+
+Benefits:
+- Access control
+- Lazy initialization
+- Remote resource representation

--- a/developer-docs/manager-architecture.md
+++ b/developer-docs/manager-architecture.md
@@ -1,0 +1,123 @@
+# Galasa Manager Architecture
+
+This document explains the manager architecture in Galasa, which is a key part of the framework's extensibility model.
+
+## What are Managers?
+
+Managers are pluggable components that provide specific functionality for different technologies and platforms. They follow a plugin architecture and are loaded dynamically at runtime. Managers are responsible for:
+
+- Provisioning and managing resources
+- Providing interfaces for test interaction with resources
+- Handling cleanup and resource release
+- Implementing test annotations for easy resource declaration
+
+## Manager Hierarchy
+
+```mermaid
+classDiagram
+    class IManager {
+        <<interface>>
+        +initialise(IFramework, List~IManager~, List~IManager~, GalasaTest)
+        +youAreRequired(List~IManager~, List~IManager~, GalasaTest)
+        +provisionGenerate()
+        +provisionBuild()
+        +provisionStart()
+        +fillAnnotatedFields(Object)
+        +startOfTestClass()
+        +startOfTestMethod(GalasaMethod)
+        +endOfTestMethod(GalasaMethod, Result, Throwable)
+        +endOfTestClass(Result, Throwable)
+        +provisionStop()
+        +provisionDiscard()
+        +shutdown()
+    }
+    
+    class AbstractManager {
+        #IFramework framework
+        #Class<?> testClass
+        #HashMap~Field, Object~ annotatedFields
+        #registerAnnotatedField(Field, Object)
+        #getAnnotatedField(Field)
+        #findAnnotatedFields(Class~Annotation~)
+        #generateAnnotatedFields(Class~Annotation~)
+    }
+    
+    class ConcreteManager {
+        +specific functionality
+    }
+    
+    IManager <|-- AbstractManager
+    AbstractManager <|-- ConcreteManager
+```
+
+## Manager Lifecycle
+
+Managers follow a specific lifecycle during test execution:
+
+1. **Initialization**: Managers are initialized with the framework and test class
+2. **Dependency Resolution**: Managers declare dependencies on other managers
+3. **Resource Provisioning**: Managers provision resources in multiple phases:
+   - Generate: Initial resource planning
+   - Build: Resource creation
+   - Start: Resource initialization
+4. **Test Execution**: Managers support test execution:
+   - Fill annotated fields in test class
+   - Support test methods
+   - Handle test results
+5. **Resource Cleanup**: Managers clean up resources:
+   - Stop: Graceful shutdown
+   - Discard: Resource deletion
+
+## Manager Annotations
+
+Managers use Java annotations to:
+
+1. Mark fields in test classes for automatic injection
+2. Define resource requirements
+3. Configure resource properties
+
+Example:
+```java
+@ZosImage(imageTag="A")
+public IZosImage zosImage;
+
+@Cics(cicsTag="CICS1", imageTag="A")
+public ICicsRegion cicsRegion;
+```
+
+## Manager Dependency Model
+
+Managers can depend on other managers to provide functionality. For example:
+
+- The CICS Manager depends on the zOS Manager for zOS image provisioning
+- The zOS3270 Manager depends on the zOS Manager for terminal connections
+
+Dependencies are resolved at runtime through the `youAreRequired()` method.
+
+## Service Provider Interface (SPI)
+
+Managers implement the Service Provider Interface (SPI) pattern:
+
+1. Core interfaces are defined in the framework
+2. Managers provide implementations of these interfaces
+3. The framework discovers and loads managers at runtime
+4. Tests interact with the interfaces, not the implementations
+
+## Resource Management
+
+Managers handle resource management through:
+
+1. **Provisioning**: Allocating resources when needed
+2. **Sharing**: Allowing resources to be shared between tests
+3. **Cleanup**: Ensuring resources are properly released
+4. **Isolation**: Preventing resource conflicts between tests
+
+## Manager Categories
+
+Galasa organizes managers into several categories:
+
+1. **Core Managers**: Essential functionality for all tests
+2. **Platform Managers**: Support for specific platforms (zOS, Linux, Windows)
+3. **Technology Managers**: Support for specific technologies (CICS, DB2, JMeter)
+4. **Cloud Managers**: Support for cloud platforms (Kubernetes, Docker)
+5. **Utility Managers**: Provide utility functions (HTTP, Artifact)

--- a/developer-docs/storage-services.md
+++ b/developer-docs/storage-services.md
@@ -1,0 +1,247 @@
+# Galasa Storage Services
+
+This document explains the storage services used in Galasa for configuration, state management, and results storage.
+
+## Overview
+
+Galasa uses several storage services to manage different types of data:
+
+1. **Configuration Property Store (CPS)**: Manages configuration properties
+2. **Dynamic Status Store (DSS)**: Maintains dynamic state information
+3. **Result Archive Store (RAS)**: Stores test results and artifacts
+4. **Credentials Store**: Securely stores and provides access to credentials
+
+These services are designed to be pluggable, allowing different backend implementations.
+
+## Architecture
+
+```mermaid
+classDiagram
+    class IFramework {
+        +getConfigurationPropertyService()
+        +getDynamicStatusStoreService()
+        +getResultArchiveStore()
+        +getCredentialsService()
+    }
+    
+    class IConfigurationPropertyStore {
+        <<interface>>
+        +getProperty()
+        +setProperty()
+    }
+    
+    class IDynamicStatusStore {
+        <<interface>>
+        +put()
+        +get()
+        +delete()
+    }
+    
+    class IResultArchiveStore {
+        <<interface>>
+        +getStoredArtifactsRoot()
+        +writeLog()
+    }
+    
+    class ICredentialsStore {
+        <<interface>>
+        +get()
+        +set()
+    }
+    
+    IFramework --> IConfigurationPropertyStore
+    IFramework --> IDynamicStatusStore
+    IFramework --> IResultArchiveStore
+    IFramework --> ICredentialsStore
+```
+
+## Configuration Property Store (CPS)
+
+The Configuration Property Store provides a hierarchical key-value store for configuration properties.
+
+### Key Features
+
+- Namespace-based property organization
+- Property inheritance and overrides
+- Support for different backend implementations
+- Property encryption for sensitive values
+
+### Usage Pattern
+
+```mermaid
+sequenceDiagram
+    participant Test as Test
+    participant Framework as Framework
+    participant CPS as CPS Service
+    participant Backend as CPS Backend
+    
+    Test->>Framework: getConfigurationPropertyService("namespace")
+    Framework->>CPS: create(namespace)
+    Test->>CPS: getProperty("key")
+    CPS->>Backend: get("namespace.key")
+    Backend-->>CPS: value
+    CPS-->>Test: value
+```
+
+### Implementation
+
+The CPS is implemented with:
+
+- `IConfigurationPropertyStore`: Core interface for the backend
+- `IConfigurationPropertyStoreService`: Service interface for clients
+- `FrameworkConfigurationPropertyService`: Default implementation
+
+## Dynamic Status Store (DSS)
+
+The Dynamic Status Store maintains dynamic state information during test execution.
+
+### Key Features
+
+- Transactional updates
+- Namespace isolation
+- Atomic operations
+- Watch capability for state changes
+
+### Usage Pattern
+
+```mermaid
+sequenceDiagram
+    participant Manager as Manager
+    participant Framework as Framework
+    participant DSS as DSS Service
+    participant Backend as DSS Backend
+    
+    Manager->>Framework: getDynamicStatusStoreService("namespace")
+    Framework->>DSS: create(namespace)
+    Manager->>DSS: put("key", "value")
+    DSS->>Backend: put("namespace.key", "value")
+    
+    Manager->>DSS: putSwap("key", "oldValue", "newValue")
+    DSS->>Backend: compareAndSwap("namespace.key", "oldValue", "newValue")
+    Backend-->>DSS: success/failure
+    DSS-->>Manager: success/failure
+```
+
+### Implementation
+
+The DSS is implemented with:
+
+- `IDynamicStatusStore`: Core interface for the backend
+- `IDynamicStatusStoreService`: Service interface for clients
+- `FrameworkDynamicStatusStoreService`: Default implementation
+
+## Result Archive Store (RAS)
+
+The Result Archive Store captures and stores test results and artifacts.
+
+### Key Features
+
+- Structured storage of test results
+- Log capture and storage
+- Artifact storage
+- Test metadata storage
+- Multiple backend support
+
+### Usage Pattern
+
+```mermaid
+sequenceDiagram
+    participant Test as Test
+    participant Framework as Framework
+    participant RAS as RAS Service
+    participant Backend as RAS Backend
+    
+    Test->>Framework: getResultArchiveStore()
+    Framework->>RAS: getInstance()
+    Test->>RAS: getStoredArtifactsRoot()
+    RAS-->>Test: artifactPath
+    Test->>RAS: writeArtifact(path, content)
+    RAS->>Backend: store(runId, path, content)
+```
+
+### Implementation
+
+The RAS is implemented with:
+
+- `IResultArchiveStore`: Core interface for the backend
+- `IResultArchiveStoreService`: Service interface for clients
+- `FrameworkMultipleResultArchiveStore`: Composite implementation supporting multiple backends
+
+## Credentials Store
+
+The Credentials Store securely manages and provides access to credentials.
+
+### Key Features
+
+- Secure storage of credentials
+- Credential access control
+- Support for different credential types
+- Integration with external credential providers
+
+### Usage Pattern
+
+```mermaid
+sequenceDiagram
+    participant Test as Test
+    participant Framework as Framework
+    participant CredService as Credentials Service
+    participant Backend as Credentials Backend
+    
+    Test->>Framework: getCredentialsService()
+    Framework->>CredService: getInstance()
+    Test->>CredService: getCredentials("id")
+    CredService->>Backend: get("id")
+    Backend-->>CredService: credentials
+    CredService-->>Test: credentials
+```
+
+### Implementation
+
+The Credentials Store is implemented with:
+
+- `ICredentialsStore`: Core interface for the backend
+- `ICredentialsService`: Service interface for clients
+- `FrameworkCredentialsService`: Default implementation
+
+## Backend Implementations
+
+Galasa supports multiple backend implementations for each storage service:
+
+### CPS Backends
+
+- File-based CPS
+- etcd CPS
+- Kubernetes ConfigMap CPS
+
+### DSS Backends
+
+- File-based DSS
+- etcd DSS
+- Redis DSS
+
+### RAS Backends
+
+- File-based RAS
+- Object storage RAS (S3, etc.)
+- Database RAS
+
+### Credentials Backends
+
+- File-based Credentials Store
+- Vault Credentials Store
+- Kubernetes Secret Credentials Store
+
+## Integration with Test Execution
+
+The storage services are integrated with the test execution lifecycle:
+
+1. **Before Test**: Load configuration, allocate resources
+2. **During Test**: Record logs and artifacts, update dynamic state
+3. **After Test**: Store final results, release resources
+
+## Security Considerations
+
+- Encryption of sensitive data
+- Access control for credentials
+- Secure communication with backends
+- Isolation between test runs

--- a/developer-docs/test-execution-lifecycle.md
+++ b/developer-docs/test-execution-lifecycle.md
@@ -1,0 +1,165 @@
+# Galasa Test Execution Lifecycle
+
+This document explains the test execution lifecycle in Galasa, from submission to completion.
+
+## Test Run States
+
+As shown in the existing documentation, a test run goes through multiple states during its lifecycle:
+
+```mermaid
+stateDiagram-v2
+    [*] --> queued :  api server submits the run
+    waiting --> queued : re-queued after a back-off time has expired
+    queued: "Queued" awaiting and engine controller to scheduled it
+    queued  --> allocated : Engine controller creates a pod
+    allocated: "Allocated" pod has been created to run the test
+    queued --> cancelling : cancel 
+    cancelling --> finished
+    allocated --> started : kube starts code running on the pod
+    started: "Started" test pod is running java code
+    started --> building
+    building --> provstart
+    provstart --> generating
+    generating --> up
+    generating --> waiting : No resources
+    up --> running
+    running --> rundone : test code executes
+    rundone --> ending
+    ending --> finished
+    finished --> [*]
+```
+
+## Detailed Execution Phases
+
+### 1. Submission and Scheduling
+
+- **Queued**: The test is submitted to the Galasa ecosystem and awaits scheduling
+- **Allocated**: Resources are allocated for the test (e.g., a Kubernetes pod)
+- **Started**: The test execution environment is initialized
+
+### 2. Resource Provisioning
+
+The framework goes through several phases to provision resources:
+
+- **Building**: Initial setup phase
+- **ProvStart**: Start of provisioning
+- **Generating**: Determining what resources are needed
+  - If resources are available: Proceeds to "up" state
+  - If resources are unavailable: Enters "waiting" state and eventually re-queues
+
+### 3. Test Execution
+
+- **Up**: All resources are provisioned and ready
+- **Running**: The actual test code is executing
+- **RunDone**: Test execution has completed
+
+### 4. Cleanup and Completion
+
+- **Ending**: Resources are being released
+- **Finished**: The test run is complete
+
+## Framework Implementation
+
+The test execution lifecycle is implemented through several key components:
+
+### TestRunner
+
+The `TestRunner` class is responsible for executing tests and managing their lifecycle. It:
+
+1. Loads the test class
+2. Initializes required managers
+3. Coordinates resource provisioning
+4. Executes test methods
+5. Handles test results
+6. Coordinates resource cleanup
+
+### TestRunManagers
+
+The `TestRunManagers` class manages the collection of managers required for a test run. It:
+
+1. Discovers available managers
+2. Resolves manager dependencies
+3. Coordinates manager lifecycle methods
+4. Handles manager exceptions
+
+### Manager Lifecycle Methods
+
+Managers participate in the test lifecycle through several methods:
+
+```mermaid
+sequenceDiagram
+    participant TR as TestRunner
+    participant TRM as TestRunManagers
+    participant M as Managers
+    
+    TR->>TRM: initialise()
+    TRM->>M: initialise()
+    TR->>TRM: provisionGenerate()
+    TRM->>M: provisionGenerate()
+    TR->>TRM: provisionBuild()
+    TRM->>M: provisionBuild()
+    TR->>TRM: provisionStart()
+    TRM->>M: provisionStart()
+    TR->>TRM: fillAnnotatedFields()
+    TRM->>M: fillAnnotatedFields()
+    TR->>TRM: startOfTestClass()
+    TRM->>M: startOfTestClass()
+    
+    loop For each test method
+        TR->>TRM: startOfTestMethod()
+        TRM->>M: startOfTestMethod()
+        TR->>TR: Execute test method
+        TR->>TRM: endOfTestMethod()
+        TRM->>M: endOfTestMethod()
+    end
+    
+    TR->>TRM: endOfTestClass()
+    TRM->>M: endOfTestClass()
+    TR->>TRM: provisionStop()
+    TRM->>M: provisionStop()
+    TR->>TRM: provisionDiscard()
+    TRM->>M: provisionDiscard()
+    TR->>TRM: endOfTestRun()
+    TRM->>M: endOfTestRun()
+```
+
+## Resource Management During Test Execution
+
+### Resource Provisioning Phases
+
+1. **Generate**: Managers determine what resources they need
+2. **Build**: Resources are created or allocated
+3. **Start**: Resources are initialized and configured
+
+### Resource Cleanup Phases
+
+1. **Stop**: Resources are gracefully stopped
+2. **Discard**: Resources are released or deleted
+
+### Resource Sharing
+
+Galasa supports resource sharing between tests through:
+
+1. **Shared Environments**: Pre-provisioned environments that can be used by multiple tests
+2. **Resource Pools**: Collections of resources that can be allocated to tests as needed
+3. **Dynamic Status Store**: Tracks resource allocation and status
+
+## Test Results and Reporting
+
+During and after test execution, Galasa captures:
+
+1. **Test Logs**: Detailed logs of test execution
+2. **Test Artifacts**: Files and data generated during the test
+3. **Test Results**: Pass/fail status and other metrics
+4. **Run Data**: Metadata about the test run
+
+These are stored in the Result Archive Store (RAS) for later retrieval and analysis.
+
+## Error Handling and Recovery
+
+Galasa includes mechanisms for handling errors during test execution:
+
+1. **Exception Handling**: Managers can handle and recover from exceptions
+2. **Resource Cleanup**: Resources are cleaned up even if tests fail
+3. **Failure Analysis**: Managers can perform analysis on test failures
+4. **Retry Mechanisms**: Tests can be automatically retried under certain conditions

--- a/developer-docs/test-run-lifecycle.md
+++ b/developer-docs/test-run-lifecycle.md
@@ -7,12 +7,16 @@ When a test runs, it passes through many states which may be apparent to anyone 
 title: Test run states
 ---
 stateDiagram-v2
-    [*] --> queued : submitted
-    waiting --> queued : re-queued
-    queued  --> allocated
-    queued --> cancelling : cancel
+    [*] --> queued :  api server submits the run
+    waiting --> queued : re-queued after a back-off time has expired
+    queued: "Queued" awaiting and engine controller to scheduled it
+    queued  --> allocated : Engine controller creates a pod
+    allocated: "Allocated" pod has been created to run the test
+    queued --> cancelling : cancel 
+    note right of cancelling: User has cancelled the test. It can't now be scheduled by the engine controller
     cancelling --> finished
-    allocated --> started
+    allocated --> started : kube starts code running on the pod
+    started: "Started" test pod is running java code
     started --> building
     building --> provstart
     provstart --> generating
@@ -25,4 +29,6 @@ stateDiagram-v2
     finished --> [*]
 ```
 
+
 If a manager used by the test fails to acquire the required resources, it enters the `waiting` state, and stays there for a while, then gets re-queued.
+

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/src/main/java/dev/galasa/extensions/common/couchdb/CouchdbStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/src/main/java/dev/galasa/extensions/common/couchdb/CouchdbStore.java
@@ -240,6 +240,7 @@ public abstract class CouchdbStore {
      *
      * @param dbName     the name of the database to delete the document from
      * @param documentId the CouchDB ID for the document to delete
+     * @param documentRevision the version of this document, to protect against race-overwrite conditions.
      * @throws CouchdbException if there was a problem accessing the CouchDB store
      *                          or its response
      */

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/bnd.bnd
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/bnd.bnd
@@ -4,6 +4,7 @@ Bundle-Description: Galasa RAS - CouchDB
 Bundle-License: https://www.eclipse.org/legal/epl-2.0
 Import-Package: com.google.gson,\
     dev.galasa,\
+    dev.galasa.framework,\
     dev.galasa.framework.spi,\
     dev.galasa.framework.spi.ras,\
     dev.galasa.framework.spi.teststructure,\

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbArtifactPath.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbArtifactPath.java
@@ -8,6 +8,9 @@ package dev.galasa.ras.couchdb.internal;
 import java.nio.file.FileSystem;
 import java.util.List;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.JsonElement;
@@ -24,12 +27,16 @@ public class CouchdbArtifactPath extends ResultArchiveStorePath {
 
     private boolean directory = false;
 
+    private final Log logger = LogFactory.getLog(CouchdbArtifactPath.class);
+
     public CouchdbArtifactPath(@NotNull FileSystem fileSystem, String pathName) {
         super(fileSystem, pathName);
+        logger.info("CouchdbArtifactPath: constructor 1. Path: "+pathName);
     }
 
     protected CouchdbArtifactPath(FileSystem fileSystem, boolean b, List<String> nameElements, int i, int size) {
         super(fileSystem, b, nameElements, i, size);
+        logger.info("CouchdbArtifactPath: constructor 2. b:"+Boolean.toString(b)+" i:"+Integer.toString(i)+" size:"+Integer.toString(size)+" nameElements:"+nameElements.toString());
     }
 
     protected CouchdbArtifactPath(@NotNull FileSystem fileSystem, String pathName, JsonObject artifactDetails,
@@ -50,6 +57,8 @@ public class CouchdbArtifactPath extends ResultArchiveStorePath {
         } else {
             this.length = 0;
         }
+
+        logger.debug("CouchdbArtifactPath constructor 3 with path "+pathName+" contentType:"+this.contentType+" length:"+Integer.toString(this.length));
     }
 
     @Override

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbArtifactPath.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbArtifactPath.java
@@ -8,9 +8,6 @@ package dev.galasa.ras.couchdb.internal;
 import java.nio.file.FileSystem;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.JsonElement;
@@ -27,16 +24,12 @@ public class CouchdbArtifactPath extends ResultArchiveStorePath {
 
     private boolean directory = false;
 
-    private final Log logger = LogFactory.getLog(CouchdbArtifactPath.class);
-
     public CouchdbArtifactPath(@NotNull FileSystem fileSystem, String pathName) {
         super(fileSystem, pathName);
-        logger.info("CouchdbArtifactPath: constructor 1. Path: "+pathName);
     }
 
     protected CouchdbArtifactPath(FileSystem fileSystem, boolean b, List<String> nameElements, int i, int size) {
         super(fileSystem, b, nameElements, i, size);
-        logger.info("CouchdbArtifactPath: constructor 2. b:"+Boolean.toString(b)+" i:"+Integer.toString(i)+" size:"+Integer.toString(size)+" nameElements:"+nameElements.toString());
     }
 
     protected CouchdbArtifactPath(@NotNull FileSystem fileSystem, String pathName, JsonObject artifactDetails,
@@ -57,8 +50,6 @@ public class CouchdbArtifactPath extends ResultArchiveStorePath {
         } else {
             this.length = 0;
         }
-
-        logger.debug("CouchdbArtifactPath constructor 3 with path "+pathName+" contentType:"+this.contentType+" length:"+Integer.toString(this.length));
     }
 
     @Override

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasFileSystemProvider.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasFileSystemProvider.java
@@ -29,15 +29,12 @@ import java.util.Set;
 
 import dev.galasa.ResultArchiveStoreContentType;
 import dev.galasa.SetContentType;
+import dev.galasa.framework.SupportedFileAttributeName;
 import dev.galasa.framework.spi.ras.ResultArchiveStoreFileSystemProvider;
 import dev.galasa.extensions.common.api.LogFactory;
 import dev.galasa.extensions.common.couchdb.CouchdbException;
 
 public class CouchdbRasFileSystemProvider extends ResultArchiveStoreFileSystemProvider {
-
-    private static final String                                RAS_CONTENT_TYPE = "ras:contentType";
-    private static final String                                BASIC_SIZE       = "size";
-    private static final String                                POSIX_SIZE       = "posix:size";
 
     private final HashMap<Path, ResultArchiveStoreContentType> contentTypes     = new HashMap<>();
 
@@ -169,11 +166,11 @@ public class CouchdbRasFileSystemProvider extends ResultArchiveStoreFileSystemPr
         while (it.hasNext()) {
             final String attr = it.next();
             if ("*".equals(attr)) {
-                returnAttrs.put(RAS_CONTENT_TYPE, caPath.getContentType());
-                returnAttrs.put(BASIC_SIZE, caPath.getLength());
-                returnAttrs.put(POSIX_SIZE, caPath.getLength());
+                returnAttrs.put(SupportedFileAttributeName.CONTENT_TYPE.getValue(), caPath.getContentType());
+                returnAttrs.put(SupportedFileAttributeName.SIZE.getValue(), caPath.getLength());
+                returnAttrs.put(SupportedFileAttributeName.POSIX_SIZE.getValue(), caPath.getLength());
             } else if ("size".equals(attr)) {
-                returnAttrs.put(BASIC_SIZE, caPath.getLength());
+                returnAttrs.put(SupportedFileAttributeName.SIZE.getValue(), caPath.getLength());
             } else {
                 final int colon = attr.indexOf(':');
                 if (colon < 0) {
@@ -185,9 +182,9 @@ public class CouchdbRasFileSystemProvider extends ResultArchiveStoreFileSystemPr
                     final String attrName = attr.substring(colon + 1);
 
                     if ("*".equals(attrName)) {
-                        returnAttrs.put(RAS_CONTENT_TYPE, caPath.getContentType());
+                        returnAttrs.put(SupportedFileAttributeName.CONTENT_TYPE.getValue(), caPath.getContentType());
                     } else if ("contentType".equals(attrName)) {
-                        returnAttrs.put(RAS_CONTENT_TYPE, caPath.getContentType());
+                        returnAttrs.put(SupportedFileAttributeName.CONTENT_TYPE.getValue(), caPath.getContentType());
                     } else {
                         throw new UnsupportedOperationException("Attribute ras:" + attrName + " is not available");
                     }
@@ -197,9 +194,9 @@ public class CouchdbRasFileSystemProvider extends ResultArchiveStoreFileSystemPr
                     final String attrName = attr.substring(colon + 1);
 
                     if ("*".equals(attrName)) {
-                        returnAttrs.put(POSIX_SIZE, caPath.getLength());
+                        returnAttrs.put(SupportedFileAttributeName.POSIX_SIZE.getValue(), caPath.getLength());
                     } else if ("size".equals(attrName)) {
-                        returnAttrs.put(POSIX_SIZE, caPath.getLength());
+                        returnAttrs.put(SupportedFileAttributeName.POSIX_SIZE.getValue(), caPath.getLength());
                     }
                 }
             }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasFileSystemProvider.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasFileSystemProvider.java
@@ -129,16 +129,20 @@ public class CouchdbRasFileSystemProvider extends ResultArchiveStoreFileSystemPr
     @Override
     public Path getPath(URI uri) {
         Path pathToReturn = null;
-        String uriString = uri.toString();
 
-        for (CouchdbArtifactPath path : this.paths) {
-            if (path.toString().equals(uriString)) {
-                pathToReturn = path;
+        if (uri != null) {
+            String uriString = uri.toString();
+
+            for (CouchdbArtifactPath path : this.paths) {
+                if (path.toString().equals(uriString)) {
+                    pathToReturn = path;
+                    break;
+                }
             }
-        }
 
-        if (pathToReturn == null) {
-            pathToReturn = new CouchdbArtifactPath(this.getActualFileSystem(), uriString);
+            if (pathToReturn == null) {
+                pathToReturn = new CouchdbArtifactPath(this.getActualFileSystem(), uriString);
+            }
         }
         return pathToReturn;
     }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasFileSystemProvider.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRasFileSystemProvider.java
@@ -128,7 +128,19 @@ public class CouchdbRasFileSystemProvider extends ResultArchiveStoreFileSystemPr
 
     @Override
     public Path getPath(URI uri) {
-        return new CouchdbArtifactPath(this.getActualFileSystem(), uri.toString());
+        Path pathToReturn = null;
+        String uriString = uri.toString();
+
+        for (CouchdbArtifactPath path : this.paths) {
+            if (path.toString().equals(uriString)) {
+                pathToReturn = path;
+            }
+        }
+
+        if (pathToReturn == null) {
+            pathToReturn = new CouchdbArtifactPath(this.getActualFileSystem(), uriString);
+        }
+        return pathToReturn;
     }
 
     @Override

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRunResult.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRunResult.java
@@ -7,6 +7,8 @@ package dev.galasa.ras.couchdb.internal;
 
 import java.nio.file.Path;
 
+import org.apache.commons.logging.Log;
+
 import dev.galasa.extensions.common.api.LogFactory;
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
@@ -23,7 +25,14 @@ public class CouchdbRunResult implements IRunResult {
     private final CouchdbDeleteRunService deleteRunService;
     private Path path;
 
+    private final Log logger;
+    private final LogFactory logFactory;
+
     public CouchdbRunResult(CouchdbRasStore store, TestStructureCouchdb testStructure, LogFactory logFactory) {
+        this.logFactory = logFactory;
+        this.logger = logFactory.getLog(getClass());
+        logger.info("CouchdbRunResult being constructed.");
+
         this.store = store;
         this.deleteRunService = new CouchdbDeleteRunService(this.store);
         this.storeService = (CouchdbDirectoryService) store.getDirectoryServices().get(0);
@@ -65,7 +74,9 @@ public class CouchdbRunResult implements IRunResult {
 
     @Override
     public void loadArtifacts() throws ResultArchiveStoreException {
+        logger.info("CouchdbRunResult loadArtifacts called...");
         this.path = storeService.getRunArtifactPath(this.testStructure);
+        logger.info("CouchdbRunResult loadArtifacts exiting...");
     }
 
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRunResult.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRunResult.java
@@ -26,10 +26,8 @@ public class CouchdbRunResult implements IRunResult {
     private Path path;
 
     private final Log logger;
-    private final LogFactory logFactory;
 
     public CouchdbRunResult(CouchdbRasStore store, TestStructureCouchdb testStructure, LogFactory logFactory) {
-        this.logFactory = logFactory;
         this.logger = logFactory.getLog(getClass());
         logger.info("CouchdbRunResult being constructed.");
 

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRunResult.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRunResult.java
@@ -25,12 +25,7 @@ public class CouchdbRunResult implements IRunResult {
     private final CouchdbDeleteRunService deleteRunService;
     private Path path;
 
-    private final Log logger;
-
     public CouchdbRunResult(CouchdbRasStore store, TestStructureCouchdb testStructure, LogFactory logFactory) {
-        this.logger = logFactory.getLog(getClass());
-        logger.info("CouchdbRunResult being constructed.");
-
         this.store = store;
         this.deleteRunService = new CouchdbDeleteRunService(this.store);
         this.storeService = (CouchdbDirectoryService) store.getDirectoryServices().get(0);
@@ -72,9 +67,7 @@ public class CouchdbRunResult implements IRunResult {
 
     @Override
     public void loadArtifacts() throws ResultArchiveStoreException {
-        logger.info("CouchdbRunResult loadArtifacts called...");
         this.path = storeService.getRunArtifactPath(this.testStructure);
-        logger.info("CouchdbRunResult loadArtifacts exiting...");
     }
 
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbRasFileSystemProviderTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbRasFileSystemProviderTest.java
@@ -53,7 +53,7 @@ public class CouchdbRasFileSystemProviderTest {
 
         @Override
         public String getExpectedHttpContentType() {
-            return "plain/text";
+            return "text/plain";
         }
 
         @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/ArtifactsProperties.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/ArtifactsProperties.java
@@ -16,6 +16,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import dev.galasa.framework.api.ras.internal.routes.RunArtifactsRoute;
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
@@ -23,6 +26,8 @@ import dev.galasa.framework.spi.ResultArchiveStoreException;
 public class ArtifactsProperties implements IRunRootArtifact {
 
     private RunArtifactsRoute runsRoute;
+
+    private static final Log logger = LogFactory.getLog(ArtifactsProperties.class);
 
     public ArtifactsProperties(RunArtifactsRoute runsRoute) {
         this.runsRoute = runsRoute;
@@ -40,8 +45,12 @@ public class ArtifactsProperties implements IRunRootArtifact {
             
             JsonElement path = artifactObject.get("path");
             JsonElement contentType = artifactObject.get("contentType");
+
             if ((path != JsonNull.INSTANCE) && (contentType != JsonNull.INSTANCE)) {
-                artifactsProperties.put(path.getAsString(), contentType.getAsString());
+                String pathAsString = path.getAsString();
+                String contentTypeAsString = contentType.getAsString();
+                logger.info("Content type detected: path:"+pathAsString+" content type:"+contentTypeAsString);
+                artifactsProperties.put(pathAsString, contentTypeAsString);
             }
         }
         

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
@@ -12,6 +12,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -24,6 +25,9 @@ import java.util.regex.Matcher;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.IFileSystem;
 import dev.galasa.framework.api.ras.internal.common.ArtifactsJson;
@@ -48,6 +52,8 @@ import dev.galasa.framework.spi.utils.GalasaGson;
  * to the artifact.
  */
 public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
+
+    private static final Log logger = LogFactory.getLog(RunArtifactsDownloadRoute.class);
 
     static final GalasaGson gson = new GalasaGson();
 
@@ -150,8 +156,12 @@ public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
                 bytesRead = channel.read(buffer);
             }
             res.setStatus(HttpServletResponse.SC_OK);
-            res.setContentType(getFileSystem().probeContentType(artifactLocation));
+
+            String contentType = getFileSystem().probeContentType(artifactLocation);
+
+            res.setContentType(contentType);
             res.setHeader("Content-Disposition", "attachment");
+            logger.info("ContentType is "+contentType);
         }
         return res;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
@@ -177,7 +177,6 @@ public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
 
             res.setContentType(contentType);
             res.setHeader("Content-Disposition", "attachment");
-            logger.info("ContentType is "+contentType);
         }
         return res;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
@@ -47,7 +47,7 @@ public class RunArtifactsListRoute extends RunArtifactsRoute {
     //  Regex to match endpoint: /ras/runs/{runId}/artifacts
     protected static final String path = "\\/runs\\/" + RUN_ID_PATTERN + "\\/artifacts\\/?";
 
-    private List<IRunRootArtifact> rootArtifacts = new ArrayList<>();
+    private List<IRunRootArtifact> virtualRootArtifacts = new ArrayList<>();
 
     public RunArtifactsListRoute(
         ResponseBuilder responseBuilder,
@@ -55,7 +55,7 @@ public class RunArtifactsListRoute extends RunArtifactsRoute {
         IFramework framework
     ) throws RBACException {
         super(responseBuilder, path, fileSystem, framework);
-        rootArtifacts = Arrays.asList(
+        virtualRootArtifacts = Arrays.asList(
             new RunLogArtifact(),
             new StructureJsonArtifact(),
             new ArtifactsProperties(this),
@@ -97,7 +97,7 @@ public class RunArtifactsListRoute extends RunArtifactsRoute {
 
     private JsonArray getRootArtifacts(IRunResult run) throws ResultArchiveStoreException, IOException {
         JsonArray artifactRecords = new JsonArray();
-        for (IRunRootArtifact rootArtifact : rootArtifacts) {
+        for (IRunRootArtifact rootArtifact : virtualRootArtifacts) {
             byte[] content = rootArtifact.getContent(run);
             if (content != null) {
                 artifactRecords.add(getArtifactAsJsonObject(rootArtifact.getPathName(), rootArtifact.getContentType(), content.length));

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsRoute.java
@@ -88,12 +88,20 @@ public abstract class RunArtifactsRoute extends RunsRoute {
 
         JsonArray artifactRecords = new JsonArray();
         List<Path> artifactPaths = getArtifactPaths(run.getArtifactsRoot(), new ArrayList<>());
+
         for (Path artifactPath : artifactPaths) {
-            JsonObject artifactRecord = getArtifactAsJsonObject("/artifacts" + artifactPath.toString(), fileSystem.probeContentType(artifactPath), fileSystem.size(artifactPath));
+
+            String contentType = fileSystem.probeContentType(artifactPath);
+            long contentSize = fileSystem.size(artifactPath);
+            String pathAsString = artifactPath.toString();
+            
+            JsonObject artifactRecord = getArtifactAsJsonObject("/artifacts" + pathAsString, contentType, contentSize);
             artifactRecords.add(artifactRecord);
         }
+
         return artifactRecords;
     }
+
 
     /**
      * Walks through an artifact directory recursively, collecting each artifact and

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FileSystem.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FileSystem.java
@@ -101,7 +101,7 @@ public class FileSystem implements IFileSystem {
         try {
             artifactFileSystem = run.getArtifactsRoot().getFileSystem();
         } catch( Exception ex) {
-            logger.warn("Failed to obtain the file system for articact run "+run.getRunId(),ex);
+            logger.warn("Failed to obtain the file system for artifact run "+run.getRunId(),ex);
             throw new IOException(ex);
         }
         

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IFileSystem.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IFileSystem.java
@@ -13,6 +13,9 @@ import java.nio.file.attribute.FileAttribute;
 import java.util.List;
 import java.util.stream.Stream;
 
+import dev.galasa.framework.spi.IRunResult;
+import dev.galasa.framework.spi.ResultArchiveStoreException;
+
 public interface IFileSystem {
 
     void createDirectories(Path folderPath ) throws IOException;
@@ -30,6 +33,8 @@ public interface IFileSystem {
     long size(Path folderPath) throws IOException;
 
     String probeContentType(Path artifactPath) throws IOException;
+
+    String getContentType( IRunResult run, Path artifactLocation) throws IOException  ;
 
     InputStream newInputStream(Path folderPath) throws IOException;
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/SupportedFileAttributeName.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/SupportedFileAttributeName.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+// Expected attributes which are available to use are :
+// "size" with a value of class: class java.lang.Long which renders to a string of:"910" (for example)
+// "ras:contentType" with a value of class: class java.lang.String which renders to a string of:"text/plain" (for example)
+// "posix:size" with a value of class: class java.lang.Long which renders to a string of:"910" (for example)
+public enum SupportedFileAttributeName {
+    SIZE("size"),
+    CONTENT_TYPE("ras:contentType"),
+    POSIX_SIZE("posix:size");
+
+    private String value ;
+
+    SupportedFileAttributeName(String value){
+        this.value = value ;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASFileSystemProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASFileSystemProvider.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import dev.galasa.framework.SupportedFileAttributeName;
 import dev.galasa.framework.spi.ras.ResultArchiveStoreFileSystem;
 import dev.galasa.framework.spi.ras.ResultArchiveStoreFileSystemProvider;
 import dev.galasa.framework.spi.ras.ResultArchiveStorePath;
@@ -49,7 +50,7 @@ import dev.galasa.SetContentType;
  */
 public class DirectoryRASFileSystemProvider extends ResultArchiveStoreFileSystemProvider {
 
-    private static final String RAS_CONTENT_TYPE      = "ras:contentType";
+
 
     private final Path          artifactDirectory;
     private final Path          artifactPropertesFile;
@@ -309,12 +310,13 @@ public class DirectoryRASFileSystemProvider extends ResultArchiveStoreFileSystem
         final ArrayList<String> attrs = new ArrayList<>(Arrays.asList(attributes.replaceAll(" ", "").split(","))); // NOSONAR
 
         // *** We need to add our attributes for * or ras:* or ras:contentType, then
-        // pass off to the basic file attributes
+        // pass off to the basic file attributes.
+        // See SupportedFileAttributeName.CONTENT_TYPE also
         final Iterator<String> it = attrs.iterator();
         while (it.hasNext()) {
             final String attr = it.next();
             if ("*".equals(attr)) {
-                returnAttrs.put(RAS_CONTENT_TYPE, contentType.value());
+                returnAttrs.put(SupportedFileAttributeName.CONTENT_TYPE.getValue(), contentType.value());
             } else {
                 final int colon = attr.indexOf(':');
                 if ((colon == 3) && "ras".equals(attr.substring(0, colon))) {
@@ -323,9 +325,9 @@ public class DirectoryRASFileSystemProvider extends ResultArchiveStoreFileSystem
                     final String attrName = attr.substring(colon + 1);
 
                     if ("*".equals(attrName)) {
-                        returnAttrs.put(RAS_CONTENT_TYPE, contentType.value());
+                        returnAttrs.put(SupportedFileAttributeName.CONTENT_TYPE.getValue(), contentType.value());
                     } else if ("contentType".equals(attrName)) {
-                        returnAttrs.put(RAS_CONTENT_TYPE, contentType.value());
+                        returnAttrs.put(SupportedFileAttributeName.CONTENT_TYPE.getValue(), contentType.value());
                     } else {
                         throw new UnsupportedOperationException("Attribute ras:" + attrName + " is not available");
                     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/ras/directory/DirectoryFileSystemTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/ras/directory/DirectoryFileSystemTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import dev.galasa.ResultArchiveStoreContentType;
 import dev.galasa.ResultArchiveStoreFileAttributeView;
+import dev.galasa.framework.SupportedFileAttributeName;
 
 public class DirectoryFileSystemTest {
 
@@ -230,21 +231,21 @@ public class DirectoryFileSystemTest {
         Assert.assertNotNull("Content type missing from view", type);
         Assert.assertEquals("Type not XML", ResultArchiveStoreContentType.XML, type);
 
-        Map<String, Object> attrs = Files.readAttributes(rasTestArtifact, "ras:contentType");
+        Map<String, Object> attrs = Files.readAttributes(rasTestArtifact, SupportedFileAttributeName.CONTENT_TYPE.getValue());
         Assert.assertEquals("Content type missing/incorrect from attributes map",
-                ResultArchiveStoreContentType.XML.value(), attrs.get("ras:contentType"));
+                ResultArchiveStoreContentType.XML.value(), attrs.get(SupportedFileAttributeName.CONTENT_TYPE.getValue()));
 
         attrs = Files.readAttributes(rasTestArtifact, "ras:*");
         Assert.assertEquals("Content type missing/incorrect from attributes map",
-                ResultArchiveStoreContentType.XML.value(), attrs.get("ras:contentType"));
+                ResultArchiveStoreContentType.XML.value(), attrs.get(SupportedFileAttributeName.CONTENT_TYPE.getValue()));
 
         attrs = Files.readAttributes(rasTestArtifact, "*");
         Assert.assertEquals("Content type missing/incorrect from attributes map",
-                ResultArchiveStoreContentType.XML.value(), attrs.get("ras:contentType"));
+                ResultArchiveStoreContentType.XML.value(), attrs.get(SupportedFileAttributeName.CONTENT_TYPE.getValue()));
 
-        attrs = Files.readAttributes(rasTestArtifact, "size,ras:contentType, lastAccessTime");
+        attrs = Files.readAttributes(rasTestArtifact, SupportedFileAttributeName.SIZE.getValue()+","+SupportedFileAttributeName.CONTENT_TYPE.getValue()+", lastAccessTime");
         Assert.assertEquals("Content type missing/incorrect from attributes map",
-                ResultArchiveStoreContentType.XML.value(), attrs.get("ras:contentType"));
+                ResultArchiveStoreContentType.XML.value(), attrs.get(SupportedFileAttributeName.CONTENT_TYPE.getValue()));
         Assert.assertEquals("Incorrect number of attributes return", 3, attrs.size());
     }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFileSystem.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFileSystem.java
@@ -24,6 +24,8 @@ import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
 
 import dev.galasa.framework.IFileSystem;
+import dev.galasa.framework.spi.IRunResult;
+import dev.galasa.framework.spi.ResultArchiveStoreException;
 
 import java.nio.file.DirectoryStream.Filter;
 import java.nio.charset.StandardCharsets;
@@ -154,6 +156,7 @@ public class MockFileSystem extends FileSystem implements IFileSystem {
         return new MockPath(first + String.join("/", more), this);
     }
 
+    @Override
     public String probeContentType(Path path) throws IOException {
         String contentType = "application/octet-stream";
         if (path.toString().endsWith(".properties") 
@@ -165,6 +168,11 @@ public class MockFileSystem extends FileSystem implements IFileSystem {
             contentType = "application/json";
         }
         return contentType;
+    }
+
+    @Override
+    public String getContentType( IRunResult run, Path artifactPath) throws IOException {
+        return probeContentType(artifactPath);
     }
 
     public List<Path> getListOfFiles(String directory, Filter<? super Path> filter) throws IOException {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFileSystemProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFileSystemProvider.java
@@ -70,6 +70,11 @@ public class MockFileSystemProvider extends FileSystemProvider {
     }
 
     @Override
+    public Path getPath(URI uri) {
+        return mockFS.getPath(uri.getPath());
+    }
+
+    @Override
     public DirectoryStream<Path> newDirectoryStream(Path dir, Filter<? super Path> filter) throws IOException {
         return new MockDirectoryStream(mockFS, filter, dir.toString());
     }
@@ -148,11 +153,6 @@ public class MockFileSystemProvider extends FileSystemProvider {
     @Override
     public FileSystem getFileSystem(URI uri) {
         throw new UnsupportedOperationException("Unimplemented method 'getFileSystem'");
-    }
-
-    @Override
-    public Path getPath(URI uri) {
-        throw new UnsupportedOperationException("Unimplemented method 'getPath'");
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/ResultArchiveStoreContentType.java
+++ b/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/ResultArchiveStoreContentType.java
@@ -17,7 +17,7 @@ public class ResultArchiveStoreContentType implements FileAttribute<String> {
 
     public static final String                        ATTRIBUTE_NAME = "contentType";
 
-    public static final ResultArchiveStoreContentType TEXT           = new ResultArchiveStoreContentType("plain/text");
+    public static final ResultArchiveStoreContentType TEXT           = new ResultArchiveStoreContentType("text/plain");
     public static final ResultArchiveStoreContentType XML            = new ResultArchiveStoreContentType(
             "application/xml");
     public static final ResultArchiveStoreContentType JSON           = new ResultArchiveStoreContentType(

--- a/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/ResultArchiveStoreContentType.java
+++ b/modules/framework/galasa-parent/dev.galasa/src/main/java/dev/galasa/ResultArchiveStoreContentType.java
@@ -10,7 +10,8 @@ import java.nio.file.attribute.FileAttribute;
 /**
  * Used to set the File Type for a Stored Artifact in the Result Archive Store
  *
- *  
+ * According to https://www.iana.org/assignments/media-types/media-types.xhtml these types are
+ * valid mime types
  *
  */
 public class ResultArchiveStoreContentType implements FileAttribute<String> {
@@ -26,6 +27,8 @@ public class ResultArchiveStoreContentType implements FileAttribute<String> {
             "application/octet-stream");
     public static final ResultArchiveStoreContentType ZIP            = new ResultArchiveStoreContentType(
             "application/zip");
+    public static final ResultArchiveStoreContentType GZIP           = new ResultArchiveStoreContentType(
+            "application/gzip");
     public static final ResultArchiveStoreContentType PNG            = new ResultArchiveStoreContentType("image/png");
 
     protected final String                            value;
@@ -70,7 +73,7 @@ public class ResultArchiveStoreContentType implements FileAttribute<String> {
      */
     @Override
     public String toString() {
-        return "RasContentType=" + this.value;
+        return this.value;
     }
 
     /*

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Zos3270TerminalImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Zos3270TerminalImpl.java
@@ -308,7 +308,7 @@ public class Zos3270TerminalImpl extends Terminal implements IScreenUpdateListen
         Path terminalPath = terminalRasDirectory.resolve(terminalFilename);
 
         try (GZIPOutputStream gos = new GZIPOutputStream(Files.newOutputStream(terminalPath,
-                new SetContentType(new ResultArchiveStoreContentType("application/zos3270terminal")),
+                new SetContentType(ResultArchiveStoreContentType.GZIP),
                 StandardOpenOption.CREATE))) {
             IOUtils.write(tempJson, gos, "utf-8");
             gos.flush();


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2299

## Changes
- Fixed the content type issue where downloaded artifacts would always default to application/octet-stream - they should now use the correct content type that was set in CouchdbArtifactPath objects
- Added architecture diagrams and docs to developer docs
- Kept some additional log messages around content types in the code for now