### PR TITLE
Add initial Galasa user agent skill to assist in Galasa test development

### DIFF
--- a/.agents/skills/galasa-user/SKILL.md
+++ b/.agents/skills/galasa-user/SKILL.md
@@ -28,10 +28,6 @@ This skill contains individual skill references that explain how the various asp
 - [Galasa architecture](./references/galasa-architecture.md) - Framework components, managers, test runner
 - [Galasa ecosystem](./references/galasa-ecosystem.md) - Running at scale, stores, services
 
-**Simple Tasks** (project creation, running tests, basic queries):
-- Load only the quick reference card
-- Avoid loading detailed documentation unless needed
-
 **CLI Operations** (creating projects, running tests, viewing results):
 - [Galasa CLI tool](./references/galasa-cli-tool.md) - Detailed command syntax and flags
 

--- a/.agents/skills/galasa-user/SKILL.md
+++ b/.agents/skills/galasa-user/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: galasa-user
+description: Documentation with references to what Galasa is, how to use the Galasa CLI tool (galasactl), and how to create Galasa test projects. Use this skill when you are asked to do anything using Galasa.
+---
+
+# Galasa User Skill
+
+## When to use this skill
+
+Use this skill when you are asked to create or do anything using Galasa.
+
+## What this skill contains
+
+This skill contains individual skill references that explain how the various aspects of the Galasa testing framework work.
+
+## Context Optimization Strategy
+
+**IMPORTANT**: To minimize token usage, load files selectively based on task type:
+
+### Always Load First
+1. **This file** (SKILL.md)
+2. **[Quick Reference](./references/galasa-quick-reference.md)** - Common commands, patterns, and configurations
+
+### Load Based on Task Type
+
+**Understanding Galasa** (what is Galasa, why use it):
+- [Galasa overview](./references/galasa-overview.md) - What Galasa is, key features, use cases
+- [Galasa architecture](./references/galasa-architecture.md) - Framework components, managers, test runner
+- [Galasa ecosystem](./references/galasa-ecosystem.md) - Running at scale, stores, services
+
+**Simple Tasks** (project creation, running tests, basic queries):
+- Load only the quick reference card
+- Avoid loading detailed documentation unless needed
+
+**CLI Operations** (creating projects, running tests, viewing results):
+- [Galasa CLI tool](./references/galasa-cli-tool.md) - Detailed command syntax and flags
+
+**Test Development** (writing test classes, configuring environments):
+- [Writing Galasa tests](./references/writing-galasa-tests.md) - Test structure, build commands, CPS/credentials
+- [Test development best practices](./references/test-development-best-practices.md) - Design principles for scalable tests
+- [Galasa CLI tool](./references/galasa-cli-tool.md) - For project creation context
+
+**Manager Setup** (adding dependencies, injecting managers):
+- [Using Galasa managers](./references/using-galasa-managers.md) - Manager dependencies and injection patterns
+- Load terminal reference ONLY if user mentions screens/fields/timing
+
+**Terminal Interaction** (working with 3270 screens):
+- [Terminal Interaction Reference](./references/terminal-interaction-reference.md) - Detailed timing, navigation, data extraction
+- Load ONLY when user explicitly works with terminal screens or mentions timing issues
+- For basic terminal patterns, use quick reference instead
+
+**Troubleshooting** (errors, build failures, test failures):
+- [Troubleshooting Galasa](./references/troubleshooting-galasa.md) - Load only when errors occur
+
+### Critical Rules
+
+1. **Never load all files at once** - This wastes tokens
+2. **Start with quick reference** - Covers 80% of common tasks
+3. **Load terminal reference last** - Only when explicitly needed (200+ lines)
+4. **Avoid redundant loading** - If quick reference answers the question, stop there
+5. **Load conceptual docs only when asked** - Architecture, ecosystem, best practices
+
+## Skill References
+
+### Quick Start
+- [Quick Reference](./references/galasa-quick-reference.md) - **START HERE** - Common commands, patterns, configurations
+
+### Understanding Galasa
+- [Galasa overview](./references/galasa-overview.md) - What Galasa is, key features, and use cases
+- [Galasa architecture](./references/galasa-architecture.md) - Framework components, managers, and test runner
+- [Galasa ecosystem](./references/galasa-ecosystem.md) - Running tests at scale, stores, and services
+
+### Working with Galasa
+- [Galasa CLI tool](./references/galasa-cli-tool.md) - CLI command details and project structure
+- [Writing Galasa tests](./references/writing-galasa-tests.md) - Test structure, build commands, environment configuration
+- [Test development best practices](./references/test-development-best-practices.md) - Design principles for scalable, maintainable tests
+- [Using Galasa managers](./references/using-galasa-managers.md) - Manager dependencies, injection patterns, basic terminal usage
+
+### Advanced Topics
+- [Terminal Interaction Reference](./references/terminal-interaction-reference.md) - **Load only when needed** - Detailed terminal timing and navigation
+
+### Troubleshooting
+- [Troubleshooting Galasa](./references/troubleshooting-galasa.md) - Error resolution guidance

--- a/.agents/skills/galasa-user/references/galasa-architecture.md
+++ b/.agents/skills/galasa-user/references/galasa-architecture.md
@@ -1,0 +1,105 @@
+---
+name: galasa-architecture
+description: Explains Galasa's architecture including the core framework, managers, and test runner components.
+---
+
+## Galasa Architecture Overview
+
+Galasa decomposes into three major components:
+
+1. **The core Galasa framework** - Orchestrates all component activities and coordinates with the test runner
+2. **A collection of Managers** - Provide interfaces to interact with various technologies
+3. **A test runner** - Executes your tests under the direction of the core framework
+
+## The Core Framework
+
+The Galasa framework:
+- Orchestrates all component activities
+- Coordinates with the test runner to execute tests
+- Automatically recognizes test definitions
+- Launches required Managers and the test runner
+- Provisions and executes tests without explicit invocation
+
+**Key benefit**: You never have to write code to *invoke* your tests - you just write the code that defines them as test classes and methods.
+
+## Managers
+
+Managers serve two main purposes:
+1. **Reduce boilerplate code** - Simplify test code by abstracting common functionality
+2. **Provide proven tool interaction code** - Use battle-tested code for interacting with systems
+
+### Manager Characteristics
+
+- Can be general-purpose (e.g., HTTPClientManager) or focused (e.g., Db2Manager)
+- Can collaborate with each other to perform joint tasks
+- Share information and delegate tasks to other Managers
+- Coordination is handled by the Galasa framework
+
+### Types of Managers
+
+**Core Managers**
+- Central, fundamental Managers with wide-ranging use
+- Examples: zosFileManager, zosBatchManager, zosCommandManager
+- Part of the core Galasa distribution
+
+**Product Managers**
+- Responsible for test interactions with specific products
+- Examples: CICSTSManager, Db2Manager
+- Some are part of core distribution, others may be custom-written
+
+**Ancillary Managers**
+- Orchestrate integration with useful software tools and components
+- Examples: SeleniumManager, JMeterManager, DockerManager
+- Teams often write custom Managers for their specific tools
+
+**Application-Specific Managers**
+- Custom Managers for your specific application under test
+- Abstract application-specific boilerplate functionality
+- Remove repetitive code from tests themselves
+
+### Available Managers
+
+Core managers provided by Galasa:
+- **z/OS Managers**: z/OS Batch, z/OS Console, z/OS File, z/OS Program, z/OS TSO, z/OS UNIX, z/OS 3270 Terminal
+- **CICS TS Managers**: CICS Terminal, CICS Region, CICS Resource, CICS CECI, CICS CEDA, CICS CEMT
+- **HTTP Manager**: HTTP client functionality
+- **Artifact Manager**: Test artifact management
+- **Core Manager**: Core Galasa functionality
+- **Docker Manager**: Docker container manipulation
+- **Kubernetes Manager**: Kubernetes resource management
+- **Selenium Manager**: Web UI testing
+- **JMeter Manager**: Performance testing
+
+For the complete list of managers, see: https://raw.githubusercontent.com/galasa-dev/galasa/refs/heads/main/docs/content/docs/managers/index.md
+
+## The Test Runner
+
+The test runner:
+- Executes your tests under the direction of the core framework
+- Handles test lifecycle management
+- Manages test execution in local JVM or ecosystem environments
+- Coordinates with Managers to provision resources
+
+## Platform and Technology Integration
+
+**Platform Integration**
+- Built with knowledge of z/OS and cloud native platforms
+- Enables end-to-end testing across different platforms
+- No stubbing or mocking required
+
+**Technology Integration**
+- Fully extensible framework
+- Managers enable interaction with any test technology
+- Examples: JMeter, Selenium, JCL, 3270 screens
+
+**Pipeline Integration**
+- Provides REST endpoint for CI/CD pipelines
+- Can be called from Jenkins, GitLab CI, or any pipeline tool
+- Enables fast, reliable testing at scale
+- Can run thousands of tests in parallel
+
+**Enterprise Integration**
+- Test catalog for understanding and managing tests
+- Single repository for test results and artifacts
+- Native Kibana and Grafana dashboard support
+- Open-source with no vendor lock-in

