### PR TITLE
Add null handling to RunFinishedRuns, perform atomic DSS updates when moving runs to the 'finished' state

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -11,6 +11,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -203,10 +204,13 @@ public class TestPodScheduler implements Runnable {
                 launchAttemptCount+=1;
                 if( launchAttemptCount > maxLaunchAttempts ) {
                     // Mark the test run as finished due to environment failure.
-                    this.dss.put("run." + run.getName() + "."+DssPropertyKeyRunNameSuffix.RESULT, "EnvFail" );
-                    this.dss.put("run." + run.getName() + "."+DssPropertyKeyRunNameSuffix.STATUS, "finished");
+                    Map<String, String> propertiesToSet = new HashMap<>();
+                    propertiesToSet.put("run." + run.getName() + "."+DssPropertyKeyRunNameSuffix.RESULT, "EnvFail" );
+                    propertiesToSet.put("run." + run.getName() + "."+DssPropertyKeyRunNameSuffix.STATUS, "finished");
                     Instant finishedTimeStamp = timeService.now();
-                    this.dss.put("run." + run.getName() + "."+DssPropertyKeyRunNameSuffix.FINISHED_DATETIME , finishedTimeStamp.toString());
+                    propertiesToSet.put("run." + run.getName() + "."+DssPropertyKeyRunNameSuffix.FINISHED_DATETIME , finishedTimeStamp.toString());
+
+                    this.dss.put(propertiesToSet);
 
                     String msg = "Engine Pod " + newPodDefinition.getMetadata().getName() + " could not be started. Giving up. Retry count "+Integer.toString(launchAttemptCount)+"exceeded!";
                     logger.error(msg);

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunFinishedRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunFinishedRuns.java
@@ -21,6 +21,7 @@ import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IFrameworkRuns;
 import dev.galasa.framework.spi.IResourceManagement;
+import dev.galasa.framework.spi.IResourceManagementProvider;
 import dev.galasa.framework.spi.IRun;
 
 public class RunFinishedRuns implements Runnable {
@@ -34,7 +35,7 @@ public class RunFinishedRuns implements Runnable {
             .withZone(ZoneId.systemDefault());
 
     protected RunFinishedRuns(IFramework framework, IResourceManagement resourceManagement,
-            IDynamicStatusStoreService dss, RunResourceManagement runResourceManagement,
+            IDynamicStatusStoreService dss, IResourceManagementProvider runResourceManagement,
             IConfigurationPropertyStoreService cps) throws FrameworkException {
         this.resourceManagement = resourceManagement;
         this.frameworkRuns = framework.getFrameworkRuns();
@@ -74,14 +75,23 @@ public class RunFinishedRuns implements Runnable {
 
                 Instant finished = run.getFinished();
                 logger.info("The runs finished time is: " + finished);
-                Instant expires = finished.plusSeconds(defaultFinishedDelete);
+                Instant expires = null;
+                if (finished != null) {
+                    expires = finished.plusSeconds(defaultFinishedDelete);
+                }
+
                 logger.info("The runs expired time is: " + expires);
                 Instant now = Instant.now();
-                if (expires.compareTo(now) <= 0) {
+                if (expires == null || expires.compareTo(now) <= 0) {
                     logger.info("The run has expired so we will attempt to delete it");
-                    String sFinished = dtf.format(LocalDateTime.ofInstant(finished, ZoneId.systemDefault()));
-                    /// TODO put time management into the framework
-                    logger.info("Deleting run " + runName + ", finished at " + sFinished);
+                    if (finished != null) {
+                        String sFinished = dtf.format(LocalDateTime.ofInstant(finished, ZoneId.systemDefault()));
+                        /// TODO put time management into the framework
+                        logger.info("Deleting run " + runName + ", finished at " + sFinished);
+                    } else {
+                        logger.info("Deleting run " + runName + ", finished is null");
+                    }
+
                     this.frameworkRuns.delete(runName);
                     logger.info("We have been able to delete the run in the delete() method");
                 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunFinishedRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/RunFinishedRuns.java
@@ -86,7 +86,6 @@ public class RunFinishedRuns implements Runnable {
                     logger.info("The run has expired so we will attempt to delete it");
                     if (finished != null) {
                         String sFinished = dtf.format(LocalDateTime.ofInstant(finished, ZoneId.systemDefault()));
-                        /// TODO put time management into the framework
                         logger.info("Deleting run " + runName + ", finished at " + sFinished);
                     } else {
                         logger.info("Deleting run " + runName + ", finished is null");

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/TestRunFinishedRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/TestRunFinishedRuns.java
@@ -1,0 +1,514 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.MockCPSStore;
+import dev.galasa.framework.mocks.MockDSSStore;
+import dev.galasa.framework.mocks.MockFramework;
+import dev.galasa.framework.mocks.MockFrameworkRuns;
+import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.resource.management.internal.mocks.MockResourceManagement;
+import dev.galasa.framework.resource.management.internal.mocks.MockResourceManagementProvider;
+import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IFrameworkRuns;
+import dev.galasa.framework.spi.IRun;
+
+public class TestRunFinishedRuns {
+
+    @Test
+    public void testCanInstantiateRunFinishedRuns() throws Exception {
+        // Given...
+        MockFrameworkRuns runs = new MockFrameworkRuns();
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return runs;
+            }
+        };
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        MockCPSStore cps = new MockCPSStore(new HashMap<String, String>());
+
+        // When...
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // Then...
+        assertThat(monitor).isNotNull();
+    }
+
+    @Test
+    public void testRunWithNoFinishedRunsCompletesSuccessfully() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        MockCPSStore cps = new MockCPSStore(new HashMap<String, String>());
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        assertThat(resourceManagement.isSuccessful).isTrue();
+        assertThat(mockFrameworkRuns.getDeletedRunNames()).isEmpty();
+    }
+
+    @Test
+    public void testRunWithNonFinishedRunsDoesNotDeleteThem() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun run1 = new MockRun("bundle", "class", "run1", "stream", "obr", "repo",
+                "requestor", false);
+        run1.setStatus("queued");
+        runs.add(run1);
+
+        MockRun run2 = new MockRun("bundle", "class", "run2", "stream", "obr", "repo",
+                "requestor", false);
+        run2.setStatus("running");
+        runs.add(run2);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        MockCPSStore cps = new MockCPSStore(new HashMap<String, String>());
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        assertThat(resourceManagement.isSuccessful).isTrue();
+        assertThat(mockFrameworkRuns.getDeletedRunNames()).isEmpty();
+    }
+
+    @Test
+    public void testRunDeletesFinishedRunThatHasExpired() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun finishedRun = new MockRun("bundle", "class", "run1", "stream", "obr", "repo",
+                "requestor", false);
+        finishedRun.setStatus("finished");
+        // Set finished time to 10 minutes ago (default timeout is 5 minutes)
+        finishedRun.setFinished(Instant.now().minus(10, ChronoUnit.MINUTES));
+        runs.add(finishedRun);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        MockCPSStore cps = new MockCPSStore(new HashMap<String, String>());
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        assertThat(resourceManagement.isSuccessful).isTrue();
+        assertThat(mockFrameworkRuns.getDeletedRunNames()).contains("run1");
+    }
+
+    @Test
+    public void testRunDoesNotDeleteFinishedRunThatHasNotExpired() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun finishedRun = new MockRun("bundle", "class", "run1", "stream", "obr", "repo",
+                "requestor", false);
+        finishedRun.setStatus("finished");
+        // Set finished time to 1 minute ago (default timeout is 5 minutes)
+        finishedRun.setFinished(Instant.now().minus(1, ChronoUnit.MINUTES));
+        runs.add(finishedRun);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        MockCPSStore cps = new MockCPSStore(new HashMap<String, String>());
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        assertThat(resourceManagement.isSuccessful).isTrue();
+        assertThat(mockFrameworkRuns.getDeletedRunNames()).isEmpty();
+    }
+
+    @Test
+    public void testRunDeletesFinishedRunWithNullFinishedTime() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun finishedRun = new MockRun("bundle", "class", "run1", "stream", "obr", "repo",
+                "requestor", false);
+        finishedRun.setStatus("finished");
+        finishedRun.setFinished(null); // No finished time
+        runs.add(finishedRun);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        MockCPSStore cps = new MockCPSStore(new HashMap<String, String>());
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        assertThat(resourceManagement.isSuccessful).isTrue();
+        assertThat(mockFrameworkRuns.getDeletedRunNames()).contains("run1");
+    }
+
+    @Test
+    public void testRunUsesCustomTimeoutFromCPS() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun finishedRun = new MockRun("bundle", "class", "run1", "stream", "obr", "repo",
+                "requestor", false);
+        finishedRun.setStatus("finished");
+        // Set finished time to 2 minutes ago
+        finishedRun.setFinished(Instant.now().minus(2, ChronoUnit.MINUTES));
+        runs.add(finishedRun);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        
+        // Set custom timeout to 60 seconds (1 minute)
+        HashMap<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("resource.management.finished.timeout", "60");
+        MockCPSStore cps = new MockCPSStore(cpsProperties);
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        // Run should be deleted because it finished 2 minutes ago and timeout is 1 minute
+        assertThat(resourceManagement.isSuccessful).isTrue();
+        assertThat(mockFrameworkRuns.getDeletedRunNames()).contains("run1");
+    }
+
+    @Test
+    public void testRunDoesNotDeleteWhenCustomTimeoutNotReached() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun finishedRun = new MockRun("bundle", "class", "run1", "stream", "obr", "repo",
+                "requestor", false);
+        finishedRun.setStatus("finished");
+        // Set finished time to 30 seconds ago
+        finishedRun.setFinished(Instant.now().minus(30, ChronoUnit.SECONDS));
+        runs.add(finishedRun);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        
+        // Set custom timeout to 600 seconds (10 minutes)
+        HashMap<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("resource.management.finished.timeout", "600");
+        MockCPSStore cps = new MockCPSStore(cpsProperties);
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        // Run should NOT be deleted because it finished 30 seconds ago and timeout is 10 minutes
+        assertThat(resourceManagement.isSuccessful).isTrue();
+        assertThat(mockFrameworkRuns.getDeletedRunNames()).isEmpty();
+    }
+
+    @Test
+    public void testRunDeletesMultipleExpiredFinishedRuns() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        
+        MockRun finishedRun1 = new MockRun("bundle", "class", "run1", "stream", "obr", "repo",
+                "requestor", false);
+        finishedRun1.setStatus("finished");
+        finishedRun1.setFinished(Instant.now().minus(10, ChronoUnit.MINUTES));
+        runs.add(finishedRun1);
+
+        MockRun finishedRun2 = new MockRun("bundle", "class", "run2", "stream", "obr", "repo",
+                "requestor", false);
+        finishedRun2.setStatus("finished");
+        finishedRun2.setFinished(Instant.now().minus(15, ChronoUnit.MINUTES));
+        runs.add(finishedRun2);
+
+        MockRun finishedRun3 = new MockRun("bundle", "class", "run3", "stream", "obr", "repo",
+                "requestor", false);
+        finishedRun3.setStatus("finished");
+        finishedRun3.setFinished(Instant.now().minus(20, ChronoUnit.MINUTES));
+        runs.add(finishedRun3);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        MockCPSStore cps = new MockCPSStore(new HashMap<String, String>());
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        assertThat(resourceManagement.isSuccessful).isTrue();
+        assertThat(mockFrameworkRuns.getDeletedRunNames()).containsExactlyInAnyOrder("run1", "run2", "run3");
+    }
+
+    @Test
+    public void testRunDeletesSomeExpiredRunsButNotOthers() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        
+        // Expired run
+        MockRun expiredRun = new MockRun("bundle", "class", "expiredRun", "stream", "obr", "repo",
+                "requestor", false);
+        expiredRun.setStatus("finished");
+        expiredRun.setFinished(Instant.now().minus(10, ChronoUnit.MINUTES));
+        runs.add(expiredRun);
+
+        // Not expired run
+        MockRun notExpiredRun = new MockRun("bundle", "class", "notExpiredRun", "stream", "obr", "repo",
+                "requestor", false);
+        notExpiredRun.setStatus("finished");
+        notExpiredRun.setFinished(Instant.now().minus(1, ChronoUnit.MINUTES));
+        runs.add(notExpiredRun);
+
+        // Non-finished run
+        MockRun runningRun = new MockRun("bundle", "class", "runningRun", "stream", "obr", "repo",
+                "requestor", false);
+        runningRun.setStatus("running");
+        runs.add(runningRun);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        MockCPSStore cps = new MockCPSStore(new HashMap<String, String>());
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        assertThat(resourceManagement.isSuccessful).isTrue();
+        assertThat(mockFrameworkRuns.getDeletedRunNames()).containsExactly("expiredRun");
+    }
+
+    @Test
+    public void testRunHandlesInvalidTimeoutPropertyGracefully() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun finishedRun = new MockRun("bundle", "class", "run1", "stream", "obr", "repo",
+                "requestor", false);
+        finishedRun.setStatus("finished");
+        finishedRun.setFinished(Instant.now().minus(10, ChronoUnit.MINUTES));
+        runs.add(finishedRun);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        
+        // Set invalid timeout property
+        HashMap<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("resource.management.finished.timeout", "invalid");
+        MockCPSStore cps = new MockCPSStore(cpsProperties);
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        // Should use default timeout (300 seconds = 5 minutes) and delete the run
+        assertThat(resourceManagement.isSuccessful).isTrue();
+        assertThat(mockFrameworkRuns.getDeletedRunNames()).contains("run1");
+    }
+
+    @Test
+    public void testRunHandlesExceptionDuringGetAllRunsGracefully() throws Exception {
+        // Given...
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns() {
+            @Override
+            public List<IRun> getAllRuns() throws FrameworkException {
+                throw new FrameworkException("Simulated error getting runs");
+            }
+        };
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        MockCPSStore cps = new MockCPSStore(new HashMap<String, String>());
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        // Should handle exception gracefully and still mark as successful
+        assertThat(resourceManagement.isSuccessful).isTrue();
+    }
+
+    @Test
+    public void testRunHandlesExceptionDuringDeleteGracefully() throws Exception {
+        // Given...
+        List<IRun> runs = new ArrayList<>();
+        MockRun finishedRun = new MockRun("bundle", "class", "run1", "stream", "obr", "repo",
+                "requestor", false);
+        finishedRun.setStatus("finished");
+        finishedRun.setFinished(Instant.now().minus(10, ChronoUnit.MINUTES));
+        runs.add(finishedRun);
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs) {
+            @Override
+            public List<IRun> getAllRuns() throws FrameworkException {
+                return runs;
+            }
+
+            @Override
+            public boolean delete(String runname) throws DynamicStatusStoreException {
+                throw new DynamicStatusStoreException("Simulated delete error");
+            }
+        };
+
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return mockFrameworkRuns;
+            }
+        };
+
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockDSSStore dss = new MockDSSStore(new HashMap<String, String>());
+        MockResourceManagementProvider runResourceManagement = new MockResourceManagementProvider();
+        MockCPSStore cps = new MockCPSStore(new HashMap<String, String>());
+
+        RunFinishedRuns monitor = new RunFinishedRuns(framework, resourceManagement, dss, runResourceManagement, cps);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        // Should handle exception gracefully and still mark as successful
+        assertThat(resourceManagement.isSuccessful).isTrue();
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -354,10 +354,13 @@ public class BaseTestRunner {
         writeTestStructure();
 
         try {
-            this.dss.put(getDSSKeyString(DssPropertyKeyRunNameSuffix.STATUS.toString()), status.toString());
+            Map<String, String> propertiesToSet = new HashMap<>();
+            propertiesToSet.put(getDSSKeyString(DssPropertyKeyRunNameSuffix.STATUS.toString()), status.toString());
             if (dssTimePropSuffix != null) {
-                this.dss.put(getDSSKeyString(dssTimePropSuffix), time.toString());
+                propertiesToSet.put(getDSSKeyString(dssTimePropSuffix), time.toString());
             }
+
+            this.dss.put(propertiesToSet);
         } catch (DynamicStatusStoreException e) {
             throw new TestRunException("Failed to update status", e);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestRunner.java
@@ -290,6 +290,11 @@ public class TestTestRunner {
         public void put(@NotNull String key, @NotNull String value) throws DynamicStatusStoreException {
             // Do nothing.
         }
+
+        @Override
+        public void put(@NotNull Map<String, String> keyValues) throws DynamicStatusStoreException {
+            // Do nothing.
+        }
     };
 
     @Test
@@ -403,7 +408,7 @@ public class TestTestRunner {
         };
 
         // When...
-        TestRunException ex = catchThrowableOfType( ()->runner.runTest(testRunData), TestRunException.class);
+        TestRunException ex = catchThrowableOfType(TestRunException.class, ()->runner.runTest(testRunData));
 
         /// Then...
         assertThat(ex).isNotNull();      

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockFrameworkRuns.java
@@ -21,6 +21,7 @@ import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.RunRasAction;
 
 public class MockFrameworkRuns implements IFrameworkRuns {
+    private List<String> deletedRunNames = new ArrayList<>();
     protected String groupName;
     List<IRun> runs ;
 
@@ -101,7 +102,12 @@ public class MockFrameworkRuns implements IFrameworkRuns {
 
     @Override
     public boolean delete(String runname) throws DynamicStatusStoreException {
+        deletedRunNames.add(runname);
         return true;
+    }
+
+    public List<String> getDeletedRunNames() {
+        return this.deletedRunNames;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockRun.java
@@ -41,6 +41,7 @@ public class MockRun implements IRun {
     private List<RunRasAction> rasActions = new ArrayList<>();
     private Set<String> tags = new HashSet<String>();
     private List<String> requestedTestMethods = new ArrayList<>();
+    private Instant finishedTime;
 
     public MockRun(
         String testBundleName,
@@ -317,6 +318,15 @@ public class MockRun implements IRun {
         this.requestedTestMethods = requestedTestMethods;
     }
 
+    @Override
+    public Instant getFinished() {
+        return this.finishedTime;
+    }
+
+    public void setFinished(Instant finishedTime) {
+        this.finishedTime = finishedTime;
+    }
+
     // ------------- un-implemented methods follow ----------------
 
     @Override
@@ -327,13 +337,6 @@ public class MockRun implements IRun {
     @Override
     public String getTest() {
         throw new UnsupportedOperationException("Unimplemented method 'getTest'");
-    }
-
-
-
-    @Override
-    public Instant getFinished() {
-        throw new UnsupportedOperationException("Unimplemented method 'getFinished'");
     }
 
     @Override


### PR DESCRIPTION
## Why?
Refer to https://github.com/galasa-dev/projectmanagement/issues/2516 

## Changes
- [x] Added null handling to the RunFinishedRuns class to avoid NullPointerExceptions from being thrown
- [x] When moving runs to the 'finished' state, DSS updates should now be performed atomically rather than via multiple DSS set operations to avoid situations where a run's status is marked as 'finished' but doesn't have a 'finished' timestamp property set
- [x] Added unit tests to the RunFinishedRuns class
