### PR TITLE
Add galasactl streams set command

### DIFF
--- a/docs/content/docs/manage-ecosystem/test-streams.md
+++ b/docs/content/docs/manage-ecosystem/test-streams.md
@@ -22,10 +22,11 @@ The following diagram shows the relationship between the test code, test catalog
 
 ## Creating and retrieving a test stream
 
-The components of the `test.stream` property are set by using `galasactl resources apply -f {yaml-filename}` command.
-The `apply` sub-command will update the stream if it already exists, but you could use the `create` or `update` sub-command as an alternative.
+The components of the `test.stream` property are set by either using the `galasactl streams set` command or the `galasactl resources apply -f {yaml-filename}` command.
 
-See [the command reference](../reference/cli-syntax/galasactl_resources_apply.md) for specific syntax help.
+When using the `galasactl resources` command, the `apply` sub-command will update the stream if it already exists, but you could use the `create` or `update` sub-command as an alternative.
+
+See the command reference for [galasactl streams set](../reference/cli-syntax/galasactl_streams_set.md) and [galasactl resources apply](../reference/cli-syntax/galasactl_resources_apply.md) for specific syntax help.
 
 Streams are explained in more detail, with an example [here](../ecosystem/ecosystem-manage-resources.md/#test-streams-as-galasastream-resources).
 

--- a/docs/content/releases/posts/v0.47.0.md
+++ b/docs/content/releases/posts/v0.47.0.md
@@ -10,3 +10,5 @@ links:
 ## Changes affecting the Galasa Service
 
 - Added new REST API endpoints `POST /streams` and `PUT /streams/<streamName>` to allow users to create and update test streams. See the [REST API reference](../../docs/reference/rest-api/index.html) for more details. See also [#2447](https://github.com/galasa-dev/projectmanagement/issues/2447).
+
+- Added a new `galasactl streams set` command that can be used to create or update test streams within a Galasa service. [See the command reference](../../docs/reference/cli-syntax/galasactl_streams_set.md).

--- a/modules/cli/docs/generated/errors-list.md
+++ b/modules/cli/docs/generated/errors-list.md
@@ -282,6 +282,14 @@ The `galasactl` tool can generate the following errors:
 - GAL1280E: An attempt to update a run named '{}' failed. Unexpected http status code {} received from the server. Error details from the server are: '{}'
 - GAL1281E: An attempt to update a run named '{}' failed. Unexpected http status code {} received from the server. Error details from the server are not in the json format.
 - GAL1282E: Invalid tag name '{}' provided. Tag names cannot be empty and must only contain characters in the Latin-1 character set.
+- GAL1283E: Invalid stream description provided. The description provided with the --description flag cannot be an empty string, and must only contain characters in the Latin-1 character set.
+- GAL1284E: Invalid URL provided. The URL '{}' is not a valid URL. Reason: '{}'
+- GAL1285E: An attempt to set stream '{}' failed. Sending the update request to the Galasa service failed. Cause is {}
+- GAL1286E: An attempt to set stream '{}' failed. Unexpected http status code {} received from the server.
+- GAL1287E: An attempt to set stream '{}' failed. Unexpected http status code {} received from the server. Error details from the server could not be read. Cause: {}
+- GAL1288E: An attempt to set stream '{}' failed. Unexpected http status code {} received from the server. Error details from the server are not in a valid json format. Cause: '{}'
+- GAL1289E: An attempt to set stream '{}' failed. Unexpected http status code {} received from the server. Error details from the server are: '{}'
+- GAL1290E: An attempt to set stream '{}' failed. Unexpected http status code {} received from the server. Error details from the server are not in the json format.
 - GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '{}', and 'pre-release' repository is '{}'
 - GAL2501I: Downloaded {} artifacts to folder '{}'
 

--- a/modules/cli/docs/generated/galasactl_streams.md
+++ b/modules/cli/docs/generated/galasactl_streams.md
@@ -27,4 +27,5 @@ Parent command for managing test streams in a Galasa service
 * [galasactl](galasactl.md)	 - CLI for Galasa
 * [galasactl streams delete](galasactl_streams_delete.md)	 - Deletes a test stream by name
 * [galasactl streams get](galasactl_streams_get.md)	 - Gets a list of test streams
+* [galasactl streams set](galasactl_streams_set.md)	 - Creates or updates a test stream in the Galasa service
 

--- a/modules/cli/docs/generated/galasactl_streams_set.md
+++ b/modules/cli/docs/generated/galasactl_streams_set.md
@@ -1,0 +1,37 @@
+## galasactl streams set
+
+Creates or updates a test stream in the Galasa service
+
+### Synopsis
+
+Creates or updates a test stream in the Galasa service
+
+```
+galasactl streams set [flags]
+```
+
+### Options
+
+```
+      --description string       the description to associate with the test stream being created or updated
+  -h, --help                     Displays the options for the 'streams set' command.
+      --maven-repo-url string    the URL to the Maven repository containing test material for the test stream to use. For example: https://my-maven-repository
+      --name string              A mandatory field indicating the name of a test stream.
+      --obr strings              The maven coordinates of the OBR bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:{OBR_GROUP_ID}/{OBR_ARTIFACT_ID}/{OBR_VERSION}/obr'. Multiple instances of this flag can be used to describe multiple OBR bundles.
+      --testcatalog-url string   the URL to the test catalog for the test stream being created or updated. For example: https://my-maven-repository/path/to/testcatalog.json
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+```
+
+### SEE ALSO
+
+* [galasactl streams](galasactl_streams.md)	 - Manages test streams in a Galasa service
+

--- a/modules/cli/docs/generated/galasactl_streams_set.md
+++ b/modules/cli/docs/generated/galasactl_streams_set.md
@@ -4,7 +4,7 @@ Creates or updates a test stream in the Galasa service
 
 ### Synopsis
 
-Creates or updates a test stream in the Galasa service
+Creates or updates a test stream in the Galasa service. When creating a new test stream, you must provide a test catalog URL, Maven repository URL, and at least one OBR. When updating an existing test stream, you only need to supply the parameter that you wish to update and that parameter will be overwritten with your new value.
 
 ```
 galasactl streams set [flags]
@@ -17,7 +17,7 @@ galasactl streams set [flags]
   -h, --help                     Displays the options for the 'streams set' command.
       --maven-repo-url string    the URL to the Maven repository containing test material for the test stream to use. For example: https://my-maven-repository
       --name string              A mandatory field indicating the name of a test stream.
-      --obr strings              The maven coordinates of the OBR bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:{OBR_GROUP_ID}/{OBR_ARTIFACT_ID}/{OBR_VERSION}/obr'. Multiple instances of this flag can be used to describe multiple OBR bundles.
+      --obr strings              The Maven coordinates of the OBR bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:{OBR_GROUP_ID}/{OBR_ARTIFACT_ID}/{OBR_VERSION}/obr'. Multiple instances of this flag can be used to describe multiple OBR bundles.
       --testcatalog-url string   the URL to the test catalog for the test stream being created or updated. For example: https://my-maven-repository/path/to/testcatalog.json
 ```
 

--- a/modules/cli/pkg/cmd/commandCollection.go
+++ b/modules/cli/pkg/cmd/commandCollection.go
@@ -81,6 +81,7 @@ const (
 	COMMAND_NAME_ROLES_GET                = "roles get"
 	COMMAND_NAME_STREAMS                  = "streams"
 	COMMAND_NAME_STREAMS_GET              = "streams get"
+	COMMAND_NAME_STREAMS_SET              = "streams set"
 	COMMAND_NAME_STREAMS_DELETE           = "streams delete"
 )
 
@@ -581,25 +582,28 @@ func (commands *commandCollectionImpl) addStreamsCommands(factory spi.Factory, r
 	var err error
 	var streamsCommand spi.GalasaCommand
 	var streamsGetCommand spi.GalasaCommand
+	var streamsSetCommand spi.GalasaCommand
 	var streamsDeleteCommand spi.GalasaCommand
 
 	streamsCommand, err = NewStreamsCommand(rootCommand, commsFlagSet)
 
 	if err == nil {
-
-		commands.commandMap[streamsCommand.Name()] = streamsCommand
 		streamsGetCommand, err = NewStreamsGetCommand(factory, streamsCommand, commsFlagSet)
+	}
 
-		if err == nil {
+	if err == nil {
+		streamsSetCommand, err = NewStreamsSetCommand(factory, streamsCommand, commsFlagSet)
+	}
 
-			commands.commandMap[streamsGetCommand.Name()] = streamsGetCommand
-			streamsDeleteCommand, err = NewStreamsDeleteCommand(factory, streamsCommand, commsFlagSet)
+	if err == nil {
+		streamsDeleteCommand, err = NewStreamsDeleteCommand(factory, streamsCommand, commsFlagSet)
+	}
 
-			if err == nil {
-				commands.commandMap[streamsDeleteCommand.Name()] = streamsDeleteCommand
-			}
-
-		}
+	if err == nil {
+		commands.commandMap[streamsCommand.Name()] = streamsCommand
+		commands.commandMap[streamsGetCommand.Name()] = streamsGetCommand
+		commands.commandMap[streamsSetCommand.Name()] = streamsSetCommand
+		commands.commandMap[streamsDeleteCommand.Name()] = streamsDeleteCommand
 	}
 
 	return err

--- a/modules/cli/pkg/cmd/streamsSet.go
+++ b/modules/cli/pkg/cmd/streamsSet.go
@@ -1,0 +1,165 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"log"
+
+	"github.com/galasa-dev/cli/pkg/api"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/galasa-dev/cli/pkg/streams"
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type StreamsSetCmdValues struct {
+	description string
+    testCatalogUrl string
+    mavenRepositoryUrl string
+    obrs []string
+}
+
+
+type StreamsSetCommand struct {
+    values *StreamsSetCmdValues
+    cobraCommand *cobra.Command
+}
+
+// ------------------------------------------------------------------------------------------------
+// Constructors methods
+// ------------------------------------------------------------------------------------------------
+func NewStreamsSetCommand(
+    factory spi.Factory,
+    streamsSetCommand spi.GalasaCommand,
+    commsFlagSet GalasaFlagSet,
+) (spi.GalasaCommand, error) {
+
+    cmd := new(StreamsSetCommand)
+
+    err := cmd.init(factory, streamsSetCommand, commsFlagSet)
+    return cmd, err
+}
+
+// ------------------------------------------------------------------------------------------------
+// Public methods
+// ------------------------------------------------------------------------------------------------
+func (cmd *StreamsSetCommand) Name() string {
+    return COMMAND_NAME_STREAMS_SET
+}
+
+func (cmd *StreamsSetCommand) CobraCommand() *cobra.Command {
+    return cmd.cobraCommand
+}
+
+func (cmd *StreamsSetCommand) Values() interface{} {
+    return cmd.values
+}
+
+// ------------------------------------------------------------------------------------------------
+// Private methods
+// ------------------------------------------------------------------------------------------------
+func (cmd *StreamsSetCommand) init(factory spi.Factory, streamsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
+    var err error
+
+    cmd.values = &StreamsSetCmdValues{}
+    cmd.cobraCommand, err = cmd.createCobraCmd(factory, streamsCommand, commsFlagSet.Values().(*CommsFlagSetValues))
+
+    return err
+}
+
+func (cmd *StreamsSetCommand) createCobraCmd(
+    factory spi.Factory,
+    streamsCommand spi.GalasaCommand,
+    commsFlagSetValues *CommsFlagSetValues,
+) (*cobra.Command, error) {
+
+    var err error
+
+    streamsCommandValues := streamsCommand.Values().(*StreamsCmdValues)
+    streamsSetCobraCmd := &cobra.Command{
+        Use:     "set",
+        Short:   "Creates or updates a test stream in the Galasa service",
+        Long:    "Creates or updates a test stream in the Galasa service",
+        Aliases: []string{COMMAND_NAME_STREAMS_SET},
+        RunE: func(cobraCommand *cobra.Command, args []string) error {
+			return cmd.executeStreamsSet(factory, streamsCommand.Values().(*StreamsCmdValues), commsFlagSetValues)
+        },
+    }
+
+    addStreamNameFlag(streamsSetCobraCmd, true, streamsCommandValues)
+
+    descriptionFlag := "description"
+    testCatalogUrlFlag := "testcatalog-url"
+    mavenRepoUrlFlag := "maven-repo-url"
+    obrFlag := "obr"
+
+    streamsSetCobraCmd.Flags().StringVar(&cmd.values.description, descriptionFlag, "", "the description to associate with the test stream being created or updated")
+    streamsSetCobraCmd.Flags().StringVar(&cmd.values.testCatalogUrl, testCatalogUrlFlag, "", "the URL to the test catalog for the test stream being created or updated. For example: https://my-maven-repository/path/to/testcatalog.json")
+    streamsSetCobraCmd.Flags().StringVar(&cmd.values.mavenRepositoryUrl, mavenRepoUrlFlag, "", "the URL to the Maven repository containing test material for the test stream to use. For example: https://my-maven-repository")
+    streamsSetCobraCmd.Flags().StringSliceVar(&cmd.values.obrs, obrFlag, make([]string, 0), "The maven coordinates of the OBR bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:{OBR_GROUP_ID}/{OBR_ARTIFACT_ID}/{OBR_VERSION}/obr'. "+
+        "Multiple instances of this flag can be used to describe multiple OBR bundles.")
+
+    // streams set requires the name flag as well as one of the following: --testcatalog, --maven-repo-url, --obr
+	streamsSetCobraCmd.MarkFlagsOneRequired(testCatalogUrlFlag, mavenRepoUrlFlag, obrFlag)
+
+    streamsCommand.CobraCommand().AddCommand(streamsSetCobraCmd)
+
+    return streamsSetCobraCmd, err
+}
+
+func (cmd *StreamsSetCommand) executeStreamsSet(
+    factory spi.Factory,
+    streamsCmdValues *StreamsCmdValues,
+    commsFlagSetValues *CommsFlagSetValues,
+) error {
+
+    var err error
+
+    // Operations on the file system will all be relative to the current folder.
+    fileSystem := factory.GetFileSystem()
+
+	err = utils.CaptureLog(fileSystem, commsFlagSetValues.logFileName)
+	if err == nil {
+		commsFlagSetValues.isCapturingLogs = true
+
+		log.Println("Galasa CLI - Set a test stream in the Galasa service")
+
+		env := factory.GetEnvironment()
+
+		var galasaHome spi.GalasaHome
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
+		if err == nil {
+
+			var commsClient api.APICommsClient
+			commsClient, err = api.NewAPICommsClient(
+				commsFlagSetValues.bootstrap,
+				commsFlagSetValues.maxRetries,
+				commsFlagSetValues.retryBackoffSeconds,
+				factory,
+				galasaHome,
+			)
+
+			if err == nil {
+				byteReader := factory.GetByteReader()
+
+                setStreamFunc := func(apiClient *galasaapi.APIClient) error {
+                    return streams.SetStream(
+                        streamsCmdValues.name,
+                        cmd.values.description,
+                        cmd.values.mavenRepositoryUrl,
+                        cmd.values.testCatalogUrl,
+                        cmd.values.obrs,
+                        apiClient,
+                        byteReader,
+                    )
+                }
+                err = commsClient.RunAuthenticatedCommandWithRateLimitRetries(setStreamFunc)
+			}
+		}
+	}
+    return err
+}

--- a/modules/cli/pkg/cmd/streamsSet.go
+++ b/modules/cli/pkg/cmd/streamsSet.go
@@ -83,7 +83,9 @@ func (cmd *StreamsSetCommand) createCobraCmd(
     streamsSetCobraCmd := &cobra.Command{
         Use:     "set",
         Short:   "Creates or updates a test stream in the Galasa service",
-        Long:    "Creates or updates a test stream in the Galasa service",
+        Long:    "Creates or updates a test stream in the Galasa service. "+
+            "When creating a new test stream, you must provide a test catalog URL, Maven repository URL, and at least one OBR. "+
+            "When updating an existing test stream, you only need to supply the parameter that you wish to update and that parameter will be overwritten with your new value.",
         Aliases: []string{COMMAND_NAME_STREAMS_SET},
         RunE: func(cobraCommand *cobra.Command, args []string) error {
 			return cmd.executeStreamsSet(factory, streamsCommand.Values().(*StreamsCmdValues), commsFlagSetValues)
@@ -100,11 +102,11 @@ func (cmd *StreamsSetCommand) createCobraCmd(
     streamsSetCobraCmd.Flags().StringVar(&cmd.values.description, descriptionFlag, "", "the description to associate with the test stream being created or updated")
     streamsSetCobraCmd.Flags().StringVar(&cmd.values.testCatalogUrl, testCatalogUrlFlag, "", "the URL to the test catalog for the test stream being created or updated. For example: https://my-maven-repository/path/to/testcatalog.json")
     streamsSetCobraCmd.Flags().StringVar(&cmd.values.mavenRepositoryUrl, mavenRepoUrlFlag, "", "the URL to the Maven repository containing test material for the test stream to use. For example: https://my-maven-repository")
-    streamsSetCobraCmd.Flags().StringSliceVar(&cmd.values.obrs, obrFlag, make([]string, 0), "The maven coordinates of the OBR bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:{OBR_GROUP_ID}/{OBR_ARTIFACT_ID}/{OBR_VERSION}/obr'. "+
+    streamsSetCobraCmd.Flags().StringSliceVar(&cmd.values.obrs, obrFlag, make([]string, 0), "The Maven coordinates of the OBR bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:{OBR_GROUP_ID}/{OBR_ARTIFACT_ID}/{OBR_VERSION}/obr'. "+
         "Multiple instances of this flag can be used to describe multiple OBR bundles.")
 
-    // streams set requires the name flag as well as one of the following: --testcatalog, --maven-repo-url, --obr
-	streamsSetCobraCmd.MarkFlagsOneRequired(testCatalogUrlFlag, mavenRepoUrlFlag, obrFlag)
+    // streams set requires the name flag as well as one of the following: --description --testcatalog, --maven-repo-url, --obr
+	streamsSetCobraCmd.MarkFlagsOneRequired(descriptionFlag, testCatalogUrlFlag, mavenRepoUrlFlag, obrFlag)
 
     streamsCommand.CobraCommand().AddCommand(streamsSetCobraCmd)
 

--- a/modules/cli/pkg/cmd/streamsSet_test.go
+++ b/modules/cli/pkg/cmd/streamsSet_test.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"testing"
+
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamsSetCommandInCommandCollectionHasName(t *testing.T) {
+
+	factory := utils.NewMockFactory()
+	commands, _ := NewCommandCollection(factory)
+
+	StreamsSetCommand, err := commands.GetCommand(COMMAND_NAME_STREAMS_SET)
+	assert.Nil(t, err)
+
+	assert.Equal(t, COMMAND_NAME_STREAMS_SET, StreamsSetCommand.Name())
+	assert.NotNil(t, StreamsSetCommand.CobraCommand())
+}
+
+func TestStreamsSetHelpFlagSetCorrectly(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+
+	var args []string = []string{"streams", "set", "--help"}
+
+	// When...
+	err := Execute(factory, args)
+
+	// Then...
+	// Check what the user saw is reasonable.
+	checkOutput("Displays the options for the 'streams set' command.", "", factory, t)
+
+	assert.Nil(t, err)
+}
+
+func TestStreamsSetNameFlagsReturnsOk(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, _ := setupTestCommandCollection(COMMAND_NAME_STREAMS_SET, factory, t)
+
+	var args []string = []string{"streams", "set", "--name", "mystream", "--description", "my description", "--maven-repo-url", "https://mymavenrepo"}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw was reasonable
+	checkOutput("", "", factory, t)
+
+	assert.Nil(t, err)
+}
+
+func TestStreamsSetRequiresNameFlag(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, _ := setupTestCommandCollection(COMMAND_NAME_STREAMS_SET, factory, t)
+
+	var args []string = []string{"streams", "set"}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "required flag(s) \"name\" not set")
+}
+
+func TestStreamsSetRequiresNameAndAtLeastOneOtherFlag(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, _ := setupTestCommandCollection(COMMAND_NAME_STREAMS_SET, factory, t)
+
+	var args []string = []string{"streams", "set", "--name", "mystream"}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "at least one of the flags in the group [testcatalog-url maven-repo-url obr] is required")
+}

--- a/modules/cli/pkg/cmd/streamsSet_test.go
+++ b/modules/cli/pkg/cmd/streamsSet_test.go
@@ -86,5 +86,5 @@ func TestStreamsSetRequiresNameAndAtLeastOneOtherFlag(t *testing.T) {
 
 	// Then...
 	assert.NotNil(t, err)
-	assert.ErrorContains(t, err, "at least one of the flags in the group [testcatalog-url maven-repo-url obr] is required")
+	assert.ErrorContains(t, err, "at least one of the flags in the group [description testcatalog-url maven-repo-url obr] is required")
 }

--- a/modules/cli/pkg/errors/errorMessage.go
+++ b/modules/cli/pkg/errors/errorMessage.go
@@ -438,6 +438,16 @@ var (
 	GALASA_ERROR_DELETE_STREAMS_SERVER_REPORTED_ERROR    = NewMessageType("GAL1245E: Failed to delete stream %s. Unexpected http status code %v received from the server. Error details from the server are: '%s'", 1245, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_DELETE_STREAMS_EXPLANATION_NOT_JSON     = NewMessageType("GAL1246E: Failed to delete stream %s. Unexpected http status code %v received from the server. Error details from the server are not in the json format.", 1246, STACK_TRACE_NOT_WANTED)
 
+	// Streams set errors
+	GALASA_ERROR_INVALID_STREAM_DESCRIPTION              = NewMessageType("GAL1283E: Invalid stream description provided. The description provided with the --description flag cannot be an empty string, and must only contain characters in the Latin-1 character set.", 1283, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_INVALID_URL                             = NewMessageType("GAL1284E: Invalid URL provided. The URL '%s' is not a valid URL. Reason: '%s'", 1284, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_SET_STREAM_REQUEST_FAILED               = NewMessageType("GAL1285E: An attempt to set stream '%s' failed. Sending the update request to the Galasa service failed. Cause is %v", 1285, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_SET_STREAM_NO_RESPONSE_CONTENT          = NewMessageType("GAL1286E: An attempt to set stream '%s' failed. Unexpected http status code %v received from the server.", 1286, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_SET_STREAM_RESPONSE_BODY_UNREADABLE     = NewMessageType("GAL1287E: An attempt to set stream '%s' failed. Unexpected http status code %v received from the server. Error details from the server could not be read. Cause: %s", 1287, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_SET_STREAM_UNPARSEABLE_CONTENT          = NewMessageType("GAL1288E: An attempt to set stream '%s' failed. Unexpected http status code %v received from the server. Error details from the server are not in a valid json format. Cause: '%s'", 1288, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_SET_STREAM_SERVER_REPORTED_ERROR        = NewMessageType("GAL1289E: An attempt to set stream '%s' failed. Unexpected http status code %v received from the server. Error details from the server are: '%s'", 1289, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_SET_STREAM_EXPLANATION_NOT_JSON         = NewMessageType("GAL1290E: An attempt to set stream '%s' failed. Unexpected http status code %v received from the server. Error details from the server are not in the json format.", 1290, STACK_TRACE_NOT_WANTED)
+
 	// When getting multiple monitors...
 	GALASA_ERROR_GET_MONITORS_REQUEST_FAILED           = NewMessageType("GAL1218E: Failed to get monitors. Sending the get request to the Galasa service failed. Cause is %v", 1218, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_GET_MONITORS_NO_RESPONSE_CONTENT      = NewMessageType("GAL1219E: Failed to get monitors. Unexpected http status code %v received from the server.", 1219, STACK_TRACE_NOT_WANTED)
@@ -529,5 +539,5 @@ var (
     // >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
     // >>>       If you do use this number for a new error template, please increment this value.
     // >>>
-    GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 1283;
+    GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 1291;
 )

--- a/modules/cli/pkg/streams/streams.go
+++ b/modules/cli/pkg/streams/streams.go
@@ -7,9 +7,11 @@
 package streams
 
 import (
+	"net/url"
 	"strings"
 
 	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/utils"
 )
 
@@ -28,4 +30,46 @@ func validateStreamName(streamName string) (string, error) {
 
 	return streamName, err
 
+}
+
+func validateDescription(description string) (string, error) {
+    var err error
+    description = strings.TrimSpace(description)
+
+    if description == "" || !utils.IsLatin1(description) {
+        err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_INVALID_STREAM_DESCRIPTION)
+    }
+    return description, err
+}
+
+func validateUrl(urlString string) (string, error) {
+	var err error
+	urlString = strings.TrimSpace(urlString)
+
+	if urlString == "" {
+		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_INVALID_URL)
+	} else {
+		_, parseErr := url.ParseRequestURI(urlString)
+		if parseErr != nil {
+			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_INVALID_URL, urlString, parseErr.Error())
+		}
+	}
+
+	return urlString, err
+}
+
+func convertObrsToObrBeans(obrCoordinates []utils.MavenCoordinates) ([]galasaapi.StreamOBRData, error) {
+	streamObrs := make([]galasaapi.StreamOBRData, 0, len(obrCoordinates))
+
+	for _, coordinates := range obrCoordinates {
+		// Create StreamOBRData object from MavenCoordinates
+		streamObrData := galasaapi.NewStreamOBRData()
+		streamObrData.SetGroupId(coordinates.GroupId)
+		streamObrData.SetArtifactId(coordinates.ArtifactId)
+		streamObrData.SetVersion(coordinates.Version)
+
+		streamObrs = append(streamObrs, *streamObrData)
+	}
+
+	return streamObrs, nil
 }

--- a/modules/cli/pkg/streams/streamsGet.go
+++ b/modules/cli/pkg/streams/streamsGet.go
@@ -140,17 +140,23 @@ func getStreamByName(
 		if resp == nil {
 			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RETRIEVING_STREAMS_FROM_API_SERVER, err.Error())
 		} else {
-			err = galasaErrors.HttpResponseToGalasaError(
-				resp,
-				"",
-				byteReader,
-				galasaErrors.GALASA_ERROR_GET_STREAMS_NO_RESPONSE_CONTENT,
-				galasaErrors.GALASA_ERROR_GET_STREAMS_RESPONSE_BODY_UNREADABLE,
-				galasaErrors.GALASA_ERROR_GET_STREAMS_UNPARSEABLE_CONTENT,
-				galasaErrors.GALASA_ERROR_GET_STREAMS_SERVER_REPORTED_ERROR,
-				galasaErrors.GALASA_ERROR_GET_STREAMS_EXPLANATION_NOT_JSON,
-			)
-			log.Println("getStreamsFromRestApi - Failed to retrieve a test stream by name from API server")
+
+			if resp.StatusCode == http.StatusNotFound {
+				// Instead of returning a 404 error, return an empty list of streams
+				err = nil
+			} else {
+				err = galasaErrors.HttpResponseToGalasaError(
+					resp,
+					"",
+					byteReader,
+					galasaErrors.GALASA_ERROR_GET_STREAMS_NO_RESPONSE_CONTENT,
+					galasaErrors.GALASA_ERROR_GET_STREAMS_RESPONSE_BODY_UNREADABLE,
+					galasaErrors.GALASA_ERROR_GET_STREAMS_UNPARSEABLE_CONTENT,
+					galasaErrors.GALASA_ERROR_GET_STREAMS_SERVER_REPORTED_ERROR,
+					galasaErrors.GALASA_ERROR_GET_STREAMS_EXPLANATION_NOT_JSON,
+				)
+				log.Println("getStreamsFromRestApi - Failed to retrieve a test stream by name from API server")
+			}
 		}
 
 	} else if streamIn != nil {
@@ -159,7 +165,6 @@ func getStreamByName(
 	}
 
 	return streamsToReturn, err
-
 }
 
 func getAllStreams(

--- a/modules/cli/pkg/streams/streamsSet.go
+++ b/modules/cli/pkg/streams/streamsSet.go
@@ -1,0 +1,155 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package streams
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/galasa-dev/cli/pkg/embedded"
+	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/galasa-dev/cli/pkg/utils"
+)
+
+func SetStream(
+	streamName string,
+	description string,
+	mavenRepositoryUrl string,
+	testCatalogUrl string,
+	obrs []string,
+	apiClient *galasaapi.APIClient,
+	byteReader spi.ByteReader,
+) error {
+	var err error
+
+	streamName, err = validateStreamName(streamName)
+
+	if err == nil {
+		if description != "" {
+			description, err = validateDescription(description)
+		}
+
+		if mavenRepositoryUrl != "" {
+			mavenRepositoryUrl, err = validateUrl(mavenRepositoryUrl)
+		}
+
+		if testCatalogUrl != "" {
+			testCatalogUrl, err = validateUrl(testCatalogUrl)
+		}
+
+		var streamObrs []galasaapi.StreamOBRData
+		if len(obrs) > 0 {
+			var obrCoordinates []utils.MavenCoordinates
+			obrCoordinates, err = utils.ValidateObrs(obrs)
+			if err == nil {
+				streamObrs, err = convertObrsToObrBeans(obrCoordinates)
+			}
+		}
+
+		if err == nil {
+			_, err = sendStreamUpdateToRestApi(
+				streamName,
+				description,
+				mavenRepositoryUrl,
+				testCatalogUrl,
+				streamObrs,
+				apiClient,
+				byteReader,
+			)
+		}
+	}
+	return err
+}
+
+func sendStreamUpdateToRestApi(
+	streamName string,
+	description string,
+	mavenRepositoryUrl string,
+	testCatalogUrl string,
+	obrs []galasaapi.StreamOBRData,
+	apiClient *galasaapi.APIClient,
+	byteReader spi.ByteReader,
+) (*galasaapi.Stream, error) {
+	var err error
+	var restApiVersion string
+	var context context.Context = nil
+	var streamGotBack *galasaapi.Stream
+
+	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
+
+	streamSetRequest := buildStreamUpdateRequest(description, mavenRepositoryUrl, testCatalogUrl, obrs)
+
+	apiCall := apiClient.StreamsAPIApi.UpdateStream(context, streamName).
+		StreamUpdateRequest(*streamSetRequest).
+		ClientApiVersion(restApiVersion)
+
+	if err == nil {
+
+		var resp *http.Response
+
+		streamGotBack, resp, err = apiCall.Execute()
+
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+
+        if err != nil {
+			log.Println("sendStreamUpdateToRestApi - Failed to update test stream record in the Galasa service")
+
+            if resp == nil {
+                err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_SET_STREAM_REQUEST_FAILED, streamName, err.Error())
+            } else {
+                err = galasaErrors.HttpResponseToGalasaError(
+                    resp,
+                    streamName,
+                    byteReader,
+                    galasaErrors.GALASA_ERROR_SET_STREAM_NO_RESPONSE_CONTENT,
+                    galasaErrors.GALASA_ERROR_SET_STREAM_RESPONSE_BODY_UNREADABLE,
+                    galasaErrors.GALASA_ERROR_SET_STREAM_UNPARSEABLE_CONTENT,
+                    galasaErrors.GALASA_ERROR_SET_STREAM_SERVER_REPORTED_ERROR,
+                    galasaErrors.GALASA_ERROR_SET_STREAM_EXPLANATION_NOT_JSON,
+                )
+            }
+        } else {
+			log.Println("sendStreamUpdateToRestApi - Test stream updated OK")
+		}
+	}
+	return streamGotBack, err
+}
+
+func buildStreamUpdateRequest(
+	description string,
+	mavenRepositoryUrl string,
+	testCatalogUrl string,
+	obrs []galasaapi.StreamOBRData,
+) *galasaapi.StreamUpdateRequest {
+	var streamSetRequest *galasaapi.StreamUpdateRequest = galasaapi.NewStreamUpdateRequest()
+
+	if description != "" {
+		streamSetRequest.SetDescription(description)
+	}
+
+	if mavenRepositoryUrl != "" {
+		repository := galasaapi.NewStreamUpdateRequestRepository()
+		repository.SetUrl(mavenRepositoryUrl)
+		streamSetRequest.SetRepository(*repository)
+	}
+
+	if testCatalogUrl != "" {
+		testCatalog := galasaapi.NewStreamUpdateRequestTestCatalog()
+		testCatalog.SetUrl(testCatalogUrl)
+		streamSetRequest.SetTestCatalog(*testCatalog)
+	}
+
+	if len(obrs) > 0 {
+		streamSetRequest.SetObrs(obrs)
+	}
+	return streamSetRequest
+}

--- a/modules/cli/pkg/streams/streamsSet_test.go
+++ b/modules/cli/pkg/streams/streamsSet_test.go
@@ -1,0 +1,397 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package streams
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/galasa-dev/cli/pkg/api"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func readStreamRequestBody(req *http.Request) galasaapi.StreamUpdateRequest {
+	var streamUpdateRequest galasaapi.StreamUpdateRequest
+	requestBodyBytes, _ := io.ReadAll(req.Body)
+	defer req.Body.Close()
+
+	_ = json.Unmarshal(requestBodyBytes, &streamUpdateRequest)
+	return streamUpdateRequest
+}
+
+func TestSetStreamWithInvalidNameReturnsError(t *testing.T) {
+	// Given...
+	streamName := ""
+	description := ""
+	mavenRepositoryUrl := ""
+	testCatalogUrl := ""
+	obrs := []string{}
+
+	interactions := []utils.HttpInteraction{}
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "GAL1233E")
+	assert.ErrorContains(t, err, "The stream name provided by the --name field cannot be an empty string")
+}
+
+func TestSetStreamWithInvalidDescriptionReturnsError(t *testing.T) {
+	// Given...
+	streamName := "mystream"
+	description := "     "
+	mavenRepositoryUrl := ""
+	testCatalogUrl := ""
+	obrs := []string{}
+
+	interactions := []utils.HttpInteraction{}
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "GAL1283E")
+	assert.ErrorContains(t, err, "Invalid stream description provided")
+}
+
+func TestSetStreamWithInvalidMavenUrlReturnsError(t *testing.T) {
+	// Given...
+	streamName := "mystream"
+	description := "my description"
+	mavenRepositoryUrl := "not a valid url"
+	testCatalogUrl := ""
+	obrs := []string{}
+
+	interactions := []utils.HttpInteraction{}
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "GAL1284E")
+	assert.ErrorContains(t, err, "Invalid URL provided")
+}
+
+func TestSetStreamWithInvalidTestCatalogUrlReturnsError(t *testing.T) {
+	// Given...
+	streamName := "mystream"
+	description := "my description"
+	mavenRepositoryUrl := ""
+	testCatalogUrl := "not a valid url"
+	obrs := []string{}
+
+	interactions := []utils.HttpInteraction{}
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "GAL1284E")
+	assert.ErrorContains(t, err, "Invalid URL provided")
+}
+
+func TestSetStreamSendsCorrectRequest(t *testing.T) {
+	// Given...
+	streamName := "mystream"
+	description := "my stream's description"
+	mavenRepositoryUrl := "https://maven.example.com/repo"
+	testCatalogUrl := "https://maven.example.com/repo/testcatalog.json"
+	obrs := []string{}
+
+	setStreamInteraction := utils.NewHttpInteraction("/streams/"+streamName, http.MethodPut)
+	setStreamInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+
+		streamUpdateRequest := readStreamRequestBody(req)
+		assert.Equal(t, description, streamUpdateRequest.GetDescription())
+		
+		repository, hasRepository := streamUpdateRequest.GetRepositoryOk()
+		assert.True(t, hasRepository)
+		assert.Equal(t, mavenRepositoryUrl, repository.GetUrl())
+		
+		testCatalog, hasTestCatalog := streamUpdateRequest.GetTestCatalogOk()
+		assert.True(t, hasTestCatalog)
+		assert.Equal(t, testCatalogUrl, testCatalog.GetUrl())
+
+		body := `{
+			"apiVersion": "v1alpha1",
+			"kind": "GalasaStream",
+			"metadata": {
+				"name": "mystream",
+				"description": "my stream's description"
+			},
+			"data": {
+				"repository": {
+					"url": "https://maven.example.com/repo"
+				},
+				"testCatalog": {
+					"url": "https://maven.example.com/repo/testcatalog.json"
+				}
+			}
+		}`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	interactions := []utils.HttpInteraction{
+		setStreamInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.Nil(t, err)
+}
+
+func TestSetStreamWithObrsUpdatesObrData(t *testing.T) {
+	// Given...
+	streamName := "mystream"
+	description := "my stream's description"
+	mavenRepositoryUrl := ""
+	testCatalogUrl := ""
+	obrs := []string{"mvn:dev.galasa/dev.galasa.obr/0.1.0/obr"}
+
+	setStreamInteraction := utils.NewHttpInteraction("/streams/"+streamName, http.MethodPut)
+	setStreamInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+
+		streamUpdateRequest := readStreamRequestBody(req)
+		assert.Equal(t, description, streamUpdateRequest.GetDescription())
+		
+		obrs := streamUpdateRequest.GetObrs()
+		assert.Len(t, obrs, 1)
+		assert.Equal(t, "dev.galasa", obrs[0].GetGroupId())
+		assert.Equal(t, "dev.galasa.obr", obrs[0].GetArtifactId())
+		assert.Equal(t, "0.1.0", obrs[0].GetVersion())
+
+		body := `{
+			"apiVersion": "v1alpha1",
+			"kind": "GalasaStream",
+			"metadata": {
+				"name": "mystream",
+				"description": "my stream's description"
+			},
+			"data": {
+				"obrs": [
+					{
+						"group-id": "dev.galasa",
+						"artifact-id": "dev.galasa.obr",
+						"version": "0.1.0"
+					}
+				]
+			}
+		}`
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("ClientApiVersion", "myVersion")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(body))
+	}
+
+	interactions := []utils.HttpInteraction{
+		setStreamInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.Nil(t, err)
+}
+
+func TestSetStreamWithTooManyObrPartsReturnsError(t *testing.T) {
+	// Given...
+	streamName := "mystream"
+	description := "my stream's description"
+	mavenRepositoryUrl := ""
+	testCatalogUrl := ""
+	obrs := []string{"mvn:/this/obr/has/too/many/parts/obr"}
+
+	interactions := []utils.HttpInteraction{}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "GAL1061E")
+	assert.ErrorContains(t, err, "Badly formed OBR parameter")
+}
+
+func TestSetStreamWithTooFewObrPartsReturnsError(t *testing.T) {
+	// Given...
+	streamName := "mystream"
+	description := "my stream's description"
+	mavenRepositoryUrl := ""
+	testCatalogUrl := ""
+	obrs := []string{"mvn:not-enough-parts/obr"}
+
+	interactions := []utils.HttpInteraction{}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "GAL1060E")
+	assert.ErrorContains(t, err, "Badly formed OBR parameter")
+}
+
+func TestSetStreamWithNoMavenPrefixReturnsError(t *testing.T) {
+	// Given...
+	streamName := "mystream"
+	description := "my stream's description"
+	mavenRepositoryUrl := ""
+	testCatalogUrl := ""
+	obrs := []string{"dev.galasa/dev.galasa.obr/0.1.0/obr"}
+
+	interactions := []utils.HttpInteraction{}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "GAL1062E")
+	assert.ErrorContains(t, err, "Badly formed OBR parameter")
+}
+
+func TestSetStreamWithNoObrSuffixReturnsError(t *testing.T) {
+	// Given...
+	streamName := "mystream"
+	description := "my stream's description"
+	mavenRepositoryUrl := ""
+	testCatalogUrl := ""
+	obrs := []string{"mvn:dev.galasa/dev.galasa.obr/0.1.0"}
+
+	interactions := []utils.HttpInteraction{}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "GAL1060E")
+	assert.ErrorContains(t, err, "Badly formed OBR parameter")
+}
+
+func TestSetStreamWithServerFailureGivesCorrectMessage(t *testing.T) {
+	// Given...
+	streamName := "mystream"
+	description := "my stream's description"
+	mavenRepositoryUrl := ""
+	testCatalogUrl := ""
+	obrs := []string{}
+
+	setStreamInteraction := utils.NewHttpInteraction("/streams/"+streamName, http.MethodPut)
+	setStreamInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+
+		streamUpdateRequest := readStreamRequestBody(req)
+		assert.Equal(t, description, streamUpdateRequest.GetDescription())
+
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusInternalServerError)
+		writer.Write([]byte(`{}`))
+	}
+
+	interactions := []utils.HttpInteraction{
+		setStreamInteraction,
+	}
+
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	apiServerUrl := server.Server.URL
+	mockByteReader := utils.NewMockByteReader()
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	// When...
+	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+
+	// Then...
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, streamName)
+	assert.ErrorContains(t, err, strconv.Itoa(http.StatusInternalServerError))
+	assert.ErrorContains(t, err, "GAL1289E")
+	assert.ErrorContains(t, err, "Error details from the server are")
+}


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2546

Note: This PR builds off from changes in https://github.com/galasa-dev/galasa/pull/537, so will need to be rebased.

## Changes
- [x] Added new `galasactl streams set` command
- [x] Updated release notes and documentation on test streams to reference the new command
- [x] Updated the `streams-tests.sh` script to use the new command instead of `properties set` to create streams
- [x] Fixed a minor issue with `galasactl streams get` where getting a non-existent stream by name caused the CLI to throw a 404 not found error. This has been changed to display `Total:0` instead.