### PR TITLE
Fix: Enable Docker Manager to authenticate with ICR

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerRegistryImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerRegistryImpl.java
@@ -149,36 +149,83 @@ public class DockerRegistryImpl {
 	}
 
 	/**
-	 * Attempts to gain a bearer token from realm, if unauthorized tries basic credentials login 
-	 * retreive token
-	 * 
-	 * @return String token
+	 * Attempts to gain a bearer token from realm with credentials.
+	 *
+	 * This method has been enhanced to support registries like IBM Container Registry (ICR)
+	 * that require credentials to be sent to the token endpoint on the first request.
+	 *
+	 * Flow:
+	 * 1. Try to get token WITH credentials (Basic Auth) - supports ICR and similar registries
+	 * 2. If that fails with 401 and WWW-Authenticate header, parse the auth type
+	 * 3. If auth type is "Basic realm", retry with Basic Auth
+	 * 4. Otherwise fail with appropriate error
+	 *
+	 * @return String token - base64-encoded Docker registry auth structure for image pull
 	 * @throws DockerManagerException
 	 */
 	public String retrieveBearerToken() throws DockerManagerException {
 		try {
 			this.realmClient.setURI(this.registryRealmURL.toURI());
+			
+			// First attempt: Try with credentials (supports ICR and similar registries)
+			ICredentials creds = null;
+			String user = null;
+			String password = null;
+			
+			try {
+				creds = getCreds();
+				if (creds instanceof ICredentialsUsernamePassword) {
+					user = ((ICredentialsUsername) creds).getUsername();
+					password = ((ICredentialsUsernamePassword) creds).getPassword();
+				}
+			} catch (CredentialsException e) {
+				logger.debug("No credentials available for bearer token request, trying without credentials");
+			}
+			
+			// If we have username/password credentials, set them for Basic Auth
+			if (user != null && password != null) {
+				this.realmClient.setAuthorisation(user, password);
+				this.realmClient.build();
+				logger.debug("Attempting bearer token retrieval with Basic Auth credentials");
+			}
+			
 			HttpClientResponse<JsonObject> response = this.realmClient.getJson("");
 			if (response.getStatusCode() == (HttpStatus.SC_OK)) {
 				JsonObject json = response.getContent();
 				String token = json.get("token").getAsString();
 				this.client.addCommonHeader("Authorization", "Bearer "+token);
+				logger.info("Successfully retrieved bearer token");
+				
+				// Generate Docker auth structure for X-Registry-Auth header
+				// Docker Engine needs base64-encoded JSON with username/password, not the bearer token
+				if (user != null && password != null) {
+					logger.debug("Generating Docker registry auth structure for image pull");
+					return generateDockerRegistryAuthStructure(user, password);
+				}
+				
+				// Fallback: return token if no credentials
 				return token;
 			}
+			
+			// If unauthorized, check if we need to retry with different auth method
 			if (response.getStatusCode() == (HttpStatus.SC_UNAUTHORIZED)) {
 				Map<String, String> headers = response.getheaders();
 				for (String key : headers.keySet()) {
 					if (key.equalsIgnoreCase("WWW-Authenticate")) {
 						String authType = parseAuthRealmType(headers.get(key));
 						if ("Basic realm".equals(authType)) {
+							logger.debug("Token endpoint requires Basic Auth, attempting with credentials");
 							return retrieveBasicToken();
 						} else {
 							throw new DockerManagerException("Dont know how to authenticate to registry: " + this.registryUrl);
 						}
 					}
 				}
+				// No WWW-Authenticate header - registry may have returned error in body
+				logger.error("Token endpoint returned 401 without WWW-Authenticate header");
+				throw new DockerManagerException("Failed to retrieve token from: " + this.registryRealmURL + " - unauthorized");
 			}
-			throw new DockerManagerException("Failed to retrieve token from:" + this.registryRealmURL);
+			throw new DockerManagerException("Failed to retrieve token from:" + this.registryRealmURL + " - status code: " + response.getStatusCode());
 		} catch (HttpClientException | URISyntaxException e) {
 			throw new DockerManagerException("Failed to connect to: " + this.registryRealmURL);
 		}


### PR DESCRIPTION

This fix addresses the issue where Galasa's Docker Manager cannot pull images from IBM Container Registry (ICR) due to authentication requirements.

Problem:
- ICR requires credentials to be sent to the OAuth token endpoint on the first request
- The bearer token alone is insufficient - Docker Engine requires base64-encoded JSON with username/password in the X-Registry-Auth header

Solution:
1. Modified retrieveBearerToken() to send Basic Auth credentials to the token endpoint on the first attempt (lines 170-185)
2. After successfully retrieving the bearer token, generate the proper Docker registry auth structure (base64-encoded JSON) for the X-Registry-Auth header (lines 195-203)

This enables Galasa to:
- Authenticate with ICR's token endpoint using Basic Auth
- Pull private images from ICR registries
- Maintain backward compatibility with registries that don't require credentials

Tested with:
- IBM Container Registry (uk.icr.io)
- Successfully pulled private images
- All integration tests passed