### PR TITLE
Iss2556 - Fix the `--user` flag on `runs submit` being case-sensitive

### DIFF
--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -263,7 +263,7 @@ Note: The `--log -` directs logging information to the stderr console.
 Omit this option if you do not want to see logging, or specify `--log myFileName.txt` if you wish 
 to capture log information in a file.
 
-When submitting runs to a Galasa ecosystem with `runs submit`, the run `requestor` will be set to the user who owns the personal access token that was used to authenticate to the Galasa ecosystem. If you wish to associate a different user with this batch of runs as the run `user`, you can use the `--user` flag. This is useful if you submit runs to a Galasa ecosystem in an automation tool or workflow and the `requestor` is a functional ID or bot account in the tool, but you wish to specify the actual user who triggered the automation, so they can query their runs later with the `runs get` command.
+When submitting runs to a Galasa ecosystem with `runs submit`, the run `requestor` will be set to the user who owns the personal access token that was used to authenticate to the Galasa ecosystem. If you wish to associate a different user with this batch of runs as the run `user`, you can use the `--user` flag. This is useful if you submit runs to a Galasa ecosystem in an automation tool or workflow and the `requestor` is a functional ID or bot account in the tool, but you wish to specify the actual user who triggered the automation, so they can query their runs later with the `runs get` command. The `--user` flag is case-insensitive, so `--user example@email.com` and `--user Example@email.com` will match the same user.
 
 ### Examples
 

--- a/modules/cli/docs/generated/galasactl_runs_get.md
+++ b/modules/cli/docs/generated/galasactl_runs_get.md
@@ -22,7 +22,7 @@ galasactl runs get [flags]
       --requestor string   the requestor of the test run we want information about. This is the owner of the personal access token that was used to submit the test. This may be an actual user or a functional ID or bot account for an automation tool. Cannot be used in conjunction with --name flag.
       --result string      A filter on the test runs we want information about. Optional. Default is to display test runs with any result. Case insensitive. Value can be a single value or a comma-separated list. For example "--result Failed,Ignored,EnvFail". Cannot be used in conjunction with --name or --active flag.
       --tags strings       the tags associated with test runs to be retrieved. Tags can be supplied in a comma-separated list (e.g. --tags tag1,tag2,tag3) or as separate '--tags' flags (e.g. --tags tag1 --tags tag2).
-      --user string        the user of the test run we want information about. This is the actual user who submitted the tests either with galasactl or through an automation tool. This may or may not be the same as the requestor. Cannot be used in conjunction with --name flag.
+      --user string        the user of the test run we want information about. This is the actual user who submitted the tests either with galasactl or through an automation tool. This may or may not be the same as the requestor. This flag is case-insensitive. Cannot be used in conjunction with --name flag.
 ```
 
 ### Options inherited from parent commands

--- a/modules/cli/docs/generated/galasactl_runs_submit.md
+++ b/modules/cli/docs/generated/galasactl_runs_submit.md
@@ -37,7 +37,7 @@ galasactl runs submit [flags]
       --throttle int               how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 3)
       --throttlefile string        a file where the current throttle is stored. Periodically the throttle value is read from the file used. Someone with edit access to the file can change it which dynamically takes effect. Long-running large portfolios can be throttled back to nothing (paused) using this mechanism (if throttle is set to 0). And they can be resumed (un-paused) if the value is set back. This facility can allow the tests to not show a failure when the system under test is taken out of service for maintainence.Optional. If not specified, no throttle file is used.
       --trace                      Trace to be enabled on the test runs
-  -u, --user string                an optional user to associate with the test runs that is different from the requestor (the owner of the personal access token that is authenticated to the system). The user must be an existing system user and must have permission to launch tests.
+  -u, --user string                an optional user to associate with the test runs that is different from the requestor (the owner of the personal access token that is authenticated to the system). The user must be an existing system user and must have permission to launch tests. This flag is case-insensitive.
 ```
 
 ### Options inherited from parent commands

