### PR TITLE
Fix release date for 0.47.0 and link to local macos creds store docs

### DIFF
--- a/docs/content/releases/posts/v0.47.0.md
+++ b/docs/content/releases/posts/v0.47.0.md
@@ -1,6 +1,6 @@
 ---
 slug: v0.47.0
-date: 2026-02-19
+date: 2026-04-09
 links:
   - v0.47.0 GitHub release: https://github.com/galasa-dev/galasa/releases/tag/v0.47.0
 ---
@@ -9,7 +9,7 @@ links:
 
 ## Changes affecting tests running locally
 
-- **macOS Keychain Credentials Store**: Added support for reading Galasa credentials from the macOS Keychain, allowing macOS users to securely manage test credentials using the native Keychain Access application. This provides a more secure alternative to storing credentials in plain text files. The store supports all Galasa credential types including username/password, tokens, and KeyStore credentials. See the [macOS Keychain Credentials Store documentation](../../docs/configuring-credentials/macos-keychain-store.md) for setup instructions and usage examples.
+- **macOS Keychain Credentials Store**: Added support for reading Galasa credentials from the macOS Keychain, allowing macOS users to securely manage test credentials using the native Keychain Access application. This provides a more secure alternative to storing credentials in plain text files. The store supports all Galasa credential types including username/password, tokens, and KeyStore credentials. See the [macOS Keychain Credentials Store documentation](../../docs/configuring-local-credentials/macos-keychain-store.md) for setup instructions and usage examples.
 
 ## Changes affecting tests running locally or on the Galasa Service
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2528. 

The date for the 0.47.0 release has been corrected and a link to the local macos credentials store has been fixed.