### PR TITLE
CLI: Show the web-ui-url field only for remote runs and populate web-ui-url and tags in summary output

### DIFF
--- a/modules/cli/pkg/launcher/jvmLauncher.go
+++ b/modules/cli/pkg/launcher/jvmLauncher.go
@@ -587,6 +587,11 @@ func (launcher *JvmLauncher) GetTestCatalog(stream string) (TestCatalog, error) 
 	return nil, nil
 }
 
+// IsLocal returns true as this launcher runs tests locally
+func (launcher *JvmLauncher) IsLocal() bool {
+	return true
+}
+
 // -----------------------------------------------------------------------------
 // Local functions
 // -----------------------------------------------------------------------------

--- a/modules/cli/pkg/launcher/launcher.go
+++ b/modules/cli/pkg/launcher/launcher.go
@@ -45,4 +45,7 @@ type Launcher interface {
 
 	// GetTestCatalog gets the test catalog for a given stream.
 	GetTestCatalog(stream string) (TestCatalog, error)
+
+	// IsLocal returns true if this launcher runs tests locally, false if remote
+	IsLocal() bool
 }

--- a/modules/cli/pkg/launcher/launcherMock.go
+++ b/modules/cli/pkg/launcher/launcherMock.go
@@ -145,3 +145,8 @@ func (launcher *MockLauncher) GetStreams() ([]string, error) {
 func (launcher *MockLauncher) GetTestCatalog(stream string) (TestCatalog, error) {
 	return nil, nil
 }
+
+// IsLocal returns false for the mock launcher
+func (launcher *MockLauncher) IsLocal() bool {
+	return false
+}

--- a/modules/cli/pkg/launcher/remoteLauncher.go
+++ b/modules/cli/pkg/launcher/remoteLauncher.go
@@ -320,6 +320,11 @@ func (launcher *RemoteLauncher) GetTestCatalog(stream string) (TestCatalog, erro
 			}
 		}
 	}
-
-	return testCatalog, err
-}
+	
+		return testCatalog, err
+	}
+	
+	// IsLocal returns false as this launcher runs tests remotely
+	func (launcher *RemoteLauncher) IsLocal() bool {
+		return false
+	}