--- a/modules/cli/pkg/cmd/runsGet.go
+++ b/modules/cli/pkg/cmd/runsGet.go
@@ -106,6 +106,7 @@ func (cmd *RunsGetCommand) createCobraCommand(
 	runsGetCobraCmd.PersistentFlags().StringVar(&cmd.values.user, "user", "", "the user of the test run we want information about."+
 		" This is the actual user who submitted the tests either with galasactl or through an automation tool."+
 		" This may or may not be the same as the requestor."+
+		" This flag is case-insensitive."+
 		" Cannot be used in conjunction with --name flag.")
 	runsGetCobraCmd.PersistentFlags().StringVar(&cmd.values.result, "result", "", "A filter on the test runs we want information about. Optional. Default is to display test runs with any result. Case insensitive. Value can be a single value or a comma-separated list. For example \"--result Failed,Ignored,EnvFail\"."+
 		" Cannot be used in conjunction with --name or --active flag.")

--- a/modules/cli/pkg/cmd/runsSubmit.go
+++ b/modules/cli/pkg/cmd/runsSubmit.go
@@ -88,7 +88,8 @@ func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 
 	runsSubmitCmd.Flags().StringVarP(&cmd.values.User, "user", "u", "", "an optional user to associate with the test runs that is different from the requestor"+
 		" (the owner of the personal access token that is authenticated to the system)."+
-		" The user must be an existing system user and must have permission to launch tests.")
+		" The user must be an existing system user and must have permission to launch tests."+
+		" This flag is case-insensitive.")
 
 	runsSubmitCmd.PersistentFlags().StringVar(&cmd.values.ReportYamlFilename, "reportyaml", "", "yaml file to record the final results in")
 	runsSubmitCmd.PersistentFlags().StringVar(&cmd.values.ReportJsonFilename, "reportjson", "", "json file to record the final results in")

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
@@ -230,7 +230,7 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
         IUser user = null;
 
         try {
-            // Fetch documents matching the loginId
+            // Fetch documents matching the loginId (case-sensitive)
             userDocument = getAllDocsByLoginId(USERS_DATABASE_NAME, loginId, USERS_DB_VIEW_NAME);
 
             // Since loginIds are unique, there should be only one document.
@@ -248,6 +248,18 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
 
                 // Assign fetchedUser to the user variable
                 user = new UserImpl(fetchedUser);
+            } else {
+                // If exact match fails, do case-insensitive search through all users
+                logger.info("Exact match failed, performing case-insensitive search for loginId: " + loginId);
+                List<IUser> allUsers = getAllUsers();
+                
+                for (IUser potentialMatch : allUsers) {
+                    if (potentialMatch.getLoginId().equalsIgnoreCase(loginId)) {
+                        user = potentialMatch;
+                        logger.info("Found case-insensitive match for loginId: " + loginId);
+                        break;
+                    }
+                }
             }
 
             logger.info("User retrieved from CouchDB OK");
@@ -274,9 +286,11 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
      * /{db}/_design/docs/_view/loginId-view?key={loginId} endpoint and returns the
      * "rows" list in the response,
      * which corresponds to the list of documents within the given database.
+     * The loginId is converted to lowercase to enable case-insensitive matching,
+     * as the CouchDB view indexes loginIds in lowercase.
      *
      * @param dbName  the name of the database to retrieve the documents of
-     * @param loginId the loginId of the user to retrieve the doucemnts of
+     * @param loginId the loginId of the user to retrieve the documents of
      * @return a list of rows corresponding to documents within the database
      * @throws CouchdbException if there was a problem accessing the
      *                          CouchDB store or its response
