### PR TITLE
Add test timeout monitor and documentation for new property

### DIFF
--- a/docs/content/docs/manage-ecosystem/runs-submit.md
+++ b/docs/content/docs/manage-ecosystem/runs-submit.md
@@ -136,3 +136,15 @@ galasactl runs submit `
     --log - \
     --user my-tester-user
 ```
+
+## Controlling how long tests are allowed to run for
+
+In some situations, tests might seem to stall or run indefinitely due to issues in the test code or wider environmental issues. To prevent tests from hanging indefinitely, you can configure a timeout for test runs using the `framework.test.run.timeout.minutes` CPS property. When a test exceeds the configured timeout period, it is automatically interrupted and assigned the `Hung` result.
+
+For example, to configure a timeout of 30 minutes for test runs, you can set the `framework.test.run.timeout.minutes` CPS property using the Galasa CLI tool:
+
+```shell
+galasactl properties set --bootstrap http://example.com:30960/bootstrap --namespace framework --name test.run.timeout.minutes --value 30
+```
+
+This helps ensure that problematic tests do not consume resources indefinitely and allows you to identify and address issues more quickly.

--- a/docs/content/releases/posts/v0.47.0.md
+++ b/docs/content/releases/posts/v0.47.0.md
@@ -7,6 +7,10 @@ links:
 
 # 0.47.0 - Release Highlights
 
