### PR TITLE
Bump MQ client library to 9.4.5.0

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2312,6 +2312,16 @@
         "verified_result": null
       }
     ],
+    "modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/README.md": [
+      {
+        "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/README.md": [
       {
         "hashed_secret": "22199ec38c6bedb7616f8e42aa3ad6e9f196cd24",

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/README.md
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/README.md
@@ -1,0 +1,35 @@
+# Galasa MQ Manager IVT
+
+This directory contains the IVTs for Galasa MQ Manager.
+
+## Prerequisites
+
+To run the IVTs, you will need:
+
+- An MQ instance running locally (see [Get an IBM MQ queue for development in a container](https://developer.ibm.com/tutorials/mq-connect-app-queue-manager-containers/) for instructions on how to set this up using Docker or podman)
+
+## Running the IVTs
+
+1. Assuming you have followed the instructions in the [Get an IBM MQ queue for development in a container](https://developer.ibm.com/tutorials/mq-connect-app-queue-manager-containers/) tutorial, you will now need to set the following properties into your CPS properties file:
+
+    ```properties
+    mq.tag.bob.instanceid=QUEUEMGR1
+    mq.queue.bob.queuename=DEV.QUEUE.1
+    mq.server.QUEUEMGR1.channel=DEV.APP.SVRCONN
+    mq.server.QUEUEMGR1.credentials.id=MQIVT
+    mq.server.QUEUEMGR1.host=127.0.0.1
+    mq.server.QUEUEMGR1.name=QM1
+    mq.server.QUEUEMGR1.port=1414
+    ```
+
+2. Now set the following properties into your credentials properties file, making sure the username and password corresponds to the details set when starting the Docker container:
+
+    ```properties
+    secure.credentials.MQIVT.username=app
+    secure.credentials.MQIVT.password=passw0rd
+    ```
+
+3. Run the IVTs using the following command, replacing `{YOUR_GALASA_VERSION}` with the version of Galasa that you want to use:
+    ```
+    galasactl runs submit local --obr mvn:dev.galasa/dev.galasa.uber.obr/{YOUR_GALASA_VERSION}/obr --class dev.galasa.mq.manager.ivt/dev.galasa.mq.manager.ivt.MqManagerIVT --log -
+    ```

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/build.gradle
@@ -7,7 +7,6 @@ description = 'Galasa MQ Manager IVTs'
 dependencies {
     implementation project(':galasa-managers-comms-parent:dev.galasa.mq.manager')
     implementation project(':galasa-managers-core-parent:dev.galasa.core.manager')
-    implementation 'javax.jms:javax.jms-api'
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/src/main/java/dev/galasa/mq/manager/ivt/MqManagerIVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/src/main/java/dev/galasa/mq/manager/ivt/MqManagerIVT.java
@@ -32,10 +32,10 @@ public class MqManagerIVT {
 	@QueueManager(tag = "bob")
 	public IMessageQueueManager qmgr;
 	
-	@Queue(archive = true, name = "GALASA.INPUT.QUEUE", tag = "ggbvg", queueMgrTag = "bob")
+	@Queue(archive = true, name = "DEV.QUEUE.1", queueMgrTag = "bob")
 	public IMessageQueue queue;
 	
-	@Queue(archive = false, name = "GALASA.INPUT.QUEUE2")
+	@Queue(archive = false, name = "DEV.QUEUE.2", queueMgrTag = "bob")
 	public IMessageQueue queue2;
 	
 //	@Queue(tag = "NEWQUEUE")

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/bnd.bnd
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/bnd.bnd
@@ -1,7 +1,8 @@
 -snapshot: ${tstamp}
 Bundle-Name: MQ Manager
 Export-Package: !dev.galasa.mq.internal*,\
-        dev.galasa.mq*
+        dev.galasa.mq*,\
+        javax.jms*
 Import-Package: !javax.validation.constraints,\
         dev.galasa,\
         dev.galasa.framework.spi,\
@@ -17,5 +18,6 @@ Import-Package: !javax.validation.constraints,\
 Embed-Transitive: true
 Embed-Dependency: *;scope=compile
 -includeresource: com.ibm.mq.allclient-*.jar; lib:=true,\
-    javax.jms-api-*.jar; lib:=true
+    javax.jms-api-*.jar; lib:=true,\
+    json-*.jar; lib:=true
     

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/build.gradle
@@ -5,10 +5,10 @@ plugins {
 description = 'MQ Manager'
 
 dependencies {
-    implementation 'javax.jms:javax.jms-api'
+    api 'javax.jms:javax.jms-api'
     implementation 'com.ibm.mq:com.ibm.mq.allclient'
 	implementation 'commons-codec:commons-codec'
-  
+    implementation 'org.json:json'  
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 
         api 'com.ibm.db2.jcc:db2jcc:db2jcc4'
 
-        api 'com.ibm.mq:com.ibm.mq.allclient:9.2.3.0'
+        api 'com.ibm.mq:com.ibm.mq.allclient:9.4.5.0'
 
         api 'com.github.mwiede:jsch:2.27.6'
 
@@ -254,9 +254,9 @@ dependencies {
 
         api 'org.bitbucket.b_c:jose4j:0.9.6'
 
-        api 'org.bouncycastle:bcpkix-jdk18on:1.82'
-        api 'org.bouncycastle:bcprov-jdk18on:1.82'
-        api 'org.bouncycastle:bcutil-jdk18on:1.82'
+        api 'org.bouncycastle:bcpkix-jdk18on:1.83'
+        api 'org.bouncycastle:bcprov-jdk18on:1.83'
+        api 'org.bouncycastle:bcutil-jdk18on:1.83'
 
         api 'org.checkerframework:checker-qual:3.43.0'
         api 'org.codehaus.mojo:animal-sniffer-annotations:1.24'
@@ -264,6 +264,8 @@ dependencies {
         api 'org.codehaus.plexus:plexus-utils:3.0.24'
 
         api 'org.jetbrains.kotlin:kotlin-osgi-bundle:2.2.0'
+
+        api 'org.json:json:20251224'
 
         api 'org.junit.jupiter:junit-jupiter:5.10.2'
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2543. 

## Changes
- [x] Bumped `com.ibm.mq:com.ibm.mq.allclient` from `9.2.3.0` to `9.4.5.0` to remove vulnerabilities in transitive dependencies
  - [x] Bumped transitive dependencies to avoid OSGi errors - see https://mvnrepository.com/artifact/com.ibm.mq/com.ibm.mq.allclient/9.4.5.0/dependencies
- [x] Added README to the MQ manager IVTs project to guide other developers on how to run the MQ IVTs and updated the IVTs to work with the instructions