### PR TITLE
James c iss2536 ras health endpoint

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/src/main/java/dev/galasa/extensions/common/couchdb/CouchdbStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/src/main/java/dev/galasa/extensions/common/couchdb/CouchdbStore.java
@@ -36,6 +36,7 @@ import dev.galasa.extensions.common.api.HttpClientFactory;
 import dev.galasa.extensions.common.api.HttpRequestFactory;
 import dev.galasa.extensions.common.couchdb.pojos.IdRev;
 import dev.galasa.extensions.common.couchdb.pojos.PutPostResponse;
+import dev.galasa.extensions.common.couchdb.pojos.UpResponse;
 import dev.galasa.extensions.common.couchdb.pojos.ViewResponse;
 import dev.galasa.extensions.common.couchdb.pojos.ViewRow;
 import dev.galasa.framework.spi.utils.GalasaGson;
@@ -325,5 +326,17 @@ public abstract class CouchdbStore {
             }
         }
         return isExpectedStatusCode;
+    }
+
+    /**
+     * Checks the health status of the CouchDB server by calling the /_up endpoint.
+     * 
+     * @return UpResponse containing the health status
+     * @throws CouchdbException if there was a problem accessing the CouchDB store
+     */
+    public UpResponse getHealth() throws CouchdbException {
+        HttpGet getHealthRequest = httpRequestFactory.getHttpGetRequest(storeUri + "/_up");
+        String responseEntity = sendHttpRequest(getHealthRequest, HttpStatus.SC_OK);
+        return gson.fromJson(responseEntity, UpResponse.class);
     }
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/src/main/java/dev/galasa/extensions/common/couchdb/pojos/UpResponse.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/src/main/java/dev/galasa/extensions/common/couchdb/pojos/UpResponse.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.extensions.common.couchdb.pojos;
+
+public class UpResponse {
+    public String status;
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
@@ -544,4 +544,15 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
 
         return runs;
     }
