### PR TITLE
Bump jackson-core and related dependencies to 2.21.1

### DIFF
--- a/modules/cli/docs/generated/galasactl_secrets_set.md
+++ b/modules/cli/docs/generated/galasactl_secrets_set.md
@@ -21,7 +21,7 @@ galasactl secrets set [flags]
       --name string              A mandatory flag that identifies the secret to be created or manipulated.
       --password string          a password to set into a secret
       --token string             a token to set into a secret
-      --type string              the desired secret type to convert an existing secret into. Supported types are: [UsernamePassword Username UsernameToken Token].
+      --type string              the desired secret type to convert an existing secret into. Supported types are: [UsernamePassword Username UsernameToken Token KeyStore].
       --username string          a username to set into a secret
 ```
 

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -36,9 +36,9 @@ dependencies {
 
         api 'com.auth0:java-jwt:4.4.0' // used by wrapper.
         
-        api 'com.fasterxml.jackson.core:jackson-annotations:2.20' // used by wrapper.
-        api 'com.fasterxml.jackson.core:jackson-core:2.20.0' // used by wrapper.
-        api 'com.fasterxml.jackson.core:jackson-databind:2.20.0' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-annotations:2.21' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-core:2.21.1' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-databind:2.21.1' // used by wrapper.
 
         api 'com.github.docker-java:docker-java-api:3.2.14' // bnd.bnd only
         api 'com.github.docker-java:docker-java-core:3.2.14'


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2561. 

## Changes
- [x] Bumped jackson-core, jackson-databind, and jackson-annotations to 2.21.1 (2.21 for jackson-annotations) to resolve the reported vulnerability