### PR TITLE
Bump plexus-utils to 4.0.3 and add plexus-xml dependency to resolve xml-related plexus imports

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/bnd.bnd
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/bnd.bnd
@@ -2,4 +2,5 @@
 Bundle-Name: Galasa framework maven repository implementation
 Import-Package: dev.galasa*,org.apache.commons.logging,org.osgi.service.url
 -includeresource: maven-repository-metadata-*.jar; lib:=true,\
-    plexus-utils-*.jar; lib:=true
+    plexus-utils-*.jar; lib:=true,\
+    plexus-xml-*.jar; lib:=true

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly project(':dev.galasa.framework.maven.repository.spi')
     implementation 'org.apache.maven:maven-repository-metadata'
     implementation 'org.codehaus.plexus:plexus-utils'
+    implementation 'org.codehaus.plexus:plexus-xml'
 
     testImplementation(testFixtures(project(':dev.galasa.framework')))
 }

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -266,7 +266,8 @@ dependencies {
         api 'org.checkerframework:checker-qual:3.43.0'
         api 'org.codehaus.mojo:animal-sniffer-annotations:1.24'
 
-        api 'org.codehaus.plexus:plexus-utils:3.0.24'
+        api 'org.codehaus.plexus:plexus-utils:4.0.3'
+        api 'org.codehaus.plexus:plexus-xml:4.1.1'
 
         api 'org.jetbrains.kotlin:kotlin-osgi-bundle:2.2.0'
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2568. 

Bumps the plexus-utils dependency in dev.galasa.framework.maven.repository to 4.0.3 to resolve a critical vulnerability. This PR also adds the plexus-xml dependency into the project as xml-related packages were moved out of plexus-utils v4 (see https://issues.apache.org/jira/browse/MNG-7798)

## Changes
- [x] Bumped plexus-utils to 4.0.3
- [x] Added plexus-xml dependency to resolve xml-related plexus imports