+    
+    @Override
+    public boolean isHealthy() {
+        try {
+            store.getHealth();
+            return true;
+        } catch (CouchdbException e) {
+            logger.warn("RAS health check failed", e);
+            return false;
+        }
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -164,7 +164,6 @@ public enum ServletErrorMessage {
     GAL5104_INVALID_CALLBACK_URL_PROVIDED             (5104, "E: Invalid callback URL provided. The callback URL must be a valid URL. Check your request parameters and try again."),
     GAL5105_INTERNAL_DSS_ERROR                        (5105, "E: Error occurred when trying to access the Dynamic Status Store. Report the problem to your Galasa Ecosystem owner."),
 
-
     // RBAC APIs...
     GAL5119_USER_CANNOT_UPDATE_OWN_PRIORITY           (5119, "E: A user is not allowed to update their own priority. Ask a Galasa service administrator to change your priority instead."),
     GAL5120_INVALID_ACTION_NAME_PROVIDED              (5120, "E: Invalid action name provided."),
@@ -210,6 +209,9 @@ public enum ServletErrorMessage {
     GAL5446_ERROR_SETTING_TAG                         (5446, "E: Internal server error occurred when trying to set the tag with the given name. Report the problem to your Galasa service administrator"),
     GAL5447_MISSING_REQUIRED_TAG_FIELD                (5447, "E: Invalid GalasaTag provided. The required field ''{0}'' was missing from the request payload. Check your request payload and try again."),
     GAL5448_INVALID_TAG_PRIORITY_PROVIDED             (5448, "E: Invalid tag priority provided. The tag priority must be a whole number. Check your request payload and try again."),
+
+    // RAS Health API
+    GAL5449_RAS_NOT_AVAILABLE                         (5449, "E: The RAS is not available for requests at this time. The RAS might be experiencing server issues. Contact your Galasa service administrator."),
     ;
 
     // >>>
@@ -218,7 +220,7 @@ public enum ServletErrorMessage {
     // >>>       Unit tests guarantee that this number is 'free' to use for a new error message.
     // >>>       If you do use this number for a new error template, please incriment this value.
     // >>>
-    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5449;
+    public static final int GALxxx_NEXT_MESSAGE_NUMBER_TO_USE = 5450;
 
 
     private String template ;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1464,6 +1464,46 @@ paths:
 ##################################################################################
 
   #--------------------------------------
+  # Get the health status of the RAS.
+  #--------------------------------------
+  /ras/health:
+    parameters:
+      - $ref: '#/components/parameters/ClientApiVersion'
+    get:
+      operationId: getRasHealth
+      summary: Get the health status of the RAS
+      description: |
+        Returns the health status of the Result Archive Store (RAS).
+        
+        This endpoint checks if the RAS is available and responding to requests.
+      tags:
+      - Result Archive Store API
+      security: []
+      responses:
+        '200':
+          description: RAS is healthy and available
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: "ok"
+        '503':
+          description: RAS is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              examples:
+                rasdown:
+                  value:
+                    error_code: 5449
+                    error_message: "The RAS is not available for requests at this time. The RAS might be experiencing server issues. Contact your Galasa service administrator."
+                  summary: RAS is down or unreachable
+
+  #--------------------------------------
   # List all known requestors.
   #--------------------------------------
   /ras/requestors:

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/RasServlet.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/RasServlet.java
@@ -13,6 +13,7 @@ import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.FileSystem;
 import dev.galasa.framework.IFileSystem;
+import dev.galasa.framework.api.ras.internal.routes.RasHealthRoute;
 import dev.galasa.framework.api.ras.internal.routes.RequestorRoute;
 import dev.galasa.framework.api.ras.internal.routes.ResultNamesRoute;
 import dev.galasa.framework.api.ras.internal.routes.RunArtifactsDownloadRoute;
@@ -61,6 +62,7 @@ public class RasServlet extends BaseServlet {
 		super.init();
 
 		try {
+			addRoute(new RasHealthRoute(getResponseBuilder(), framework));
 			addRoute(new RunDetailsRoute(getResponseBuilder(), framework, env));
 			addRoute(new RunLogRoute(getResponseBuilder(), framework));
 			addRoute(new RunArtifactsListRoute(getResponseBuilder(), fileSystem, framework));

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RasHealthRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RasHealthRoute.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.ras.internal.routes;
+
+import static dev.galasa.framework.api.common.ServletErrorMessage.*;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.gson.JsonObject;
+
+import dev.galasa.framework.api.common.BaseRoute;
+import dev.galasa.framework.api.common.HttpRequestContext;
+import dev.galasa.framework.api.common.InternalServletException;
+import dev.galasa.framework.api.common.QueryParameters;
+import dev.galasa.framework.api.common.ResponseBuilder;
+import dev.galasa.framework.api.common.ServletError;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IFramework;
+import dev.galasa.framework.spi.IResultArchiveStoreDirectoryService;
+import dev.galasa.framework.spi.rbac.BuiltInAction;
+
+/**
+ * Route to check the health status of the Result Archive Store (RAS).
+ * This endpoint is publicly accessible (no authentication required).
+ */
+public class RasHealthRoute extends BaseRoute {
+
+    protected static final String path = "\\/health\\/?";
+
+    private IFramework framework;
+
+    public RasHealthRoute(ResponseBuilder responseBuilder, IFramework framework) {
+        /*
+         * Regex to match endpoints:
+         * -> /ras/health
+         * -> /ras/health/
+         */
+        super(responseBuilder, path);
+        this.framework = framework;
+    }
+
+    @Override
+    public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,
+            HttpRequestContext requestContext, HttpServletResponse response)
+            throws ServletException, IOException, FrameworkException {
+
+        HttpServletRequest request = requestContext.getRequest();
+
+        boolean isHealthy = checkRasHealth();
+
+        if (isHealthy) {
+            JsonObject healthResponse = new JsonObject();
+            healthResponse.addProperty("status", "ok");
+            String outputString = healthResponse.toString();
+            return getResponseBuilder().buildResponse(request, response, "application/json",
+                    outputString, HttpServletResponse.SC_OK);
+        } else {
+            ServletError error = new ServletError(GAL5449_RAS_NOT_AVAILABLE);
+            throw new InternalServletException(error, HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        }
+    }
+
+    /**
+     * Checks if the RAS is healthy by querying all directory services.
+     * 
+     * @return true if at least one RAS directory service is healthy, false
+     *         otherwise
+     */
+    private boolean checkRasHealth() {
+        try {
+            for (IResultArchiveStoreDirectoryService directoryService : framework.getResultArchiveStore()
+                    .getDirectoryServices()) {
+                if (directoryService.isHealthy()) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isActionPermitted(BuiltInAction action, String loginId) throws InternalServletException {
+        // Health endpoint is publicly accessible, no authentication required
+        return true;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RasHealthRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RasHealthRoute.java
@@ -14,22 +14,21 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.google.gson.JsonObject;
 
-import dev.galasa.framework.api.common.BaseRoute;
 import dev.galasa.framework.api.common.HttpRequestContext;
 import dev.galasa.framework.api.common.InternalServletException;
+import dev.galasa.framework.api.common.PublicRoute;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IResultArchiveStoreDirectoryService;
-import dev.galasa.framework.spi.rbac.BuiltInAction;
 
 /**
  * Route to check the health status of the Result Archive Store (RAS).
  * This endpoint is publicly accessible (no authentication required).
  */
-public class RasHealthRoute extends BaseRoute {
+public class RasHealthRoute extends PublicRoute {
 
     protected static final String path = "\\/health\\/?";
 
@@ -84,11 +83,5 @@ public class RasHealthRoute extends BaseRoute {
         } catch (Exception e) {
             return false;
         }
-    }
-
-    @Override
-    public boolean isActionPermitted(BuiltInAction action, String loginId) throws InternalServletException {
-        // Health endpoint is publicly accessible, no authentication required
-        return true;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RasHealthRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RasHealthRoute.java
@@ -51,7 +51,7 @@ public class RasHealthRoute extends PublicRoute {
 
         HttpServletRequest request = requestContext.getRequest();
 
-        boolean isHealthy = checkRasHealth();
+        boolean isHealthy = isRasHealthy();
 
         if (isHealthy) {
             JsonObject healthResponse = new JsonObject();
@@ -71,7 +71,7 @@ public class RasHealthRoute extends PublicRoute {
      * @return true if at least one RAS directory service is healthy, false
      *         otherwise
      */
-    private boolean checkRasHealth() {
+    private boolean isRasHealthy() {
         try {
             for (IResultArchiveStoreDirectoryService directoryService : framework.getResultArchiveStore()
                     .getDirectoryServices()) {
@@ -79,9 +79,7 @@ public class RasHealthRoute extends PublicRoute {
                     return true;
                 }
             }
-            return false;
-        } catch (Exception e) {
-            return false;
-        }
+        } catch (Exception e) { }
+        return false;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRasHealthRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRasHealthRoute.java
@@ -5,6 +5,7 @@
  */
 package dev.galasa.framework.api.ras.internal.routes;
 
+import dev.galasa.framework.api.common.HttpMethod;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.ras.internal.RasServlet;
 import dev.galasa.framework.api.ras.internal.RasServletTest;
@@ -52,6 +53,19 @@ public class TestRasHealthRoute extends RasServletTest {
 
     // Then...
     assertThat(matches).isTrue();
+  }
+
+    @Test
+  public void testPathRegexDoesNotMatchHealthEndpointWithMultipleTrailingSlashes() {
+    // Given...
+    String expectedPath = RasHealthRoute.path;
+    String inputPath = "/health//";
+
+    // When...
+    boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+
+    // Then...
+    assertThat(matches).isFalse();
   }
 
   @Test
@@ -152,6 +166,7 @@ public class TestRasHealthRoute extends RasServletTest {
     List<IRunResult> mockInputRunResults = new ArrayList<>();
     Map<String, String[]> parameterMap = new HashMap<>();
     MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/health");
+    mockRequest.setMethod(HttpMethod.POST.toString());
 
     MockResultArchiveStoreDirectoryService mockRasStore = new MockResultArchiveStoreDirectoryService(
         mockInputRunResults);
@@ -178,6 +193,7 @@ public class TestRasHealthRoute extends RasServletTest {
     List<IRunResult> mockInputRunResults = new ArrayList<>();
     Map<String, String[]> parameterMap = new HashMap<>();
     MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/health");
+    mockRequest.setMethod(HttpMethod.PUT.toString());
 
     MockResultArchiveStoreDirectoryService mockRasStore = new MockResultArchiveStoreDirectoryService(
         mockInputRunResults);
@@ -204,6 +220,7 @@ public class TestRasHealthRoute extends RasServletTest {
     List<IRunResult> mockInputRunResults = new ArrayList<>();
     Map<String, String[]> parameterMap = new HashMap<>();
     MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/health");
+    mockRequest.setMethod(HttpMethod.DELETE.toString());
 
     MockResultArchiveStoreDirectoryService mockRasStore = new MockResultArchiveStoreDirectoryService(
         mockInputRunResults);
@@ -224,5 +241,3 @@ public class TestRasHealthRoute extends RasServletTest {
     assertThat(resp.getStatus()).isEqualTo(405);
   }
 }
-
-// Made with Bob

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRasHealthRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRasHealthRoute.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.ras.internal.routes;
+
+import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
+import dev.galasa.framework.api.ras.internal.RasServlet;
+import dev.galasa.framework.api.ras.internal.RasServletTest;
+import dev.galasa.framework.api.ras.internal.mocks.MockRasServletEnvironment;
+import dev.galasa.framework.mocks.MockResultArchiveStoreDirectoryService;
+import dev.galasa.framework.spi.IRunResult;
+import dev.galasa.framework.spi.ResultArchiveStoreException;
+
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class TestRasHealthRoute extends RasServletTest {
+
+  @Test
+  public void testPathRegexMatchesHealthEndpoint() {
+    // Given...
+    String expectedPath = RasHealthRoute.path;
+    String inputPath = "/health";
+
+    // When...
+    boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+
+    // Then...
+    assertThat(matches).isTrue();
+  }
+
+  @Test
+  public void testPathRegexMatchesHealthEndpointWithTrailingSlash() {
+    // Given...
+    String expectedPath = RasHealthRoute.path;
+    String inputPath = "/health/";
+
+    // When...
+    boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+
+    // Then...
+    assertThat(matches).isTrue();
+  }
+
+  @Test
+  public void testHealthEndpointWithHealthyRasReturnsOkStatus() throws Exception {
+    // Given...
+    List<IRunResult> mockInputRunResults = new ArrayList<>();
+    Map<String, String[]> parameterMap = new HashMap<>();
+    MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/health");
+
+    MockResultArchiveStoreDirectoryService mockRasStore = new MockResultArchiveStoreDirectoryService(
+        mockInputRunResults);
+    mockRasStore.setHealthy(true);
+
+    MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest,
+        mockRasStore);
+
+    RasServlet servlet = mockServletEnvironment.getServlet();
+    HttpServletRequest req = mockServletEnvironment.getRequest();
+    HttpServletResponse resp = mockServletEnvironment.getResponse();
+    ServletOutputStream outStream = resp.getOutputStream();
+
+    // When...
+    servlet.init();
+    servlet.doGet(req, resp);
+
+    // Then...
+    JsonObject expectedJson = new JsonObject();
+    expectedJson.addProperty("status", "ok");
+
+    assertThat(resp.getStatus()).isEqualTo(200);
+    assertThat(outStream.toString()).isEqualTo(expectedJson.toString());
+    assertThat(resp.getContentType()).isEqualTo("application/json");
+  }
+
+  @Test
+  public void testHealthEndpointWithUnhealthyRasReturnsServiceUnavailable() throws Exception {
+    // Given...
+    List<IRunResult> mockInputRunResults = new ArrayList<>();
+    Map<String, String[]> parameterMap = new HashMap<>();
+    MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/health");
+
+    MockResultArchiveStoreDirectoryService mockRasStore = new MockResultArchiveStoreDirectoryService(
+        mockInputRunResults);
+    mockRasStore.setHealthy(false);
+
+    MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest,
+        mockRasStore);
+
+    RasServlet servlet = mockServletEnvironment.getServlet();
+    HttpServletRequest req = mockServletEnvironment.getRequest();
+    HttpServletResponse resp = mockServletEnvironment.getResponse();
+
+    // When...
+    servlet.init();
+    servlet.doGet(req, resp);
+
+    // Then...
+    assertThat(resp.getStatus()).isEqualTo(503);
+    assertThat(resp.getContentType()).isEqualTo("application/json");
+
+    String responseBody = resp.getOutputStream().toString();
+    assertThat(responseBody).contains("GAL5449");
+  }
+
+  @Test
+  public void testHealthEndpointWithExceptionInHealthCheckReturnsServiceUnavailable() throws Exception {
+    // Given...
+    List<IRunResult> mockInputRunResults = new ArrayList<>();
+    Map<String, String[]> parameterMap = new HashMap<>();
+    MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/health");
+
+    MockResultArchiveStoreDirectoryService mockRasStore = new MockResultArchiveStoreDirectoryService(
+        mockInputRunResults) {
+      @Override
+      public boolean isHealthy() throws ResultArchiveStoreException {
+        throw new ResultArchiveStoreException("Simulated RAS exception");
+      }
+    };
+
+    MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest,
+        mockRasStore);
+
+    RasServlet servlet = mockServletEnvironment.getServlet();
+    HttpServletRequest req = mockServletEnvironment.getRequest();
+    HttpServletResponse resp = mockServletEnvironment.getResponse();
+
+    // When...
+    servlet.init();
+    servlet.doGet(req, resp);
+
+    // Then...
+    assertThat(resp.getStatus()).isEqualTo(503);
+  }
+
+  @Test
+  public void testHealthEndpointWithPostRequestReturnsMethodNotAllowed() throws Exception {
+    // Given...
+    List<IRunResult> mockInputRunResults = new ArrayList<>();
+    Map<String, String[]> parameterMap = new HashMap<>();
+    MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/health");
+
+    MockResultArchiveStoreDirectoryService mockRasStore = new MockResultArchiveStoreDirectoryService(
+        mockInputRunResults);
+    mockRasStore.setHealthy(true);
+
+    MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest,
+        mockRasStore);
+
+    RasServlet servlet = mockServletEnvironment.getServlet();
+    HttpServletRequest req = mockServletEnvironment.getRequest();
+    HttpServletResponse resp = mockServletEnvironment.getResponse();
+
+    // When...
+    servlet.init();
+    servlet.doPost(req, resp);
+
+    // Then...
+    assertThat(resp.getStatus()).isEqualTo(405);
+  }
+
+  @Test
+  public void testHealthEndpointWithPutRequestReturnsMethodNotAllowed() throws Exception {
+    // Given...
+    List<IRunResult> mockInputRunResults = new ArrayList<>();
+    Map<String, String[]> parameterMap = new HashMap<>();
+    MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/health");
+
+    MockResultArchiveStoreDirectoryService mockRasStore = new MockResultArchiveStoreDirectoryService(
+        mockInputRunResults);
+    mockRasStore.setHealthy(true);
+
+    MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest,
+        mockRasStore);
+
+    RasServlet servlet = mockServletEnvironment.getServlet();
+    HttpServletRequest req = mockServletEnvironment.getRequest();
+    HttpServletResponse resp = mockServletEnvironment.getResponse();
+
+    // When...
+    servlet.init();
+    servlet.doPut(req, resp);
+
+    // Then...
+    assertThat(resp.getStatus()).isEqualTo(405);
+  }
+
+  @Test
+  public void testHealthEndpointWithDeleteRequestReturnsMethodNotAllowed() throws Exception {
+    // Given...
+    List<IRunResult> mockInputRunResults = new ArrayList<>();
+    Map<String, String[]> parameterMap = new HashMap<>();
+    MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/health");
+
+    MockResultArchiveStoreDirectoryService mockRasStore = new MockResultArchiveStoreDirectoryService(
+        mockInputRunResults);
+    mockRasStore.setHealthy(true);
+
+    MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest,
+        mockRasStore);
+
+    RasServlet servlet = mockServletEnvironment.getServlet();
+    HttpServletRequest req = mockServletEnvironment.getRequest();
+    HttpServletResponse resp = mockServletEnvironment.getResponse();
+
+    // When...
+    servlet.init();
+    servlet.doDelete(req, resp);
+
+    // Then...
+    assertThat(resp.getStatus()).isEqualTo(405);
+  }
+}
+
+// Made with Bob

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASDirectoryService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASDirectoryService.java
@@ -256,4 +256,10 @@ public class DirectoryRASDirectoryService implements IResultArchiveStoreDirector
         return matchingRuns;
 
     }
+
+    @Override
+    public boolean isHealthy() throws ResultArchiveStoreException {
+        // Assume file system always healthy
+        return true;
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStoreDirectoryService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStoreDirectoryService.java
@@ -54,4 +54,11 @@ public interface IResultArchiveStoreDirectoryService {
 
     List<IRunResult> getRunsByGroupName(@NotNull String groupName) throws ResultArchiveStoreException;
     
+    /**
+     * Check the health status of the RAS.
+     * 
+     * @return true if the RAS is healthy and available, false otherwise
+     */
+    boolean isHealthy() throws ResultArchiveStoreException;
+    
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockResultArchiveStoreDirectoryService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockResultArchiveStoreDirectoryService.java
@@ -23,10 +23,6 @@ public class MockResultArchiveStoreDirectoryService implements IResultArchiveSto
     private String nextCursor;
 		private boolean isHealthy;
 
-		public void setHealthy(boolean isHealthy) {
-			this.isHealthy = isHealthy;
-		}
-
     public MockResultArchiveStoreDirectoryService(List<IRunResult> runsResults) {
         this.runResults = runsResults;
     }
@@ -157,6 +153,10 @@ public class MockResultArchiveStoreDirectoryService implements IResultArchiveSto
             }
         }
         return matchingRuns;
+	}
+
+	public void setHealthy(boolean isHealthy) {
+	    this.isHealthy = isHealthy;
 	}
 
 	@Override

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockResultArchiveStoreDirectoryService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockResultArchiveStoreDirectoryService.java
@@ -21,6 +21,11 @@ public class MockResultArchiveStoreDirectoryService implements IResultArchiveSto
 
     private List<IRunResult> runResults;
     private String nextCursor;
+		private boolean isHealthy;
+
+		public void setHealthy(boolean isHealthy) {
+			this.isHealthy = isHealthy;
+		}
 
     public MockResultArchiveStoreDirectoryService(List<IRunResult> runsResults) {
         this.runResults = runsResults;
@@ -153,5 +158,10 @@ public class MockResultArchiveStoreDirectoryService implements IResultArchiveSto
         }
         return matchingRuns;
 	}
+
+	@Override
+    public boolean isHealthy() throws ResultArchiveStoreException {
+        return isHealthy;
+    }
 
 }


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2536. 

Added new api route `/ras/health` to replicate the result of CouchDB's `_GO/` request.

## Changes
- [x] New API route `/ras/health`
- [x] Unit tests (if applicable)
