### PR TITLE
Fill in a test run's structure with as many details as possible earlier in the test run's lifecycle

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -210,26 +210,8 @@ public class BaseTestRunner {
      * @return A TestStructure which is written into the RAS eventually.
      */
     protected TestStructure createNewTestStructure(IRun run) {
-        TestStructure testStructure = new TestStructure();
-
-        String runName = run.getName();
-        String group = run.getGroup();
-        String submissionId = run.getSubmissionId();
-        Instant queuedAt = run.getQueued();
-        String requestor = AbstractManager.defaultString(run.getRequestor(), "unknown");
-        String user = AbstractManager.defaultString(run.getUser(), "unknown");          
-
-        testStructure.setQueued(queuedAt);
+        TestStructure testStructure = run.toTestStructure();
         testStructure.setStartTime(Instant.now());
-        testStructure.setRunName(runName);
-        testStructure.setRequestor(requestor);
-        testStructure.setUser(user);
-        testStructure.setGroup(group);
-        testStructure.setSubmissionId(submissionId);
-        
-        for( String tag : run.getTags()) {
-            testStructure.addTag(tag);
-        }
 
         return testStructure;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -95,6 +95,7 @@ public class GherkinTestRunner extends BaseTestRunner {
                 updateStatus(TestRunLifecycleStatus.STARTED, "started");
                 
             } catch (Exception ex) {
+                this.testStructure.setResult(Result.envfail(ex).getName());
                 updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
                 throw new TestRunException(ex.getMessage(),ex);
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -104,6 +104,7 @@ public class TestRunner extends BaseTestRunner {
 
 
             } catch (Exception ex) {
+                this.testStructure.setResult(Result.envfail(ex).getName());
                 updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
                 throw new TestRunException(ex.getMessage(),ex);
             }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestTestRunner.java
@@ -176,14 +176,14 @@ public class TestTestRunner {
 
         // initial setup.
         assertThat(rasHistory.get(0)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
-            .containsExactly("myTestRun",null,null, null, "daffyduck", null,null);
+            .containsExactly("myTestRun","myTestBundle","dev.galasa.framework.MyActualTestClass", null, "daffyduck", null,null);
 
         // Check that the RAS structure is populated with tags from the outset.
         assertThat(rasHistory.get(0).getTags()).containsOnly("tag1","tag2");
 
         // status = started
         assertThat(rasHistory.get(1)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
-            .containsExactly("myTestRun",null,null, null, "daffyduck", "started",null);
+            .containsExactly("myTestRun", "myTestBundle", "dev.galasa.framework.MyActualTestClass", null, "daffyduck", "started",null);
 
         // status = generating
         assertThat(rasHistory.get(2)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
@@ -420,11 +420,11 @@ public class TestTestRunner {
 
         // initial setup.
         assertThat(rasHistory.get(0)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
-            .containsExactly("myTestRun",null,null, null, "daffyduck", null,null);
+            .containsExactly("myTestRun", "myTestBundle", "dev.galasa.framework.MyActualTestClass", null, "daffyduck", null,null);
 
         // status = started
         assertThat(rasHistory.get(1)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")
-            .containsExactly("myTestRun",null,null, null, "daffyduck", "started",null);
+            .containsExactly("myTestRun", "myTestBundle", "dev.galasa.framework.MyActualTestClass", null, "daffyduck", "started",null);
 
         // status = finished
         assertThat(rasHistory.get(2)).extracting("runName","bundle", "testName", "testShortName", "requestor", "status", "result")


### PR DESCRIPTION
## Why?
Refer to https://github.com/galasa-dev/projectmanagement/issues/2550.

## Changes
- [x] Updated the test runner's `createNewTestStructure` method to use the run's existing `toTestStructure()` method which fills the test structure with more details than it was previously setting (including the bundle name, class name, test short name, etc.)
- [x] When OBR loading fails and an exception is thrown, the test runner will now set the result of the test run to `EnvFail` rather than leaving it as `UNKNOWN`
- [x] Updated existing unit tests to check that details like the bundle name and test class name are populated correctly


### How this affects the web UI
**Before:**
<img width="525" height="671" alt="Screenshot 2026-02-25 at 15 22 13" src="https://github.com/user-attachments/assets/96417c43-2b59-42b1-a6d0-3277a62a5500" />

**After:**
<img width="495" height="601" alt="Screenshot 2026-02-25 at 15 23 17" src="https://github.com/user-attachments/assets/cc216ad3-9646-4465-9dda-c482c738c74c" />
