### PR TITLE
Stop the check-client-java-version workflow from closing and opening a PR with the same changes

### DIFF
--- a/.github/workflows/check-client-java-version.yaml
+++ b/.github/workflows/check-client-java-version.yaml
@@ -105,8 +105,46 @@ jobs:
           echo "Galasa version: $GALASA_VERSION"
           echo "version=$GALASA_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Create PR with updates
+      - name: Check for existing PR
         if: steps.compare.outputs.needs_update == 'true'
+        id: check-existing-pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const latest = '${{ steps.latest-client-java-version.outputs.version }}';
+            const PR_REPOSITORY = process.env.PR_REPOSITORY;
+            const branchName = `update-k8s-client-java-to-${latest}`;
+            
+            try {
+              // Check if a PR already exists for this specific version
+              const { data: existingPRs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: PR_REPOSITORY,
+                state: 'open',
+                head: `${context.repo.owner}:${branchName}`
+              });
+              
+              if (existingPRs.length > 0) {
+                const prNumber = existingPRs[0].number;
+                const prUrl = `https://github.com/${context.repo.owner}/${PR_REPOSITORY}/pull/${prNumber}`;
+                console.log(`✅ PR #${prNumber} already exists for version ${latest}: ${prUrl}`);
+                console.log('Skipping PR creation as the correct version is already being tracked.');
+                
+                core.setOutput('pr_exists', 'true');
+                core.setOutput('pr_number', prNumber);
+                core.setOutput('pr_url', prUrl);
+                return;
+              }
+              
+              console.log(`No existing PR found for version ${latest}. Will create a new one.`);
+              core.setOutput('pr_exists', 'false');
+            } catch (error) {
+              core.setFailed(`Failed to check for existing PR: ${error.message}`);
+              throw error;
+            }
+
+      - name: Create PR with updates
+        if: steps.compare.outputs.needs_update == 'true' && steps.check-existing-pr.outputs.pr_exists == 'false'
         id: create-pr
         uses: actions/github-script@v7
         with:
@@ -359,7 +397,7 @@ jobs:
             }
 
       - name: Close outdated PRs
-        if: steps.compare.outputs.needs_update == 'true'
+        if: steps.compare.outputs.needs_update == 'true' && steps.check-existing-pr.outputs.pr_exists == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -414,7 +452,7 @@ jobs:
             }
 
       - name: Create or update issue if update needed
-        if: steps.compare.outputs.needs_update == 'true'
+        if: steps.compare.outputs.needs_update == 'true' && steps.check-existing-pr.outputs.pr_exists == 'false'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2539 and changes in https://github.com/galasa-dev/galasa/pull/530

At the moment, the GH actions workflow that raises a PR to update the client-java dependencies is closing the existing PR and then opening a new PR with the same changes every time it runs. It should leave the existing PR as-is if it already exists.

## Changes
- [x] The check-client-java-version workflow now has a separate step that checks whether a PR already exists for the latest client-java version and does not update the existing PR