@@ -284,7 +298,9 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
     protected List<ViewRow> getAllDocsByLoginId(String dbName, String loginId, String viewName)
             throws CouchdbException {
 
-        String encodedLoginId = URLEncoder.encode("\"" + loginId + "\"", StandardCharsets.UTF_8);
+        // Convert loginId to lowercase to match the lowercase keys emitted in the CouchDB view
+        String lowercaseLoginId = loginId.toLowerCase();
+        String encodedLoginId = URLEncoder.encode("\"" + lowercaseLoginId + "\"", StandardCharsets.UTF_8);
         String url = storeUri + "/" + dbName + "/_design/docs/_view/" + viewName + "?key=" + encodedLoginId;
 
         HttpGet getDocs = httpRequestFactory.getHttpGetRequest(url);

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStoreValidator.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStoreValidator.java
@@ -42,8 +42,9 @@ public class CouchdbAuthStoreValidator extends CouchdbBaseValidator {
     private final LogFactory logFactory;
 
     // A couchDB view, it gets all the access tokens of a the user based on the loginId provided.
-    public static final String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId, doc); } }";
-    public static final String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'], doc); } }";
+    // The emit key is lowercased to enable case-insensitive lookups
+    public static final String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), doc); } }";
+    public static final String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), doc); } }";
 
     public CouchdbAuthStoreValidator() {
         this(new LogFactory(){

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStore.java
@@ -255,6 +255,55 @@ public class TestCouchdbAuthStore {
     }
 
     @Test
+    public void testGetTokensByLoginIdCaseInsensitiveReturnsTokensOK() throws Exception {
+        // Given...
+        URI authStoreUri = URI.create("couchdb:https://my-auth-store");
+        MockLogFactory logFactory = new MockLogFactory();
+
+        ViewRow tokenDoc = new ViewRow();
+        tokenDoc.id = "token1";
+        List<ViewRow> mockDocs = List.of(tokenDoc);
+
+        ViewResponse mockAllDocsResponse = new ViewResponse();
+        mockAllDocsResponse.rows = mockDocs;
+
+        // Token owned by user "JohnDoe" (mixed case stored in document)
+        CouchdbAuthToken mockToken = new CouchdbAuthToken("token1", "dex-client", "test token 1", Instant.now(),
+                new CouchdbUser("JohnDoe", "dex-user-id"));
+        // Another token owned by a different user
+        CouchdbAuthToken mockToken2 = new CouchdbAuthToken("token2", "dex-client", "test token 2", Instant.now(),
+                new CouchdbUser("notJohnDoe", "dex-user-id"));
+        List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
+        // The view query will search for lowercase "johndoe" (converted from "JOHNDOE")
+        interactions.add(new GetAllDocumentsInteraction(
+                "https://my-auth-store/galasa_tokens/_design/docs/_view/loginId-view?key=%22johndoe%22",
+                HttpStatus.SC_OK, mockAllDocsResponse));
+        interactions.add(new GetDocumentInteraction<CouchdbAuthToken>(
+                "https://my-auth-store/galasa_tokens/token1",
+                HttpStatus.SC_OK, mockToken));
+        interactions.add(new GetDocumentInteraction<CouchdbAuthToken>(
+                "https://my-auth-store/galasa_tokens/token2",
+                HttpStatus.SC_OK, mockToken2));
+
+        MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
+
+        MockHttpClientFactory httpClientFactory = new MockHttpClientFactory(mockHttpClient);
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+
+        CouchdbAuthStore authStore = new CouchdbAuthStore(authStoreUri, httpClientFactory, new HttpRequestFactoryImpl(),
+                logFactory, new MockCouchdbValidator(), mockTimeService);
+        
+        // When...
+        // Search for tokens with "JOHNDOE" (uppercase) when tokens exist for "JohnDoe" (mixed case)
+        List<IInternalAuthToken> tokens = authStore.getTokensByLoginId("JOHNDOE");
+
+        // Then...
+        // Should find the tokens via case-insensitive CouchDB view lookup
+        assertThat(tokens).hasSize(1);
+        assertThat(tokens.get(0)).usingRecursiveComparison().isEqualTo(mockToken);
+    }
+
+    @Test
     public void testStoreTokenSendsRequestToCreateTokenDocumentOK() throws Exception {
         // Given...
         URI authStoreUri = URI.create("couchdb:https://my-auth-store");
@@ -646,7 +695,7 @@ public class TestCouchdbAuthStore {
 
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         interactions.add(new GetAllDocumentsInteraction(
-                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22notJohndoe%22",
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22notjohndoe%22",
                 HttpStatus.SC_OK, mockAllDocsResponse));
         interactions.add(new GetDocumentInteraction<UserDoc>("https://my-auth-store/galasa_users/user1",
                 HttpStatus.SC_OK, mockUser));
@@ -663,6 +712,73 @@ public class TestCouchdbAuthStore {
         IUser user = authStore.getUserByLoginId("notJohndoe");
 
         assertThat(user).usingRecursiveComparison().isNotEqualTo(mockUser);
+    }
+
+    @Test
+    public void testGetUserByLoginIdCaseInsensitiveReturnsUserOK() throws Exception {
+        // Given...
+        URI authStoreUri = URI.create("couchdb:https://my-auth-store");
+        MockLogFactory logFactory = new MockLogFactory();
+
+        ViewResponse emptyResponse = new ViewResponse();
+        emptyResponse.rows = List.of();
+
+        ViewRow userDoc1 = new ViewRow();
+        userDoc1.id = "user1";
+        
+        ViewRow userDoc2 = new ViewRow();
+        userDoc2.id = "user2";
+        
+        List<ViewRow> mockDocs = List.of(userDoc1, userDoc2);
+        ViewResponse mockAllDocsResponse = new ViewResponse();
+        mockAllDocsResponse.rows = mockDocs;
+
+        FrontEndClient client = new FrontEndClient();
+
+        client.setClientName("web-ui");
+        client.setLastLogin(Instant.now());
+
+        // User with loginId "JohnDoe" (capital letters)
+        UserDoc mockUser1 = new UserDoc("JohnDoe", List.of(client), "2");
+        UserDoc mockUser2 = new UserDoc("janedoe", List.of(client), "3");
+
+        List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
+        
+        // Exact match search for "johndoe" returns empty
+        interactions.add(new GetAllDocumentsInteraction(
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22johndoe%22",
+                HttpStatus.SC_OK, emptyResponse));
+        
+        // getAllUsers to perform case-insensitive search
+        interactions.add(new GetAllDocumentsInteraction(
+                "https://my-auth-store/galasa_users/_all_docs",
+                HttpStatus.SC_OK, mockAllDocsResponse));
+        
+        // Get individual user documents
+        interactions.add(new GetDocumentInteraction<UserDoc>(
+                "https://my-auth-store/galasa_users/user1",
+                HttpStatus.SC_OK, mockUser1));
+        interactions.add(new GetDocumentInteraction<UserDoc>(
+                "https://my-auth-store/galasa_users/user2",
+                HttpStatus.SC_OK, mockUser2));
+
+        MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
+
+        MockHttpClientFactory httpClientFactory = new MockHttpClientFactory(mockHttpClient);
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+
+        CouchdbAuthStore authStore = new CouchdbAuthStore(authStoreUri, httpClientFactory, new HttpRequestFactoryImpl(),
+                logFactory, new MockCouchdbValidator(), mockTimeService);
+        
+        // When...
+        // Search for "johndoe" (lowercase) when user exists as "JohnDoe" (mixed case)
+        IUser user = authStore.getUserByLoginId("johndoe");
+
+        // Then...
+        // Should find the user via case-insensitive fallback
+        assertThat(user).isNotNull();
+        assertThat(user).isInstanceOf(UserImpl.class);
+        assertThat(user.getLoginId()).isEqualTo("JohnDoe");
     }
 
     @Test

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStoreValidator.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStoreValidator.java
@@ -137,7 +137,7 @@ public class TestCouchdbAuthStoreValidator {
         //   "language": "javascript"
         // }
         AuthStoreDBLoginView view = new AuthStoreDBLoginView();
-        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId, doc);\n  }\n}";
+        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), doc);\n  }\n}";
         AuthStoreDBViews views = new AuthStoreDBViews();
         views.loginIdView = view;
         AuthDBNameViewDesign designDocToPassBack = new AuthDBNameViewDesign();
