### PR TITLE
Add /ras/health endpoint to the unauthenticated routes enum

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/UnauthenticatedRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/UnauthenticatedRoute.java
@@ -26,6 +26,7 @@ public enum UnauthenticatedRoute {
     BOOTSTRAP_EXTERNAL("/bootstrap", HttpMethod.GET),
     HEALTH("/health", HttpMethod.GET),
     OPENAPI("/openapi", HttpMethod.GET),
+    RAS_HEALTH("/ras/health", HttpMethod.GET),
     ;
 
     private String route;


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2536. 

When going to `GET /ras/health`, the endpoint currently returns a 401 Unauthorized error. This is because the endpoint isn't being considered an "unauthenticated" route, so this PR fixes that.

## Changes
- [x] Added `GET /ras/health` to the enum of unauthenticated routes
