### PR TITLE
Allow additional --obr flags to be supplied with --gherkin

### DIFF
--- a/docs/content/releases/posts/v0.47.0.md
+++ b/docs/content/releases/posts/v0.47.0.md
@@ -14,6 +14,8 @@ links:
 - **HTTP Client Manager**: Upgraded the underlying HTTP client library from Apache HttpClient 4 to Apache HttpClient 5.
   - The existing `getFile()` methods that return `CloseableHttpResponse` are now deprecated but remain functional for backward compatibility. Users are encouraged to migrate to the new `getFileStream()` methods. See the [HTTP Client Manager documentation](../../docs/managers/communications-managers/http-client-manager.md) for examples.
 
+- The `galasactl runs submit local` command now allows additional `--obr` flags to be supplied alongside a `--gherkin` flag. See [#2562](https://github.com/galasa-dev/projectmanagement/issues/2562).
+
 ## Changes affecting the Galasa Service
 
 - Added new REST API endpoints `POST /streams` and `PUT /streams/<streamName>` to allow users to create and update test streams. See the [REST API reference](../../docs/reference/rest-api/index.html) for more details. See also [#2447](https://github.com/galasa-dev/projectmanagement/issues/2447).

--- a/modules/cli/pkg/cmd/runsSubmitLocal.go
+++ b/modules/cli/pkg/cmd/runsSubmitLocal.go
@@ -150,7 +150,6 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 
 	runs.AddGherkinFlag(runsSubmitLocalCobraCmd, cmd.values.submitLocalSelectionFlags, false, "Gherkin feature file URL. Should start with 'file://'. ")
 
-	runsSubmitLocalCobraCmd.MarkFlagsRequiredTogether("class", "obr")
 	runsSubmitLocalCobraCmd.MarkFlagsOneRequired("class", "gherkin")
 	runsSubmitLocalCobraCmd.MarkFlagsMutuallyExclusive("methods", "gherkin")
 

--- a/modules/cli/pkg/cmd/runsSubmitLocal_test.go
+++ b/modules/cli/pkg/cmd/runsSubmitLocal_test.go
@@ -43,40 +43,6 @@ func TestRunsSubmitLocalHelpFlagSetCorrectly(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestRunsSubmitLocalWithoutObrWithClassErrors(t *testing.T) {
-	// Given...
-	factory := utils.NewMockFactory()
-	var args []string = []string{"runs", "submit", "local", "--class", "osgi.bundle/class.path"}
-
-	// When...
-	err := Execute(factory, args)
-
-	// Then...
-	// Check what the user saw was reasonable
-	checkOutput("", "if any flags in the group [class obr] are set they must all be set; missing [obr]", factory, t)
-
-	// Should throw an error asking for flags to be set
-	assert.NotNil(t, err, "err should have been set!")
-	assert.Contains(t, err.Error(), "if any flags in the group [class obr] are set they must all be set; missing [obr]")
-}
-
-func TestRunsSubmitLocalWithoutClassWithObrErrors(t *testing.T) {
-	// Given...
-	factory := utils.NewMockFactory()
-	var args []string = []string{"runs", "submit", "local", "--obr", "mvn:second.breakfast/elevenses/0.1.0/brunch"}
-
-	// When...
-	err := Execute(factory, args)
-
-	// Then...
-	// Check what the user saw was reasonable
-	checkOutput("", "if any flags in the group [class obr] are set they must all be set; missing [class]", factory, t)
-
-	// Should throw an error asking for flags to be set
-	assert.NotNil(t, err, "err should have been set!")
-	assert.Contains(t, err.Error(), "if any flags in the group [class obr] are set they must all be set; missing [class]")
-}
-
 func TestMultipleRequiredFlagsNotSetReturnsListInError(t *testing.T) {
 	// Given...
 	factory := utils.NewMockFactory()
@@ -321,5 +287,28 @@ func TestRunsSubmitLocaGherkinFlagsWork(t *testing.T) {
 	assert.Contains(t, cmd.Values().(*RunsSubmitLocalCmdValues).runsSubmitLocalCmdParams.LocalMaven, "local/maven/location")
 	assert.Contains(t, cmd.Values().(*RunsSubmitLocalCmdValues).runsSubmitLocalCmdParams.RemoteMaven, "remote.maven.location")
 	assert.Empty(t, cmd.Values().(*RunsSubmitLocalCmdValues).runsSubmitLocalCmdParams.Obrs)
+	assert.Empty(t, cmd.Values().(*RunsSubmitLocalCmdValues).submitLocalSelectionFlags.Classes)
+}
+
+func TestRunsSubmitLocalGherkinFlagWithObrWorks(t *testing.T) {
+	// Given...
+	factory := utils.NewMockFactory()
+	commandCollection, cmd := setupTestCommandCollection(COMMAND_NAME_RUNS_SUBMIT_LOCAL, factory, t)
+
+	var args []string = []string{"runs", "submit", "local",
+		"--gherkin", "gherkin.feature",
+		"--obr", "mvn:my.group/my.group.obr/0.0.1/obr"}
+
+	// When...
+	err := commandCollection.Execute(args)
+
+	// Then...
+	assert.Nil(t, err)
+
+	// Check what the user saw is reasonable.
+	checkOutput("", "", factory, t)
+
+	assert.Contains(t, *cmd.Values().(*RunsSubmitLocalCmdValues).submitLocalSelectionFlags.GherkinUrl, "gherkin.feature")
+	assert.Contains(t, cmd.Values().(*RunsSubmitLocalCmdValues).runsSubmitLocalCmdParams.Obrs, "mvn:my.group/my.group.obr/0.0.1/obr")
 	assert.Empty(t, cmd.Values().(*RunsSubmitLocalCmdValues).submitLocalSelectionFlags.Classes)
 }


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2562. 

## Changes
- [x] Fixed an issue where `--obr` flags were not allowed to be supplied with `--gherkin`, so users can now load their own managers with custom Gherkin step definitions as necessary
- [x] Unit tests
- [x] Release notes updates