@@ -210,7 +210,7 @@ public class TestCouchdbAuthStoreValidator {
         interactions.add(new CreateDatabaseInteraction(couchdbUriStr + "/" + usersDatabaseName, HttpStatus.SC_CREATED));
 
         AuthStoreDBLoginView view = new AuthStoreDBLoginView();
-        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId, doc);\n  }\n}";
+        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), doc);\n  }\n}";
         AuthStoreDBViews views = new AuthStoreDBViews();
         views.loginIdView = view;
         AuthDBNameViewDesign designDocToPassBack = new AuthDBNameViewDesign();
@@ -448,7 +448,7 @@ public class TestCouchdbAuthStoreValidator {
         //   "language": "javascript"
         // }
         AuthStoreDBLoginView view = new AuthStoreDBLoginView();
-        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId, doc);\n  }\n}";
+        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), doc);\n  }\n}";
         AuthStoreDBViews views = new AuthStoreDBViews();
         views.loginIdView = view;
         AuthDBNameViewDesign designDocToPassBack = new AuthDBNameViewDesign();
@@ -499,7 +499,7 @@ public class TestCouchdbAuthStoreValidator {
         //   "language": "javascript"
         // }
         AuthStoreDBLoginView view = new AuthStoreDBLoginView();
-        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId, doc);\n  }\n}";
+        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), doc);\n  }\n}";
         AuthStoreDBViews views = new AuthStoreDBViews();
         views.loginIdView = view;
         AuthDBNameViewDesign designDocToPassBack = new AuthDBNameViewDesign();
