### PR TITLE
Only load requested artifacts once when downloading runs instead of loading all artifacts for every file download

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRunResult.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRunResult.java
@@ -7,8 +7,6 @@ package dev.galasa.ras.couchdb.internal;
 
 import java.nio.file.Path;
 
-import org.apache.commons.logging.Log;
-
 import dev.galasa.extensions.common.api.LogFactory;
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
@@ -70,4 +68,8 @@ public class CouchdbRunResult implements IRunResult {
         this.path = storeService.getRunArtifactPath(this.testStructure);
     }
 
+    @Override
+    public void loadArtifact(String artifactPath) throws ResultArchiveStoreException {
+        this.path = storeService.getRunArtifactPath(this.testStructure, artifactPath);
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
@@ -107,7 +107,6 @@ public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
         // Get run details in order to find artifacts
         try {
             run = getRunByRunId(runId);
-            run.loadArtifacts();
             runName = run.getTestStructure().getRunName();
         } catch (ResultArchiveStoreException e) {
             ServletError error = new ServletError(GAL5002_INVALID_RUN_ID,runId);
@@ -135,11 +134,13 @@ public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
     private HttpServletResponse downloadStoredArtifact(HttpServletResponse res, IRunResult run, String artifactPath) throws ResultArchiveStoreException, IOException, InternalServletException {
         URI artifactUri = null;
         try {
+            run.loadArtifact(artifactPath);
             artifactUri = new URI(artifactPath);
         } catch (URISyntaxException e) {
             ServletError error = new ServletError(GAL5008_ERROR_LOCATING_ARTIFACT, artifactPath, run.getTestStructure().getRunName());
             throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
         }
+
 
         FileSystem artifactFileSystem = run.getArtifactsRoot().getFileSystem();
         FileSystemProvider artifactFileSystemProvider = artifactFileSystem.provider();

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
@@ -78,7 +78,6 @@ public class RunArtifactsListRoute extends RunArtifactsRoute {
         JsonArray artifacts = new JsonArray();
         try {
             run = getRunByRunId(runId);
-            run.loadArtifacts();
         } catch (ResultArchiveStoreException e) {
             ServletError error = new ServletError(GAL5002_INVALID_RUN_ID, runId);
             throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND, e);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsRoute.java
@@ -85,6 +85,7 @@ public abstract class RunArtifactsRoute extends RunsRoute {
      * @throws IOException
      */
     public JsonArray getArtifacts(IRunResult run) throws ResultArchiveStoreException, IOException {
+        run.loadArtifacts();
 
         JsonArray artifactRecords = new JsonArray();
         List<Path> artifactPaths = getArtifactPaths(run.getArtifactsRoot(), new ArrayList<>());

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASRunResult.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASRunResult.java
@@ -86,4 +86,9 @@ public class DirectoryRASRunResult implements IRunResult {
     public void loadArtifacts() throws ResultArchiveStoreException {
         // Artifacts for local runs are already available on the filesystem so there is no need to load anything
     }
+
+    @Override
+    public void loadArtifact(String artifactPath) throws ResultArchiveStoreException {
+        // Artifacts for local runs are already available on the filesystem so there is no need to load anything
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRunResult.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRunResult.java
@@ -23,4 +23,6 @@ public interface IRunResult {
 
     void loadArtifacts() throws ResultArchiveStoreException;
 
+    void loadArtifact(String artifactPath) throws ResultArchiveStoreException;
+
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRunResult.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRunResult.java
@@ -62,6 +62,11 @@ public class MockRunResult implements IRunResult {
         isLoadingArtifactsEnabled = true;
     }
 
+    @Override
+    public void loadArtifact(String artifactPath) throws ResultArchiveStoreException {
+        isLoadingArtifactsEnabled = true;
+    }
+
     public boolean isDiscarded() {
         return this.isDiscarded;
     }


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2541

Note: this PR builds off of changes in https://github.com/galasa-dev/galasa/pull/527 so this branch will need to be rebased.

## Changes
- [x] Updated the RAS file download endpoint to only load an artifact from CouchDB once for each request rather than loading all artifacts when requesting to download a single file