### PR TITLE
Add documentation on Gateway API support for the Galasa service

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -98,10 +98,10 @@
     ],
     "docs/content/docs/ecosystem/ecosystem-installing-k8s.md": [
       {
-        "hashed_secret": "17407b9f6b814464de51ccc98f24c5a54163c6f2",
+        "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 157,
+        "line_number": 244,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
+++ b/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
@@ -2,26 +2,97 @@
 title: "Installing an Ecosystem using Helm"
 ---
 
-If you want to run scalable, highly available testing for enterprise level workloads, you need to install your Galasa Ecosystem in a Kubernetes cluster. Running Galasa in a Kubernetes cluster means that you can run many tests in parallel on a resilient and scalable platform, where the clean-up of test resources can be managed, and test results can be centralised and gathered easily. 
+If you want to run scalable, highly available testing for enterprise level workloads, you need to install your Galasa Ecosystem in a Kubernetes cluster. Running Galasa in a Kubernetes cluster means that you can run many tests in parallel on a resilient and scalable platform, where the clean-up of test resources can be managed, and test results can be centralised and gathered easily.
 
 Galasa provides a Galasa Ecosystem Helm chart to install a Galasa Ecosystem. You can install the chart into a Kubernetes cluster or minikube. However, note that minikube is not suitable for production purposes because it provides a single Kubernetes node and therefore does not scale well. Use minikube only for development and testing purposes.
-
-The following sections explain how to install a Galasa Ecosystem on a Kubernetes cluster (and on minikube) by using Helm and validate that the Ecosystem is installed correctly. 
 
 The [Galasa Helm repository](https://github.com/galasa-dev/helm){target="_blank"} contains the Galasa Ecosystem Helm chart that is referenced in the following sections.
 
 _Note:_ The Galasa Ecosystem Helm chart currently supports only x86-64 systems. It cannot be installed on ARM64-based systems.
 
+## Quick Start
 
-## Prerequisites
+### Prerequisites
 
-- [Helm](https://helm.sh){target="_blank"} must be installed to use the chart. See the [Helm documentation](https://helm.sh/docs/){target="_blank"} for installation instructions.
+- [Helm 3 or later](https://helm.sh/docs/intro/install/){target="_blank"} installed
+- Access to a Kubernetes cluster (v1.28 or later). See [Supported Kubernetes Versions](#supported-kubernetes-versions) for compatibility details.
+- `kubectl` configured to access your cluster
 
-- The Kubernetes command-line tool *kubectl* must be installed on the machine that is used to run the commands and must be configured to point at your Kubernetes cluster. To find out more about Kubernetes, see the [Kubernetes Documentation](https://kubernetes.io/docs/home/){target="_blank"}.
+### Basic Installation Steps
 
-- You must have a Kubernetes cluster at version 1.28 or higher. You can check the version number by running the `kubectl version` command. See the [Supported Kubernetes Versions](#supported-kubernetes-versions) section for a table of Kubernetes versions that are compatible with recent Galasa releases.
+1\. **Add the Galasa Helm repository:**
 
-- If you want to install the chart into minikube, ensure you have minikube installed and that it is running with `minikube status`. If minikube is not running, start it by running `minikube start`. Once minikube is running, follow the instructions in the following sections to install the Galasa Ecosystem Helm chart.
+   ```bash
+   helm repo add galasa https://galasa-dev.github.io/helm
+   helm repo update
+   ```
+
+2\. **Download and configure values:**
+
+   Download the `values.yaml` file for your chosen Galasa version from the [Galasa Helm repository's releases page](https://github.com/galasa-dev/helm/releases){target="_blank"}:
+
+=== "macOS or Linux"
+
+    ```bash
+    curl -O https://raw.githubusercontent.com/galasa-dev/helm/main/charts/ecosystem/values.yaml
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    Invoke-WebRequest -Uri https://raw.githubusercontent.com/galasa-dev/helm/main/charts/ecosystem/values.yaml -OutFile values.yaml
+    ```
+
+Edit `values.yaml` and set:
+
+- `galasaVersion`: Your desired Galasa version (see [Releases](../../releases/index.md) documentation). Do not use `latest` to ensure all pods run at the same level.
+- `externalHostname`: The hostname for accessing your ecosystem (e.g., `galasa.example.com`)
+
+3\. **Configure network access:**
+
+   Choose either Ingress (default) or Gateway API. For Ingress, update:
+   ```yaml
+   ingress:
+     enabled: true
+     ingressClassName: nginx  # Change to your IngressClass
+   ```
+
+   For Gateway API or HTTPS setup, see [Network Access Configuration](#network-access-configuration).
+
+4\. **Configure authentication (Dex):**
+
+   Update the `dex` section in `values.yaml`:
+   ```yaml
+   dex:
+     config:
+       issuer: https://galasa.example.com/dex  # Use your hostname
+       connectors:
+       - type: github  # Or another supported connector
+         id: github
+         name: GitHub
+         config:
+           clientID: $GITHUB_CLIENT_ID
+           clientSecret: $GITHUB_CLIENT_SECRET
+           redirectURI: https://galasa.example.com/dex/callback
+   ```
+
+   See [Configuring Authentication](#configuring-authentication) for detailed setup.
+
+5\. **Install the ecosystem:**
+
+   ```bash
+   helm install my-galasa galasa/ecosystem -f values.yaml --wait
+   ```
+
+   where `my-galasa` is the name you want to give the Ecosystem.
+
+6\. **Verify the installation:**
+
+   ```bash
+   helm test my-galasa
+   ```
+
+Your Galasa Ecosystem is now accessible at `https://galasa.example.com/api/bootstrap`
 
 ## Supported Kubernetes Versions
 
@@ -39,335 +110,417 @@ The following table shows the minimum and maximum Kubernetes versions supported 
 | 0.41.0 | 1.28 | 1.33 |
 | 0.40.0 | 1.28 | 1.33 |
 
-### Notes:
+**Notes:**
+
 - Kubernetes versions outside these ranges may work but are **not officially supported**.
 - Only **x86-64 architectures** are supported. ARM64-based systems are not currently supported.
 - Ensure your Helm version is **3.x or later** for all Galasa service releases.
 
-## Kubernetes role-based access control
+You can check your Kubernetes version by running:
+```bash
+kubectl version
+```
 
-If role-based access control (RBAC) is active on your Kubernetes cluster, a user with the `galasa-admin` role (or a role with equivalent permissions) is needed to run Helm commands on the cluster. The `galasa-admin` role allows assigned users to run the Helm install, upgrade, and delete commands to interact with the Helm chart. 
+## Configuration Guide
 
-You can assign the `galasa-admin` role to a user by replacing the placeholder username in the [rbac-admin.yaml](https://github.com/galasa-dev/helm/blob/main/charts/ecosystem/rbac-admin.yaml){target="_blank"} file with a username that corresponds to a user with access to your cluster. If multiple users require admin privileges, you can assign the `galasa-admin` role to multiple groups, users, or service accounts by extending the `subjects` list. See the [Using RBAC Authorization Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/){target="_blank"} for more information.
+### RBAC Setup
 
-You also need a Galasa service account. The Galasa service account allows the API, Engine Controller, Metrics, and Resource Monitor to co-ordinate between themselves, and allows the Engine Controller to create and manage engine pods. 
+If role-based access control (RBAC) is active on your Kubernetes cluster, configure user permissions:
 
-For chart versions later than `0.23.0`, the Galasa service account is automatically created, if one does not already exist, when installing the Galasa Ecosystem Helm chart.  The Galasa service account enables the API, Engine Controller, Metrics, and Resource Monitor to co-ordinate, while allowing the Engine Controller to create and manage engine pods.
+**For chart versions after 0.23.0:** RBAC is configured automatically during installation.
 
-For chart versions `0.23.0` and earlier, you must create the Galasa service account manually by running the following command in the repository's [ecosystem](https://github.com/galasa-dev/helm/tree/main/charts/ecosystem){target="_blank"} directory:
+**For chart version 0.23.0 and earlier:** Apply RBAC manually:
+```bash
+kubectl apply -f https://raw.githubusercontent.com/galasa-dev/helm/ecosystem-0.23.0/charts/ecosystem/rbac.yaml
+```
 
-```shell
-kubectl apply -f \
-https://raw.githubusercontent.com/galasa-dev/helm/ecosystem-0.23.0/charts/ecosystem/rbac.yaml
-``` 
+**Admin access:** To grant users the `galasa-admin` role for managing the Helm chart, update the [`rbac-admin.yaml`](https://github.com/galasa-dev/helm/blob/main/charts/ecosystem/rbac-admin.yaml){target="_blank"} file. Replace the placeholder username with actual usernames or add multiple subjects as needed. See the [Using RBAC Authorization Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/){target="_blank"} for more information.
 
+### Network Access Configuration
 
-## Installing a Galasa Ecosystem 
+Choose one method to expose your Galasa services:
 
-Complete the following steps to install a Galasa Ecosystem by using Helm:
+#### Option 1: Ingress (Default)
 
-### Adding the Galasa repository
+Most common for production deployments. Configure in `values.yaml`:
 
-1.	Add or update the Galasa repository.
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx  # Change to your IngressClass
+```
 
-    - If the repository does not exist, add the repository by running the following command:
+**For HTTPS**, add a TLS configuration:
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - galasa.example.com
+      secretName: galasa-tls-secret
+```
 
-        ```shell
-        helm repo add galasa https://galasa-dev.github.io/helm
-        ```
+See the [Kubernetes Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls){target="_blank"} for information on how to set up TLS.
 
-    - If the repository exists, run the `helm repo update` command to get the latest versions of the packages and then run `helm search repo galasa` to see the available charts.    
+#### Option 2: Gateway API (v0.47.0+)
 
-    _Note:_ The Galasa Ecosystem Helm chart deploys three persistent volumes (PVs). If you need to provide a Kubernetes storage class for these PVs, download the `values.yaml` file for your chosen Galasa Ecosystem version from the [Galasa Helm repository's releases page](https://github.com/galasa-dev/helm/releases){target="_blank"} and update the `storageClass` value in the file with the name of a valid storage class on your cluster. If you are deploying to minikube, you can optionally use the standard storage class that is created for you by minikube, but this is not required.
+**Prerequisites:**
 
-2. Download the values.yaml file for your chosen Galasa Ecosystem version from the [Galasa Helm repository's releases page](https://github.com/galasa-dev/helm/releases){target="_blank"} if you have not done so already, and edit the values of the following properties:
+- [Gateway Controller](https://gateway-api.sigs.k8s.io/guides/getting-started/#installing-a-gateway-controller){target="_blank"} installed
+- [Gateway API CRDs](https://gateway-api.sigs.k8s.io/guides/getting-started/#installing-gateway-api){target="_blank"} installed
 
-    - Set `galasaVersion` to the version of Galasa that you want to run. (See the [Releases](../../releases/index.md) documentation for released versions). To ensure that each pod in the Ecosystem is running at the same level, do not use `latest` as the Galasa version.
+For clusters with Gateway API support, configure in `values.yaml`:
 
-    - Set `externalHostname` to the DNS hostname that you wish to use to access the Galasa Ecosystem services.
+```yaml
+gateway:
+  enabled: true
+  gatewayClassName: my-gateway-class
+```
 
-After updating the `galasaVersion` and `externalHostname` values, complete the following instructions to set up Ingress for your Ecosystem. 
+**For HTTPS**, add certificate references:
+```yaml
+gateway:
+  enabled: true
+  gatewayClassName: my-gateway-class
+  tls:
+    certificateRefs:
+      - kind: Secret
+        group: ""
+        name: my-certificate-secret
+```
 
-### Configuring Ingress
+### Configuring Authentication
 
-The Galasa Ecosystem Helm chart uses Ingress to reach services that are running within a Kubernetes cluster. To learn more about Ingress, see the [Kubernetes Documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/){target="_blank"}.
+Galasa uses [Dex](https://dexidp.io){target="_blank"} for authentication (version 0.32.0 and later). Configure a connector to your identity provider.
 
-*Note:* If you are deploying to minikube, ensure the NGINX Ingress controller is enabled by running the `minikube addons enable ingress` command.
+#### GitHub Example
 
-Assuming that your Ingress controller is set up on your Kubernetes cluster, configure the use of Ingress in your Ecosystem by completing the following updates to the values that are listed under the `ingress` section within your `values.yaml` file:
+1. **Create a GitHub OAuth App:**
+   - Go to [GitHub OAuth Apps](https://github.com/settings/applications/new){target="_blank"}
+   - Set **Homepage URL** to your external hostname (e.g., `https://galasa.example.com`)
+   - Set **Callback URL** to `https://<your-external-hostname>/dex/callback` (e.g., `https://galasa.example.com/dex/callback`)
+   - Generate a client secret and save both the client ID and secret
 
-1. Replace the `ingressClassName` value with the name of the IngressClass that is configured in your cluster. By default, `nginx` is used.
+2. **Configure Dex in values.yaml:**
 
-2. If you are using HTTPS, add a `tls` configuration within the `ingress` section, specifying the `hosts` list and a `secretName` value corresponding to the name of the Kubernetes Secret that contains your TLS private key and certificate. See the [Kubernetes Documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls){target="_blank"} for information on how to set up TLS.
+   ```yaml
+   dex:
+     config:
+       issuer: https://galasa.example.com/dex
+       
+       connectors:
+       - type: github
+         id: github
+         name: GitHub
+         config:
+           clientID: $GITHUB_CLIENT_ID
+           clientSecret: $GITHUB_CLIENT_SECRET
+           redirectURI: https://galasa.example.com/dex/callback
+           # Optional: Restrict to organization/team
+           orgs:
+           - name: my-org
+             teams:
+             - my-team
+   ```
 
-After updating the values under the `ingress` section of your `values.yaml` file, complete the following instructions to configure Dex in your Ecosystem.
+3. **Store credentials securely (recommended):**
 
-### Configuring Dex 
+   Create a Kubernetes Secret with your OAuth credentials:
 
-For Galasa version 0.32.0 and later, Dex is used to authenticate users interacting with a Galasa Ecosystem.
+=== "macOS or Linux"
 
-To configure Dex in your Ecosystem, complete the following steps to update your `values.yaml` file:
-
-1. Replace the hostname in your `issuer` value with the same hostname given in `externalHostname` and set the URI scheme to either `http` or `https`. For example:
-
-    ```yaml
-    issuer: http://<your-external-hostname>/dex
+    ```bash
+    kubectl create secret generic github-oauth-credentials \
+      --from-literal=GITHUB_CLIENT_ID="your-client-id" \
+      --from-literal=GITHUB_CLIENT_SECRET="your-client-secret"
     ```
 
-2. Optional. Update the `expiry` section to configure the expiry of JSON Web Tokens (JWTs) and refresh tokens issued by Dex. By default, JWTs expire 24 hours after being issued and refresh tokens remain valid unless they have not been used for one year. See the [Dex documentation on ID tokens](https://dexidp.io/docs/tokens){target="_blank"} for information and available expiry settings. 
+=== "Windows (PowerShell)"
 
-You can now configure Dex to authenticate via a connector to authenticate with an upstream identity provider, for example, GitHub, Microsoft, or an LDAP server. For a full list of supported connectors, refer to the [Dex documentation](https://dexidp.io/docs/connectors){target="_blank"}. The following instructions explain how to configure Dex to authenticate through GitHub.
-
-
-### Configuring authentication
-
-Complete the following steps to configure Dex to authenticate through GitHub:
-
-
-1. Register an OAuth application in [GitHub](https://github.com/settings/applications/new){target="_blank"}, ensuring the callback URL of the application is set to your Dex `issuer` value, followed by `/callback`. For example, if your `issuer` value is `https://prod-ecosystem.galasa.dev/dex`, then your callback URL is `https://prod-ecosystem.galasa.dev/dex/callback`.
-
-2. Add a GitHub connector to your Dex configuration, providing the name of your GitHub organisation and any teams that you require users to be part of to be able to use your Ecosystem as follows:
-
-    ```yaml
-    dex:
-      config:
-        # Other Dex configuration values...
-
-        connectors:
-        - type: github
-          id: github
-          name: GitHub
-          config:
-            clientID: $GITHUB_CLIENT_ID
-            clientSecret: $GITHUB_CLIENT_SECRET
-            redirectURI: <your-dex-issuer-url>/callback
-            orgs:
-            - name: my-org
-              teams:
-              - my-team
+    ```powershell
+    kubectl create secret generic github-oauth-credentials `
+      --from-literal=GITHUB_CLIENT_ID="your-client-id" `
+      --from-literal=GITHUB_CLIENT_SECRET="your-client-secret"
     ```
 
-    where `$GITHUB_CLIENT_ID` and `$GITHUB_CLIENT_SECRET` correspond to the registered OAuth application's client ID and secret. Ensure that the `redirectURI` value is the same value that you provided when setting up your GitHub OAuth application in step 1.
+Then reference the secret in `values.yaml`:
+   ```yaml
+   dex:
+     envFrom:
+       - secretRef:
+           name: github-oauth-credentials
+     
+     config:
+       issuer: https://galasa.example.com/dex
+       
+       connectors:
+       - type: github
+         id: github
+         name: GitHub
+         config:
+           clientID: $GITHUB_CLIENT_ID
+           clientSecret: $GITHUB_CLIENT_SECRET
+           redirectURI: https://galasa.example.com/dex/callback
+           orgs:
+           - name: my-org
+             teams:
+             - my-team
+   ```
 
-    If you want to pull the client ID and secret values of your OAuth application from a Kubernetes Secret, create a Secret by running the following `kubectl` command, ensuring that the Secret's keys match those given in the GitHub connector's `clientID` and `clientSecret` values without the leading `$` (i.e. `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` as shown in the following example):
+#### Other Identity Providers
 
-    ```shell
-    kubectl create secret generic my-github-oauth-app-credentials \
-    --from-literal=GITHUB_CLIENT_ID="myclientid" \
-    --from-literal=GITHUB_CLIENT_SECRET="myclientsecret"
-    ```
+Dex supports many connectors including Microsoft, LDAP, OIDC, and more. See the [Dex connectors documentation](https://dexidp.io/docs/connectors){target="_blank"} for configuration examples.
 
-    When your Kubernetes Secret is created, supply the name of the Secret by using the `envFrom` value in your `values.yaml` file to mount the Secret as shown in the following example:
+#### Optional: Configure Token Expiry
 
-    ```yaml
-    dex:
-      envFrom:
-        - secretRef:
-          name: my-github-oauth-app-credentials
+Update the `expiry` section to configure the expiry of JSON Web Tokens (JWTs) and refresh tokens issued by Dex. By default, JWTs expire 24 hours after being issued and refresh tokens remain valid unless they have not been used for one year. See the [Dex documentation on ID tokens](https://dexidp.io/docs/tokens){target="_blank"} for information and available expiry settings.
 
-      config:
-        # Other Dex configuration values...
+### Configuring User Roles and Owners
 
-        connectors:
-        - type: github
-          id: github
-          name: GitHub
-          config:
-            clientID: $GITHUB_CLIENT_ID
-            clientSecret: $GITHUB_CLIENT_SECRET
-            redirectURI: <your-dex-issuer-url>/callback
-            orgs:
-            - name: my-org
-              teams:
-              - my-team
-    ```
+When the Galasa Ecosystem is first installed, users logging in are assigned a default role as specified by the `galasaDefaultUserRole` property (e.g., `tester`). This means no user initially has administrator privileges.
 
-By default, the Galasa Ecosystem Helm chart creates a Kubernetes Secret containing configuration details for Dex. 
-If you want to apply your own Dex configuration as a Secret, your Dex configuration must be provided in a `config.yaml` key within the Secret, 
-and the value of the `config.yaml` key must be a valid Dex configuration.
+To grant administration rights, nominate one or more users as 'owners' of the service using the `galasaOwnersLoginIds` property in your `values.yaml` file:
 
-For more information on configuring Dex, see the [Dex documentation](https://dexidp.io/docs){target="_blank"}.
+```yaml
+galasaOwnersLoginIds: "user1,user2,user3"
+```
 
-### Configuring Logging for the Galasa service (Optional)
+When a nominated owner logs into the Galasa Ecosystem, they are granted the `owner` role. They can then assign the `admin` role to other users using the `galasactl` command line or the web user interface.
 
-The Galasa service generates log messages using Log4j and these messages are sent to each process' standard output stream by default.
+**Important notes:**
 
-If you would like to modify the format of the Galasa service's log messages or configure additional Log4j appenders:
+- Each login-id must match the login-id allocated to the user by the authentication service (e.g., Dex).
+- If you are unsure what login-id to use, log into the Galasa Ecosystem using a browser and view the user profile page.
+- Once you have users with the `admin` role, you can remove the `owner` designation if desired.
+- The `owner` role exists solely to fix situations where there are no administrators on the Galasa Ecosystem.
 
-1. Provide a custom set of Log4j2 properties using the `log4j2Properties` value as a multi-line string in the form:
+### Optional Configurations
 
-    ```yaml
-    log4j2Properties: |
-      status = error
-      name = Default
-    
-      appender.console.type = Console
-      appender.console.name = stdout
-      appender.console.layout.type = PatternLayout
-      appender.console.layout.pattern = %d{dd/MM/yyyy HH:mm:ss.SSS} %-5p %c{1.} - %m%n
-    
-      rootLogger.level = debug
-      rootLogger.appenderRef.stdout.ref = stdout
-    ```
+#### Storage Class
 
-If you are using Log4j's `JsonTemplateLayout` layout type and would like to use a custom JSON template for your log messages, then you can create a ConfigMap containing the JSON templates that you wish to make available to the Galasa service and supply the name of that ConfigMap in the `log4jJsonTemplatesConfigMapName` value.
+If your cluster requires a specific StorageClass for persistent volumes:
 
-The ConfigMap is mounted into the Galasa service pods in the `/log4j-config` directory, so any Log4j properties that need to refer to a template's URI will need a value to be prefixed with `file:/log4j-config`.
+```yaml
+storageClass: my-storage-class
+```
 
-For example, if you have a custom JSON template in a file called `MyLayout.json`, then you would take the following steps:
+If you are deploying to minikube, you can optionally use the standard storage class that is created for you by minikube, but this is not required and can be left empty.
 
-1. Create a ConfigMap by running:
-    ```
+#### Custom Logging (Log4j2)
+
+Customize log format by setting `log4j2Properties` in `values.yaml`:
+
+```yaml
+log4j2Properties: |
+  status = error
+  name = Default
+
+  appender.console.type = Console
+  appender.console.name = stdout
+  appender.console.layout.type = PatternLayout
+  appender.console.layout.pattern = %d{dd/MM/yyyy HH:mm:ss.SSS} %-5p %c{1.} - %m%n
+
+  rootLogger.level = debug
+  rootLogger.appenderRef.stdout.ref = stdout
+```
+
+For JSON templates, create a ConfigMap and reference it:
+
+=== "macOS or Linux"
+
+    ```bash
     kubectl create configmap my-json-layouts --from-file=/path/to/MyLayout.json
     ```
 
-2. Set `log4jJsonTemplatesConfigMapName` in the Helm values to:
-    ```yaml
-    log4jJsonTemplatesConfigMapName: "my-json-layouts"
+=== "Windows (PowerShell)"
+
+    ```powershell
+    kubectl create configmap my-json-layouts --from-file=C:\path\to\MyLayout.json
     ```
 
-3. Use the custom layout in the `log4j2Properties` value by adding these properties:
-    ```properties
-    appender.myAppender.layout.type = JsonTemplateLayout
-    appender.myAppender.layout.eventTemplateUri = file:/log4j-config/MyLayout.json
+```yaml
+log4jJsonTemplatesConfigMapName: my-json-layouts
+```
+
+The ConfigMap is mounted into the Galasa service pods in the `/log4j-config` directory. Refer to the [Log4j documentation](https://logging.apache.org/log4j/2.x/manual/configuration.html){target="_blank"} for available properties.
+
+#### Internal Certificates
+
+For connecting to servers with internal or corporate certificates:
+
+1\. Create a ConfigMap with your certificates:
+
+=== "macOS or Linux"
+
+    ```bash
+    kubectl create configmap my-certificates \
+      --from-file=/path/to/certificate1.pem \
+      --from-file=/path/to/certificate2.pem
     ```
 
-Refer to the [Log4j documentation](https://logging.apache.org/log4j/2.x/manual/configuration.html) for available properties.
+=== "Windows (PowerShell)"
 
-#### Configuring Public Certificates (Optional)
-
-If you are deploying your Galasa service on an internal or corporate network and expect your Galasa tests to connect to servers that use internal certificates, you will need to supply the public certificates so that Galasa can contact those servers successfully.
-
-You can use the `certificatesConfigMapName` value to provide the name of an existing ConfigMap containing the certificates that you wish to inject into the Galasa service pods. To do this, take the following steps:
-
-1. Create a ConfigMap by running:
-    ```
-    kubectl create configmap my-certificates --from-file=/path/to/my/certificate.pem
-    ```
-    where `/path/to/my/certificate.pem` is a file path on your machine to a certificate that you wish to include. You can supply multiple `--from-file` flags if you wish to load multiple certificates into the ConfigMap.
-
-2. Set `certificatesConfigMapName` in the Helm values to the name of the ConfigMap that you created (in this example, the name is `my-certificates`):
-    ```yaml
-    certificatesConfigMapName: "my-certificates"
+    ```powershell
+    kubectl create configmap my-certificates `
+      --from-file=C:\path\to\certificate1.pem `
+      --from-file=C:\path\to\certificate2.pem
     ```
 
-You can then proceed with the installation of the Galasa service and the Helm chart will inject the certificates inside the ConfigMap into the Galasa service pods.
+2\. Reference it in `values.yaml`:
+   ```yaml
+   certificatesConfigMapName: my-certificates
+   ```
 
-## Configure the default user role, and 'owner' of the Galasa service
+## Installing on Minikube
 
-When the Galasa service is first installed, users logging in will be assigned a role as dictated by the `galasaDefaultUserRole` Helm chart property. For example 'tester'.
-This means nobody initially logging into the Galasa service will have administrator privileges.
-We would discourage ever setting this property to `admin` as doing so would provide a less secure Galasa service, with any action in the system available to anyone on the system.
+⚠️ **Minikube is for development/testing only, not production use.**
 
-To obtain administration rights to the Galasa service, the kubernetes install must nominate one or more users as 'owners' of the service.
-When a service owner next logs into the Galasa service, they will be granted a role of `owner`.
-From this point on, that user can assign the 'admin' role to anyone else who needs it using the `galasactl` command line or by using the web user interface via a browser.
+### Prerequisites
 
-Once the Galasa service has one or more users with the 'admin' role, kubernetes can be updated so that the system doesn't have any "owner" if desired. 
-The `owner` role exists solely to fix situations where there are no administrators on the Galasa service, such as when the Galasa service is initially installed, or when none of the
-members in the organisation have the `admin` role.
-If a user was a nominated "owner", performs some administration tasks, and is then removed from the list of "owners", their role on the Galasa service will revert to what it was initially.
+- [Minikube](https://minikube.sigs.k8s.io/docs/start/){target="_blank"} installed and running
+- Verify with: `minikube status`
+- If minikube is not running, start it: `minikube start`
 
-To configure a list of owners, use the `galasaOwnersLoginIds` property of the `values.yaml` file and use Helm to deploy it.
-You can set multiple owners by adding a comma-separated list of login-ids.
+### Installation Steps
 
-Each login-id must match the login-id allocated to the user by the authentication service to which Galasa connects.
-If you are unsure what login-id to use, try setting up your system without an owner and logging into the Galasa service using a browser, then viewing the user profile page before returning to update the owner login-id in your `values.yaml` and deploying it to kubernetes using `helm upgrade`.
+1\. **Enable Ingress:**
+   ```bash
+   minikube addons enable ingress
+   ```
 
-## Installing the chart
+2\. **Configure hosts file:**
+   
+   Add an entry to your hosts file, ensuring the IP address matches the output of `minikube ip`:
 
-After configuring your `values.yaml` file, complete the following steps to install the Galasa Ecosystem Helm chart:
+=== "Mac or Linux"
 
-1.  Install the Galasa Ecosystem chart by running the following command:
-
-    ```console
-	helm install -f /path/to/values.yaml <release-name> galasa/ecosystem --wait
+    ```bash
+    # Get the minikube IP
+    minikube ip
+    
+    # Add this line to /etc/hosts (replace IP with your minikube IP)
+    192.168.49.2 galasa.local
     ```
 
-    where:
+=== "Windows (run as Administrator)"
 
-    - `/path/to/values.yaml` is the path to where the `values.yaml` file is downloaded and
-
-    - `<release-name>` is the name that you want to give the Ecosystem.
-
-    The `--wait` flag ensures that the chart installation completes before marking it as `Deployed`. During the installation, the API pod waits for the etcd and RAS pods to initialise while the Engine Controller, Metrics, and Resource Monitor pods wait for the API pod to initialise.
-
-2.	View the status of the deployed pods by running `kubectl get pods` in another terminal. The returned results should look similar to the following example:
-
-    ```console
-    NAME                                      READY   STATUS     RESTARTS      AGE
-    test-api-7945f959dd-v8tbs                 1/1     Running    0             65s
-    test-engine-controller-56fb476f45-msj4x   1/1     Running    0             65s
-    test-etcd-0                               1/1     Running    0             65s
-    test-metrics-5fd9f687b6-rwcww             1/1     Running    0             65s
-    test-ras-0                                1/1     Running    0             65s
-    test-resource-monitor-778c647995-x75z9    1/1     Running    0             65s
+    ```powershell
+    # Get the minikube IP
+    minikube ip
+    
+    # Add this line to C:\Windows\System32\drivers\etc\hosts (replace IP with your minikube IP)
+    192.168.49.2 galasa.local
     ```
 
+3\. **Configure values.yaml:**
+   - Set `externalHostname: galasa.local`
+   - Configure Dex and Ingress as described in the [Configuration Guide](#configuration-guide)
 
-## Verifying the installation
+4\. **Install:**
+   ```bash
+   helm install my-galasa galasa/ecosystem -f values.yaml --wait
+   ```
 
-After the `helm install` command completes with a successful deployment message, run the following command to check that the Ecosystem can be accessed externally to Kubernetes so that a simple test engine can be run:
+5\. **Verify:**
+   ```bash
+   kubectl get pods  # Wait for all pods to be Ready
+   helm test my-galasa
+   ```
 
-```shell
+Your Galasa Ecosystem is now accessible at `http://galasa.local/api/bootstrap`
+
+## Verifying the Installation
+
+After the `helm install` command completes, verify your ecosystem is working:
+
+```bash
 helm test <release-name>
 ```
 
-where:
-
-`<release-name>` is the name that you gave the Ecosystem during installation.
-
-When the `helm test` command ends and displays a success message, the Ecosystem is set up correctly and is ready to be used.
-
-
-## Accessing services
-
-The URL of the Ecosystem bootstrap will be your external hostname, followed by `/api/bootstrap`.
-
-For example, if the external hostname that you provided was `example.com` and you provided values for using TLS, the bootstrap URL would be `https://example.com/api/bootstrap`. This is the URL that you would enter into a galasactl command's `--bootstrap` option to interact with your Ecosystem.
-
-If you are deploying to minikube, add an entry to your `/etc/hosts` file, ensuring the IP address matches the output of `minikube ip`. For example:
-
-```console
-192.168.49.2 example.com
+Expected output:
+```
+TEST SUITE:     my-galasa-validate
+Last Started:   Mon Mar  3 11:44:24 2025
+Last Completed: Mon Mar  3 11:45:45 2025
+Phase:          Succeeded
 ```
 
+**Access your ecosystem:**
 
-## Running Galasa tests
+- Bootstrap URL: `https://<your-hostname>/api/bootstrap`
+- Web UI: `https://<your-hostname>`
 
-Once you have successfully installed the Ecosystem, you can then deploy your Galasa tests to a Maven repository and set up a test stream. For more information on managing tests, see the [Managing tests in a Galasa Ecosystem](../manage-ecosystem/index.md) documentation.
+This is the URL that you would enter into a galasactl command's `--bootstrap` option to interact with your Ecosystem.
 
+**Monitor pods:**
+```bash
+kubectl get pods
+```
+
+All pods should show `Running` status and `1/1` ready. Example output:
+```console
+NAME                                      READY   STATUS     RESTARTS      AGE
+test-api-7945f959dd-v8tbs                 1/1     Running    0             65s
+test-engine-controller-56fb476f45-msj4x   1/1     Running    0             65s
+test-etcd-0                               1/1     Running    0             65s
+test-metrics-5fd9f687b6-rwcww             1/1     Running    0             65s
+test-ras-0                                1/1     Running    0             65s
+test-resource-monitor-778c647995-x75z9    1/1     Running    0             65s
+```
+
+## Running Galasa Tests
+
+Once you have successfully installed the Ecosystem, you can deploy your Galasa tests to a Maven repository and set up a test stream. For more information on managing tests, see the [Managing tests in a Galasa Ecosystem](../manage-ecosystem/index.md) documentation.
 
 ## Upgrading the Galasa Ecosystem
 
-Get the latest version of the Ecosystem chart and upgrade the Galasa Ecosystem to use the newer version of Galasa - for example version 0.46.1 - by running the following command:
+To upgrade to a newer Galasa version:
 
-On Mac or Unix:
+=== "macOS or Linux"
 
-```shell
-helm repo update \
-helm upgrade <release-name> galasa/ecosystem --reuse-values \
---set galasaVersion=0.46.1 --wait
-```
+    ```bash
+    helm repo update
+    helm upgrade <release-name> galasa/ecosystem \
+      --reuse-values \
+      --set galasaVersion=0.46.1 \
+      --wait
+    ```
 
-On Windows (Powershell):
+=== "Windows (PowerShell)"
 
-```powershell
-helm repo update `
-helm upgrade <release-name> galasa/ecosystem --reuse-values `
---set galasaVersion=0.46.1 --wait
+    ```powershell
+    helm repo update
+    helm upgrade <release-name> galasa/ecosystem `
+      --reuse-values `
+      --set galasaVersion=0.46.1 `
+      --wait
+    ```
+
+Or update your `values.yaml` and run:
+
+```bash
+helm upgrade <release-name> galasa/ecosystem -f values.yaml --wait
 ```
 
 where:
 
-- `galasaVersion` is set to the version that you want to use and
-
+- `galasaVersion` is set to the version that you want to use
 - `<release-name>` is the name that you gave to the Ecosystem during installation
 
+## Uninstalling the Galasa Ecosystem
 
-### Troubleshooting
+To uninstall the Galasa Ecosystem:
 
-- Check the logs by running the ```kubectl logs``` command. 
-- Check that the Galasa version number in the sample is correct by running the ```kubectl describe pod <podname>``` command.  If the version number is not the latest one, update the version number in the sample and apply the update.
-- If an 'unknown fields' error message is displayed, you can turn off validation by using the  ```--validate=false``` command. 
+```bash
+helm uninstall <release-name>
+```
 
+This removes all Kubernetes resources created by the chart.
+
+## Troubleshooting
+
+- **Check pod logs:** Run `kubectl logs <pod-name>` to view logs for a specific pod
+- **Check pod details:** Run `kubectl describe pod <pod-name>` to see detailed information about a pod
+- **Verify Galasa version:** Ensure the version number in your `values.yaml` matches your intended version
+- **Validation errors:** If an 'unknown fields' error message is displayed, you can turn off validation by using the `--validate=false` flag with kubectl commands

--- a/docs/content/releases/posts/v0.47.0.md
+++ b/docs/content/releases/posts/v0.47.0.md
@@ -17,4 +17,4 @@ links:
 
 - Added a new `galasactl streams set` command that can be used to create or update test streams within a Galasa service. [See the command reference](../../docs/reference/cli-syntax/galasactl_streams_set.md).
 
-- Added support for Gateway API for accessing the Galasa service. See [Installing an Ecosystem using Helm](../../docs/ecosystem/ecosystem-installing-k8s.md#option-2-gateway-api-v0470) for details on how to configure Gateway API.
+- Added support for Gateway API for accessing the Galasa service. See [Installing an Ecosystem using Helm](../../docs/ecosystem/ecosystem-installing-k8s.md#option-2-gateway-api-v0470) for details on how to configure Gateway API. Ingress is still used for accessing the Galasa service by default but can be replaced with Gateway API by setting the `ingress.enabled` value to `false` and the `gatewayApi.enabled` value to `true` in the `values.yaml` file used when installing the Helm chart.

--- a/docs/content/releases/posts/v0.47.0.md
+++ b/docs/content/releases/posts/v0.47.0.md
@@ -16,3 +16,5 @@ links:
 - Added new REST API endpoints `POST /streams` and `PUT /streams/<streamName>` to allow users to create and update test streams. See the [REST API reference](../../docs/reference/rest-api/index.html) for more details. See also [#2447](https://github.com/galasa-dev/projectmanagement/issues/2447).
 
 - Added a new `galasactl streams set` command that can be used to create or update test streams within a Galasa service. [See the command reference](../../docs/reference/cli-syntax/galasactl_streams_set.md).
+
+- Added support for Gateway API for accessing the Galasa service. See [Installing an Ecosystem using Helm](../../docs/ecosystem/ecosystem-installing-k8s.md#option-2-gateway-api-v0470) for details on how to configure Gateway API.


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2542. Links to changes in https://github.com/galasa-dev/helm/pull/116

## Changes
- [x] Updated the docs on installing a Galasa service to be simpler and easier to follow
- [x] Added section in the docs about configuring Gateway API before installing the helm chart
- [x] Added release note on the new Gateway API support