@@ -534,7 +534,7 @@ public class TestCouchdbAuthStoreValidator {
 
         boolean isUpdated = validator.updateDesignDocToDesiredDesignDoc(tableDesign, dbName);
 
-        String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId, doc); } }";
+        String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), doc); } }";
 
         assertTrue(isUpdated);
         assertNotNull(tableDesign.views);
@@ -553,7 +553,7 @@ public class TestCouchdbAuthStoreValidator {
 
         boolean isUpdated = validator.updateDesignDocToDesiredDesignDoc(tableDesign, dbName);
 
-        String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'], doc); } }";
+        String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), doc); } }";
 
         assertTrue(isUpdated);
         assertNotNull(tableDesign.views);

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -3416,7 +3416,7 @@ components:
             This field exists so that users can associate a user ID with any tests that were
             kicked off by an automation tool using the automation's JWT, which will be set into
             the requestor field. This means the user can then query and find tests that were
-            launched on their behalf by an automation tool.
+            launched on their behalf by an automation tool. This field is case-insensitive.
         testStream:
           type: string
           description: |-

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaRequestor.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaRequestor.java
@@ -22,18 +22,18 @@ public class RasSearchCriteriaRequestor implements IRasSearchCriteria {
 	public boolean criteriaMatched(@NotNull TestStructure structure) {
 		
 		if(structure == null) {
-			return Boolean.FALSE;	
+			return false;
 		}
 		
 		if(requestors != null) {
 			for(String requestor : requestors) {
-				if(requestor.equals(structure.getRequestor())){
-					return Boolean.TRUE;
+				if(requestor.equalsIgnoreCase(structure.getRequestor())){
+					return true;
 				}
 			}
 		}
 		
-		return Boolean.FALSE;
+		return false;
 	}
 
     public String[] getRequestors() {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaUser.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaUser.java
@@ -29,7 +29,7 @@ public class RasSearchCriteriaUser implements IRasSearchCriteria {
         if (users != null) {
             for (String user : users) {
                 // When searching by user, match on either the test user or requestor.
-                if (user.equals(structure.getUser()) || user.equals(structure.getRequestor())) {
+                if (user.equalsIgnoreCase(structure.getUser()) || user.equalsIgnoreCase(structure.getRequestor())) {
                     return true;
                 }
             }


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2556.

CouchdbAuthStore falls back to a case-insensitive search on all users if the first exact search comes back with no users. This means that the `--user` flag is now case insensitive, and does not return an error if automation changes the casing of the user to different than is stored in CouchDB

## Changes
- [x] Change to CouchdbAuthStore to emit loginIds as lower-case to support case-insensitive search.
- [x] Updates to CLI syntax help, README.md and openapi.yaml to doc that 'user' is now case-insensitive.
- [x] Unit tests (if applicable)
- [x] Documentation updates (if applicable)
- [x] Release notes updates (if applicable)
