### PR TITLE
Iss2556 - Fix `--user` option on `runs submit` being case-sensitive

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -99,7 +99,7 @@
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 91,
+        "line_number": 97,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -107,7 +107,7 @@
         "hashed_secret": "551a1295556c210fee83aa71da02d8821850e8b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 96,
+        "line_number": 134,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
@@ -65,6 +65,7 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
 
     public static final String TOKENS_DB_VIEW_NAME = "loginId-view";
     public static final String USERS_DB_VIEW_NAME = "loginId-view";
+    public static final String USERS_DB_LOWERCASE_VIEW_NAME = "loginId-lowercase-view";
 
     private Log logger;
     private ITimeService timeService;
@@ -251,6 +252,47 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
             }
 
             logger.info("User retrieved from CouchDB OK");
+
+        } catch (CouchdbException e) {
+            String errorMessage = ERROR_FAILED_TO_RETRIEVE_USERS.getMessage(e.getMessage());
+            throw new AuthStoreException(errorMessage, e);
+        }
+
+        return user;
+    }
+
+    @Override
+    public IUser getUserByLoginIdCaseInsensitive(String loginId) throws AuthStoreException {
+        logger.info("Retrieving user by loginId (case-insensitive) from CouchDB");
+        List<ViewRow> userDocument;
+        IUser user = null;
+
+        try {
+            // Convert the loginId to lowercase for the lookup
+            String lowerCaseLoginId = loginId.toLowerCase();
+            
+            // Fetch documents matching the lowercase loginId using the lowercase view
+            userDocument = getAllDocsByLoginId(USERS_DATABASE_NAME, lowerCaseLoginId, USERS_DB_LOWERCASE_VIEW_NAME);
+
+            // Since loginIds are unique (case-insensitive), there should be only one document.
+            if (!userDocument.isEmpty()) {
+                ViewRow row = userDocument.get(0); // Get the first entry since loginId is unique
+
+                // Fetch the user document from the CouchDB using the ID from the row
+                UserDoc fetchedUser = getUserFromDocument(row.id);
+
+                if (row.value != null) {
+                    AuthDBNameViewDesign nameViewDesign = gson.fromJson(gson.toJson(row.value),
+                            AuthDBNameViewDesign.class);
+                    fetchedUser.setVersion(nameViewDesign._rev); // Set the version from the CouchDB rev
+                }
+
+                // Assign fetchedUser to the user variable
+                // The UserImpl will contain the actual case-accurate loginId from the database
+                user = new UserImpl(fetchedUser);
+            }
+
+            logger.info("User retrieved from CouchDB OK (case-insensitive lookup)");
 
         } catch (CouchdbException e) {
             String errorMessage = ERROR_FAILED_TO_RETRIEVE_USERS.getMessage(e.getMessage());

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
@@ -235,7 +235,7 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
             userDocument = getAllDocsByLoginId(USERS_DATABASE_NAME, loginId, USERS_DB_VIEW_NAME);
 
             // Since loginIds are unique, there should be only one document.
-            if (!userDocument.isEmpty()) {
+            if (userDocument != null && !userDocument.isEmpty()) {
                 ViewRow row = userDocument.get(0); // Get the first entry since loginId is unique
 
                 // Fetch the user document from the CouchDB using the ID from the row
@@ -275,7 +275,7 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
             userDocument = getAllDocsByLoginId(USERS_DATABASE_NAME, lowerCaseLoginId, USERS_DB_LOWERCASE_VIEW_NAME);
 
             // Since loginIds are unique (case-insensitive), there should be only one document.
-            if (!userDocument.isEmpty()) {
+            if (userDocument != null && !userDocument.isEmpty()) {
                 ViewRow row = userDocument.get(0); // Get the first entry since loginId is unique
 
                 // Fetch the user document from the CouchDB using the ID from the row

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStoreValidator.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStoreValidator.java
@@ -44,6 +44,7 @@ public class CouchdbAuthStoreValidator extends CouchdbBaseValidator {
     // A couchDB view, it gets all the access tokens of a the user based on the loginId provided.
     public static final String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId, doc); } }";
     public static final String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'], doc); } }";
+    public static final String DB_TABLE_USERS_LOWERCASE_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), doc); } }";
 
     public CouchdbAuthStoreValidator() {
         this(new LogFactory(){
@@ -138,6 +139,19 @@ public class CouchdbAuthStoreValidator extends CouchdbBaseValidator {
             }
             else{
                 tableDesign.views.loginIdView.map = DB_TABLE_USERS_DESIGN;
+            }
+        }
+
+        // Add the lowercase view for users database only
+        if (dbName.equals(CouchdbAuthStore.USERS_DATABASE_NAME)) {
+            if (tableDesign.views.loginIdLowerCaseView == null) {
+                isUpdated = true;
+                tableDesign.views.loginIdLowerCaseView = new AuthStoreDBLoginLowerCaseView();
+            }
+
+            if (tableDesign.views.loginIdLowerCaseView.map == null) {
+                isUpdated = true;
+                tableDesign.views.loginIdLowerCaseView.map = DB_TABLE_USERS_LOWERCASE_DESIGN;
             }
         }
 

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/beans/AuthStoreDBLoginLowerCaseView.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/beans/AuthStoreDBLoginLowerCaseView.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.auth.couchdb.internal.beans;
+
+public class AuthStoreDBLoginLowerCaseView {
+    public String map;
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/beans/AuthStoreDBViews.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/beans/AuthStoreDBViews.java
@@ -10,4 +10,7 @@ import com.google.gson.annotations.SerializedName;
 public class AuthStoreDBViews {
     @SerializedName("loginId-view")
     public AuthStoreDBLoginView loginIdView;
+
+    @SerializedName("loginId-lowercase-view")
+    public AuthStoreDBLoginLowerCaseView loginIdLowerCaseView;
 }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStore.java
@@ -666,6 +666,119 @@ public class TestCouchdbAuthStore {
     }
 
     @Test
+    public void testGetUserByLoginIdCaseInsensitiveReturnsUserFromCouchdbOK() throws Exception {
+        // Given...
+        URI authStoreUri = URI.create("couchdb:https://my-auth-store");
+        MockLogFactory logFactory = new MockLogFactory();
+
+        ViewRow userDoc1 = new ViewRow();
+        userDoc1.id = "user1";
+        List<ViewRow> mockDocs = List.of(userDoc1);
+
+        ViewResponse mockAllDocsResponse = new ViewResponse();
+        mockAllDocsResponse.rows = mockDocs;
+
+        FrontEndClient client = new FrontEndClient();
+        client.setClientName("web-ui");
+        client.setLastLogin(Instant.now());
+
+        UserDoc mockUser = new UserDoc("JohnDoe", List.of(client), "2");
+
+        List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
+        // The lowercase view should be queried with the lowercase version of the loginId
+        interactions.add(new GetAllDocumentsInteraction(
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-lowercase-view?key=%22johndoe%22",
+                HttpStatus.SC_OK, mockAllDocsResponse));
+        interactions.add(new GetDocumentInteraction<UserDoc>("https://my-auth-store/galasa_users/user1",
+                HttpStatus.SC_OK, mockUser));
+
+        MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
+
+        MockHttpClientFactory httpClientFactory = new MockHttpClientFactory(mockHttpClient);
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+
+        CouchdbAuthStore authStore = new CouchdbAuthStore(authStoreUri, httpClientFactory, new HttpRequestFactoryImpl(),
+                logFactory, new MockCouchdbValidator(), mockTimeService);
+        
+        // When... querying with different casing
+        IUser user = authStore.getUserByLoginIdCaseInsensitive("johndoe");
+
+        // Then... should return the user with case-accurate loginId
+        assertThat(user).isInstanceOf(UserImpl.class);
+        assertThat(user).isNotNull();
+        assertThat(user.getLoginId()).isEqualTo("JohnDoe");
+    }
+
+    @Test
+    public void testGetUserByLoginIdCaseInsensitiveWithUppercaseReturnsUserFromCouchdbOK() throws Exception {
+        // Given...
+        URI authStoreUri = URI.create("couchdb:https://my-auth-store");
+        MockLogFactory logFactory = new MockLogFactory();
+
+        ViewRow userDoc1 = new ViewRow();
+        userDoc1.id = "user1";
+        List<ViewRow> mockDocs = List.of(userDoc1);
+
+        ViewResponse mockAllDocsResponse = new ViewResponse();
+        mockAllDocsResponse.rows = mockDocs;
+
+        UserDoc mockUser = new UserDoc("admin", List.of(new FrontEndClient("web-ui", Instant.now())), "2");
+
+        List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
+        // The lowercase view should be queried with the lowercase version of the loginId
+        interactions.add(new GetAllDocumentsInteraction(
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-lowercase-view?key=%22admin%22",
+                HttpStatus.SC_OK, mockAllDocsResponse));
+        interactions.add(new GetDocumentInteraction<UserDoc>("https://my-auth-store/galasa_users/user1",
+                HttpStatus.SC_OK, mockUser));
+
+        MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
+
+        MockHttpClientFactory httpClientFactory = new MockHttpClientFactory(mockHttpClient);
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+
+        CouchdbAuthStore authStore = new CouchdbAuthStore(authStoreUri,
+                httpClientFactory, new HttpRequestFactoryImpl(), logFactory, new MockCouchdbValidator(),
+                mockTimeService);
+        
+        // When... querying with uppercase
+        IUser user = authStore.getUserByLoginIdCaseInsensitive("ADMIN");
+
+        // Then... should return the user with case-accurate loginId from the store
+        assertThat(user).isNotNull();
+        assertThat(user.getLoginId()).isEqualTo("admin");
+    }
+
+    @Test
+    public void testGetUserByLoginIdCaseInsensitiveReturnsNullWhenUserNotFound() throws Exception {
+        // Given...
+        URI authStoreUri = URI.create("couchdb:https://my-auth-store");
+        MockLogFactory logFactory = new MockLogFactory();
+
+        ViewResponse mockEmptyResponse = new ViewResponse();
+        mockEmptyResponse.rows = new ArrayList<>();
+
+        List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
+        interactions.add(new GetAllDocumentsInteraction(
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-lowercase-view?key=%22nonexistent%22",
+                HttpStatus.SC_OK, mockEmptyResponse));
+
+        MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
+
+        MockHttpClientFactory httpClientFactory = new MockHttpClientFactory(mockHttpClient);
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+
+        CouchdbAuthStore authStore = new CouchdbAuthStore(authStoreUri, httpClientFactory, new HttpRequestFactoryImpl(),
+                logFactory, new MockCouchdbValidator(), mockTimeService);
+        
+        // When... querying for a non-existent user
+        IUser user = authStore.getUserByLoginIdCaseInsensitive("nonexistent");
+
+        // Then... should return null
+        assertThat(user).isNull();
+    }
+
+    @Test
     public void testUpdateUserUpdatesExisitingClientOK() throws Exception {
         // Given...
         UserImpl mockUser = new UserImpl(new UserDoc("johndoe", List.of(new FrontEndClient("web-ui", Instant.MIN)),"2"));

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockFramework.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockFramework.java
@@ -73,6 +73,12 @@ public class MockFramework implements IFramework {
         this.frameworkRuns = frameworkRuns;
     }
 
+    public MockFramework(IFrameworkRuns frameworkRuns, IAuthStoreService authStoreService){
+        this();
+        this.frameworkRuns = frameworkRuns;
+        this.authStoreService = authStoreService;
+    }
+
     public MockFramework(RBACService rbacService){ 
         this.rbacService = rbacService;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/routes/GroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/routes/GroupRunsRoute.java
@@ -29,6 +29,9 @@ import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
+import dev.galasa.framework.spi.auth.AuthStoreException;
+import dev.galasa.framework.spi.auth.IAuthStoreService;
+import dev.galasa.framework.spi.auth.IUser;
 import dev.galasa.framework.spi.rbac.BuiltInAction;
 import dev.galasa.framework.spi.rbac.RBACException;
 import dev.galasa.framework.spi.utils.GalasaGson;
@@ -89,7 +92,16 @@ public class GroupRunsRoute extends GroupRuns{
         if (user != null && !user.isBlank()) {
             boolean isRequestorPermittedToSetUser = isActionPermitted(BuiltInAction.TEST_RUN_SET_USER, requestor);
             if (isRequestorPermittedToSetUser) {
-                validateActionPermitted(BuiltInAction.TEST_RUN_LAUNCH, user);
+                // Try to get the case-accurate loginId using case-insensitive lookup
+                String caseAccurateUser = getCaseAccurateLoginId(user);
+                // If we found a case-accurate user, use it; otherwise use the provided user
+                String userToValidate = (caseAccurateUser != null) ? caseAccurateUser : user;
+                
+                // Validate the user has permission to launch tests
+                validateActionPermitted(BuiltInAction.TEST_RUN_LAUNCH, userToValidate);
+                
+                // Update the schedule request with the validated user (case-accurate if found)
+                scheduleRequest.setUser(userToValidate);
             } else {
                 // If the requestor login ID does not have the TEST_RUN_SET_USER action,
                 // don't block them from launching the test, but don't let them override the user.
@@ -99,6 +111,26 @@ public class GroupRunsRoute extends GroupRuns{
 
         ScheduleStatus scheduleStatus = scheduleRun(scheduleRequest, groupName.substring(1), requestor, env);
         return getResponseBuilder().buildResponse(request, response, "application/json", gson.toJson(scheduleStatus), HttpServletResponse.SC_CREATED);
+    }
+
+    /**
+     * Retrieves the case-accurate loginId for a given user using case-insensitive matching.
+     *
+     * @param loginId the loginId to look up (case-insensitive)
+     * @return the case-accurate loginId from the auth store, or null if not found
+     * @throws FrameworkException if there is an issue accessing the auth store
+     */
+    private String getCaseAccurateLoginId(String loginId) throws FrameworkException {
+        try {
+            IAuthStoreService authStoreService = framework.getAuthStoreService();
+            IUser user = authStoreService.getUserByLoginIdCaseInsensitive(loginId);
+            if (user != null) {
+                return user.getLoginId();
+            }
+            return null;
+        } catch (AuthStoreException e) {
+            throw new FrameworkException("Failed to retrieve user from auth store", e);
+        }
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -8,6 +8,7 @@ package dev.galasa.framework.api.runs.routes;
 import static dev.galasa.framework.spi.rbac.BuiltInAction.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -38,8 +39,10 @@ import dev.galasa.framework.api.common.mocks.MockIFrameworkRuns;
 import dev.galasa.framework.api.common.mocks.MockIRun;
 import dev.galasa.framework.api.runs.mocks.MockRunsServlet;
 import dev.galasa.framework.mocks.FilledMockRBACService;
+import dev.galasa.framework.mocks.MockAuthStoreService;
 import dev.galasa.framework.mocks.MockIResultArchiveStore;
 import dev.galasa.framework.mocks.MockRBACService;
+import dev.galasa.framework.mocks.MockTimeService;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.rbac.Action;
 import dev.galasa.framework.spi.teststructure.TestStructure;
@@ -1061,7 +1064,12 @@ public class TestGroupRunsRoute extends BaseServletTest {
         MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
         MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
 
-        MockFramework mockFramework = new MockFramework(mockFrameworkRuns);
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
+        mockAuthStoreService.createUser(JWT_USERNAME, "client-name", "");
+        mockAuthStoreService.createUser(NON_ADMIN_JWT_USERNAME, "client-name", "");
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns, mockAuthStoreService);
         mockFramework.setResultArchiveStore(mockRasStore);
         mockFramework.setRBACService(mockRbacService);
 
@@ -1169,8 +1177,12 @@ public class TestGroupRunsRoute extends BaseServletTest {
 
         MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
 
-        MockFramework mockFramework = new MockFramework();
-        mockFramework.setRBACService(mockRbacService);
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
+        mockAuthStoreService.createUser(JWT_USERNAME, "client-name", "");
+        mockAuthStoreService.createUser(NON_ADMIN_JWT_USERNAME, "client-name", "");
+
+        MockFramework mockFramework = new MockFramework(mockAuthStoreService, mockRbacService);
 
 		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -1200,6 +1200,142 @@ public class TestGroupRunsRoute extends BaseServletTest {
         checkErrorStructure(outStream.toString(), 5125, "GAL5125E", "TEST_RUN_LAUNCH");
     }
 
+    @Test
+    public void testPostRunsWithValidBodyAdminRequestorCanSetUserWithDifferentCasingOK() throws Exception {
+        // Given...
+		String groupName = "valid";
+        String testName1 = "package.class";
+        String class1 = "bundle/" + testName1;
+        String[] classes = new String[]{class1};
+        String submissionId = "submission1";
+        Set<String> tags = new HashSet<>();
+        List<IRun> runs = new ArrayList<IRun>();
+
+        // The user in the auth store is "joeTester"
+        MockIRun run = new MockIRun("runname", "requestorType", JWT_USERNAME, NON_ADMIN_JWT_USERNAME, class1, "submitted", class1.split("/")[0], testName1, groupName, submissionId, tags);
+        runs.add(run);
+        
+        // We will submit with "JOETESTER" to test case-insensitive lookup
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "JOETESTER", "this.test.stream", groupName, null, submissionId, tags);
+
+        // Set up permissions - 
+        // The JWT_USERNAME has all actions including TEST_RUN_SET_USER.
+        // The NON_ADMIN_JWT_USERNAME has GENERAL_API_ACCESS and TEST_RUN_LAUNCH.
+        List<Action> permittedActions = List.of(GENERAL_API_ACCESS.getAction(), TEST_RUN_LAUNCH.getAction());
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithAdminAndTestUser(JWT_USERNAME, NON_ADMIN_JWT_USERNAME, permittedActions);
+
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
+        mockAuthStoreService.createUser(JWT_USERNAME, "client-name", "");
+        // Create user with mixed case
+        mockAuthStoreService.createUser(NON_ADMIN_JWT_USERNAME, "client-name", "");
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns, mockAuthStoreService);
+        mockFramework.setResultArchiveStore(mockRasStore);
+        mockFramework.setRBACService(mockRbacService);
+
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
+        ServletOutputStream outStream = resp.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(req, resp);
+
+        // Then...
+        // Should succeed and use the case-accurate loginId from the auth store
+        String expectedJson = generateExpectedJson(runs, false);
+        assertThat(resp.getStatus()).isEqualTo(201);
+        assertThat(outStream.toString()).isEqualTo(expectedJson);
+
+        List<TestStructure> testStructureHistory = mockRasStore.getTestStructureHistory();
+        assertThat(testStructureHistory).hasSize(1);
+
+        TestStructure testStructure = testStructureHistory.get(0);
+        assertThat(testStructure.getRequestor()).isEqualTo(run.getRequestor());
+        // The user should be stored with the case-accurate loginId from the auth store
+        assertThat(testStructure.getUser()).isEqualTo(NON_ADMIN_JWT_USERNAME);
+        assertThat(testStructure.getRunName()).isEqualTo(run.getName());
+        assertThat(testStructure.getBundle()).isEqualTo(run.getTestBundleName());
+        assertThat(testStructure.getTestName()).isEqualTo(run.getTestClassName());
+        assertThat(testStructure.getSubmissionId()).isEqualTo(run.getSubmissionId());
+        assertThat(testStructure.getGroup()).isEqualTo(run.getGroup());
+    }
+
+    @Test
+    public void testPostRunsWithValidBodyAdminRequestorCanSetUserWithLowercaseCasingOK() throws Exception {
+        // Given...
+		String groupName = "valid";
+        String testName1 = "package.class";
+        String class1 = "bundle/" + testName1;
+        String[] classes = new String[]{class1};
+        String submissionId = "submission1";
+        Set<String> tags = new HashSet<>();
+        List<IRun> runs = new ArrayList<IRun>();
+
+        // The user in the auth store is "joeTester"
+        MockIRun run = new MockIRun("runname", "requestorType", JWT_USERNAME, NON_ADMIN_JWT_USERNAME, class1, "submitted", class1.split("/")[0], testName1, groupName, submissionId, tags);
+        runs.add(run);
+        
+        // We'll submit with "joetester" to test case-insensitive lookup
+        String payload = generatePayload(classes, "requestorType", JWT_USERNAME, "joetester", "this.test.stream", groupName, null, submissionId, tags);
+
+        // Set up permissions - 
+        // The JWT_USERNAME has all actions including TEST_RUN_SET_USER.
+        // The NON_ADMIN_JWT_USERNAME has GENERAL_API_ACCESS and TEST_RUN_LAUNCH.
+        List<Action> permittedActions = List.of(GENERAL_API_ACCESS.getAction(), TEST_RUN_LAUNCH.getAction());
+        MockRBACService mockRbacService = FilledMockRBACService.createTestRBACServiceWithAdminAndTestUser(JWT_USERNAME, NON_ADMIN_JWT_USERNAME, permittedActions);
+
+        MockEnvironment mockEnv = FilledMockEnvironment.createTestEnvironment();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(groupName, runs);
+        MockIResultArchiveStore mockRasStore = new MockIResultArchiveStore();
+
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(timeService);
+        mockAuthStoreService.createUser(JWT_USERNAME, "client-name", "");
+        // Create user with mixed case
+        mockAuthStoreService.createUser(NON_ADMIN_JWT_USERNAME, "client-name", "");
+
+        MockFramework mockFramework = new MockFramework(mockFrameworkRuns, mockAuthStoreService);
+        mockFramework.setResultArchiveStore(mockRasStore);
+        mockFramework.setRBACService(mockRbacService);
+
+		MockRunsServlet servlet = new MockRunsServlet(mockEnv, mockFramework);
+
+		HttpServletRequest req = new MockHttpServletRequest("/"+groupName, payload, HttpMethod.POST.toString(), REQUIRED_HEADERS);
+		HttpServletResponse resp = new MockHttpServletResponse();
+        ServletOutputStream outStream = resp.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(req, resp);
+
+        // Then...
+        // Should succeed and use the case-accurate loginId from the auth store
+        String expectedJson = generateExpectedJson(runs, false);
+        assertThat(resp.getStatus()).isEqualTo(201);
+        assertThat(outStream.toString()).isEqualTo(expectedJson);
+
+        List<TestStructure> testStructureHistory = mockRasStore.getTestStructureHistory();
+        assertThat(testStructureHistory).hasSize(1);
+
+        TestStructure testStructure = testStructureHistory.get(0);
+        assertThat(testStructure.getRequestor()).isEqualTo(run.getRequestor());
+        // The user should be stored with the case-accurate loginId from the auth store
+        assertThat(testStructure.getUser()).isEqualTo(NON_ADMIN_JWT_USERNAME);
+        assertThat(testStructure.getRunName()).isEqualTo(run.getName());
+        assertThat(testStructure.getBundle()).isEqualTo(run.getTestBundleName());
+        assertThat(testStructure.getTestName()).isEqualTo(run.getTestClassName());
+        assertThat(testStructure.getSubmissionId()).isEqualTo(run.getSubmissionId());
+        assertThat(testStructure.getGroup()).isEqualTo(run.getGroup());
+    }
+
     /*
      * PUT requests
      */

--- a/modules/framework/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStore.java
@@ -81,4 +81,9 @@ public class MockAuthStore implements IAuthStore, IAuthStoreService {
     public IFrontEndClient createClient(String clientName) {
         throw new UnsupportedOperationException("Unimplemented method 'createClient'");
     }
+
+    @Override
+    public IUser getUserByLoginIdCaseInsensitive(String loginId) throws AuthStoreException {
+        throw new UnsupportedOperationException("Unimplemented method 'getUserByLoginIdCaseInsensitive'");
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/auth/FrameworkAuthStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/auth/FrameworkAuthStoreService.java
@@ -76,6 +76,11 @@ public class FrameworkAuthStoreService implements IAuthStoreService {
     }
 
     @Override
+    public IUser getUserByLoginIdCaseInsensitive(String loginId) throws AuthStoreException {
+        return authStore.getUserByLoginIdCaseInsensitive(loginId);
+    }
+
+    @Override
     public IUser getUser(String userNumber) throws AuthStoreException {
         return authStore.getUser(userNumber);
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStore.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStore.java
@@ -72,6 +72,17 @@ public interface IAuthStore {
     IUser getUserByLoginId(String loginId) throws AuthStoreException;
 
     /**
+     * Retrieves a user record in the users store's database using case-insensitive matching.
+     * This method converts the provided loginId to lowercase and searches for a matching user.
+     * If a match is found, the actual case-accurate loginId from the store is returned.
+     *
+     * @param loginId    the loginId of the user trying to access Galasa API (case-insensitive)
+     * @return the user with the case-accurate loginId, or null if no match is found
+     * @throws AuthStoreException if there is an issue accessing the users store.
+     */
+    IUser getUserByLoginIdCaseInsensitive(String loginId) throws AuthStoreException;
+
+    /**
      * Retrieves a user record in the users store's database.
      *
      * @param userNumber    the ID of the user record to retrieve

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStoreService.java
@@ -88,6 +88,17 @@ public interface IAuthStoreService {
     IUser getUser(String userNumber) throws AuthStoreException;
 
     /**
+     * Retrieves a user record in the users database using case-insensitive matching.
+     * This method converts the provided loginId to lowercase and searches for a matching user.
+     * If a match is found, the actual case-accurate loginId from the store is returned.
+     *
+     * @param loginId    the loginId of the user trying to access Galasa API (case-insensitive)
+     * @return the user with the case-accurate loginId, or null if no match is found
+     * @throws AuthStoreException if there is an issue accessing the auth store.
+     */
+    IUser getUserByLoginIdCaseInsensitive(String loginId) throws AuthStoreException;
+
+    /**
      * Updates a user record in the users store's database.
      *
      * @param user    The user that needs to be updated

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockAuthStoreService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockAuthStoreService.java
@@ -144,6 +144,23 @@ public class MockAuthStoreService implements IAuthStoreService {
     }
 
     @Override
+    public IUser getUserByLoginIdCaseInsensitive(String loginId) throws AuthStoreException {
+        // Convert the provided loginId to lowercase for comparison
+        String lowerCaseLoginId = loginId.toLowerCase();
+        
+        // Search for a user with a matching lowercase loginId
+        for (Map.Entry<String, IUser> entry : usersByLoginId.entrySet()) {
+            if (entry.getKey().toLowerCase().equals(lowerCaseLoginId)) {
+                // Return the user with the actual case-accurate loginId
+                return entry.getValue();
+            }
+        }
+        
+        // No matching user found
+        return null;
+    }
+
+    @Override
     public IUser getUser(String userNumber) throws AuthStoreException {
 
         IUser userOut = null;


### PR DESCRIPTION
## Why?

Fixes https://github.com/galasa-dev/projectmanagement/issues/2556

The `--user` parameter for run submission was case-sensitive, causing permission errors when Jenkins passed user IDs in different casing than stored in the auth store.

This fix adds a case-insensitive user lookup method to the auth store interfaces and implements it using a new CouchDB view that emits lowercase loginIds. When submitting runs with `--user`, the system now performs case-insensitive matching against the auth store and uses the case-accurate loginId for permissions validation, and for storage in the Test Structure. Users can now submit runs with `--user` in any casing (e.g., admin, ADMIN, Admin) and it will correctly match the user in the auth store.

**Note:** This change set does not make searching by user with `--user` in `runs get` or with the REST API case-insensitive also. Currently, the Web UI provides dropdown options for users by retrieving them from CouchDB and these are in the correct case as stored in the auth store, so this is not an issue. For CLI and REST API calls, for now the `--user` field is still case sensitive. This could be completed as part of a second change set if requested.

## Changes
- [x] IAuthStore.java / IAuthStoreService.java: Added getUserByLoginIdCaseInsensitive() method for case-insensitive user lookup
- [x] AuthStoreDBLoginLowerCaseView.java: New CouchDB view bean for lowercase loginId matching
- [x] AuthStoreDBViews.java: Added reference to new lowercase view
- [x] CouchdbAuthStoreValidator.java: Added view definition that emits lowercase loginIds
- [x] CouchdbAuthStore.java: Implemented getUserByLoginIdCaseInsensitive() using the new CouchDB view
- [x] GroupRunsRoute.java: Updated run submission to use case-insensitive lookup and return case-accurate loginId for test structure storage
- [x] TestGroupRunsRoute.java: Added test for case-insensitive user lookup during run submission
- [x] MockAuthStoreService.java / MockAuthStore.java: Added mock implementation for testing
- [x] FrameworkAuthStoreService.java: Implemented delegation to underlying auth store
- [x] Tested on Minikube that ADMIN, admin and Admin could submit tests in the same way
- [x] Tested on Minikube that searching has not been regressed (although not yet case-insensitive)
