### PR TITLE
Remove unused runOverrides parameter from CLI submitter

### DIFF
--- a/modules/cli/pkg/runs/submitter.go
+++ b/modules/cli/pkg/runs/submitter.go
@@ -100,7 +100,7 @@ func (submitter *Submitter) executePortfolio(portfolio *Portfolio,
 	var finishedRuns map[string]*TestRun
 	var lostRuns map[string]*TestRun
 	finishedRuns, lostRuns, err = submitter.executeSubmitRuns(
-		params, readyRuns, runOverrides)
+		params, readyRuns)
 
 	// Report on the results.
 	if err == nil {
@@ -144,7 +144,6 @@ func reportRendedImages(finishedRuns map[string]*TestRun, submitter *Submitter) 
 func (submitter *Submitter) executeSubmitRuns(
 	params utils.RunsSubmitCmdValues,
 	readyRuns []TestRun,
-	runOverrides map[string]string,
 ) (map[string]*TestRun, map[string]*TestRun, error) {
 
 	var err error
@@ -181,7 +180,7 @@ func (submitter *Submitter) executeSubmitRuns(
 		for len(submittedRuns) < throttle && len(readyRuns) > 0 {
 
 			readyRuns, err = submitter.submitRun(params.GroupName, readyRuns, submittedRuns,
-				lostRuns, &runOverrides, params.Trace, currentSystemUser, params.User, params.RequestType, params.Tags)
+				lostRuns, params.Trace, currentSystemUser, params.User, params.RequestType, params.Tags)
 
 			if err != nil {
 				// Ignore the error and continue to process the list of available runs.
@@ -315,7 +314,6 @@ func (submitter *Submitter) submitRun(
 	readyRuns []TestRun,
 	submittedRuns map[string]*TestRun,
 	lostRuns map[string]*TestRun,
-	runOverrides *map[string]string, // This doesn't appear to be used. Why not ?
 	trace bool,
 	requestor string,
 	user string,

--- a/modules/cli/pkg/runs/submitter_test.go
+++ b/modules/cli/pkg/runs/submitter_test.go
@@ -515,14 +515,13 @@ func TestSubmitRunwithGherkinFile(t *testing.T) {
 	readyRuns = append(readyRuns, testRun)
 	submittedRuns := make(map[string]*TestRun)
 	lostRuns := make(map[string]*TestRun)
-	runOverrides := new(map[string]string)
 	trace := false
 	requestor := "galasa"
 	user := "galasa"
 	requestType := ""
 	tags := []string{}
 
-	run, err := submitter.submitRun(groupName, readyRuns, submittedRuns, lostRuns, runOverrides, trace, requestor, user, requestType, tags)
+	run, err := submitter.submitRun(groupName, readyRuns, submittedRuns, lostRuns, trace, requestor, user, requestType, tags)
 	assert.Nil(t, err)
 	assert.Empty(t, run)
 	assert.Contains(t, submittedRuns["M100"].GherkinUrl, "gherkin.feature")


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2545. 

## Changes
- [x] Removed the unused `runOverrides` parameter from functions in submitter.go in the CLI module