--- a/.agents/skills/galasa-user/references/galasa-cli-tool.md
+++ b/.agents/skills/galasa-user/references/galasa-cli-tool.md
@@ -91,7 +91,7 @@ To run Galasa tests in a local Java Virtual Machine (JVM), you can use the `gala
 
 Optionally, the `--trace` flag can be supplied if you would like to enable trace-level logging for the test run.
 
-- If a user would like to run specific test methods, the `--methods` flag can be supplied any number of times with the name of the test method or test methods to run. For example: `--methods testMethod1 --methods testMethod2`
+- If a user would like to run specific test methods, the `--methods` flag can be supplied any number of times with the name of the test method or test methods to run. Alternatively, a comma-separated list of methods can be supplied in a single `--methods` flag. For example: `--methods testMethod1 --methods testMethod2`, or `--methods testMethod1,testMethod2`.
 
 - **IMPORTANT**: Every Galasa test run is assigned a unique run name, in the form `XY` where `X` is a single capital letter (example: `L` for local) and `Y` is a number (example: `12`). You **MUST** retain knowledge of this run name for context in case the user want information about the test run's result.
 

--- a/.agents/skills/galasa-user/references/galasa-cli-tool.md
+++ b/.agents/skills/galasa-user/references/galasa-cli-tool.md
@@ -1,0 +1,111 @@
+---
+name: galasa-cli-tool
+description: Provides information about how to use the Galasa CLI tool to set up a local environment, create Galasa test projects, and run Galasa tests.
+---
+
+## Getting started
+
+- The Galasa CLI tool, called `galasactl` is installed on this machine and is used to run Galasa tests.
+- You **MUST** check that the Galasa CLI tool is installed by running `galasactl --version`.
+- For any `galasactl` command that is mentioned in this file, you can find the corresponding reference information for that command at - https://raw.githubusercontent.com/galasa-dev/galasa/refs/heads/main/modules/cli/docs/generated/{COMMAND_NAME}.md/ (where `{COMMAND_NAME}` is the name of the command where any spaces are replaced with `_`)
+
+### Initialising the local environment
+
+**Note**: The `~` character represents the current user's home directory. This can be retrieved by running `echo $HOME`, where `$HOME` is the environment variable that points to the current user's home directory.
+
+- Before creating a Galasa project, make sure that the `~/.galasa` directory exists and is populated with the following files:
+  - `bootstrap.properties`: A file containing properties to configure the core framework
+  - `cps.properties`: A file containing key-value properties to configure test environments
+  - `dss.properties`: A file containing key-value properties that are set dynamically at runtime. **IMPORTANT**: You **MUST NOT** edit this file under any circumstances
+  - `credentials.properties` file: A file containing key-value properties to configure the credentials used to access your configured test systems
+- If the `~/.galasa` directory does not exist, run the `galasactl local init` command to create it
+
+### Creating a Galasa project
+
+- Create a new Galasa project in the current directory by running the `galasactl project create` command. The command requires the following flags to be passed in:
+  -  `--package {PACKAGE_NAME}`: The name of the Java package to be used for the Galasa project. This **MUST** be a valid Java package name, like `dev.galasa.example`.
+  -  `--features {FEATURES_TO_TEST}`: One or more application features to be tested in the Galasa project. If multiple features are specified, the `--features` command can be supplied with commas to separate different features (e.g. `--features customer,account`).
+  -  `--gradle` or `--maven`: The build tool to be used for the Galasa project, either Gradle or Maven. Only one of these flags is needed. Prefer Gradle wherever possible.
+  -  `--obr`: Tells Galasa to create an OBR project
+
+**Note**: OBR (OSGi Bundle Repository) projects package test bundles for distribution and execution. The `--obr` flag is recommended for most projects.
+
+- If a user wants to create a Galasa project in a different directory, you should navigate to that directory before running the `galasactl project create` command.
+- If a user asks to create a single test suite, do not create multiple features. Instead, create a single feature and add all the tests to that feature as a single test class.
+- Do **NOT** use the `--gherkin` flag. This flag is reserved for Gherkin-based projects.
+
+**IMPORTANT**: If a user does not provide a package name or features, ask them to give you this information. **NEVER** expect the user to provide the Galasa CLI command themselves.
+
+For example, running the command `galasactl project create --package dev.galasa.example --features account --obr --gradle`, the created project will have the following structure:
+```
+.
+└── dev.galasa.example
+    ├── dev.galasa.example.account
+    │   ├── src
+    │   │   └── main
+    │   │       ├── resources
+    │   │       |   └── textfiles
+    │   │       |       └── sampleText.txt
+    │   │       └── java
+    │   │           └── dev
+    │   │               └── galasa
+    │   │                   └── example
+    │   │                       └── account
+    │   │                           ├── TestAccount.java
+    │   │                           └── TestAccountExtended.java
+    │   └── build.gradle
+    │   └── bnd.bnd
+    └── dev.galasa.example.account.obr
+        └── build.gradle
+```
+
+Where:
+- `dev.galasa.example` is the root of the project.
+- `dev.galasa.example.account` is the name of the test project for the `account` feature.
+- `dev.galasa.example.account.obr` is the name of the OBR project.
+- `src/main/resources/textfiles/sampleText.txt` is a sample text file that is used by the `TestAccountExtended` class.
+- `dev.galasa.example.account.TestAccount.java` is a simple Galasa test class for the `account` feature.
+- `dev.galasa.example.account.TestAccountExtended.java` is a more in-depth Galasa test class for the `account` feature.
+- `build.gradle` is the Gradle build file for the project.
+- `bnd.bnd` is the BND file for the project.
+- `dev.galasa.example.account.obr/build.gradle` is the Gradle build file for the OBR project.
+
+
+**IMPORTANT**: The `Test{FEATURE}Extended` and `Test{Feature}` classes can be deleted and replaced with your own test classes, and the `textfiles` directory can also be deleted. They simply serve as initial templates for a Galasa project.
+
+**IMPORTANT**: **ALWAYS** read the created project structure to make sure that all of the expected files were successfully created.
+
+If the user asks to create a Galasa project with a specific test class, you **MUST** replace the templated test class files and associated resources with a new test class that the user asked for.
+
+## Running Galasa tests
+
+To run Galasa tests in a local Java Virtual Machine (JVM), you can use the `galasactl runs submit local` command. This command **MUST** have the following flags supplied to it:
+- `--class {CLASS_NAME}`: The fully qualified name of the test class to be run in the form `{BUNDLE_NAME}/{CLASS_NAME}`, where `{BUNDLE_NAME}` is the name of the bundle that contains the test class and `{CLASS_NAME}` is the fully qualified name of the test class. The `{BUNDLE_NAME}` can be found in the `Bundle-Name` manifest header in the test project's `bnd.bnd` file.
+  - Example `bnd.bnd` content: `Bundle-Name: dev.galasa.example.account`
+  - Example: `--class dev.galasa.example.account/dev.galasa.example.account.TestAccount`
+- `--obr {OBR_COORDINATES}`: A list of maven coordinates of the OBR bundles which refer to your test class bundles. The format of this flag is 'mvn:${GROUP_ID}/${ARTIFACT_ID}/${VERSION}/obr', where '{GROUP_ID}' and `{VERSION}` can be found in the `build.gradle` file of the OBR project, and `{ARTIFACT_ID}` is typically the OBR project's directory name. Multiple instances of this flag can be used to describe multiple OBRs.
+  - Example: `--obr mvn:dev.galasa.example/dev.galasa.example.obr/0.0.1-SNAPSHOT/obr`
+- `--log -`: Output log messages to the terminal instead of a log file.
+
+Optionally, the `--trace` flag can be supplied if you would like to enable trace-level logging for the test run.
+
+- If a user would like to run specific test methods, the `--methods` flag can be supplied any number of times with the name of the test method or test methods to run. For example: `--methods testMethod1 --methods testMethod2`
+
+- **IMPORTANT**: Every Galasa test run is assigned a unique run name, in the form `XY` where `X` is a single capital letter (example: `L` for local) and `Y` is a number (example: `12`). You **MUST** retain knowledge of this run name for context in case the user want information about the test run's result.
+
+**IMPORTANT**: If a user does not provide enough information for you to fill in the required flags, ask them to give you this information. **NEVER** expect the user to provide the Galasa CLI command themselves.
+
+## Viewing Galasa test results
+
+- Galasa test runs are saved in a local Result Archive Store (RAS), which is found at `~/.galasa/ras` by default.
+- Inside the `~/.galasa/ras` folder, you will find folders corresponding to all of the test runs that have previously been executed.
+- Inside each test run folder, you will find the following files:
+    - `structure.json`: The structure of the test run and its details, including:
+      - Test run name (e.g., `L12`)
+      - Test run ID (unique identifier)
+      - Start and end times
+      - Test run status: `Passed`, `Failed`, `EnvFail` (environment failure), or `Ignored`
+      - Test methods executed and their individual results
+    - `run.log`: The log file for the test run.
+    - `artifacts/`: A directory containing artifacts associated with the test run.
+    - `artifacts.properties`: A file containing key-value pairs, where the keys correspond to the individual artifact paths that have been saved and the values correspond to the artifact's content type.

--- a/.agents/skills/galasa-user/references/galasa-cli-tool.md
+++ b/.agents/skills/galasa-user/references/galasa-cli-tool.md
@@ -6,8 +6,10 @@ description: Provides information about how to use the Galasa CLI tool to set up
 ## Getting started
 
 - The Galasa CLI tool, called `galasactl` is installed on this machine and is used to run Galasa tests.
-- You **MUST** check that the Galasa CLI tool is installed by running `galasactl --version`.
+- You can check that the Galasa CLI tool is installed by running `galasactl --version`.
 - For any `galasactl` command that is mentioned in this file, you can find the corresponding reference information for that command at - https://raw.githubusercontent.com/galasa-dev/galasa/refs/heads/main/modules/cli/docs/generated/{COMMAND_NAME}.md/ (where `{COMMAND_NAME}` is the name of the command where any spaces are replaced with `_`)
+
+**Note**: If the Galasa CLI tool is not installed, you should direct the user to the [Installing the Galasa CLI online](https://galasa.dev/docs/cli-command-reference/installing-cli-tool/) documentation page, or the [Installing the Galasa CLI offline](https://galasa.dev/docs/cli-command-reference/installing-offline/) page if they do not have access to the internet.
 
 ### Initialising the local environment
 

--- a/.agents/skills/galasa-user/references/galasa-ecosystem.md
+++ b/.agents/skills/galasa-user/references/galasa-ecosystem.md
@@ -1,0 +1,185 @@
+---
+name: galasa-ecosystem
+description: Explains the Galasa Ecosystem for running tests at scale, including stores, services, and key concepts.
+---
+
+## What is the Galasa Ecosystem?
+
+The Galasa Ecosystem is a cloud native application that enables you to run automated testing away from your workstation, outside of a local JVM. It provides the full power of Galasa for enterprise-scale testing.
+
+## Why Use the Ecosystem?
+
+### Limitations of Local-Only Testing
+
+Running tests only locally has several limitations:
+- Configuration settings, test results and artifacts are stored locally and cannot be easily shared
+- Tests cannot run headlessly - workstation must remain active
+- Scaling is limited by workstation resources
+- No monitoring and management features (test streams, test catalog, dashboards)
+
+### Benefits of the Ecosystem
+
+**Sharing tests across an enterprise**
+- Scale horizontally to run large numbers of tests in parallel
+- More testing completes in shorter timeframes
+- Data is locked whilst in use, preventing cross-contamination
+- Key differentiator from other test frameworks
+
+**Re-usability**
+- One person configures properties for use across all test runs
+- Configurations maintained in single location (CPS)
+- Single source of truth for test configurations
+- Test results, logs, and artifacts stored centrally
+- Easy sharing across teams
+
+**Testing as a service**
+- Run regression tests, application tests, system verification tests on demand
+- Integrate with DevOps pipelines
+- Run in dedicated cloud environment
+- Workload separated from CI pipeline
+- Prevents resource diversion from other pipeline jobs
+
+**Automated test runs**
+- Test catalog stores related tests in shared location
+- Tests automatically selected for any given change set
+- Uses latest version of test cases
+- No need for local test material
+
+## Ecosystem Architecture
+
+The Ecosystem is made up of:
+- Collection of microservices for orchestrating runtimes
+- Monitoring services for tests and resources
+- Resource cleanup services
+- Centralized store for run configurations
+- Single location for all test results and artifacts
+- REST endpoint callable from any IDE or pipeline
+
+## Key Components
+
+### Galasa Stores
+
+**Configuration Property Store (CPS)**
+- Defines object properties, topologies, system configurations
+- Instructs how Galasa tests run
+- Contains properties for endpoints, ports, timeouts
+- All tests use same CPS configuration (unless overridden at submission)
+- Enables tests to run against multiple environments without code changes
+- **Security note**: Hard drive encryption recommended as IP addresses and ports are stored
+
+**Dynamic Status Store (DSS)**
+- Provides status information about ecosystem and running tests
+- Used by resource manager and engine controller
+- Ensures CPS limits are not exceeded
+- Property values change dynamically as tests run
+- Shows resources currently being used, shared, or locked
+- Prevents throttling by limiting workloads
+- Shared by every framework instance in automation
+
+**Result Archive Store (RAS)**
+- Single database storing all test elements
+- Contains test results, run logs, test artifacts
+- Helps diagnose failures
+- Gathers information about tests
+- Enables entire teams to view results in one place
+
+**Credentials Store (CREDs)**
+- Securely provides credentials for test automation
+- Stores passwords, usernames, personal access tokens
+- Supports KeyStore credentials (PKCS12, JKS format) for SSL/TLS certificates
+- Hosted in etcd server
+- Validated during credential creation
+
+**etcd Server**
+- Highly available key-value pair store
+- Hosts CPS, DSS, and CREDs
+- Maintains single, consistent source of truth
+- Tracks ecosystem status at any given point in time
+
+**CouchDB**
+- Runs inside Docker container or Kubernetes pod
+- Contains the Result Archive Store (RAS)
+
+### Galasa Services
+
+**Engine Controller**
+- Enables tests to run at scale
+- Instantiates individual test engines
+- Creates Docker containers or Kubernetes pods for test runs
+- Allocates test engine if required resources are available
+- Puts tests in waiting state if resources unavailable
+
+**Resource Management**
+- Monitors running tests and in-use resources
+- Performs cleanup if test becomes stale or is ended manually
+- Returns resources to pool for other tests
+- Can de-provision entire environments
+
+**Metrics Server**
+- Indicates ecosystem health
+- Provides metrics on successful test runs
+- Tracks throughput and performance
+
+**API Server**
+- Central point for controlling Galasa Ecosystem
+- Endpoint for IDEs and pipelines
+- Used for submitting tests and retrieving results
+- Hosts the bootstrap server
+
+**Bootstrap Server**
+- Part of the API server
+- Stores initial configuration for instantiating Galasa framework
+- IDE must point to bootstrap configured for ecosystem
+
+**Galasa Web UI**
+- Currently under construction (planned for future release)
+- Dashboard overview of current and historical health
+- Run, schedule, or reschedule tests
+- Analyze output from failed test runs
+- Manage configuration for maximum throughput, resilience, flexibility
+
+**Dex**
+- Authenticates users interacting with Galasa Ecosystem
+
+### Code Deployment
+
+**Maven Repositories and OBRs**
+- Tests require compiled artifacts hosted in Maven repository
+- Artifacts must be bundled as OSGI bundles
+- Galasa provides Maven plug-in to create bundles
+
+**Nexus**
+- Enables deployment of Maven artifacts to ecosystem
+- Can host Docker images
+- Alternative internal artifact repositories can be used
+
+## Key Concepts
+
+### Universal Concepts (Local and Remote)
+
+**Test Case**
+- Piece of test logic that can be compiled or translated
+- Runnable by Galasa framework
+- Can be Java code or Gherkin test feature
+
+**Test Run (Run)**
+- Execution of a test case
+- Started at specific point in time
+- Executes logic steps
+- Either still running or finished with status and result (Passed/Failed)
+
+### Ecosystem-Only Concepts
+
+**User**
+- Authorized person manipulating the Galasa system
+
+**Role Based Access Control (RBAC)**
+- Mechanism to allow/limit user actions
+- Some users can perform any task
+- Other users have limited capabilities
+- Helps isolate system capabilities for safety and security
+
+**Test Streams**
+- Organize and manage test execution
+- Can be created and updated via REST API or CLI
+- Enable automated test selection and scheduling

--- a/.agents/skills/galasa-user/references/galasa-overview.md
+++ b/.agents/skills/galasa-user/references/galasa-overview.md
@@ -1,0 +1,147 @@
+---
+name: galasa-overview
+description: Provides an overview of what Galasa is, why it is needed, and its key features.
+---
+
+## What is Galasa?
+
+Galasa is an open source **deep integration testing framework** for testing complex, interconnected enterprise systems. It specializes in:
+- **Integration testing**: Multiple systems working together
+- **End-to-end testing**: Complete business workflows
+- **Mainframe testing**: z/OS, CICS, and other mainframe technologies
+- **Automated testing**: No manual intervention required
+
+Galasa is an [Open Mainframe Project](https://openmainframeproject.org/projects/galasa/) that enables deep integration testing across platforms and technologies within DevOps pipelines.
+
+## Why Galasa is Different
+
+Galasa differs from other test tools by:
+- Supporting repeatable, reliable, agile testing at scale
+- Enabling deep integration testing across platforms without stubbing or mocking
+- Providing enterprise-level test management and reporting
+- Being fully open-source with no vendor lock-in
+
+## Key Features
+
+### Consistent Testing for All Technologies
+
+**Write once, run anywhere:**
+- Write tests as JUnit-style Java classes
+- Run locally from IDE or in automation
+- No code changes needed between environments
+
+**Deep z/OS integration:**
+- Verify data by interrogating CICS applications directly
+- Check z/OS resources (queues, files, etc.) without stubs or mocking
+- Native support for 3270 terminals, batch jobs, TSO commands
+
+### Focus on Testing, Not Integration Problems
+
+**Multi-technology integration:**
+- One test case can interact with 3270, Selenium, JMeter, batch jobs, and more
+- Framework handles integration complexity
+- Tests focus on validation, not infrastructure
+
+**DevOps integration:**
+- Integrates easily into DevOps strategies
+- Works alongside other test tools
+- REST API for pipeline integration
+
+### Fast Test Data Provisioning
+
+**Test data management:**
+- Integrate with test data strategy
+- Provision new or existing test data records
+- Lock test data for parallel test execution
+- Repeat tests under identical conditions
+
+**Automatic cleanup:**
+- Provisioned environments automatically deprovisioned
+- Clean test system state after completion
+- Ready for next tests immediately
+
+### Centralized Results and Artifacts
+
+**Single location storage:**
+- All test results in uniform style
+- Easy extraction of big picture information
+- Single place to search all test output
+- Quick identification of failure causes
+
+**Local debugging:**
+- Run tests locally to assist debugging
+- Access to all test artifacts
+- Complete test history available
+
+### Test Planning and Recording
+
+**Test catalog:**
+- Define areas under test
+- Automate arduous manual tests
+- Record what tests have run
+- Plan what tests are left to do
+
+**Test organization:**
+- Categorize tests by function, type, priority
+- Easy test selection and scheduling
+- Comprehensive test coverage tracking
+
+### Scalability and Extensibility
+
+**Open source benefits:**
+- Extend to support additional tooling
+- No vendor lock-in
+- No initial cost
+- Community-driven development
+
+**Enterprise throughput:**
+- Scale horizontally in cloud environment
+- Run thousands of tests in parallel
+- Handle enterprise-level workloads
+- Dedicated test execution environment
+
+## Hybrid Cloud Testing
+
+Galasa simplifies testing in hybrid cloud environments where applications span multiple platforms:
+
+**Platform support:**
+- z/OS mainframe systems
+- Cloud native platforms
+- Distributed systems
+- Mixed technology stacks
+
+**Technology support:**
+- 3270 terminal emulation
+- JCL batch jobs
+- Selenium Web Driver
+- REST APIs
+- Message queues
+- Databases
+
+**End-to-end testing:**
+- Test complete business workflows
+- Validate across platform boundaries
+- No stubbing or mocking required
+- Real integration validation
+
+## Use Galasa to:
+
+- **Simplify test construction**: Build new integration tests easily and incorporate into regression suites
+- **Validate against updates**: Quickly test applications against new middleware or OS releases
+- **Deliver with confidence**: Deploy new functions fast with comprehensive testing
+- **Verify system functionality**: Easily verify systems post-maintenance
+- **Scale testing**: Run thousands of tests in parallel for faster feedback
+- **Share test assets**: Centralize test code, data, and results across teams
+- **Automate testing**: Run tests headlessly in CI/CD pipelines
+- **Reduce technical debt**: Use proven Manager code instead of custom implementations
+
+## Getting Started
+
+To start using Galasa:
+1. Install the Galasa CLI tool (galasactl)
+2. Initialize your local environment
+3. Create a Galasa project
+4. Write and run tests
+5. Optionally, set up a Galasa Ecosystem for enterprise-scale testing
+
+For detailed instructions, see the other skill references in this skill.

--- a/.agents/skills/galasa-user/references/galasa-overview.md
+++ b/.agents/skills/galasa-user/references/galasa-overview.md
@@ -27,7 +27,7 @@ Galasa differs from other test tools by:
 
 **Write once, run anywhere:**
 - Write tests as JUnit-style Java classes
-- Run locally from IDE or in automation
+- Run locally using a CLI tool or in automation
 - No code changes needed between environments
 
 **Deep z/OS integration:**

--- a/.agents/skills/galasa-user/references/galasa-quick-reference.md
+++ b/.agents/skills/galasa-user/references/galasa-quick-reference.md
@@ -1,0 +1,206 @@
+---
+name: galasa-quick-reference
+description: Quick reference for common Galasa commands, patterns, and configurations. Load this first for simple tasks.
+---
+
+## When to Use This Reference
+
+Use this quick reference for:
+- Simple project creation and test execution
+- Common command syntax lookups
+- Basic manager setup
+- Standard test patterns
+
+For detailed guidance, load the specific skill files as needed.
+
+## Command Quick Reference
+
+### Environment Setup
+```bash
+# Initialize Galasa environment (creates ~/.galasa directory)
+galasactl local init
+
+# Check CLI version
+galasactl --version
+```
+
+### Project Creation
+```bash
+# Create new Galasa project (Gradle example - recommended)
+galasactl project create --package {PACKAGE_NAME} --features {FEATURE} --gradle --obr
+
+# Create new Galasa project (Maven example)
+galasactl project create --package {PACKAGE_NAME} --features {FEATURE} --maven --obr
+
+# Example
+galasactl project create --package dev.galasa.example --features account --gradle --obr
+```
+
+### Building Projects
+```bash
+# Gradle (recommended)
+gradle clean build publishToMavenLocal
+
+# Maven
+mvn clean install
+```
+
+### Running Tests
+```bash
+# Run a test class
+galasactl runs submit local \
+  --class {BUNDLE_NAME}/{FULLY_QUALIFIED_CLASS} \
+  --obr mvn:{GROUP_ID}/{ARTIFACT_ID}/{VERSION}/obr \
+  --log -
+
+# Example
+galasactl runs submit local \
+  --class dev.galasa.example.account/dev.galasa.example.account.TestAccount \
+  --obr mvn:dev.galasa.example/dev.galasa.example.obr/0.0.1-SNAPSHOT/obr \
+  --log -
+
+# Run specific test methods
+--methods testMethod1 --methods testMethod2
+
+# Enable trace logging
+--trace
+```
+
+## Manager Quick Reference
+
+### Common Manager Dependencies
+
+**Gradle (`build.gradle`)**:
+```groovy
+dependencies {
+    implementation 'dev.galasa:dev.galasa.{manager}.manager'
+}
+```
+
+**Maven (`pom.xml`)**:
+```xml
+<dependency>
+    <groupId>dev.galasa</groupId>
+    <artifactId>dev.galasa.{manager}.manager</artifactId>
+    <scope>provided</scope>
+</dependency>
+```
+
+### Manager Injection Patterns
+
+```java
+// z/OS and 3270 Terminal
+@ZosImage(imageTag = "PRIMARY")
+public IZosImage zosImage;
+
+@Zos3270Terminal(imageTag = "PRIMARY")
+public ITerminal terminal;
+
+// CICS (requires z/OS managers too, but does not need ZosImage and Zos3270Terminal fields if used)
+@CicsRegion(cicsTag = "PRIMARY")
+public ICicsRegion cics;
+
+@CicsTerminal(cicsTag = "PRIMARY")
+public ICicsTerminal terminal;
+
+// HTTP Client
+@HttpClient
+public IHttpClient httpClient;
+
+// Logger (only include if log messages are added)
+@Logger
+public Log logger;
+```
+
+### Critical Manager Rules
+
+- **z/OS 3270**: Always add both `dev.galasa.zos.manager` AND `dev.galasa.zos3270.manager`
+- **CICS**: Requires `dev.galasa.cicsts.manager` + z/OS managers
+- **Build after adding**: Run build command after adding new managers
+
+## Common Test Patterns
+
+### Test Class Structure
+```java
+@Test
+public class YourTestClass {
+
+    @BeforeClass
+    public void setup() throws Exception {
+        // One-time setup
+    }
+    
+    @Test
+    public void testSomething() throws Exception {
+        // Test implementation
+    }
+    
+    @AfterClass
+    public void cleanup() throws Exception {
+        // One-time cleanup
+    }
+}
+```
+
+### Terminal Interaction (Critical Pattern)
+```java
+// ALWAYS chain methods and wait for keyboard
+terminal.type("value")
+    .enter()
+    .waitForKeyboard()
+    .waitForTextInField("Expected text");
+
+// Extract field values (always trim)
+String value = terminal.retrieveFieldTextAfterFieldWithString("Label").trim();
+
+// Verify with assertions (always include message)
+assertThat(value).as("Field should match").isEqualTo("expected");
+
+// Function keys
+terminal.pf3().waitForKeyboard();  // F3 to exit/return
+terminal.pf5().waitForKeyboard();  // F5 to delete
+```
+
+### Assertions (AssertJ)
+```java
+// Always include descriptive message with .as()
+assertThat(actual).as("Description of what's being checked").isEqualTo(expected);
+assertThat(screen).as("Should contain success message").contains("Success");
+assertThat(value).as("Should not be empty").isNotEmpty();
+```
+
+## Configuration Quick Reference
+
+### CPS Properties (`~/.galasa/cps.properties`)
+```properties
+# Format: NAMESPACE.PROPERTY_NAME=VALUE
+zos.image.PRIMARY.ipv4.hostname=system.example.com
+zos.image.PRIMARY.telnet.port=992
+zos.image.PRIMARY.telnet.tls=true
+zos.image.PRIMARY.credentials=SYSTEM1
+```
+
+### Credentials (`~/.galasa/credentials.properties`)
+```properties
+# Format: secure.credentials.TAG.TYPE=VALUE
+secure.credentials.SYSTEM1.username=MYUSER
+secure.credentials.SYSTEM1.password=PASSW0RD
+```
+
+## Test Results Location
+
+- **RAS Directory**: `~/.galasa/ras/`
+- **Run folders**: Named by run ID (e.g., `L12`)
+- **Key files**:
+  - `structure.json`: Test run details and status
+  - `run.log`: Full test execution log
+  - `artifacts/`: Test artifacts
+
+## When to Load Detailed Documentation
+
+Load specific skill files when you need:
+- **galasa-cli-tool.md**: Detailed CLI command explanations, project structure details
+- **writing-galasa-tests.md**: Test class structure details, build configuration, CPS/credentials setup
+- **using-galasa-managers.md**: Manager injection details, basic terminal interaction
+- **terminal-interaction-reference.md**: Detailed terminal timing, field navigation, complete examples
+- **troubleshooting-galasa.md**: Error resolution guidance

--- a/.agents/skills/galasa-user/references/terminal-interaction-reference.md
+++ b/.agents/skills/galasa-user/references/terminal-interaction-reference.md
@@ -1,0 +1,250 @@
+---
+name: terminal-interaction-reference
+description: Detailed reference for 3270 terminal interaction timing, field navigation, and data extraction. Load only when working with terminal screens.
+---
+
+## When to Use This Reference
+
+Load this file only when:
+- Working with 3270 terminal screens (z/OS or CICS)
+- Debugging terminal timing issues
+- Implementing complex field navigation
+- User mentions screens, fields, or terminal interaction problems
+
+For basic terminal patterns, see the quick reference card.
+
+## Understanding Keyboard Lock States
+
+3270 terminals have two keyboard states:
+- **Locked**: Keyboard is locked while the terminal processes a command or waits for the host to respond
+- **Unlocked**: Keyboard is ready to accept input
+
+**Key actions that lock the keyboard:**
+- `enter()` - Submits data to the host
+- `clear()` - Clears the screen
+- `pf3()`, `pf5()`, `pf10()`, etc. - Function key presses
+- Any action that sends data to the host
+
+**Critical Rule:** Always call `waitForKeyboard()` after any action that locks the keyboard.
+
+## Method Chaining Pattern
+
+Always chain terminal method calls rather than invoking them on separate lines:
+
+```java
+// BAD - Don't do this
+terminal.type("Hello, World!");
+terminal.enter();
+terminal.waitForKeyboard();
+
+// GOOD - Chain the calls
+terminal.type("Hello, World!").enter().waitForKeyboard();
+```
+
+## Timing Best Practices
+
+### 1. Wait for Keyboard After Commands
+
+Always use `waitForKeyboard()` after commands that lock the keyboard:
+
+```java
+// Clearing the screen
+terminal.clear().waitForKeyboard();
+
+// Submitting data
+terminal.type("1").enter().waitForKeyboard();
+
+// Pressing function keys
+terminal.pf3().waitForKeyboard();
+```
+
+### 2. Wait for Screen Content to Load
+
+`waitForKeyboard()` ensures the keyboard is unlocked, but the screen content may still be loading. Use `waitForTextInField()` to ensure specific content has appeared:
+
+```java
+// Navigate to a screen and wait for it to fully load
+terminal.type("MENU")
+    .enter()
+    .waitForKeyboard()
+    .waitForTextInField("Select an option");  // Wait for menu to appear
+```
+
+### 3. Common Timing Mistakes to Avoid
+
+- ❌ Not waiting for keyboard after `enter()`, `clear()`, or PF keys
+- ❌ Proceeding to next action before screen content loads
+- ❌ Not verifying expected text appears before interacting with fields
+
+```java
+// WRONG - May fail if screen hasn't loaded
+terminal.type("1").enter().waitForKeyboard();
+terminal.type("1234").enter().waitForKeyboard();  // May type into wrong field!
+
+// CORRECT - Verify screen loaded before proceeding
+terminal.type("1").enter().waitForKeyboard()
+    .waitForTextInField("CUSTOMER NUMBER");  // Ensure we're on the right screen
+terminal.type("1234").enter().waitForKeyboard();
+```
+
+## Field Navigation and Interaction
+
+### Moving Between Fields
+
+```java
+// Tab to next field
+terminal.tab();
+
+// Back tab to previous field
+terminal.backTab();
+
+// Position cursor at a specific field by its label
+terminal.positionCursorToFieldContaining("Customer Number");
+```
+
+### Typical Field Interaction Pattern
+
+```java
+// Navigate to field, enter data, and submit
+terminal.positionCursorToFieldContaining("Customer Number")
+    .type("1234")
+    .enter()
+    .waitForKeyboard()
+    .waitForTextInField("Customer found OK");
+```
+
+## Extracting Data from Screens
+
+### CRITICAL: Capitalization Matters
+
+When a user provides expected values or field names in quotes (like "Customer Number", "Sort Code", or "Mr Galasa Tester"), you **MUST** adhere to the exact capitalization of letters in the quotes. Incorrect capitalization will cause assertions to fail or field lookups to return incorrect results.
+
+Examples:
+- If the user says the field is called "Customer Number", use `"Customer Number"` (not `"customer number"` or `"CUSTOMER NUMBER"`)
+- If the user says the expected value is "Sort Code", use `"Sort Code"` (not `"sort code"` or `"SORT CODE"`)
+- If the user says the name should be "Mr Galasa Tester", use `"Mr Galasa Tester"` (not `"mr galasa tester"`)
+
+### 1. Retrieving Labeled Field Values
+
+Use `retrieveFieldTextAfterFieldWithString()` to get the value of a labeled field:
+
+```java
+// Get the value after a label (works even if on different lines)
+String id = terminal.retrieveFieldTextAfterFieldWithString("ID");
+assertThat(id.trim()).as("ID should match").isEqualTo("987654");
+
+String name = terminal.retrieveFieldTextAfterFieldWithString("Customer Name");
+assertThat(name.trim()).as("Name should match").isEqualTo("Galasa Tester");
+```
+
+**Important:** Always use `.trim()` when comparing field values, as they may contain leading/trailing whitespace.
+
+### 2. Checking for Messages or Unlabeled Text
+
+Use `retrieveScreen()` to get the entire screen content as a string:
+
+```java
+// Check for success/error messages
+String screen = terminal.retrieveScreen();
+assertThat(screen).as("Success message should appear").contains("Customer found OK");
+
+// Check for error messages
+assertThat(screen).as("Should not show error").doesNotContain("ERROR");
+```
+
+### 3. Verifying Screen State
+
+Before interacting with a screen, verify you're on the expected screen:
+
+```java
+// Verify we're on the customer display screen
+terminal.waitForTextInField("Display Customer");
+
+// Or check for specific prompt text
+terminal.waitForTextInField("Provide a Customer number");
+```
+
+## Complete Interaction Example
+
+Here's a complete example showing proper timing and verification:
+
+```java
+@Test
+public void testCustomerLookup() throws Exception {
+    // Navigate to customer display screen
+    terminal.type("LOOKUP CUSTOMER")                              // Run a 'LOOKUP CUSTOMER' command
+        .enter()                                    // Submit
+        .waitForKeyboard()                          // Wait for keyboard to unlock
+        .waitForTextInField("CUSTOMER NUMBER");     // Verify screen loaded
+    
+    // Enter customer number
+    terminal.type("1234")                           // Type customer number
+        .enter()                                    // Submit
+        .waitForKeyboard()                          // Wait for keyboard to unlock
+        .waitForTextInField("Customer found OK");  // Verify success
+    
+    // Extract and verify field values
+    String sortCode = terminal.retrieveFieldTextAfterFieldWithString("Sort code");
+    assertThat(sortCode.trim()).as("Sort code should match").isEqualTo("112233");
+    
+    String customerName = terminal.retrieveFieldTextAfterFieldWithString("Customer name");
+    assertThat(customerName.trim()).as("Customer name should match").isEqualTo("Mr Michael Z Barker");
+}
+```
+
+## Error Detection
+
+Error messages vary by application. When checking for errors:
+
+1. Ask the user what specific error text to expect
+2. Use `retrieveScreen()` to get full screen content
+3. Check for the specific error text in assertions
+
+```java
+// Check for specific error message
+String screen = terminal.retrieveScreen();
+assertThat(screen).as("Should show invalid customer error")
+    .contains("Customer not found");
+```
+
+## Terminal Size Configuration
+
+Default terminal size is 24 rows × 80 columns. To use a different size:
+
+```java
+@Zos3270Terminal(imageTag = "PRIMARY", primaryColumns = 100, primaryRows = 30)
+public ITerminal largeTerminal;
+```
+
+The framework handles different screen sizes automatically, so you typically don't need to worry about this unless your application requires a specific size.
+
+## Common Function Keys
+
+- `pf3()` - Exit/Return to previous screen or main menu
+- `pf5()` - Delete (when viewing a customer or account)
+- `pf10()` - Update (when viewing a customer or account)
+- `pf12()` - Cancel current operation
+
+Always use `terminal.pf3()` (not `terminal.type("F3")`) to press function keys.
+
+## Troubleshooting Terminal Issues
+
+### Screen Not Loading
+- Ensure `waitForKeyboard()` is called after every keyboard-locking action
+- Add `waitForTextInField()` to verify screen content has appeared
+- Check that expected text matches exact capitalization
+
+### Wrong Field Being Updated
+- Verify screen loaded with `waitForTextInField()` before typing
+- Use `positionCursorToFieldContaining()` to explicitly position cursor
+- Check field labels match exact capitalization
+
+### Timing Failures
+- Increase wait time by chaining multiple `waitForKeyboard()` calls if needed
+- Use `waitForTextInField()` instead of fixed delays
+- Verify keyboard state before each interaction
+
+### Assertion Failures
+- Always use `.trim()` when comparing field values
+- Match exact capitalization of expected values
+- Use `retrieveScreen()` to debug what's actually on screen

--- a/.agents/skills/galasa-user/references/test-development-best-practices.md
+++ b/.agents/skills/galasa-user/references/test-development-best-practices.md
@@ -1,0 +1,220 @@
+---
+name: test-development-best-practices
+description: Key principles and best practices for writing Galasa tests that scale and run in automation.
+---
+
+## Overview
+
+These guidelines help you develop tests that can run in automation environments targeting multiple application instances simultaneously. Follow these principles even when starting with local, sequential testing to develop good habits for testing at scale.
+
+## Design for Parallel Execution
+
+### Expect tests to run multiple times in parallel
+
+**Why it matters:**
+- In CI/CD pipelines, automated tests often run against different target environments simultaneously
+- Tests must not interfere with each other
+
+**Best practices:**
+- Ensure remote resource usage won't clash with other test instances
+- Use Galasa framework to identify which test instance you're testing against
+- Never hard code locations, ports, or names - these might change
+- Don't assume a specific number of test environments - they may scale dynamically
+
+## Avoid Hard-Coded Values
+
+### Do not hard code resource names
+
+**Why it matters:**
+- Hard-coded values make tests non-portable
+- Cannot run same test against development one day and QA the next
+- Builds up technical debt in test code
+
+**Best practices:**
+- Use test properties to pass resource names to tests
+- If no application Manager exists, use CPS properties for configuration
+- Avoid hard-coding: application IDs, target hostnames, ports, credentials, file paths
+
+**Example of what NOT to do:**
+```java
+// BAD - Hard-coded values
+String hostname = "system.example.com";
+int port = 992;
+String username = "MYUSER";
+```
+
+**Example of what TO do:**
+```java
+// GOOD - Use injected configuration
+@ZosImage(imageTag = "PRIMARY")
+public IZosImage zosImage;
+
+// Configuration comes from CPS properties
+```
+
+## Test Granularity
+
+### Many short, sharp tests are better than few long tests
+
+**Why it matters:**
+- More parallelism = faster feedback in CI/CD
+- Galasa ecosystem designed for scale - can handle thousands of parallel tests
+- Single hour-long test with six methods can run in 10 minutes if split into six parallel tests
+
+**Best practices:**
+- Break long tests into smaller, focused tests
+- Each test should validate one specific function
+- Maximize parallel execution opportunities
+- Reduce overall test suite execution time
+
+## Leverage Managers
+
+### Use Manager facilities instead of writing custom code
+
+**Why it matters:**
+- Manager code uses best practices and is battle-proven
+- Automatic benefits when Managers improve
+- Reduces technical debt in test code
+
+**Best practices:**
+- Check if a Manager exists for your needs before writing custom code
+- Use Manager methods instead of reimplementing functionality
+- Abstract common code into Application Managers as patterns emerge
+- Expect some refactoring as test functionality settles
+
+## Testing vs. Exercising
+
+### Understand the difference between testing and exercising code
+
+**Testing a function:**
+- Examine all aspects: UI, API, logging, audit messages
+- Verify all parts work correctly
+- Comprehensive validation
+
+**Exercising a function:**
+- Use the function as part of testing another function
+- Don't examine all parts - just accept it works or not
+- Speeds up tests by reducing unnecessary validation
+
+**Example:**
+- When testing login functionality: verify all UI elements, error messages, audit logs
+- When exercising login to test another feature: just login and proceed
+
+## Lifecycle Management
+
+### Use `@Before` and `@After` for state management
+
+**Purpose:**
+- `@Before`: Runs before each test method - reset resources before tests
+- `@After`: Runs after each test method - cleanup resources after tests
+- `@BeforeClass`: One-time setup before all tests in class
+- `@AfterClass`: One-time cleanup after all tests in class
+
+**Use cases:**
+- Reset HTTP clients between tests
+- Clear terminal screens
+- Initialize test data
+- Release resources
+
+**Example:**
+```java
+@BeforeClass
+public void setupOnce() throws Exception {
+    // One-time setup for all tests
+}
+
+@Before
+public void setupEachTest() throws Exception {
+    // Reset state before each test
+}
+
+@Test
+public void testSomething() throws Exception {
+    // Test logic
+}
+
+@After
+public void cleanupEachTest() throws Exception {
+    // Cleanup after each test
+}
+
+@AfterClass
+public void cleanupOnce() throws Exception {
+    // One-time cleanup after all tests
+}
+```
+
+## Test Organization
+
+### Understand your meta-information
+
+**Why it matters:**
+- Meta-information builds test catalog
+- Enables test selection and reporting
+- Provides structure to test suite
+
+**Best practices:**
+- Use annotations to categorize tests
+- Divide tests by: functional area, test type, priority, etc.
+- Add structure early - harder to retrofit later
+- Use `@Summary` annotation to describe test purpose
+
+**Example:**
+```java
+@Summary("Verify customer account creation")
+@Test
+public class TestAccountCreation {
+    // Test methods
+}
+```
+
+### Scope tests appropriately
+
+**Why it matters:**
+- Well-scoped tests scale better
+- Easier to maintain and debug
+- Clearer test purpose and results
+
+**Best practices:**
+- Each test should validate a single application function
+- Avoid testing multiple functions in one test class
+- Keep test classes focused and manageable
+- Reduce information overload
+
+## Debugging and Diagnostics
+
+### Make tests easy to debug
+
+**Use logging effectively:**
+```java
+@Logger
+public Log logger;
+
+@Test
+public void testSomething() throws Exception {
+    logger.info("Starting test with customer ID: " + customerId);
+    // Test logic
+    logger.info("Retrieved account balance: " + balance);
+}
+```
+
+**Best practices:**
+- Log test state and pertinent variables
+- Helps align run log with test class during analysis
+- Be explicit about errors: "Expected message-A but saw message-B" not "Did not see expected result"
+
+## Test Code Quality
+
+### Your test code is a valuable asset
+
+**Why it matters:**
+- Test code is as important as application code
+- Key indicator of application quality
+- Poor test code jeopardizes quality assessment
+
+**Best practices:**
+- Source control manage all test code
+- Use static code analyzers
+- Perform buddy checks/code reviews
+- Maintain high quality standards
+- Follow coding standards and conventions

--- a/.agents/skills/galasa-user/references/troubleshooting-galasa.md
+++ b/.agents/skills/galasa-user/references/troubleshooting-galasa.md
@@ -1,0 +1,28 @@
+---
+name: troubleshooting-galasa
+description: How to troubleshoot common issues with Galasa
+---
+
+## Troubleshooting Common Issues
+
+### Build Failures
+- Ensure all manager dependencies are correctly specified in `build.gradle` or `pom.xml`
+- Check that Java version is compatible (Java 17 or later recommended)
+
+### Test Execution Failures
+- Verify CPS properties are correctly configured in `~/.galasa/cps.properties`
+- Ensure credentials are properly set in `~/.galasa/credentials.properties`
+- Check that the OBR coordinates match your project's group ID and version
+- Review `run.log` in the RAS directory for detailed error messages
+
+### Manager Import Errors
+- Run the build command after adding new manager dependencies
+- Verify the manager artifact ID matches the documentation
+- For z/OS 3270 manager, ensure both z/OS and z/OS 3270 managers are added
+
+## Quick Reference Examples
+
+### Common Manager Combinations
+- **z/OS Testing**: z/OS Manager + z/OS 3270 Manager
+- **CICS Testing**: CICS Region Manager + z/OS Manager + z/OS 3270 Terminal Manager
+- **Web Testing**: HTTP Manager + Selenium Manager

--- a/.agents/skills/galasa-user/references/using-galasa-managers.md
+++ b/.agents/skills/galasa-user/references/using-galasa-managers.md
@@ -1,0 +1,83 @@
+---
+name: using-galasa-managers
+description: Provides information about how to add Galasa managers to a Galasa test project and best practices for commonly-used managers.
+---
+
+## Using Galasa Managers
+
+- Galasa managers provide interfaces to work with various technologies. For example, the Galasa z/OS manager can be used to connect to z/OS systems and the Galasa Docker manager can be used to manipulate Docker containers.
+- Refer to https://raw.githubusercontent.com/galasa-dev/galasa/refs/heads/main/docs/content/docs/managers/index.md for the most up-to-date list of managers that Galasa offers.
+
+Core managers provided by the Galasa framework:
+- z/OS Managers: z/OS Batch, z/OS Console, z/OS File, z/OS Program, z/OS TSO, z/OS UNIX
+- CICS TS Managers: CICS Terminal, CICS Region, CICS Resource
+- HTTP Manager: HTTP client functionality
+- Artifact Manager: Test artifact management
+- Core Manager: Core Galasa functionality
+
+### Injecting Managers into Test Classes
+
+Managers are injected into test classes using annotations. Example:
+
+```java
+@ZosImage(imageTag = "PRIMARY")
+public IZosImage zosImage;
+
+@Zos3270Terminal(imageTag = "PRIMARY")
+public ITerminal terminal;
+
+// You can customize terminal size if needed (default is 24x80)
+@Zos3270Terminal(imageTag = "PRIMARY", primaryColumns = 100, primaryRows = 30)
+public ITerminal largeTerminal;
+
+@HttpClient
+public IHttpClient httpClient;
+
+@CicsRegion(cicsTag = "PRIMARY")
+public ICicsRegion cics;
+
+@CicsTerminal(cicsTag = "PRIMARY")
+public ICicsTerminal terminal;
+```
+
+The `imageTag` and `cicsTag` parameters reference CPS properties that define target systems.
+
+### Terminal Interaction Basics
+
+When using the `ITerminal` interface from the z/OS 3270 manager or the `ICicsTerminal` interface from the CICS TS manager:
+
+**Critical Rules:**
+- Always chain method calls: `terminal.type("X").enter().waitForKeyboard()`
+- Always call `waitForKeyboard()` after `enter()`, `clear()`, or PF keys
+- Wait for content with `waitForTextInField("expected text")` before proceeding
+- Extract field values: `terminal.retrieveFieldTextAfterFieldWithString("Label").trim()`
+- **Match exact capitalization** in field names and expected values
+
+**Common Pattern:**
+```java
+terminal.type("X")
+    .enter()
+    .waitForKeyboard()
+    .waitForTextInField("EXPECTED MESSAGE");  // Verify screen loaded
+
+String value = terminal.retrieveFieldTextAfterFieldWithString("Field Name").trim();
+assertThat(value).as("Value should match").isEqualTo("Expected Value");
+```
+
+**For detailed terminal interaction guidance** (timing, field navigation, complete examples, troubleshooting), see [Terminal Interaction Reference](terminal-interaction-reference.md). Load that file only when working with terminal screens or debugging timing issues.
+
+### Adding a manager to your project
+
+To add a manager to your project:
+1. Check that the manager has not already been added to `build.gradle` or `pom.xml`
+2. Add the manager dependency:
+    - **Gradle**: `implementation 'dev.galasa:dev.galasa.{manager}.manager'`
+    - **Maven**: `<artifactId>dev.galasa.{manager}.manager</artifactId>` with `<scope>provided</scope>`
+3. Build the project (see [writing-galasa-tests.md](writing-galasa-tests.md#building-galasa-projects))
+
+**Note**: Manager dependencies inherit version from the Galasa framework version in your build configuration.
+
+**IMPORTANT**: The z/OS 3270 manager requires the z/OS manager to also be added as a dependency, so **ALWAYS** be sure to add both if the user wants to interact with z/OS 3270 terminals in their tests.
+**IMPORTANT**: If a user wants to interact with a CICS region, you should use the CICS TS manager, which includes using the `@CicsRegion` and `@CicsTerminal` annotations, and the z/OS and z/OS 3270 managers. See the [CICS TS IVT](https://raw.githubusercontent.com/galasa-dev/galasa/refs/heads/main/modules/ivts/galasa-ivts-parent/dev.galasa.zos.ivts/dev.galasa.zos.ivts.cicsts/src/main/java/dev/galasa/zos/ivts/cicsts/CICSTSManagerIVT.java) for an example CICS test suite.
+
+Examples of how Galasa managers are used in test classes can be found in the Galasa repository's `ivts` subproject at https://github.com/galasa-dev/galasa/tree/main/modules/ivts

--- a/.agents/skills/galasa-user/references/writing-galasa-tests.md
+++ b/.agents/skills/galasa-user/references/writing-galasa-tests.md
@@ -72,7 +72,13 @@ Where:
 
 **IMPORTANT**: Every manager has its own set of supported CPS property. **DO NOT** assume that managers share the same CPS properties. The supported CPS properties for each manager can be found in the managers' documentation pages https://raw.githubusercontent.com/galasa-dev/galasa/refs/heads/main/docs/content/docs/managers/index.md. Example: the z/OS manager's supported CPS properties can be found at https://raw.githubusercontent.com/galasa-dev/galasa/refs/heads/main/docs/content/docs/managers/zos-managers/zos-manager.md
 
-Galasa tests often also need to supply credentials to connect to protected systems. Credentials can be configured into the Credentials Store file found at `~/.galasa/credentials.properties` by default.
+### Configuring Credentials
+
+Galasa tests often need to supply credentials to connect to protected systems. There are two ways to configure credentials:
+
+#### Option 1: Plaintext Credentials File (Default)
+
+Credentials can be configured into the Credentials Store file found at `~/.galasa/credentials.properties` by default.
 
 Credentials properties are key-value pairs in the form:
 ```properties