--- a/modules/cli/pkg/runs/runTypes.go
+++ b/modules/cli/pkg/runs/runTypes.go
@@ -24,6 +24,8 @@ type TestRun struct {
 	SubmissionId   string            `yaml:"submissionId" json:"submissionId"`
 	RunId          string            `yaml:"runId,omitempty" json:"runId,omitempty"`
 	Tags           []string          `yaml:"tags,omitempty" json:"tags,omitempty"`
+	IsLocal        bool              `yaml:"isLocal,omitempty" json:"isLocal,omitempty"`
+	WebUiUrl       string            `yaml:"webUiUrl,omitempty" json:"webUiUrl,omitempty"`
 }
 
 type TestMethod struct {

--- a/modules/cli/pkg/runs/runsConverter.go
+++ b/modules/cli/pkg/runs/runsConverter.go
@@ -171,6 +171,8 @@ func getTestRunData(run TestRun, isLost bool) runsformatter.FormattableTest {
 	newFormattableTest.Lost = isLost
 	newFormattableTest.Group = run.Group
 	newFormattableTest.Tags = run.Tags
+	newFormattableTest.IsLocal = run.IsLocal
+	newFormattableTest.WebUiUrl = run.WebUiUrl
 
 	return newFormattableTest
 }

--- a/modules/cli/pkg/runs/submitter.go
+++ b/modules/cli/pkg/runs/submitter.go
@@ -360,6 +360,12 @@ func (submitter *Submitter) submitRun(
 				}
 				nextRun.Name = *submittedRun.Name
 
+				nextRun.Tags = submittedRun.GetTags()
+
+				if submittedRun.WebUiUrl != nil {
+					nextRun.WebUiUrl = *submittedRun.WebUiUrl
+				}
+
 				submittedRuns[nextRun.Name] = &nextRun
 
 				if nextRun.GherkinUrl != "" {
@@ -630,6 +636,7 @@ func (submitter *Submitter) buildListOfRunsToSubmit(portfolio *Portfolio, runOve
 	log.Printf("buildListOfRunsToSubmit - portfolio %v, runOverrides %v", portfolio, runOverrides)
 	readyRuns := make([]TestRun, 0, len(portfolio.Classes))
 	currentSystemUser := submitter.GetCurrentSystemUserName()
+	isLocal := submitter.launcher.IsLocal()
 	for _, portfolioTest := range portfolio.Classes {
 		newTestrun := TestRun{
 			Bundle:         portfolioTest.Bundle,
@@ -642,6 +649,7 @@ func (submitter *Submitter) buildListOfRunsToSubmit(portfolio *Portfolio, runOve
 			Overrides:      make(map[string]string, 0),
 			GherkinUrl:     portfolioTest.GherkinUrl,
 			GherkinFeature: submitter.getFeatureFromGherkinUrl(portfolioTest.GherkinUrl),
+			IsLocal:        isLocal,
 		}
 
 		// load the run overrides

--- a/modules/cli/pkg/runsformatter/runsFormatter.go
+++ b/modules/cli/pkg/runsformatter/runsFormatter.go
@@ -74,6 +74,7 @@ type FormattableTest struct {
 	Tags          []string
 	WebUiUrl      string
 	RestApiUrl    string
+	IsLocal       bool
 }
 
 func NewFormattableTest() FormattableTest {

--- a/modules/cli/pkg/runsformatter/summaryFormatter.go
+++ b/modules/cli/pkg/runsformatter/summaryFormatter.go
@@ -45,7 +45,20 @@ func (*SummaryFormatter) FormatRuns(testResultsData []FormattableTest) (string, 
 	if totalResults > 0 {
 		var table [][]string
 
-		var headers = []string{HEADER_SUBMITTED_TIME, HEADER_RUNNAME, HEADER_REQUESTOR, HEADER_STATUS, HEADER_RESULT, HEADER_TEST_NAME, HEADER_GROUP, HEADER_TAGS, HEADER_WEBUI_URL}
+		includeWebUiUrl := false
+		for _, run := range testResultsData {
+			if !run.IsLocal {
+				includeWebUiUrl = true
+				break
+			}
+		}
+
+		var headers []string
+		if includeWebUiUrl {
+			headers = []string{HEADER_SUBMITTED_TIME, HEADER_RUNNAME, HEADER_REQUESTOR, HEADER_STATUS, HEADER_RESULT, HEADER_TEST_NAME, HEADER_GROUP, HEADER_TAGS, HEADER_WEBUI_URL}
+		} else {
+			headers = []string{HEADER_SUBMITTED_TIME, HEADER_RUNNAME, HEADER_REQUESTOR, HEADER_STATUS, HEADER_RESULT, HEADER_TEST_NAME, HEADER_GROUP, HEADER_TAGS}
+		}
 
 		table = append(table, headers)
 		for _, run := range testResultsData {
@@ -59,7 +72,11 @@ func (*SummaryFormatter) FormatRuns(testResultsData []FormattableTest) (string, 
 				accumulateResults(resultCountsMap, run)
 
 				tagsList := strings.Join(run.Tags[:], ",")
-				line = append(line, submittedTimeReadable, run.Name, run.Requestor, run.Status, run.Result, run.TestName, run.Group, tagsList, run.WebUiUrl)
+				if includeWebUiUrl {
+					line = append(line, submittedTimeReadable, run.Name, run.Requestor, run.Status, run.Result, run.TestName, run.Group, tagsList, run.WebUiUrl)
+				} else {
+					line = append(line, submittedTimeReadable, run.Name, run.Requestor, run.Status, run.Result, run.TestName, run.Group, tagsList)
+				}
 				table = append(table, line)
 			}
 		}


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2553. 

## Changes
- [x] The `web-ui-url` field no longer appears for local test runs
- [x] The `web-ui-url` field now gets populated when remote test runs finish
- [x] The `tags` field also gets populated when both local and remote runs finish
- [x] Unit tests