+## Changes affecting tests running locally or on the Galasa Service
+
+- Added a new CPS property `framework.test.run.timeout.minutes` that can be used to configure the maximum amount of time that a test can run for before being interrupted and assigned the 'Hung' result. See [#2551](https://github.com/galasa-dev/projectmanagement/issues/2551).
+
 ## Changes affecting the Galasa Service
 
 - Added new REST API endpoints `POST /streams` and `PUT /streams/<streamName>` to allow users to create and update test streams. See the [REST API reference](../../docs/reference/rest-api/index.html) for more details. See also [#2447](https://github.com/galasa-dev/projectmanagement/issues/2447).

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -44,6 +44,8 @@ import dev.galasa.framework.spi.utils.SystemTimeService;
 
 public class BaseTestRunner {
 
+    private static final long THREAD_SHUTDOWN_TIMEOUT_MS = 2000;
+
     private Log logger = LogFactory.getLog(BaseTestRunner.class);
 
     protected BundleContext bundleContext;
@@ -250,7 +252,7 @@ public class BaseTestRunner {
 
         heartbeat.shutdown();
         try {
-            heartbeat.join(2000);
+            heartbeat.join(THREAD_SHUTDOWN_TIMEOUT_MS);
         } catch (Exception e) {
         }
 
@@ -274,7 +276,7 @@ public class BaseTestRunner {
 
         timeoutMonitor.shutdown();
         try {
-            timeoutMonitor.join(2000);
+            timeoutMonitor.join(THREAD_SHUTDOWN_TIMEOUT_MS);
         } catch (Exception e) {
             logger.error("Error occurred while stopping timeout monitor", e);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunTimeoutMonitor.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunTimeoutMonitor.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IFramework;
+import dev.galasa.framework.spi.Result;
+import dev.galasa.framework.spi.utils.ITimeService;
+
+/**
+ * A thread that monitors the test run duration and interrupts the test if it exceeds
+ * the configured timeout period. This helps prevent tests from hanging indefinitely.
+ */
+public class TestRunTimeoutMonitor extends Thread {
+
+    // Poll every 30 seconds
+    private static final long TIMEOUT_POLL_DELAY_MS = 30 * 1000;
+
+    private final Log logger = LogFactory.getLog(this.getClass());
+
+    private final IFramework framework;
+    private final ITimeService timeService;
+    private final Instant endTime;
+    private final String runName;
+
+    private boolean shutdown = false;
+
+    /**
+     * Creates a new timeout monitor for a test run.
+     *
+     * @param framework the framework instance
+     * @param timeoutMinutes the timeout duration in minutes
+     * @throws FrameworkException if the monitor cannot be initialized
+     */
+    protected TestRunTimeoutMonitor(IFramework framework, long timeoutMinutes, ITimeService timeService) throws FrameworkException {
+        this.framework = framework;
+        this.timeService = timeService;
+
+        this.runName = framework.getTestRunName();
+        this.endTime = timeService.now().plus(timeoutMinutes, ChronoUnit.MINUTES);
+
+        logger.info("Test run timeout monitor initialized. The test run will be interrupted if it runs beyond " + endTime.toString());
+    }
+
+    /**
+     * Shuts down the timeout monitor thread.
+     */
+    public void shutdown() {
+        this.shutdown = true;
+    }
+
+    @Override
+    public void run() {
+        while (!shutdown) {
+            Instant now = timeService.now();
+
+            // Check if the current time has exceeded the end time
+            if (now.isAfter(endTime)) {
+                logger.warn("Test run has exceeded the timeout limit. Interrupting test run: " + runName);
+                interruptTestRun();
+                break;
+            }
+
+            try {
+                timeService.sleepMillis(TIMEOUT_POLL_DELAY_MS);
+            } catch (InterruptedException e) {
+                shutdown = true;
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        logger.info("Test run timeout monitor stopped for run: " + runName);
+    }
+
+    /**
+     * Interrupts the test run by marking it as hung in the DSS.
+     */
+    private void interruptTestRun() {
+        try {
+            logger.info("Marking test run as 'Hung' due to timeout: " + runName);
+            framework.getFrameworkRuns().markRunInterrupted(runName, Result.HUNG);
+        } catch (FrameworkException e) {
+            logger.error("Failed to mark test run as hung", e);
+        }
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -119,6 +119,7 @@ public class TestRunner extends BaseTestRunner {
             switch(this.runType) {
             case TEST:
                 heartbeat = createBeatingHeart(framework);
+                timeoutMonitor = createTimeoutMonitor(framework);
                 incrimentMetric(dss,run);
                 break;
             case SHARED_ENVIRONMENT_BUILD:
@@ -221,6 +222,9 @@ public class TestRunner extends BaseTestRunner {
 
         logger.debug("Stopping heartbeat...");
         stopHeartbeat();
+        
+        logger.debug("Stopping timeout monitor...");
+        stopTimeoutMonitor();
 
         // Record all the CPS properties that were accessed
         saveUsedCPSPropertiesToArtifact(this.framework.getRecordProperties(), this.fileSystem, this.ras);

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestRunTimeoutMonitorTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestRunTimeoutMonitorTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.MockFramework;
+import dev.galasa.framework.mocks.MockFrameworkRuns;
+import dev.galasa.framework.mocks.MockRun;
+import dev.galasa.framework.mocks.MockTimeService;
+import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IFrameworkRuns;
+import dev.galasa.framework.spi.Result;
+import dev.galasa.framework.spi.utils.ITimeService;
+
+public class TestRunTimeoutMonitorTest {
+
+    class MockTimeServiceWithSleepCount extends MockTimeService {
+        int sleepCount = 0;
+
+        public MockTimeServiceWithSleepCount(Instant currentTime) {
+            super(currentTime);
+        }
+
+        @Override
+        public void sleepMillis(long millisToSleep) throws InterruptedException {
+            sleepCount++;
+            super.sleepMillis(millisToSleep);
+        }
+
+        public int getSleepCount() {
+            return sleepCount;
+        }
+    }
+
+    class MockTimeServiceThatThrowsInterrupt extends MockTimeServiceWithSleepCount {
+
+        public MockTimeServiceThatThrowsInterrupt(Instant currentTime) {
+            super(currentTime);
+        }
+
+        @Override
+        public void sleepMillis(long millisToSleep) throws InterruptedException {
+            super.sleepMillis(millisToSleep);
+
+            if (getSleepCount() >= 2) {
+                throw new InterruptedException("Test interrupt");
+            }
+        }
+    }
+
+    @Test
+    public void testRunMethodStopsWhenInterruptOccurs() throws Exception {
+        // Given...
+        String runName = "RUN001";
+        long timeoutMinutes = 60;
+        Instant startTime = Instant.now();
+
+        MockTimeServiceThatThrowsInterrupt timeService = new MockTimeServiceThatThrowsInterrupt(startTime);
+
+        MockRun mockRun = createMockRun(runName);
+        MockFrameworkRuns frameworkRuns = new MockFrameworkRuns(List.of(mockRun));
+        MockFramework framework = createMockFramework(runName, frameworkRuns);
+
+        TestRunTimeoutMonitor monitor = new TestRunTimeoutMonitor(framework, timeoutMinutes, timeService);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        assertThat(mockRun.getInterruptReason()).isNull();
+        assertThat(timeService.getSleepCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void testRunMethodDetectsTimeoutAndInterruptsRun() throws Exception {
+        // Given...
+        String runName = "RUN001";
+        long timeoutMinutes = 1;
+        Instant startTime = Instant.now();
+
+        MockTimeServiceWithSleepCount timeService = new MockTimeServiceWithSleepCount(startTime);
+
+        MockRun mockRun = createMockRun(runName);
+        MockFrameworkRuns frameworkRuns = new MockFrameworkRuns(List.of(mockRun));
+        MockFramework framework = createMockFramework(runName, frameworkRuns);
+
+        TestRunTimeoutMonitor monitor = new TestRunTimeoutMonitor(framework, timeoutMinutes, timeService);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        assertThat(mockRun.getInterruptReason()).isEqualTo(Result.HUNG);
+        assertThat(timeService.getSleepCount()).isEqualTo(3);
+    }
+
+    @Test
+    public void testRunMethodStopsImmediatelyWhenTimeAlreadyExceeded() throws Exception {
+        // Given...
+        String runName = "RUN001";
+        long timeoutMinutes = 1;
+        Instant startTime = Instant.now();
+
+        // Create a time service where current time is already past the timeout
+        ITimeService timeService = new MockTimeService(startTime.plus(2, ChronoUnit.MINUTES));
+
+        MockRun mockRun = createMockRun(runName);
+        MockFrameworkRuns frameworkRuns = new MockFrameworkRuns(List.of(mockRun));
+        MockFramework framework = createMockFramework(runName, frameworkRuns);
+
+        TestRunTimeoutMonitor monitor = new TestRunTimeoutMonitor(framework, timeoutMinutes, timeService);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        assertThat(mockRun.getInterruptReason()).isEqualTo(Result.HUNG);
+    }
+
+    @Test
+    public void testRunMethodHandlesFrameworkExceptionGracefully() throws Exception {
+        // Given...
+        String runName = "RUN001";
+        long timeoutMinutes = 1;
+        Instant startTime = Instant.now();
+
+        ITimeService timeService = new MockTimeService(startTime);
+
+        // Create a framework runs that throws an exception
+        MockFrameworkRuns frameworkRuns = new MockFrameworkRuns(new ArrayList<>()) {
+            @Override
+            public boolean markRunInterrupted(String runName, String interruptReason) throws DynamicStatusStoreException {
+                throw new DynamicStatusStoreException("Simulated framework exception");
+            }
+        };
+
+        MockFramework framework = createMockFramework(runName, frameworkRuns);
+
+        TestRunTimeoutMonitor monitor = new TestRunTimeoutMonitor(framework, timeoutMinutes, timeService);
+
+        // When...
+        monitor.run();
+
+        // Then...
+        // The run method should complete without throwing an exception
+    }
+
+    private MockFramework createMockFramework(String runName, MockFrameworkRuns frameworkRuns) throws FrameworkException {
+        MockFramework framework = new MockFramework() {
+            @Override
+            public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+                return frameworkRuns;
+            }
+        };
+        framework.setTestRunName(runName);
+        return framework;
+    }
+
+    private MockRun createMockRun(String runName) {
+        return new MockRun(
+            "test.bundle",
+            "TestClass",
+            runName,
+            "testStream",
+            "testOBR",
+            "http://repo.url",
+            "testUser",
+            false
+        );
+    }
+}


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2551. 

## Changes
- [x] Added new TestRunTimeoutMonitor that gets started as a separate thread by the test runner if the `framework.test.run.timeout.minutes` CPS property is set. This thread periodically checks whether the test run has been running for longer than the given timeout period, interrupting the run and setting its result to 'Hung' if so

  - **Important note**: This currently works well for remote runs but not local runs. Local runs may continue to hang as there is nothing that continuously monitors the interrupted status of a test run for local runs. The interrupted status of local runs is only checked before and between test method invocations. Further work on the TestRunner would be needed to better support local run timeouts.
- [x] Unit tests
- [x] Documentation updates
- [x] Release notes updates