@@ -95,3 +101,46 @@ Then, the CPS properties can use the credentials like this:
 ```properties
 zos.image.MYZOSSYSTEM.credentials=SYSTEM1
 ```
+
+#### Option 2: macOS Keychain Store (macOS only, more secure)
+
+**If you are on macOS**, you can use the macOS Keychain to store credentials securely instead of storing them in plaintext in `credentials.properties`.
+
+**Benefits:**
+- Credentials are encrypted by macOS
+- No plaintext passwords in configuration files
+- Leverages macOS security features
+
+**Setup:**
+
+1. Enable the OS Credentials Store by adding this to `~/.galasa/bootstrap.properties`:
+   ```properties
+   framework.credentials.store=os:auto
+   framework.extra.bundles=dev.galasa.creds.os
+   ```
+
+2. Add credentials to the macOS Keychain using the `security` command or Keychain Access.app. **ALWAYS** ask the user if they would like you to do this for them:
+   ```bash
+   # Example: Add username + password credentials
+   security add-generic-password \
+     -s "galasa.credentials.SYSTEM1" \
+     -a "MYUSER" \
+     -w "PASSW0RD" \
+     -U
+   ```
+
+3. Reference credentials in CPS properties the same way:
+   ```properties
+   zos.image.MYZOSSYSTEM.credentials=SYSTEM1
+   ```
+
+**Supported credential types:**
+- Username + Password
+- Username only
+- Token only
+- Username + Token
+- KeyStore (for SSL/TLS certificates)
+
+**Note:** The first time Galasa accesses a credential, macOS will prompt you to allow access.
+
+For complete documentation on using the macOS Keychain store, including all credential types and troubleshooting, see: https://raw.githubusercontent.com/galasa-dev/galasa/refs/heads/main/docs/content/docs/configuring-local-credentials/macos-keychain-store.md

