### PR TITLE
Stop the MQ manager from being listed as an optional requirement when loading the framework bundle

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/bnd.bnd
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/bnd.bnd
@@ -1,2 +1,5 @@
 -snapshot: ${tstamp}
 Bundle-Name: Galasa MQ Manager IVTs
+Embed-Transitive: true
+Embed-Dependency: *;scope=compile
+-includeresource: javax.jms-api-*.jar; lib:=true

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/build.gradle
@@ -7,6 +7,7 @@ description = 'Galasa MQ Manager IVTs'
 dependencies {
     implementation project(':galasa-managers-comms-parent:dev.galasa.mq.manager')
     implementation project(':galasa-managers-core-parent:dev.galasa.core.manager')
+    implementation 'javax.jms:javax.jms-api'
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/bnd.bnd
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/bnd.bnd
@@ -1,8 +1,7 @@
 -snapshot: ${tstamp}
 Bundle-Name: MQ Manager
 Export-Package: !dev.galasa.mq.internal*,\
-        dev.galasa.mq*,\
-        javax.jms*
+        dev.galasa.mq*
 Import-Package: !javax.validation.constraints,\
         dev.galasa,\
         dev.galasa.framework.spi,\

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/build.gradle
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/build.gradle
@@ -5,7 +5,7 @@ plugins {
 description = 'MQ Manager'
 
 dependencies {
-    api 'javax.jms:javax.jms-api'
+    implementation 'javax.jms:javax.jms-api'
     implementation 'com.ibm.mq:com.ibm.mq.allclient'
 	implementation 'commons-codec:commons-codec'
     implementation 'org.json:json'  


### PR DESCRIPTION
## Why?

Linked to changes in https://github.com/galasa-dev/galasa/pull/541.

The MQ manager was being listed as an optional requirement when loading the dev.galasa.framework bundle. This caused issues when attempting to run the simbank tests using the MVP distribution as MVP doesn't include the MQ manager bundle, so the framework bundle would always fail to be resolved.

This seems to have been caused by the additional exported javax package that was added in a previous PR, so I've reverted the export change. This does mean that tests using the MQ manager will still need to embed javax.jms-api into their bundles, which is the same as it was previously.

## Changes
- [x] The MQ manager no longer exports javax.jms* packages
- [x] The MQ manager IVT now needs to embed the javax.jms-api package in its bundle to avoid OSGi errors (since javax.jms-api isn't an OSGi bundle)