--- a/.agents/skills/galasa-user/references/writing-galasa-tests.md
+++ b/.agents/skills/galasa-user/references/writing-galasa-tests.md
@@ -1,0 +1,97 @@
+---
+name: writing-galasa-tests
+description: Provides information about how Galasa test classes are structured, how they are built, and how test environments are configured.
+---
+
+### Galasa Test Class Structure
+
+Galasa test classes are Java files with this structure:
+
+**Required elements:**
+- Package: `{PACKAGE_NAME}.{FEATURE_NAME}`
+- Imports: AssertJ (`assertThat`), Galasa annotations (`@Test`, `@Logger`)
+- Class: `@Test` annotation + `@Summary("description")`
+- Logger: `@Logger public Log logger;` (only if log messages are added to tests)
+- Test methods: `@Test` annotation on each test method
+
+**Optional lifecycle methods:**
+- `@BeforeClass` / `@AfterClass`: One-time setup/cleanup
+- `@Before` / `@After`: Per-test setup/cleanup
+
+**Assertion rules:**
+- Use AssertJ: `assertThat(value).as("Description").isEqualTo(expected)`
+- Always include descriptive message with `.as()`
+- Remove unused imports
+
+**Example structure:**
+```java
+package dev.galasa.example.feature;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.commons.logging.Log;
+import dev.galasa.*;
+import dev.galasa.core.manager.Logger;
+
+@Summary("Test suite description")
+@Test
+public class TestClass {
+    @Logger
+    public Log logger;
+    
+    @Test
+    public void testSomething() throws Exception {
+        assertThat(result).as("Should match expected").isEqualTo(expected);
+    }
+}
+```
+
+For complete examples, see [Galasa IVT tests](https://github.com/galasa-dev/galasa/tree/main/modules/ivts).
+
+## Building Galasa projects
+
+- If you are using Gradle: Run `gradle clean build publishToMavenLocal` from the Galasa project's root directory to build the project.
+- If you are using Maven: Run `mvn clean install` from the Galasa project's root directory to build the project.
+
+**Note**: When building for the first time, Gradle/Maven will download all required dependencies. This may take several minutes. Subsequent builds will be faster.
+
+**Tip**: To check which version of Galasa is being used, examine the `build.gradle` or `pom.xml` file for the Galasa version property.
+
+## Configuring test environments
+
+Galasa tests often need to connect to external systems. The details of these systems can be configured into the Configuration Property Store (CPS) file found at `~/.galasa/cps.properties` by default.
+
+CPS properties are key-value pairs in the form:
+```properties
+NAMESPACE.PROPERTY_NAME=PROPERTY_VALUE
+```
+
+Where:
+- `NAMESPACE`: The namespace of the manager that this property is associated with, typically the name of the manager itself. Example: The z/OS manager is `zos`, the Docker manager is `docker`, and the z/OS 3270 manager is `zos3270`.
+- `PROPERTY_NAME`: The name of the CPS property to configure.
+- `PROPERTY_VALUE`: The value to be associated with the CPS property.
+
+**IMPORTANT**: Every manager has its own set of supported CPS property. **DO NOT** assume that managers share the same CPS properties. The supported CPS properties for each manager can be found in the managers' documentation pages https://raw.githubusercontent.com/galasa-dev/galasa/refs/heads/main/docs/content/docs/managers/index.md. Example: the z/OS manager's supported CPS properties can be found at https://raw.githubusercontent.com/galasa-dev/galasa/refs/heads/main/docs/content/docs/managers/zos-managers/zos-manager.md
+
+Galasa tests often also need to supply credentials to connect to protected systems. Credentials can be configured into the Credentials Store file found at `~/.galasa/credentials.properties` by default.
+
+Credentials properties are key-value pairs in the form:
+```properties
+secure.credentials.TAG.CREDENTIALS_TYPE=CREDENTIAL_VALUE
+```
+
+Where:
+- `TAG`: A tag that identifies the credentials. This tag is used to reference the credentials from the CPS properties.
+- `CREDENTIALS_TYPE`: The type of credentials. Supported types are: `username`, `password`, and `token`.
+- `CREDENTIAL_VALUE`: The value of the credentials.
+
+Example: To create a username `MYUSER` and password `PASSW0RD` associated with the tag `SYSTEM1`, you would set these properties:
+
+```properties
+secure.credentials.SYSTEM1.username=MYUSER
+secure.credentials.SYSTEM1.password=PASSW0RD
+```
+
+Then, the CPS properties can use the credentials like this:
+```properties
+zos.image.MYZOSSYSTEM.credentials=SYSTEM1
+```

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,42 @@
     }
   ],
   "results": {
+    ".agents/skills/galasa-user/references/galasa-quick-reference.md": [
+      {
+        "hashed_secret": "551a1295556c210fee83aa71da02d8821850e8b1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 180,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 187,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    ".agents/skills/galasa-user/references/writing-galasa-tests.md": [
+      {
+        "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 91,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "551a1295556c210fee83aa71da02d8821850e8b1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 96,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "developer-docs/cli-architecture.md": [
       {
         "hashed_secret": "ec7ae9b5d26766673ddea9d4b4ebdc6129ccb9c3",

--- a/docs/content/releases/posts/v0.47.0.md
+++ b/docs/content/releases/posts/v0.47.0.md
@@ -24,3 +24,7 @@ links:
 - Added a new `galasactl streams set` command that can be used to create or update test streams within a Galasa service. [See the command reference](../../docs/reference/cli-syntax/galasactl_streams_set.md).
 
 - Added support for Gateway API for accessing the Galasa service. See [Installing an Ecosystem using Helm](../../docs/ecosystem/ecosystem-installing-k8s.md#option-2-gateway-api-v0470) for details on how to configure Gateway API. Ingress is still used for accessing the Galasa service by default but can be replaced with Gateway API by setting the `ingress.enabled` value to `false` and the `gatewayApi.enabled` value to `true` in the `values.yaml` file used when installing the Helm chart.
+
+## Other changes
+
+- Added an initial Galasa agent skill to the [Galasa repository](https://github.com/galasa-dev/galasa/tree/main/.agents/skills/galasa-user) that provides AI agents with context necessary to use Galasa more effectively. Download the `galasa-user` skill from the Galasa repository and configure your AI-powered development environment to use it.


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2565.

This PR adds an initial Galasa user agent skill which is expected to evolve over time. It currently contains:
- Info on what Galasa is + its architecture
- Info on what the Galasa ecosystem/service is (currently ecosystem as that's what is mentioned on the galasa.dev site)
- Quick reference on what galasactl commands are most frequently used
- How managers are used
- How to write and build Galasa tests + how to configure test environments
- Terminal interaction docs (specific for the 3270 manager)
- Troubleshooting docs
- a parent SKILL.md file which acts as an index for the reference material


## Changes
- [x] Added initial Galasa user agent skill to a new `.agents/skills` directory
- [x] Release note
