### PR TITLE
Add background RAS cleanup process in the resource monitor

### DIFF
--- a/docs/content/docs/manage-ecosystem/automatic-runs-cleanup.md
+++ b/docs/content/docs/manage-ecosystem/automatic-runs-cleanup.md
@@ -1,0 +1,110 @@
+---
+title: "Configuring automatic cleanup of test runs"
+---
+
+Over time, test run results build up and take up space in the Galasa Ecosystem's Result Archive Store (RAS). To help manage storage, the Galasa service includes an automatic cleanup process that deletes old test runs based on configurable criteria.
+
+This automatic cleanup process complements the manual deletion capability provided by the [`galasactl runs delete`](./runs-delete.md) command, allowing you to maintain your test run history without manual intervention.
+
+## How the cleanup process works
+
+The cleanup process runs periodically to identify and delete test runs that meet the configured age criteria. By default:
+
+- Test runs older than 30 days are deleted
+- The cleanup process runs once every 24 hours
+
+You can configure both the age threshold and the cleanup frequency to suit your needs.
+
+## Configuring cleanup settings
+
+There are two ways to configure the automatic cleanup process:
+
+1. **Using Helm chart values** - Set values when deploying or upgrading the Galasa service
+2. **Using CPS properties** - Configure settings at runtime without redeploying the Galasa service
+
+### Configuring via Helm chart
+
+When deploying or upgrading the Galasa service using Helm, you can set the following values:
+
+- `resourceMonitor.testRunCleanupMaxAgeDays` - The maximum age in days for test runs before they are deleted (default: 30)
+- `resourceMonitor.testRunCleanupIntervalHours` - How often the cleanup process runs, in hours (default: 24)
+
+Example values file snippet:
+
+```yaml
+resourceMonitor:
+  testRunCleanupMaxAgeDays: 60
+  testRunCleanupIntervalHours: 12
+```
+
+This configuration would delete test runs older than 60 days and run the cleanup process every 12 hours.
+
+### Configuring via CPS properties
+
+You can also configure the cleanup process at runtime by setting Configuration Property Store (CPS) properties. This allows you to adjust settings without redeploying the Galasa service.
+
+Use the [`galasactl properties set`](../reference/cli-syntax/galasactl_properties_set.md) command to configure the following properties in the `framework` namespace:
+
+- `framework.ras.cleanup.test.run.age.max.days` - The maximum age in days for test runs before they are deleted
+- `framework.ras.cleanup.test.run.age.interval.hours` - How often the cleanup process runs, in hours
+
+Example commands:
+
+```shell
+galasactl properties set --namespace framework \
+  --name ras.cleanup.test.run.age.max.days \
+  --value 60 \
+  --bootstrap https://example.com/api/bootstrap
+
+galasactl properties set --namespace framework \
+  --name ras.cleanup.test.run.age.interval.hours \
+  --value 12 \
+  --bootstrap https://example.com/api/bootstrap
+```
+
+**Note:** CPS property settings take precedence over Helm chart values. If both are configured, the CPS property values will be used.
+
+## Excluding test runs from cleanup
+
+You may want to preserve certain test runs indefinitely, such as baseline results or runs from important releases. You can exclude test runs from the automatic cleanup process by configuring exclusion rules based on test run fields.
+
+### Configuring exclusions
+
+Use the `framework.ras.cleanup.test.run.exclude.[FIELD_NAME]` CPS property pattern to exclude test runs based on specific field values, where `[FIELD_NAME]` is the name of the field to filter by.
+
+The property accepts a comma-separated list of values. Test runs matching any of the specified values for that field will be excluded from cleanup.
+
+### Example: Excluding by tags
+
+To exclude test runs that are tagged with `keepMe` or `doNotDelete`:
+
+```shell
+galasactl properties set --namespace framework \
+  --name ras.cleanup.test.run.exclude.tags \
+  --value keepMe,doNotDelete \
+  --bootstrap https://example.com/api/bootstrap
+```
+
+Any test run with either the `keepMe` or `doNotDelete` tag will be preserved, regardless of its age.
+
+### Example: Excluding by result
+
+To exclude test runs that failed or had environmental failures:
+
+```shell
+galasactl properties set --namespace framework \
+  --name ras.cleanup.test.run.exclude.result \
+  --value Failed,EnvFail \
+  --bootstrap https://example.com/api/bootstrap
+```
+
+### Example: Excluding by requestor
+
+To exclude test runs submitted by specific requestors:
+
+```shell
+galasactl properties set --namespace framework \
+  --name ras.cleanup.test.run.exclude.requestor \
+  --value alice,bob \
+  --bootstrap https://example.com/api/bootstrap
+```

--- a/docs/content/docs/manage-ecosystem/automatic-runs-cleanup.md
+++ b/docs/content/docs/manage-ecosystem/automatic-runs-cleanup.md
@@ -74,6 +74,16 @@ Use the `framework.ras.cleanup.test.run.exclude.[FIELD_NAME]` CPS property patte
 
 The property accepts a comma-separated list of values. Test runs matching any of the specified values for that field will be excluded from cleanup.
 
+Supported test run field names are:
+
+- `group`
+- `requestor`
+- `result`
+- `runName`
+- `status`
+- `tags`
+- `user`
+
 ### Example: Excluding by tags
 
 To exclude test runs that are tagged with `keepMe` or `doNotDelete`:

--- a/docs/content/docs/manage-ecosystem/runs-delete.md
+++ b/docs/content/docs/manage-ecosystem/runs-delete.md
@@ -4,6 +4,8 @@ title: "Deleting test run results"
 
 Over time, test run results build up and take up space in the Galasa Ecosystem. You can delete test runs which have completed in the past by using the `galasactl runs delete` command.
 
+For information about configuring automatic cleanup of old test runs, see [Configuring automatic cleanup of test runs](./automatic-runs-cleanup.md).
+
 To view the full command syntax, see the [galasactl runs delete](../reference/cli-syntax/galasactl_runs_delete.md) command reference.
 
 

--- a/docs/content/releases/posts/v0.48.0.md
+++ b/docs/content/releases/posts/v0.48.0.md
@@ -1,0 +1,14 @@
+---
+slug: v0.48.0
+date: 2026-04-10
+links:
+  - v0.48.0 GitHub release: https://github.com/galasa-dev/galasa/releases/tag/v0.48.0
+---
+
+# 0.48.0 - Release Highlights
+
+## Changes affecting the Galasa Service
+
+- Added a background cleanup process for the Galasa service's result archive store which automatically deletes test runs that meet the configured criteria.
+  - By default, test runs older than 30 days are deleted and the cleanup process runs once every 24 hours.
+  - For information on how to configure the cleanup process, including how to adjust the age threshold, cleanup frequency, and exclude specific test runs from cleanup, see [Configuring automatic cleanup of test runs](../../docs/manage-ecosystem/automatic-runs-cleanup.md).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -220,6 +220,7 @@ nav:
       - docs/manage-ecosystem/runs-reset-cancel.md
       - docs/manage-ecosystem/runs-get.md
       - docs/manage-ecosystem/runs-download.md
+      - docs/manage-ecosystem/automatic-runs-cleanup.md
       - docs/manage-ecosystem/runs-delete.md
     - Upgrading:
       - docs/upgrading/index.md 

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
@@ -11,7 +11,6 @@ import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -23,15 +22,12 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 
 import dev.galasa.framework.maven.repository.spi.IMavenRepository;
-import dev.galasa.framework.resource.management.internal.rascleanup.RasRunCleanupScheduler;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
-import dev.galasa.framework.spi.SystemEnvironment;
-import dev.galasa.framework.spi.utils.SystemTimeService;
 import io.prometheus.client.Counter;
 import io.prometheus.client.exporter.HTTPServer;
 
@@ -40,8 +36,6 @@ import io.prometheus.client.exporter.HTTPServer;
  */
 @Component(service = { ResourceManagement.class })
 public class ResourceManagement extends AbstractResourceManagement {
-
-    private static final int RESOURCE_MANAGEMENT_RAS_CLEANUP_POLL_INTERVAL_MINUTES = 5;
 
     private Log logger = LogFactory.getLog(this.getClass());
 
@@ -129,8 +123,6 @@ public class ResourceManagement extends AbstractResourceManagement {
             // *** Start the Run watch thread
             ResourceManagementRunWatch runWatch = new ResourceManagementRunWatch(framework, resourceManagementProviders, getScheduledExecutorService());
 
-            startRasRunCleanupScheduler();
-
             logger.info("Resource Manager has started");
 
             // *** Loop until we are asked to shutdown
@@ -150,22 +142,6 @@ public class ResourceManagement extends AbstractResourceManagement {
             // Let the ShutDownHook know that the main thread has shut things down via this shared-state boolean.
             shutdownComplete = true;
         }
-    }
-
-    private void startRasRunCleanupScheduler() throws FrameworkException {
-        RasRunCleanupScheduler rasRunCleanupScheduler = new RasRunCleanupScheduler(
-            framework,
-            getScheduledExecutorService(),
-            new SystemTimeService(),
-            new SystemEnvironment()
-        );
-
-        getScheduledExecutorService().scheduleWithFixedDelay(
-            rasRunCleanupScheduler,
-            0,
-            RESOURCE_MANAGEMENT_RAS_CLEANUP_POLL_INTERVAL_MINUTES,
-            TimeUnit.MINUTES
-        );
     }
 
     private void shutdown(ResourceManagementRunWatch runWatch) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
@@ -30,6 +30,7 @@ import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.SystemEnvironment;
 import dev.galasa.framework.spi.utils.SystemTimeService;
 import io.prometheus.client.Counter;
 import io.prometheus.client.exporter.HTTPServer;
@@ -152,7 +153,13 @@ public class ResourceManagement extends AbstractResourceManagement {
     }
 
     private void startRasRunCleanupScheduler() throws FrameworkException {
-        RasRunCleanupScheduler rasRunCleanupScheduler = new RasRunCleanupScheduler(framework, getScheduledExecutorService(), new SystemTimeService());
+        RasRunCleanupScheduler rasRunCleanupScheduler = new RasRunCleanupScheduler(
+            framework,
+            getScheduledExecutorService(),
+            new SystemTimeService(),
+            new SystemEnvironment()
+        );
+
         getScheduledExecutorService().scheduleWithFixedDelay(
             rasRunCleanupScheduler,
             0,

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
@@ -40,6 +40,8 @@ import io.prometheus.client.exporter.HTTPServer;
 @Component(service = { ResourceManagement.class })
 public class ResourceManagement extends AbstractResourceManagement {
 
+    private static final int RESOURCE_MANAGEMENT_RAS_CLEANUP_POLL_INTERVAL_MINUTES = 5;
+
     private Log logger = LogFactory.getLog(this.getClass());
 
     private BundleContext                                bundleContext;
@@ -126,8 +128,7 @@ public class ResourceManagement extends AbstractResourceManagement {
             // *** Start the Run watch thread
             ResourceManagementRunWatch runWatch = new ResourceManagementRunWatch(framework, resourceManagementProviders, getScheduledExecutorService());
 
-            RasRunCleanupScheduler rasRunCleanupScheduler = new RasRunCleanupScheduler(framework, getScheduledExecutorService(), new SystemTimeService());
-            getScheduledExecutorService().scheduleWithFixedDelay(rasRunCleanupScheduler, 0, 5, TimeUnit.MINUTES);
+            startRasRunCleanupScheduler();
 
             logger.info("Resource Manager has started");
 
@@ -148,6 +149,16 @@ public class ResourceManagement extends AbstractResourceManagement {
             // Let the ShutDownHook know that the main thread has shut things down via this shared-state boolean.
             shutdownComplete = true;
         }
+    }
+
+    private void startRasRunCleanupScheduler() throws FrameworkException {
+        RasRunCleanupScheduler rasRunCleanupScheduler = new RasRunCleanupScheduler(framework, getScheduledExecutorService(), new SystemTimeService());
+        getScheduledExecutorService().scheduleWithFixedDelay(
+            rasRunCleanupScheduler,
+            0,
+            RESOURCE_MANAGEMENT_RAS_CLEANUP_POLL_INTERVAL_MINUTES,
+            TimeUnit.MINUTES
+        );
     }
 
     private void shutdown(ResourceManagementRunWatch runWatch) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
@@ -11,6 +11,7 @@ import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -22,12 +23,14 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 
 import dev.galasa.framework.maven.repository.spi.IMavenRepository;
+import dev.galasa.framework.resource.management.internal.rascleanup.RasRunCleanupScheduler;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.utils.SystemTimeService;
 import io.prometheus.client.Counter;
 import io.prometheus.client.exporter.HTTPServer;
 
@@ -122,6 +125,9 @@ public class ResourceManagement extends AbstractResourceManagement {
             
             // *** Start the Run watch thread
             ResourceManagementRunWatch runWatch = new ResourceManagementRunWatch(framework, resourceManagementProviders, getScheduledExecutorService());
+
+            RasRunCleanupScheduler rasRunCleanupScheduler = new RasRunCleanupScheduler(framework, getScheduledExecutorService(), new SystemTimeService());
+            getScheduledExecutorService().scheduleWithFixedDelay(rasRunCleanupScheduler, 0, 5, TimeUnit.MINUTES);
 
             logger.info("Resource Manager has started");
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/ExcludeCriteria.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/ExcludeCriteria.java
@@ -5,11 +5,17 @@
  */
 package dev.galasa.framework.resource.management.internal.rascleanup;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.ras.IRasSearchCriteria;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaGroup;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaRequestor;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaResult;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaRunName;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaStatus;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaTags;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaUser;
 import dev.galasa.framework.spi.teststructure.TestStructure;
@@ -18,6 +24,8 @@ public enum ExcludeCriteria {
     GROUP("group"),
     REQUESTOR("requestor"),
     RESULT("result"),
+    RUN_NAME("runName"),
+    STATUS("status"),
     TAGS("tags"),
     USER("user");
 
@@ -40,15 +48,32 @@ public enum ExcludeCriteria {
                 return new RasSearchCriteriaTags(values);
             case RESULT:
                 return new RasSearchCriteriaResult(values);
+            case RUN_NAME:
+                return new RasSearchCriteriaRunName(values);
             case GROUP:
                 return new RasSearchCriteriaGroup(values);
             case USER:
                 return new RasSearchCriteriaUser(values);
             case REQUESTOR:
                 return new RasSearchCriteriaRequestor(values);
+            case STATUS:
+                List<TestRunLifecycleStatus> statuses = getTestRunStatusesFromValues(values);
+                return new RasSearchCriteriaStatus(statuses);
             default:
                 throw new FrameworkException("Unknown criteria type: " + this);
         }
+    }
+
+    private List<TestRunLifecycleStatus> getTestRunStatusesFromValues(String[] values) {
+        List<TestRunLifecycleStatus> statuses = new ArrayList<>();
+
+        for (String value : values) {
+            TestRunLifecycleStatus status = TestRunLifecycleStatus.getFromString(value);
+            if (status != null) {
+                statuses.add(status);
+            }
+        }
+        return statuses;
     }
 
     /**

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/ExcludeCriteria.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/ExcludeCriteria.java
@@ -7,15 +7,19 @@ package dev.galasa.framework.resource.management.internal.rascleanup;
 
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.ras.IRasSearchCriteria;
-import dev.galasa.framework.spi.ras.RasSearchCriteriaBundle;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaGroup;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaRequestor;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaResult;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaTags;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaUser;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public enum ExcludeCriteria {
+    GROUP("group"),
+    REQUESTOR("requestor"),
+    RESULT("result"),
     TAGS("tags"),
-    USER("user"),
-    BUNDLE("bundle");
+    USER("user");
 
     private String criteriaName;
 
@@ -34,10 +38,14 @@ public enum ExcludeCriteria {
         switch (this) {
             case TAGS:
                 return new RasSearchCriteriaTags(values);
+            case RESULT:
+                return new RasSearchCriteriaResult(values);
+            case GROUP:
+                return new RasSearchCriteriaGroup(values);
             case USER:
                 return new RasSearchCriteriaUser(values);
-            case BUNDLE:
-                return new RasSearchCriteriaBundle(values);
+            case REQUESTOR:
+                return new RasSearchCriteriaRequestor(values);
             default:
                 throw new FrameworkException("Unknown criteria type: " + this);
         }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/ExcludeCriteria.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/ExcludeCriteria.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal.rascleanup;
+
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.ras.IRasSearchCriteria;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaBundle;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaTags;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaUser;
+import dev.galasa.framework.spi.teststructure.TestStructure;
+
+public enum ExcludeCriteria {
+    TAGS("tags"),
+    USER("user"),
+    BUNDLE("bundle");
+
+    private String criteriaName;
+
+    private ExcludeCriteria(String criteriaName) {
+        this.criteriaName = criteriaName;
+    }
+
+    /**
+     * Creates an IRasSearchCriteria instance with the provided values.
+     *
+     * @param values The criteria values to match against
+     * @return A new IRasSearchCriteria instance configured with the values
+     * @throws FrameworkException if an unknown criteria type is provided
+     */
+    public IRasSearchCriteria createCriteria(String[] values) throws FrameworkException {
+        switch (this) {
+            case TAGS:
+                return new RasSearchCriteriaTags(values);
+            case USER:
+                return new RasSearchCriteriaUser(values);
+            case BUNDLE:
+                return new RasSearchCriteriaBundle(values);
+            default:
+                throw new FrameworkException("Unknown criteria type: " + this);
+        }
+    }
+
+    /**
+     * Checks if a test run should be kept based on the criteria values.
+     *
+     * @param testStructure The test structure to check
+     * @param excludeValues The values to match against for exclusion from cleanup
+     * @return true if the run matches the criteria, false otherwise
+     * @throws FrameworkException if an unknown criteria type is provided
+     */
+    public boolean shouldRunBeKept(TestStructure testStructure, String[] excludeValues) throws FrameworkException {
+        boolean shouldKeep = false;
+        if (excludeValues != null && excludeValues.length > 0) {
+            IRasSearchCriteria criteria = createCriteria(excludeValues);
+            shouldKeep = criteria.criteriaMatched(testStructure);
+        }
+        return shouldKeep;
+    }
+
+    public static ExcludeCriteria getFromString(String criteria) {
+        ExcludeCriteria match = null;
+        for (ExcludeCriteria resource : values()) {
+            if (resource.toString().equalsIgnoreCase(criteria.trim())) {
+                match = resource;
+                break;
+            }
+        }
+        return match;
+    }
+
+    @Override
+    public String toString() {
+        return criteriaName;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
@@ -148,8 +148,6 @@ public class RasRunCleanup implements Runnable {
         // If a maximum age is set, add queued time criteria
         if (runMaxAgeDays > 0) {
             Instant searchToTime = timeService.now().minus(runMaxAgeDays, ChronoUnit.DAYS);
-
-            // Add 'from' and 'to' time criteria
             criteria.add(new RasSearchCriteriaQueuedTo(searchToTime));
         }
         return criteria;

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
@@ -32,8 +32,8 @@ public class RasRunCleanup implements Runnable {
 
     private static final String TEST_RUN_CLEANUP_CPS_PREFIX = "ras.cleanup";
     private static final String TEST_RUN_MAX_DAYS_CPS_PROPERTY = "test.run.age.max.days";
-    private static final String TEST_RUN_EXCLUDE_PREFIX = "test.run.exclude.";
-    
+    private static final String TEST_RUN_EXCLUDE_PREFIX = TEST_RUN_CLEANUP_CPS_PREFIX + ".test.run.exclude.";
+
     private final int initialRunCleanupMaxAgeDays;
 
     private IResultArchiveStore rasService;
@@ -86,11 +86,11 @@ public class RasRunCleanup implements Runnable {
             for (IResultArchiveStoreDirectoryService directoryService : rasService.getDirectoryServices()) {
                 runs.addAll(directoryService.getRuns(searchCriteria.toArray(new IRasSearchCriteria[0])));
             }
-            logger.info("Found " + runs.size() + " runs matching cleanup criteria");
+            logger.info("Found " + runs.size() + " run(s) matching cleanup criteria");
 
             // Filter out excluded runs - returns only runs that should still be cleaned up
             runs = filterOutRunsToKeep(runs);
-            logger.info(runs.size() + " runs will be deleted from the RAS");
+            logger.info(runs.size() + " run(s) will be deleted from the RAS");
         }
         return runs;
     }
@@ -98,37 +98,77 @@ public class RasRunCleanup implements Runnable {
     private List<IRunResult> filterOutRunsToKeep(List<IRunResult> runsToCleanUp) throws FrameworkException {
         Set<IRunResult> runsToKeep = new HashSet<>();
 
-        // Get all the properties in the form framework.test.run.exclude.<field>=<comma-separated-values-to-exclude>
+        // Get all the properties in the form framework.ras.cleanup.test.run.exclude.<field>=<comma-separated-values-to-exclude>
         Map<String, String> excludeProperties = cpsService.getPrefixedProperties(TEST_RUN_EXCLUDE_PREFIX);
 
         if (!excludeProperties.isEmpty()) {
-            for (Map.Entry<String, String> entry : excludeProperties.entrySet()) {
-                String key = entry.getKey();
-                String fieldName = key.substring(key.lastIndexOf(".") + 1).toLowerCase();
 
-                ExcludeCriteria criteria = ExcludeCriteria.getFromString(fieldName);
-                if (criteria != null) {
-                    // Split by comma and trim whitespace from each value
-                    String[] valuesToKeep = entry.getValue().split(",");
-                    for (int i = 0; i < valuesToKeep.length; i++) {
-                        valuesToKeep[i] = valuesToKeep[i].trim();
-                    }
+            // Build a list of exclude criteria
+            List<ParsedExcludeCriteria> criteriaList = buildExcludeCriteria(excludeProperties);
 
-                    for (IRunResult run : runsToCleanUp) {
-                        if (criteria.shouldRunBeKept(run.getTestStructure(), valuesToKeep)) {
-                            runsToKeep.add(run);
-                            logger.trace("Run " + run.getRunId() + " excluded from cleanup by " + fieldName + " criteria");
-                        }
+            // Build a list of runs to keep
+            for (IRunResult run : runsToCleanUp) {
+                for (ParsedExcludeCriteria parsedCriteria : criteriaList) {
+                    if (parsedCriteria.getCriteria().shouldRunBeKept(run.getTestStructure(), parsedCriteria.getValues())) {
+                        runsToKeep.add(run);
+                        logger.trace("Run " + run.getRunId() + " excluded from cleanup by " + parsedCriteria.getRunFieldName() + " criteria");
+                        break;
                     }
                 }
             }
-            logger.trace("Excluded " + (runsToCleanUp.size() - runsToKeep.size()) + " runs from cleanup");
+            logger.trace("Excluded " + runsToKeep.size() + " run(s) from cleanup");
 
             // Remove the runs to keep from the list of runs that should be cleaned up
             runsToCleanUp.removeAll(runsToKeep);
         }
 
         return runsToCleanUp;
+    }
+
+    private List<ParsedExcludeCriteria> buildExcludeCriteria(Map<String, String> excludeProperties) {
+        List<ParsedExcludeCriteria> criteriaList = new ArrayList<>();
+
+        for (Map.Entry<String, String> entry : excludeProperties.entrySet()) {
+            String key = entry.getKey();
+            String fieldName = key.substring(key.lastIndexOf(".") + 1).toLowerCase();
+
+            ExcludeCriteria criteria = ExcludeCriteria.getFromString(fieldName);
+            if (criteria != null) {
+
+                // Values may be provided as comma-separated lists,
+                // so split by the commas and trim each value
+                String[] valuesToKeep = entry.getValue().split(",");
+                for (int i = 0; i < valuesToKeep.length; i++) {
+                    valuesToKeep[i] = valuesToKeep[i].trim();
+                }
+                criteriaList.add(new ParsedExcludeCriteria(criteria, valuesToKeep, fieldName));
+            }
+        }
+        return criteriaList;
+    }
+
+    private class ParsedExcludeCriteria {
+        final ExcludeCriteria criteria;
+        final String[] values;
+        final String fieldName;
+
+        ParsedExcludeCriteria(ExcludeCriteria criteria, String[] values, String fieldName) {
+            this.criteria = criteria;
+            this.values = values;
+            this.fieldName = fieldName;
+        }
+
+        public ExcludeCriteria getCriteria() {
+            return criteria;
+        }
+
+        public String[] getValues() {
+            return values;
+        }
+
+        public String getRunFieldName() {
+            return fieldName;
+        }
     }
 
     private List<IRasSearchCriteria> buildSearchCriteria() throws ConfigurationPropertyStoreException {

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
@@ -79,7 +79,7 @@ public class RasRunCleanup implements Runnable {
 
             // Filter out excluded runs - returns only runs that should still be cleaned up
             runs = filterOutRunsToKeep(runs);
-            logger.info(runs.size() + " runs will be cleaned up after applying exclusions");
+            logger.info(runs.size() + " runs will be deleted from the RAS");
         }
         return runs;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
@@ -33,6 +33,8 @@ public class RasRunCleanup implements Runnable {
     private static final String TEST_RUN_CLEANUP_CPS_PREFIX = "ras.cleanup";
     private static final String TEST_RUN_MAX_DAYS_CPS_PROPERTY = "test.run.age.max.days";
     private static final String TEST_RUN_EXCLUDE_PREFIX = "test.run.exclude.";
+    
+    private final int initialRunCleanupMaxAgeDays;
 
     private IResultArchiveStore rasService;
     private IConfigurationPropertyStoreService cpsService;
@@ -41,11 +43,13 @@ public class RasRunCleanup implements Runnable {
     public RasRunCleanup(
         IConfigurationPropertyStoreService cpsService,
         IResultArchiveStore rasService,
-        ITimeService timeService
+        ITimeService timeService,
+        int initialRunCleanupMaxAgeDays
     ) throws FrameworkException {
         this.rasService = rasService;
         this.cpsService = cpsService;
         this.timeService = timeService;
+        this.initialRunCleanupMaxAgeDays = initialRunCleanupMaxAgeDays;
     }
 
     @Override
@@ -123,7 +127,7 @@ public class RasRunCleanup implements Runnable {
     private List<IRasSearchCriteria> buildSearchCriteria() throws ConfigurationPropertyStoreException {
         List<IRasSearchCriteria> criteria = new ArrayList<>();
 
-        int runMaxAgeDays = -1;
+        int runMaxAgeDays = initialRunCleanupMaxAgeDays;
         try {
             String runMaxAgeStr = cpsService.getProperty(TEST_RUN_CLEANUP_CPS_PREFIX, TEST_RUN_MAX_DAYS_CPS_PROPERTY);
             if (runMaxAgeStr != null) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
@@ -56,16 +56,23 @@ public class RasRunCleanup implements Runnable {
     public void run() {
         logger.info("Starting scan for runs to clean up from the RAS");
 
+        List<IRunResult> runs = new ArrayList<>();
         try {
-            List<IRunResult> runs = getRunsToCleanUp();
-
-            for (IRunResult run : runs) {
-                logger.trace("Deleting run " + run.getRunId());
-                run.discard();
-                logger.trace("Deleted run " + run.getRunId());
-            }
+            runs = getRunsToCleanUp();
         } catch (Exception e) {
             logger.error("Error while scanning for runs to clean up", e);
+        }
+
+        for (IRunResult run : runs) {
+            String runId = run.getRunId();
+
+            try {
+                logger.trace("Deleting run " + runId);
+                run.discard();
+                logger.trace("Deleted run " + runId);
+            } catch (Exception e) {
+                logger.error("Error while deleting run " + runId, e);
+            }
         }
 
         logger.info("Finished scan for runs to clean up from the RAS");

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanup.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal.rascleanup;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.IResultArchiveStore;
+import dev.galasa.framework.spi.IResultArchiveStoreDirectoryService;
+import dev.galasa.framework.spi.IRunResult;
+import dev.galasa.framework.spi.ras.IRasSearchCriteria;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaQueuedTo;
+import dev.galasa.framework.spi.utils.ITimeService;
+
+public class RasRunCleanup implements Runnable {
+
+    private final Log logger = LogFactory.getLog(getClass());
+
+    private static final String TEST_RUN_CLEANUP_CPS_PREFIX = "ras.cleanup";
+    private static final String TEST_RUN_MAX_DAYS_CPS_PROPERTY = "test.run.age.max.days";
+    private static final String TEST_RUN_EXCLUDE_PREFIX = "test.run.exclude.";
+
+    private IResultArchiveStore rasService;
+    private IConfigurationPropertyStoreService cpsService;
+    private ITimeService timeService;
+
+    public RasRunCleanup(
+        IConfigurationPropertyStoreService cpsService,
+        IResultArchiveStore rasService,
+        ITimeService timeService
+    ) throws FrameworkException {
+        this.rasService = rasService;
+        this.cpsService = cpsService;
+        this.timeService = timeService;
+    }
+
+    @Override
+    public void run() {
+        logger.info("Starting scan for runs to clean up from the RAS");
+
+        try {
+            List<IRunResult> runs = getRunsToCleanUp();
+
+            for (IRunResult run : runs) {
+                logger.trace("Deleting run " + run.getRunId());
+                run.discard();
+                logger.trace("Deleted run " + run.getRunId());
+            }
+        } catch (Exception e) {
+            logger.error("Error while scanning for runs to clean up", e);
+        }
+
+        logger.info("Finished scan for runs to clean up from the RAS");
+    }
+
+    private List<IRunResult> getRunsToCleanUp() throws FrameworkException {
+        List<IRunResult> runs = new ArrayList<>();
+        List<IRasSearchCriteria> searchCriteria = buildSearchCriteria();
+
+        if (searchCriteria != null && !searchCriteria.isEmpty()) {
+            for (IResultArchiveStoreDirectoryService directoryService : rasService.getDirectoryServices()) {
+                runs.addAll(directoryService.getRuns(searchCriteria.toArray(new IRasSearchCriteria[0])));
+            }
+            logger.info("Found " + runs.size() + " runs matching cleanup criteria");
+
+            // Filter out excluded runs - returns only runs that should still be cleaned up
+            runs = filterOutRunsToKeep(runs);
+            logger.info(runs.size() + " runs will be cleaned up after applying exclusions");
+        }
+        return runs;
+    }
+
+    private List<IRunResult> filterOutRunsToKeep(List<IRunResult> runsToCleanUp) throws FrameworkException {
+        Set<IRunResult> runsToKeep = new HashSet<>();
+
+        // Get all the properties in the form framework.test.run.exclude.<field>=<comma-separated-values-to-exclude>
+        Map<String, String> excludeProperties = cpsService.getPrefixedProperties(TEST_RUN_EXCLUDE_PREFIX);
+
+        if (!excludeProperties.isEmpty()) {
+            for (Map.Entry<String, String> entry : excludeProperties.entrySet()) {
+                String key = entry.getKey();
+                String fieldName = key.substring(key.lastIndexOf(".") + 1).toLowerCase();
+
+                ExcludeCriteria criteria = ExcludeCriteria.getFromString(fieldName);
+                if (criteria != null) {
+                    // Split by comma and trim whitespace from each value
+                    String[] valuesToKeep = entry.getValue().split(",");
+                    for (int i = 0; i < valuesToKeep.length; i++) {
+                        valuesToKeep[i] = valuesToKeep[i].trim();
+                    }
+
+                    for (IRunResult run : runsToCleanUp) {
+                        if (criteria.shouldRunBeKept(run.getTestStructure(), valuesToKeep)) {
+                            runsToKeep.add(run);
+                            logger.trace("Run " + run.getRunId() + " excluded from cleanup by " + fieldName + " criteria");
+                        }
+                    }
+                }
+            }
+            logger.trace("Excluded " + (runsToCleanUp.size() - runsToKeep.size()) + " runs from cleanup");
+
+            // Remove the runs to keep from the list of runs that should be cleaned up
+            runsToCleanUp.removeAll(runsToKeep);
+        }
+
+        return runsToCleanUp;
+    }
+
+    private List<IRasSearchCriteria> buildSearchCriteria() throws ConfigurationPropertyStoreException {
+        List<IRasSearchCriteria> criteria = new ArrayList<>();
+
+        int runMaxAgeDays = -1;
+        try {
+            String runMaxAgeStr = cpsService.getProperty(TEST_RUN_CLEANUP_CPS_PREFIX, TEST_RUN_MAX_DAYS_CPS_PROPERTY);
+            if (runMaxAgeStr != null) {
+                runMaxAgeDays = Integer.parseInt(runMaxAgeStr);
+            }
+
+        } catch (NumberFormatException e) {
+            logger.warn("Invalid CPS property value provided. A numeric value is expected for '" + TEST_RUN_MAX_DAYS_CPS_PROPERTY + "'.");
+        }
+
+        // If a maximum age is set, add queued time criteria
+        if (runMaxAgeDays > 0) {
+            Instant searchToTime = timeService.now().minus(runMaxAgeDays, ChronoUnit.DAYS);
+
+            // Add 'from' and 'to' time criteria
+            criteria.add(new RasSearchCriteriaQueuedTo(searchToTime));
+        }
+        return criteria;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanupResourceManagementProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanupResourceManagementProvider.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal.rascleanup;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.annotations.Component;
+
+import dev.galasa.framework.spi.Environment;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IFramework;
+import dev.galasa.framework.spi.IResourceManagement;
+import dev.galasa.framework.spi.IResourceManagementProvider;
+import dev.galasa.framework.spi.ResourceManagerException;
+import dev.galasa.framework.spi.SystemEnvironment;
+import dev.galasa.framework.spi.utils.ITimeService;
+import dev.galasa.framework.spi.utils.SystemTimeService;
+
+@Component(service = { IResourceManagementProvider.class })
+public class RasRunCleanupResourceManagementProvider implements IResourceManagementProvider {
+
+    public static final String TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR = "GALASA_TEST_RUN_CLEANUP_INTERVAL_HOURS";
+    public static final String TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR = "GALASA_TEST_RUN_CLEANUP_MAX_AGE_DAYS";
+
+    private static final int RESOURCE_MANAGEMENT_RAS_CLEANUP_POLL_INTERVAL_MINUTES = 5;
+
+    private final Log logger = LogFactory.getLog(getClass());
+
+    private RasRunCleanupScheduler rasRunCleanupScheduler;
+    private IResourceManagement resourceManagement;
+    private ITimeService timeService;
+    private Environment env;
+
+    public RasRunCleanupResourceManagementProvider() {
+        this(new SystemTimeService(), new SystemEnvironment());
+    }
+
+    public RasRunCleanupResourceManagementProvider(ITimeService timeService, Environment env) {
+        this.timeService = timeService;
+        this.env = env;
+    }
+
+    @Override
+    public boolean initialise(IFramework framework, IResourceManagement resourceManagement)
+            throws ResourceManagerException {
+        this.resourceManagement = resourceManagement;
+
+        String testRunCleanupIntervalHoursStr = env.getenv(TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR);
+        String testRunCleanupMaxAgeDaysStr = env.getenv(TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR);
+
+        long initialRunCleanupIntervalHours = parseLong(testRunCleanupIntervalHoursStr, 0, TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR);
+        int initialRunCleanupMaxAgeDays = parseInt(testRunCleanupMaxAgeDaysStr, 0, TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR);
+
+        // Only initialise the scheduler if the interval and max age are set
+        if (initialRunCleanupIntervalHours > 0 && initialRunCleanupMaxAgeDays > 0) {
+            try {
+                this.rasRunCleanupScheduler = new RasRunCleanupScheduler(
+                    framework,
+                    resourceManagement.getScheduledExecutorService(),
+                    initialRunCleanupIntervalHours,
+                    initialRunCleanupMaxAgeDays,
+                    this.timeService
+                );
+            } catch (FrameworkException e) {
+                logger.error("Unable to initialise RAS cleanup scheduler", e);
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public void start() {
+        if (this.rasRunCleanupScheduler != null) {
+            this.resourceManagement.getScheduledExecutorService().scheduleWithFixedDelay(
+                rasRunCleanupScheduler,
+                0,
+                RESOURCE_MANAGEMENT_RAS_CLEANUP_POLL_INTERVAL_MINUTES,
+                TimeUnit.MINUTES
+            );
+        } else {
+            logger.info("RAS cleanup process will not be scheduled");
+        }
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    @Override
+    public void runFinishedOrDeleted(String runName) {
+    }
+
+    private long parseLong(String valueToParse, long defaultValue, String identifier) {
+        long valueToReturn = defaultValue;
+        try {
+            valueToReturn = Long.parseLong(valueToParse);
+        } catch (NumberFormatException e) {
+            logger.warn("Invalid value provided. A numeric value is expected for '" + identifier + "'.");
+        }
+        return valueToReturn;
+    }
+
+    private int parseInt(String valueToParse, int defaultValue, String identifier) {
+        int valueToReturn = defaultValue;
+        try {
+            valueToReturn = Integer.parseInt(valueToParse);
+        } catch (NumberFormatException e) {
+            logger.warn("Invalid value provided. A numeric value is expected for '" + identifier + "'.");
+        }
+        return valueToReturn;
+    }
+    
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanupScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanupScheduler.java
@@ -13,7 +13,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
-import dev.galasa.framework.spi.Environment;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IFramework;
@@ -23,18 +22,11 @@ public class RasRunCleanupScheduler implements Runnable {
 
     private final Log logger = LogFactory.getLog(getClass());
 
-    public static final String TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR = "GALASA_TEST_RUN_CLEANUP_INTERVAL_HOURS";
-    public static final String TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR = "GALASA_TEST_RUN_CLEANUP_MAX_AGE_DAYS";
-
     private static final String CPS_NAMESPACE = "framework";
     private static final String TEST_RUN_CLEANUP_CPS_PREFIX = "ras.cleanup";
     private static final String TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY = "test.run.interval.hours";
 
-    private static final long DEFAULT_RUN_CLEANUP_INTERVAL_HOURS = 24;
-    private static final int DEFAULT_RUN_CLEANUP_MAX_AGE_DAYS = 30;
-
     private long initialRunCleanupIntervalHours;
-    private int initialRunCleanupMaxAgeDays;
 
     private IConfigurationPropertyStoreService cpsService;
     private ScheduledExecutorService scheduledExecutorService;
@@ -46,17 +38,13 @@ public class RasRunCleanupScheduler implements Runnable {
     public RasRunCleanupScheduler(
         IFramework framework,
         ScheduledExecutorService scheduledExecutorService,
-        ITimeService timeService,
-        Environment env
+        long initialRunCleanupIntervalHours,
+        int initialRunCleanupMaxAgeDays,
+        ITimeService timeService
     ) throws FrameworkException {
         this.cpsService = framework.getConfigurationPropertyService(CPS_NAMESPACE);
         this.scheduledExecutorService = scheduledExecutorService;
-
-        String testRunCleanupIntervalHoursStr = env.getenv(TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR);
-        String testRunCleanupMaxAgeDaysStr = env.getenv(TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR);
-
-        this.initialRunCleanupIntervalHours = parseLong(testRunCleanupIntervalHoursStr, DEFAULT_RUN_CLEANUP_INTERVAL_HOURS, TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR);
-        this.initialRunCleanupMaxAgeDays = parseInt(testRunCleanupMaxAgeDaysStr, DEFAULT_RUN_CLEANUP_MAX_AGE_DAYS, TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR);
+        this.initialRunCleanupIntervalHours = initialRunCleanupIntervalHours;
 
         rasRunCleanup = new RasRunCleanup(cpsService, framework.getResultArchiveStore(), timeService, initialRunCleanupMaxAgeDays);
     }
@@ -93,29 +81,13 @@ public class RasRunCleanupScheduler implements Runnable {
         long runCleanupIntervalHours = initialRunCleanupIntervalHours;
         String runCleanupIntervalHoursStr = cpsService.getProperty(TEST_RUN_CLEANUP_CPS_PREFIX, TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY);
         if (runCleanupIntervalHoursStr != null) {
-            runCleanupIntervalHours = parseLong(runCleanupIntervalHoursStr, runCleanupIntervalHours, TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY);
+            try {
+                runCleanupIntervalHours = Long.parseLong(runCleanupIntervalHoursStr);
+            } catch (NumberFormatException e) {
+                logger.warn("Invalid value provided. A numeric value is expected for '" + TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY + "'.");
+            }
         }
 
         return runCleanupIntervalHours;
-    }
-
-    private long parseLong(String valueToParse, long defaultValue, String identifier) {
-        long valueToReturn = defaultValue;
-        try {
-            valueToReturn = Long.parseLong(valueToParse);
-        } catch (NumberFormatException e) {
-            logger.warn("Invalid value provided. A numeric value is expected for '" + identifier + "'.");
-        }
-        return valueToReturn;
-    }
-
-    private int parseInt(String valueToParse, int defaultValue, String identifier) {
-        int valueToReturn = defaultValue;
-        try {
-            valueToReturn = Integer.parseInt(valueToParse);
-        } catch (NumberFormatException e) {
-            logger.warn("Invalid value provided. A numeric value is expected for '" + identifier + "'.");
-        }
-        return valueToReturn;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanupScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanupScheduler.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal.rascleanup;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.IFramework;
+import dev.galasa.framework.spi.utils.ITimeService;
+
+public class RasRunCleanupScheduler implements Runnable {
+
+    private final Log logger = LogFactory.getLog(getClass());
+
+    private static final String CPS_NAMESPACE = "framework";
+    private static final String TEST_RUN_CLEANUP_CPS_PREFIX = "ras.cleanup";
+    private static final String TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY = "test.run.interval.hours";
+
+    private IConfigurationPropertyStoreService cpsService;
+    private ScheduledExecutorService scheduledExecutorService;
+    private RasRunCleanup rasRunCleanup;
+
+    private ScheduledFuture<?> cleanupTask;
+    private long previousRunCleanupIntervalHours = Long.MIN_VALUE;
+
+    public RasRunCleanupScheduler(
+        IFramework framework,
+        ScheduledExecutorService scheduledExecutorService,
+        ITimeService timeService
+    ) throws FrameworkException {
+        this.cpsService = framework.getConfigurationPropertyService(CPS_NAMESPACE);
+        this.scheduledExecutorService = scheduledExecutorService;
+
+        rasRunCleanup = new RasRunCleanup(cpsService, framework.getResultArchiveStore(), timeService);
+    }
+
+    @Override
+    public void run() {
+        try {
+            long runCleanupIntervalHours = getRunCleanupIntervalHours();
+
+            if (runCleanupIntervalHours > 0 && runCleanupIntervalHours != previousRunCleanupIntervalHours) {
+                // Only reschedule if the interval has changed
+                previousRunCleanupIntervalHours = runCleanupIntervalHours;
+                scheduleCleanupTask(runCleanupIntervalHours);
+
+            }
+        } catch (Exception e) {
+            logger.error("Error while getting run cleanup interval", e);
+        }
+
+    }
+
+    private void scheduleCleanupTask(long runCleanupIntervalHours) {
+        if (cleanupTask != null) {
+            // Cancel the previous task before scheduling a new one
+            cleanupTask.cancel(false);
+        }
+        cleanupTask = scheduledExecutorService.scheduleWithFixedDelay(rasRunCleanup, 0, runCleanupIntervalHours, TimeUnit.HOURS);
+    }
+
+    private long getRunCleanupIntervalHours() throws ConfigurationPropertyStoreException {
+        long runCleanupIntervalHours = 0;
+        try {
+            String runCleanupIntervalHoursStr = cpsService.getProperty(TEST_RUN_CLEANUP_CPS_PREFIX, TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY);
+            if (runCleanupIntervalHoursStr != null) {
+                runCleanupIntervalHours = Long.parseLong(runCleanupIntervalHoursStr);
+            }
+
+        } catch (NumberFormatException e) {
+            logger.warn("Invalid CPS property value provided. A numeric value is expected for '" + TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY + "'.");
+        }
+        return runCleanupIntervalHours;
+    }
+    
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanupScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanupScheduler.java
@@ -79,11 +79,14 @@ public class RasRunCleanupScheduler implements Runnable {
     }
 
     private void scheduleCleanupTask(long runCleanupIntervalHours) {
+        logger.trace("Scheduling cleanup task with interval (in hours): " + runCleanupIntervalHours);
         if (cleanupTask != null) {
             // Cancel the previous task before scheduling a new one
+            logger.trace("Cancelling previously scheduled cleanup task");
             cleanupTask.cancel(false);
         }
         cleanupTask = scheduledExecutorService.scheduleWithFixedDelay(rasRunCleanup, 0, runCleanupIntervalHours, TimeUnit.HOURS);
+        logger.trace("Scheduled cleanup task with interval (in hours): " + runCleanupIntervalHours);
     }
 
     private long getRunCleanupIntervalHours() throws ConfigurationPropertyStoreException {

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanupScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/rascleanup/RasRunCleanupScheduler.java
@@ -13,6 +13,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.Environment;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IFramework;
@@ -22,9 +23,18 @@ public class RasRunCleanupScheduler implements Runnable {
 
     private final Log logger = LogFactory.getLog(getClass());
 
+    public static final String TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR = "GALASA_TEST_RUN_CLEANUP_INTERVAL_HOURS";
+    public static final String TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR = "GALASA_TEST_RUN_CLEANUP_MAX_AGE_DAYS";
+
     private static final String CPS_NAMESPACE = "framework";
     private static final String TEST_RUN_CLEANUP_CPS_PREFIX = "ras.cleanup";
     private static final String TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY = "test.run.interval.hours";
+
+    private static final long DEFAULT_RUN_CLEANUP_INTERVAL_HOURS = 24;
+    private static final int DEFAULT_RUN_CLEANUP_MAX_AGE_DAYS = 30;
+
+    private long initialRunCleanupIntervalHours;
+    private int initialRunCleanupMaxAgeDays;
 
     private IConfigurationPropertyStoreService cpsService;
     private ScheduledExecutorService scheduledExecutorService;
@@ -36,12 +46,19 @@ public class RasRunCleanupScheduler implements Runnable {
     public RasRunCleanupScheduler(
         IFramework framework,
         ScheduledExecutorService scheduledExecutorService,
-        ITimeService timeService
+        ITimeService timeService,
+        Environment env
     ) throws FrameworkException {
         this.cpsService = framework.getConfigurationPropertyService(CPS_NAMESPACE);
         this.scheduledExecutorService = scheduledExecutorService;
 
-        rasRunCleanup = new RasRunCleanup(cpsService, framework.getResultArchiveStore(), timeService);
+        String testRunCleanupIntervalHoursStr = env.getenv(TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR);
+        String testRunCleanupMaxAgeDaysStr = env.getenv(TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR);
+
+        this.initialRunCleanupIntervalHours = parseLong(testRunCleanupIntervalHoursStr, DEFAULT_RUN_CLEANUP_INTERVAL_HOURS, TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR);
+        this.initialRunCleanupMaxAgeDays = parseInt(testRunCleanupMaxAgeDaysStr, DEFAULT_RUN_CLEANUP_MAX_AGE_DAYS, TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR);
+
+        rasRunCleanup = new RasRunCleanup(cpsService, framework.getResultArchiveStore(), timeService, initialRunCleanupMaxAgeDays);
     }
 
     @Override
@@ -70,17 +87,32 @@ public class RasRunCleanupScheduler implements Runnable {
     }
 
     private long getRunCleanupIntervalHours() throws ConfigurationPropertyStoreException {
-        long runCleanupIntervalHours = 0;
-        try {
-            String runCleanupIntervalHoursStr = cpsService.getProperty(TEST_RUN_CLEANUP_CPS_PREFIX, TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY);
-            if (runCleanupIntervalHoursStr != null) {
-                runCleanupIntervalHours = Long.parseLong(runCleanupIntervalHoursStr);
-            }
-
-        } catch (NumberFormatException e) {
-            logger.warn("Invalid CPS property value provided. A numeric value is expected for '" + TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY + "'.");
+        long runCleanupIntervalHours = initialRunCleanupIntervalHours;
+        String runCleanupIntervalHoursStr = cpsService.getProperty(TEST_RUN_CLEANUP_CPS_PREFIX, TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY);
+        if (runCleanupIntervalHoursStr != null) {
+            runCleanupIntervalHours = parseLong(runCleanupIntervalHoursStr, runCleanupIntervalHours, TEST_RUN_CLEANUP_INTERVAL_HOURS_CPS_PROPERTY);
         }
+
         return runCleanupIntervalHours;
     }
-    
+
+    private long parseLong(String valueToParse, long defaultValue, String identifier) {
+        long valueToReturn = defaultValue;
+        try {
+            valueToReturn = Long.parseLong(valueToParse);
+        } catch (NumberFormatException e) {
+            logger.warn("Invalid value provided. A numeric value is expected for '" + identifier + "'.");
+        }
+        return valueToReturn;
+    }
+
+    private int parseInt(String valueToParse, int defaultValue, String identifier) {
+        int valueToReturn = defaultValue;
+        try {
+            valueToReturn = Integer.parseInt(valueToParse);
+        } catch (NumberFormatException e) {
+            logger.warn("Invalid value provided. A numeric value is expected for '" + identifier + "'.");
+        }
+        return valueToReturn;
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockResourceManagement.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockResourceManagement.java
@@ -5,18 +5,17 @@
  */
 package dev.galasa.framework.resource.management.internal.mocks;
 
-import java.util.concurrent.ScheduledExecutorService;
-
 import dev.galasa.framework.spi.IResourceManagement;
 
 
 public class MockResourceManagement implements IResourceManagement {
 
     public boolean isSuccessful;
+    private MockScheduledExecutorService scheduledExecutorService = new MockScheduledExecutorService();
 
     @Override
-    public ScheduledExecutorService getScheduledExecutorService() {
-        throw new UnsupportedOperationException("Unimplemented method 'getScheduledExecutorService'");
+    public MockScheduledExecutorService getScheduledExecutorService() {
+        return scheduledExecutorService;
     }
 
     @Override

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockScheduledExecutorService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockScheduledExecutorService.java
@@ -18,6 +18,10 @@ import java.util.concurrent.TimeoutException;
 public class MockScheduledExecutorService implements ScheduledExecutorService {
 
     private boolean isShutdown = false;
+    
+    public int scheduleWithFixedDelayCallCount = 0;
+    public long lastDelay;
+    public MockScheduledFuture lastScheduledFuture;
 
     @Override
     public void shutdown() {
@@ -103,6 +107,9 @@ public class MockScheduledExecutorService implements ScheduledExecutorService {
 
     @Override
     public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-        return null;
+        scheduleWithFixedDelayCallCount++;
+        lastDelay = delay;
+        lastScheduledFuture = new MockScheduledFuture();
+        return lastScheduledFuture;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockScheduledFuture.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/mocks/MockScheduledFuture.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal.mocks;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class MockScheduledFuture implements ScheduledFuture<Object> {
+
+    private boolean isCancelled = false;
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        this.isCancelled = true;
+        return true;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+
+    @Override
+    public boolean isDone() {
+        return false;
+    }
+
+    @Override
+    public Object get() {
+        return null;
+    }
+
+    @Override
+    public Object get(long timeout, TimeUnit unit) {
+        return null;
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        return 0;
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        return 0;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestExcludeCriteria.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestExcludeCriteria.java
@@ -357,7 +357,7 @@ public class TestExcludeCriteria {
         ExcludeCriteria[] values = ExcludeCriteria.values();
 
         // Then...
-        assertThat(values).as("Should have 3 enum values").hasSize(7);
+        assertThat(values).as("Should have 7 enum values").hasSize(7);
         assertThat(values).as("Should contain TAGS").contains(ExcludeCriteria.TAGS);
         assertThat(values).as("Should contain USER").contains(ExcludeCriteria.USER);
         assertThat(values).as("Should contain GROUP").contains(ExcludeCriteria.GROUP);

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestExcludeCriteria.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestExcludeCriteria.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal.rascleanup;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import dev.galasa.framework.spi.ras.IRasSearchCriteria;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaGroup;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaTags;
+import dev.galasa.framework.spi.ras.RasSearchCriteriaUser;
+import dev.galasa.framework.spi.teststructure.TestStructure;
+
+public class TestExcludeCriteria {
+
+    @Test
+    public void testGetFromStringReturnsTagsCriteria() {
+        // When...
+        ExcludeCriteria criteria = ExcludeCriteria.getFromString("tags");
+
+        // Then...
+        assertThat(criteria).as("Should return TAGS criteria").isEqualTo(ExcludeCriteria.TAGS);
+    }
+
+    @Test
+    public void testGetFromStringReturnsUserCriteria() {
+        // When...
+        ExcludeCriteria criteria = ExcludeCriteria.getFromString("user");
+
+        // Then...
+        assertThat(criteria).as("Should return USER criteria").isEqualTo(ExcludeCriteria.USER);
+    }
+
+    @Test
+    public void testGetFromStringReturnsGroupCriteria() {
+        // When...
+        ExcludeCriteria criteria = ExcludeCriteria.getFromString("group");
+
+        // Then...
+        assertThat(criteria).as("Should return GROUP criteria").isEqualTo(ExcludeCriteria.GROUP);
+    }
+
+    @Test
+    public void testGetFromStringReturnsRequestorCriteria() {
+        // When...
+        ExcludeCriteria criteria = ExcludeCriteria.getFromString("requestor");
+
+        // Then...
+        assertThat(criteria).as("Should return REQUESTOR criteria").isEqualTo(ExcludeCriteria.REQUESTOR);
+    }
+
+    @Test
+    public void testGetFromStringIsCaseInsensitive() {
+        // When...
+        ExcludeCriteria upperCase = ExcludeCriteria.getFromString("TAGS");
+        ExcludeCriteria mixedCase = ExcludeCriteria.getFromString("TaGs");
+        ExcludeCriteria lowerCase = ExcludeCriteria.getFromString("tags");
+
+        // Then...
+        assertThat(upperCase).as("Uppercase should work").isEqualTo(ExcludeCriteria.TAGS);
+        assertThat(mixedCase).as("Mixed case should work").isEqualTo(ExcludeCriteria.TAGS);
+        assertThat(lowerCase).as("Lowercase should work").isEqualTo(ExcludeCriteria.TAGS);
+    }
+
+    @Test
+    public void testGetFromStringTrimsWhitespace() {
+        // When...
+        ExcludeCriteria criteria = ExcludeCriteria.getFromString("  tags  ");
+
+        // Then...
+        assertThat(criteria).as("Should trim whitespace").isEqualTo(ExcludeCriteria.TAGS);
+    }
+
+    @Test
+    public void testGetFromStringReturnsNullForUnknownCriteria() {
+        // When...
+        ExcludeCriteria criteria = ExcludeCriteria.getFromString("unknown");
+
+        // Then...
+        assertThat(criteria).as("Should return null for unknown criteria").isNull();
+    }
+
+    @Test
+    public void testGetFromStringReturnsNullForEmptyString() {
+        // When...
+        ExcludeCriteria criteria = ExcludeCriteria.getFromString("");
+
+        // Then...
+        assertThat(criteria).as("Should return null for empty string").isNull();
+    }
+
+    @Test
+    public void testToStringReturnsCorrectName() {
+        // When/Then...
+        assertThat(ExcludeCriteria.TAGS.toString()).isEqualTo("tags");
+        assertThat(ExcludeCriteria.USER.toString()).isEqualTo("user");
+        assertThat(ExcludeCriteria.GROUP.toString()).isEqualTo("group");
+        assertThat(ExcludeCriteria.REQUESTOR.toString()).isEqualTo("requestor");
+        assertThat(ExcludeCriteria.RESULT.toString()).isEqualTo("result");
+    }
+
+    @Test
+    public void testCreateCriteriaForTagsReturnsRasSearchCriteriaTags() throws Exception {
+        // Given...
+        String[] tags = {"production", "critical"};
+
+        // When...
+        IRasSearchCriteria criteria = ExcludeCriteria.TAGS.createCriteria(tags);
+
+        // Then...
+        assertThat(criteria).as("Should return RasSearchCriteriaTags instance").isInstanceOf(RasSearchCriteriaTags.class);
+        assertThat(criteria.getCriteriaContent()).as("Should contain the tags").isEqualTo(tags);
+    }
+
+    @Test
+    public void testCreateCriteriaForUserReturnsRasSearchCriteriaUser() throws Exception {
+        // Given...
+        String[] users = {"admin", "system"};
+
+        // When...
+        IRasSearchCriteria criteria = ExcludeCriteria.USER.createCriteria(users);
+
+        // Then...
+        assertThat(criteria).as("Should return RasSearchCriteriaUser instance").isInstanceOf(RasSearchCriteriaUser.class);
+        assertThat(criteria.getCriteriaContent()).as("Should contain the users").isEqualTo(users);
+    }
+
+    @Test
+    public void testCreateCriteriaForGroupReturnsRasSearchCriteriaGroup() throws Exception {
+        // Given...
+        String[] groups = {"dev.galasa.important.tests"};
+
+        // When...
+        IRasSearchCriteria criteria = ExcludeCriteria.GROUP.createCriteria(groups);
+
+        // Then...
+        assertThat(criteria).as("Should return RasSearchCriteriaGroup instance").isInstanceOf(RasSearchCriteriaGroup.class);
+        assertThat(criteria.getCriteriaContent()).as("Should contain the groups").isEqualTo(groups);
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsTrueWhenTagMatches() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        Set<String> tags = new HashSet<>();
+        tags.add("production");
+        testStructure.setTags(tags);
+
+        String[] excludeValues = {"production", "critical"};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.TAGS.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return true when tag matches").isTrue();
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsFalseWhenTagDoesNotMatch() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        Set<String> tags = new HashSet<>();
+        tags.add("test");
+        testStructure.setTags(tags);
+
+        String[] excludeValues = {"production", "critical"};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.TAGS.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return false when tag does not match").isFalse();
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsTrueWhenUserMatches() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        testStructure.setRequestor("admin");
+
+        String[] excludeValues = {"admin", "system"};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.USER.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return true when user matches").isTrue();
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsFalseWhenUserDoesNotMatch() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        testStructure.setRequestor("developer");
+
+        String[] excludeValues = {"admin", "system"};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.USER.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return false when user does not match").isFalse();
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsTrueWhenGroupMatches() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        testStructure.setGroup("dev.galasa.important.tests");
+
+        String[] excludeValues = {"dev.galasa.important.tests"};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.GROUP.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return true when group matches").isTrue();
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsFalseWhenGroupDoesNotMatch() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        testStructure.setGroup("dev.galasa.other.tests");
+
+        String[] excludeValues = {"dev.galasa.important.tests"};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.GROUP.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return false when group does not match").isFalse();
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsFalseWhenExcludeValuesIsNull() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        Set<String> tags = new HashSet<>();
+        tags.add("production");
+        testStructure.setTags(tags);
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.TAGS.shouldRunBeKept(testStructure, null);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return false when exclude values is null").isFalse();
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsFalseWhenExcludeValuesIsEmpty() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        Set<String> tags = new HashSet<>();
+        tags.add("production");
+        testStructure.setTags(tags);
+
+        String[] excludeValues = {};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.TAGS.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return false when exclude values is empty").isFalse();
+    }
+
+    @Test
+    public void testAllEnumValuesAreAccessible() {
+        // When...
+        ExcludeCriteria[] values = ExcludeCriteria.values();
+
+        // Then...
+        assertThat(values).as("Should have 3 enum values").hasSize(5);
+        assertThat(values).as("Should contain TAGS").contains(ExcludeCriteria.TAGS);
+        assertThat(values).as("Should contain USER").contains(ExcludeCriteria.USER);
+        assertThat(values).as("Should contain GROUP").contains(ExcludeCriteria.GROUP);
+        assertThat(values).as("Should contain REQUESTOR").contains(ExcludeCriteria.REQUESTOR);
+        assertThat(values).as("Should contain RESULT").contains(ExcludeCriteria.RESULT);
+    }
+
+    @Test
+    public void testValueOfReturnsCorrectEnum() {
+        // When/Then...
+        assertThat(ExcludeCriteria.valueOf("TAGS")).as("valueOf TAGS").isEqualTo(ExcludeCriteria.TAGS);
+        assertThat(ExcludeCriteria.valueOf("USER")).as("valueOf USER").isEqualTo(ExcludeCriteria.USER);
+        assertThat(ExcludeCriteria.valueOf("GROUP")).as("valueOf GROUP").isEqualTo(ExcludeCriteria.GROUP);
+        assertThat(ExcludeCriteria.valueOf("REQUESTOR")).as("valueOf REQUESTOR").isEqualTo(ExcludeCriteria.REQUESTOR);
+        assertThat(ExcludeCriteria.valueOf("RESULT")).as("valueOf RESULT").isEqualTo(ExcludeCriteria.RESULT);
+    }
+
+    @Test
+    public void testValueOfThrowsExceptionForInvalidName() {
+        // When/Then...
+        assertThatThrownBy(() -> ExcludeCriteria.valueOf("INVALID"))
+            .as("Should throw IllegalArgumentException for invalid name")
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestExcludeCriteria.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestExcludeCriteria.java
@@ -57,6 +57,24 @@ public class TestExcludeCriteria {
     }
 
     @Test
+    public void testGetFromStringReturnsStatusCriteria() {
+        // When...
+        ExcludeCriteria criteria = ExcludeCriteria.getFromString("status");
+
+        // Then...
+        assertThat(criteria).as("Should return STATUS criteria").isEqualTo(ExcludeCriteria.STATUS);
+    }
+
+    @Test
+    public void testGetFromStringReturnsRunNameCriteria() {
+        // When...
+        ExcludeCriteria criteria = ExcludeCriteria.getFromString("runName");
+
+        // Then...
+        assertThat(criteria).as("Should return RUN_NAME criteria").isEqualTo(ExcludeCriteria.RUN_NAME);
+    }
+
+    @Test
     public void testGetFromStringIsCaseInsensitive() {
         // When...
         ExcludeCriteria upperCase = ExcludeCriteria.getFromString("TAGS");
@@ -104,6 +122,8 @@ public class TestExcludeCriteria {
         assertThat(ExcludeCriteria.GROUP.toString()).isEqualTo("group");
         assertThat(ExcludeCriteria.REQUESTOR.toString()).isEqualTo("requestor");
         assertThat(ExcludeCriteria.RESULT.toString()).isEqualTo("result");
+        assertThat(ExcludeCriteria.RUN_NAME.toString()).isEqualTo("runName");
+        assertThat(ExcludeCriteria.STATUS.toString()).isEqualTo("status");
     }
 
     @Test
@@ -240,6 +260,66 @@ public class TestExcludeCriteria {
     }
 
     @Test
+    public void testShouldRunBeKeptReturnsTrueWhenStatusMatches() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        testStructure.setStatus("running");
+
+        String[] excludeValues = {"running"};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.STATUS.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return true when status matches").isTrue();
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsFalseWhenStatusDoesNotMatch() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        testStructure.setStatus("other");
+
+        String[] excludeValues = {"running"};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.STATUS.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return false when status does not match").isFalse();
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsTrueWhenRunNameMatches() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        testStructure.setRunName("RUN1");
+
+        String[] excludeValues = {"RUN1"};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.RUN_NAME.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return true when run name matches").isTrue();
+    }
+
+    @Test
+    public void testShouldRunBeKeptReturnsFalseWhenRunNameDoesNotMatch() throws Exception {
+        // Given...
+        TestStructure testStructure = new TestStructure();
+        testStructure.setRunName("other");
+
+        String[] excludeValues = {"RUN1"};
+
+        // When...
+        boolean shouldKeep = ExcludeCriteria.RUN_NAME.shouldRunBeKept(testStructure, excludeValues);
+
+        // Then...
+        assertThat(shouldKeep).as("Should return false when run name does not match").isFalse();
+    }
+
+    @Test
     public void testShouldRunBeKeptReturnsFalseWhenExcludeValuesIsNull() throws Exception {
         // Given...
         TestStructure testStructure = new TestStructure();
@@ -277,12 +357,14 @@ public class TestExcludeCriteria {
         ExcludeCriteria[] values = ExcludeCriteria.values();
 
         // Then...
-        assertThat(values).as("Should have 3 enum values").hasSize(5);
+        assertThat(values).as("Should have 3 enum values").hasSize(7);
         assertThat(values).as("Should contain TAGS").contains(ExcludeCriteria.TAGS);
         assertThat(values).as("Should contain USER").contains(ExcludeCriteria.USER);
         assertThat(values).as("Should contain GROUP").contains(ExcludeCriteria.GROUP);
         assertThat(values).as("Should contain REQUESTOR").contains(ExcludeCriteria.REQUESTOR);
         assertThat(values).as("Should contain RESULT").contains(ExcludeCriteria.RESULT);
+        assertThat(values).as("Should contain STATUS").contains(ExcludeCriteria.STATUS);
+        assertThat(values).as("Should contain RUN_NAME").contains(ExcludeCriteria.RUN_NAME);
     }
 
     @Test

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanup.java
@@ -35,9 +35,10 @@ public class TestRasRunCleanup {
         MockCPSStore cps = createMockCPSStore(new HashMap<>());
         MockIResultArchiveStore ras = new MockIResultArchiveStore();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        int initialRunCleanupMaxAgeDays = 10;
 
         // When...
-        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService, initialRunCleanupMaxAgeDays);
 
         // Then...
         assertThat(cleanup).isNotNull();
@@ -54,10 +55,11 @@ public class TestRasRunCleanup {
         MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
         MockIResultArchiveStore ras = new MockIResultArchiveStore();
         ras.addDirectoryService(directoryService);
+        int initialRunCleanupMaxAgeDays = 0;
         
         MockTimeService timeService = new MockTimeService(Instant.now());
 
-        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService, initialRunCleanupMaxAgeDays);
 
         // When...
         cleanup.run();
@@ -74,6 +76,7 @@ public class TestRasRunCleanup {
         // Given...
         Instant now = Instant.now();
         int maxAgeDays = 30;
+        int initialRunCleanupMaxAgeDays = 10;
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
@@ -92,7 +95,7 @@ public class TestRasRunCleanup {
         
         MockTimeService timeService = new MockTimeService(now);
 
-        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService, initialRunCleanupMaxAgeDays);
 
         // When...
         cleanup.run();
@@ -114,6 +117,7 @@ public class TestRasRunCleanup {
         // Given...
         Instant now = Instant.now();
         int maxAgeDays = 30;
+        int initialRunCleanupMaxAgeDays = 10;
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
@@ -133,7 +137,7 @@ public class TestRasRunCleanup {
         
         MockTimeService timeService = new MockTimeService(now);
 
-        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService, initialRunCleanupMaxAgeDays);
 
         // When...
         cleanup.run();
@@ -155,6 +159,7 @@ public class TestRasRunCleanup {
         // Given...
         Instant now = Instant.now();
         int maxAgeDays = 30;
+        int initialRunCleanupMaxAgeDays = 10;
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
@@ -174,7 +179,7 @@ public class TestRasRunCleanup {
         
         MockTimeService timeService = new MockTimeService(now);
 
-        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService, initialRunCleanupMaxAgeDays);
 
         // When...
         cleanup.run();
@@ -196,6 +201,7 @@ public class TestRasRunCleanup {
         // Given...
         Instant now = Instant.now();
         int maxAgeDays = 30;
+        int initialRunCleanupMaxAgeDays = 10;
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
@@ -213,7 +219,7 @@ public class TestRasRunCleanup {
         
         MockTimeService timeService = new MockTimeService(now);
 
-        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService, initialRunCleanupMaxAgeDays);
 
         // When...
         cleanup.run();
@@ -231,6 +237,7 @@ public class TestRasRunCleanup {
         // Given...
         Instant now = Instant.now();
         int maxAgeDays = 30;
+        int initialRunCleanupMaxAgeDays = 10;
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
@@ -250,7 +257,7 @@ public class TestRasRunCleanup {
         
         MockTimeService timeService = new MockTimeService(now);
 
-        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService, initialRunCleanupMaxAgeDays);
 
         // When...
         cleanup.run();
@@ -266,8 +273,10 @@ public class TestRasRunCleanup {
     }
 
     @Test
-    public void testRunWithInvalidMaxAgeDaysProperty() throws Exception {
+    public void testRunWithInvalidMaxAgeDaysPropertyShouldUseDefault() throws Exception {
         // Given...
+        int initialRunCleanupMaxAgeDays = 30;
+
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", "invalid");
         MockCPSStore cps = createMockCPSStore(cpsProperties);
@@ -279,16 +288,15 @@ public class TestRasRunCleanup {
         
         MockTimeService timeService = new MockTimeService(Instant.now());
 
-        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService, initialRunCleanupMaxAgeDays);
 
         // When...
         cleanup.run();
 
         // Then...
-        // Should not throw exception, just log warning and not clean up runs
         for (IRunResult run : runs) {
             MockRunResult mockRun = (MockRunResult) run;
-            assertThat(mockRun.isDiscarded()).as("Run should not be discarded with invalid max age").isFalse();
+            assertThat(mockRun.isDiscarded()).as("Run should be discarded using the initial max age").isTrue();
         }
     }
 
@@ -297,6 +305,7 @@ public class TestRasRunCleanup {
         // Given...
         Instant now = Instant.now();
         int maxAgeDays = 30;
+        int initialRunCleanupMaxAgeDays = 10;
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
@@ -314,7 +323,7 @@ public class TestRasRunCleanup {
         
         MockTimeService timeService = new MockTimeService(now);
 
-        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService, initialRunCleanupMaxAgeDays);
 
         // When...
         cleanup.run();

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanup.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal.rascleanup;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.MockCPSStore;
+import dev.galasa.framework.mocks.MockIResultArchiveStore;
+import dev.galasa.framework.mocks.MockResultArchiveStoreDirectoryService;
+import dev.galasa.framework.mocks.MockRunResult;
+import dev.galasa.framework.mocks.MockTimeService;
+import dev.galasa.framework.spi.IRunResult;
+import dev.galasa.framework.spi.teststructure.TestStructure;
+
+public class TestRasRunCleanup {
+
+    @Test
+    public void testCanInstantiateRasRunCleanup() throws Exception {
+        // Given...
+        MockCPSStore cps = createMockCPSStore(new HashMap<>());
+        MockIResultArchiveStore ras = new MockIResultArchiveStore();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        // When...
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+
+        // Then...
+        assertThat(cleanup).isNotNull();
+    }
+
+    @Test
+    public void testRunWithNoMaxAgeDaysDoesNotCleanUpRuns() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        // No max age days property set
+        MockCPSStore cps = createMockCPSStore(cpsProperties);
+        
+        List<IRunResult> runs = createMockRuns(5);
+        MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
+        MockIResultArchiveStore ras = new MockIResultArchiveStore();
+        ras.addDirectoryService(directoryService);
+        
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+
+        // When...
+        cleanup.run();
+
+        // Then...
+        for (IRunResult run : runs) {
+            MockRunResult mockRun = (MockRunResult) run;
+            assertThat(mockRun.isDiscarded()).as("Run should not be discarded when no max age is set").isFalse();
+        }
+    }
+
+    @Test
+    public void testRunCleansUpOldRuns() throws Exception {
+        // Given...
+        Instant now = Instant.now();
+        int maxAgeDays = 30;
+        
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
+        MockCPSStore cps = createMockCPSStore(cpsProperties);
+        
+        // Create runs: 2 old (should be cleaned), 2 recent (should not be cleaned)
+        List<IRunResult> runs = new ArrayList<>();
+        runs.add(createMockRun("run1", now.minus(40, ChronoUnit.DAYS))); // Old
+        runs.add(createMockRun("run2", now.minus(35, ChronoUnit.DAYS))); // Old
+        runs.add(createMockRun("run3", now.minus(20, ChronoUnit.DAYS))); // Recent
+        runs.add(createMockRun("run4", now.minus(10, ChronoUnit.DAYS))); // Recent
+        
+        MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
+        MockIResultArchiveStore ras = new MockIResultArchiveStore();
+        ras.addDirectoryService(directoryService);
+        
+        MockTimeService timeService = new MockTimeService(now);
+
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+
+        // When...
+        cleanup.run();
+
+        // Then...
+        MockRunResult run1 = (MockRunResult) runs.get(0);
+        MockRunResult run2 = (MockRunResult) runs.get(1);
+        MockRunResult run3 = (MockRunResult) runs.get(2);
+        MockRunResult run4 = (MockRunResult) runs.get(3);
+        
+        assertThat(run1.isDiscarded()).as("Old run1 should be discarded").isTrue();
+        assertThat(run2.isDiscarded()).as("Old run2 should be discarded").isTrue();
+        assertThat(run3.isDiscarded()).as("Recent run3 should not be discarded").isFalse();
+        assertThat(run4.isDiscarded()).as("Recent run4 should not be discarded").isFalse();
+    }
+
+    @Test
+    public void testRunExcludesRunsWithMatchingTags() throws Exception {
+        // Given...
+        Instant now = Instant.now();
+        int maxAgeDays = 30;
+        
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
+        cpsProperties.put("test.run.exclude.tags", "production,critical");
+        MockCPSStore cps = createMockCPSStore(cpsProperties);
+        
+        // Create old runs with different tags
+        List<IRunResult> runs = new ArrayList<>();
+        runs.add(createMockRunWithTags("run1", now.minus(40, ChronoUnit.DAYS), "production")); // Excluded
+        runs.add(createMockRunWithTags("run2", now.minus(35, ChronoUnit.DAYS), "critical")); // Excluded
+        runs.add(createMockRunWithTags("run3", now.minus(40, ChronoUnit.DAYS), "test")); // Should be cleaned
+        runs.add(createMockRunWithTags("run4", now.minus(35, ChronoUnit.DAYS), "dev")); // Should be cleaned
+        
+        MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
+        MockIResultArchiveStore ras = new MockIResultArchiveStore();
+        ras.addDirectoryService(directoryService);
+        
+        MockTimeService timeService = new MockTimeService(now);
+
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+
+        // When...
+        cleanup.run();
+
+        // Then...
+        MockRunResult run1 = (MockRunResult) runs.get(0);
+        MockRunResult run2 = (MockRunResult) runs.get(1);
+        MockRunResult run3 = (MockRunResult) runs.get(2);
+        MockRunResult run4 = (MockRunResult) runs.get(3);
+        
+        assertThat(run1.isDiscarded()).as("Run with 'production' tag should be excluded from cleanup").isFalse();
+        assertThat(run2.isDiscarded()).as("Run with 'critical' tag should be excluded from cleanup").isFalse();
+        assertThat(run3.isDiscarded()).as("Run with 'test' tag should be cleaned up").isTrue();
+        assertThat(run4.isDiscarded()).as("Run with 'dev' tag should be cleaned up").isTrue();
+    }
+
+    @Test
+    public void testRunExcludesRunsWithMatchingUser() throws Exception {
+        // Given...
+        Instant now = Instant.now();
+        int maxAgeDays = 30;
+        
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
+        cpsProperties.put("test.run.exclude.user", "admin,system");
+        MockCPSStore cps = createMockCPSStore(cpsProperties);
+        
+        // Create old runs with different users
+        List<IRunResult> runs = new ArrayList<>();
+        runs.add(createMockRunWithUser("run1", now.minus(40, ChronoUnit.DAYS), "admin")); // Excluded
+        runs.add(createMockRunWithUser("run2", now.minus(35, ChronoUnit.DAYS), "system")); // Excluded
+        runs.add(createMockRunWithUser("run3", now.minus(40, ChronoUnit.DAYS), "developer")); // Should be cleaned
+        runs.add(createMockRunWithUser("run4", now.minus(35, ChronoUnit.DAYS), "tester")); // Should be cleaned
+        
+        MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
+        MockIResultArchiveStore ras = new MockIResultArchiveStore();
+        ras.addDirectoryService(directoryService);
+        
+        MockTimeService timeService = new MockTimeService(now);
+
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+
+        // When...
+        cleanup.run();
+
+        // Then...
+        MockRunResult run1 = (MockRunResult) runs.get(0);
+        MockRunResult run2 = (MockRunResult) runs.get(1);
+        MockRunResult run3 = (MockRunResult) runs.get(2);
+        MockRunResult run4 = (MockRunResult) runs.get(3);
+        
+        assertThat(run1.isDiscarded()).as("Run by 'admin' user should be excluded from cleanup").isFalse();
+        assertThat(run2.isDiscarded()).as("Run by 'system' user should be excluded from cleanup").isFalse();
+        assertThat(run3.isDiscarded()).as("Run by 'developer' user should be cleaned up").isTrue();
+        assertThat(run4.isDiscarded()).as("Run by 'tester' user should be cleaned up").isTrue();
+    }
+
+    @Test
+    public void testRunExcludesRunsWithMatchingBundle() throws Exception {
+        // Given...
+        Instant now = Instant.now();
+        int maxAgeDays = 30;
+        
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
+        cpsProperties.put("test.run.exclude.bundle", "dev.galasa.important.tests");
+        MockCPSStore cps = createMockCPSStore(cpsProperties);
+        
+        // Create old runs with different bundles
+        List<IRunResult> runs = new ArrayList<>();
+        runs.add(createMockRunWithBundle("run1", now.minus(40, ChronoUnit.DAYS), "dev.galasa.important.tests")); // Excluded
+        runs.add(createMockRunWithBundle("run2", now.minus(35, ChronoUnit.DAYS), "dev.galasa.other.tests")); // Should be cleaned
+        
+        MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
+        MockIResultArchiveStore ras = new MockIResultArchiveStore();
+        ras.addDirectoryService(directoryService);
+        
+        MockTimeService timeService = new MockTimeService(now);
+
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+
+        // When...
+        cleanup.run();
+
+        // Then...
+        MockRunResult run1 = (MockRunResult) runs.get(0);
+        MockRunResult run2 = (MockRunResult) runs.get(1);
+        
+        assertThat(run1.isDiscarded()).as("Run from important bundle should be excluded from cleanup").isFalse();
+        assertThat(run2.isDiscarded()).as("Run from other bundle should be cleaned up").isTrue();
+    }
+
+    @Test
+    public void testRunWithMultipleExcludeCriteria() throws Exception {
+        // Given...
+        Instant now = Instant.now();
+        int maxAgeDays = 30;
+        
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
+        cpsProperties.put("test.run.exclude.tags", "production");
+        cpsProperties.put("test.run.exclude.user", "admin");
+        MockCPSStore cps = createMockCPSStore(cpsProperties);
+        
+        // Create old runs
+        List<IRunResult> runs = new ArrayList<>();
+        runs.add(createMockRunWithTagsAndUser("run1", now.minus(40, ChronoUnit.DAYS), "production", "developer")); // Excluded by tag
+        runs.add(createMockRunWithTagsAndUser("run2", now.minus(35, ChronoUnit.DAYS), "test", "admin")); // Excluded by user
+        runs.add(createMockRunWithTagsAndUser("run3", now.minus(40, ChronoUnit.DAYS), "test", "developer")); // Should be cleaned
+        
+        MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
+        MockIResultArchiveStore ras = new MockIResultArchiveStore();
+        ras.addDirectoryService(directoryService);
+        
+        MockTimeService timeService = new MockTimeService(now);
+
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+
+        // When...
+        cleanup.run();
+
+        // Then...
+        MockRunResult run1 = (MockRunResult) runs.get(0);
+        MockRunResult run2 = (MockRunResult) runs.get(1);
+        MockRunResult run3 = (MockRunResult) runs.get(2);
+        
+        assertThat(run1.isDiscarded()).as("Run with 'production' tag should be excluded").isFalse();
+        assertThat(run2.isDiscarded()).as("Run by 'admin' user should be excluded").isFalse();
+        assertThat(run3.isDiscarded()).as("Run matching no exclusions should be cleaned up").isTrue();
+    }
+
+    @Test
+    public void testRunWithInvalidMaxAgeDaysProperty() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.age.max.days", "invalid");
+        MockCPSStore cps = createMockCPSStore(cpsProperties);
+        
+        List<IRunResult> runs = createMockRuns(3);
+        MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
+        MockIResultArchiveStore ras = new MockIResultArchiveStore();
+        ras.addDirectoryService(directoryService);
+        
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+
+        // When...
+        cleanup.run();
+
+        // Then...
+        // Should not throw exception, just log warning and not clean up runs
+        for (IRunResult run : runs) {
+            MockRunResult mockRun = (MockRunResult) run;
+            assertThat(mockRun.isDiscarded()).as("Run should not be discarded with invalid max age").isFalse();
+        }
+    }
+
+    @Test
+    public void testRunWithWhitespaceInExcludeValues() throws Exception {
+        // Given...
+        Instant now = Instant.now();
+        int maxAgeDays = 30;
+        
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
+        cpsProperties.put("test.run.exclude.tags", " production , critical "); // With whitespace
+        MockCPSStore cps = createMockCPSStore(cpsProperties);
+        
+        // Create old runs
+        List<IRunResult> runs = new ArrayList<>();
+        runs.add(createMockRunWithTags("run1", now.minus(40, ChronoUnit.DAYS), "production")); // Should be excluded
+        runs.add(createMockRunWithTags("run2", now.minus(35, ChronoUnit.DAYS), "critical")); // Should be excluded
+        
+        MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
+        MockIResultArchiveStore ras = new MockIResultArchiveStore();
+        ras.addDirectoryService(directoryService);
+        
+        MockTimeService timeService = new MockTimeService(now);
+
+        RasRunCleanup cleanup = new RasRunCleanup(cps, ras, timeService);
+
+        // When...
+        cleanup.run();
+
+        // Then...
+        MockRunResult run1 = (MockRunResult) runs.get(0);
+        MockRunResult run2 = (MockRunResult) runs.get(1);
+        
+        assertThat(run1.isDiscarded()).as("Whitespace should be trimmed, run should be excluded").isFalse();
+        assertThat(run2.isDiscarded()).as("Whitespace should be trimmed, run should be excluded").isFalse();
+    }
+
+    // Helper methods
+
+    private MockCPSStore createMockCPSStore(Map<String, String> properties) {
+        return new MockCPSStore(properties) {
+            @Override
+            public Map<String, String> getPrefixedProperties(String prefix) {
+                Map<String, String> result = new HashMap<>();
+                for (Map.Entry<String, String> entry : properties.entrySet()) {
+                    if (entry.getKey().startsWith(prefix)) {
+                        result.put(entry.getKey(), entry.getValue());
+                    }
+                }
+                return result;
+            }
+        };
+    }
+
+    private List<IRunResult> createMockRuns(int count) {
+        List<IRunResult> runs = new ArrayList<>();
+        Instant now = Instant.now();
+        for (int i = 0; i < count; i++) {
+            runs.add(createMockRun("run" + i, now.minus(40, ChronoUnit.DAYS), null, null));
+        }
+        return runs;
+    }
+
+    private IRunResult createMockRun(String runId, Instant startTime) {
+        return createMockRun(runId, startTime, null, null);
+    }
+
+    private IRunResult createMockRunWithTags(String runId, Instant startTime, String... tags) {
+        return createMockRun(runId, startTime, null, null, tags);
+    }
+
+    private IRunResult createMockRunWithUser(String runId, Instant startTime, String user) {
+        return createMockRun(runId, startTime, null, user);
+    }
+
+    private IRunResult createMockRunWithBundle(String runId, Instant startTime, String bundle) {
+        return createMockRun(runId, startTime, bundle, null);
+    }
+
+    private IRunResult createMockRunWithTagsAndUser(String runId, Instant startTime, String tag, String user) {
+        return createMockRun(runId, startTime, null, user, tag);
+    }
+
+    private IRunResult createMockRun(String runId, Instant startTime, String bundle, String user, String... tags) {
+        TestStructure testStructure = new TestStructure();
+        testStructure.setRunName(runId);
+        testStructure.setStartTime(startTime);
+        testStructure.setBundle(bundle != null ? bundle : "dev.galasa.test");
+        testStructure.setTestName("TestClass");
+        
+        if (user != null) {
+            testStructure.setRequestor(user);
+        }
+        
+        if (tags != null && tags.length > 0) {
+            Set<String> tagSet = new HashSet<>();
+            for (String tag : tags) {
+                tagSet.add(tag);
+            }
+            testStructure.setTags(tagSet);
+        }
+        
+        return new MockRunResult(runId, testStructure, null, "");
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanup.java
@@ -121,7 +121,7 @@ public class TestRasRunCleanup {
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
-        cpsProperties.put("test.run.exclude.tags", "production,critical");
+        cpsProperties.put("ras.cleanup.test.run.exclude.tags", "production,critical");
         MockCPSStore cps = createMockCPSStore(cpsProperties);
         
         // Create old runs with different tags
@@ -163,7 +163,7 @@ public class TestRasRunCleanup {
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
-        cpsProperties.put("test.run.exclude.user", "admin,system");
+        cpsProperties.put("ras.cleanup.test.run.exclude.user", "admin,system");
         MockCPSStore cps = createMockCPSStore(cpsProperties);
         
         // Create old runs with different users
@@ -205,7 +205,7 @@ public class TestRasRunCleanup {
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
-        cpsProperties.put("test.run.exclude.result", Result.HUNG);
+        cpsProperties.put("ras.cleanup.test.run.exclude.result", Result.HUNG);
         MockCPSStore cps = createMockCPSStore(cpsProperties);
         
         // Create old runs with different results
@@ -241,8 +241,8 @@ public class TestRasRunCleanup {
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
-        cpsProperties.put("test.run.exclude.tags", "production");
-        cpsProperties.put("test.run.exclude.user", "admin");
+        cpsProperties.put("ras.cleanup.test.run.exclude.tags", "production");
+        cpsProperties.put("ras.cleanup.test.run.exclude.user", "admin");
         MockCPSStore cps = createMockCPSStore(cpsProperties);
         
         // Create old runs
@@ -309,7 +309,7 @@ public class TestRasRunCleanup {
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
-        cpsProperties.put("test.run.exclude.tags", " production , critical ");
+        cpsProperties.put("ras.cleanup.test.run.exclude.tags", " production , critical ");
         MockCPSStore cps = createMockCPSStore(cpsProperties);
         
         // Create old runs

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanup.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanup.java
@@ -24,6 +24,7 @@ import dev.galasa.framework.mocks.MockResultArchiveStoreDirectoryService;
 import dev.galasa.framework.mocks.MockRunResult;
 import dev.galasa.framework.mocks.MockTimeService;
 import dev.galasa.framework.spi.IRunResult;
+import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class TestRasRunCleanup {
@@ -80,10 +81,10 @@ public class TestRasRunCleanup {
         
         // Create runs: 2 old (should be cleaned), 2 recent (should not be cleaned)
         List<IRunResult> runs = new ArrayList<>();
-        runs.add(createMockRun("run1", now.minus(40, ChronoUnit.DAYS))); // Old
-        runs.add(createMockRun("run2", now.minus(35, ChronoUnit.DAYS))); // Old
-        runs.add(createMockRun("run3", now.minus(20, ChronoUnit.DAYS))); // Recent
-        runs.add(createMockRun("run4", now.minus(10, ChronoUnit.DAYS))); // Recent
+        runs.add(createMockRun("run1", now.minus(40, ChronoUnit.DAYS)));
+        runs.add(createMockRun("run2", now.minus(35, ChronoUnit.DAYS)));
+        runs.add(createMockRun("run3", now.minus(20, ChronoUnit.DAYS)));
+        runs.add(createMockRun("run4", now.minus(10, ChronoUnit.DAYS)));
         
         MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
         MockIResultArchiveStore ras = new MockIResultArchiveStore();
@@ -121,10 +122,10 @@ public class TestRasRunCleanup {
         
         // Create old runs with different tags
         List<IRunResult> runs = new ArrayList<>();
-        runs.add(createMockRunWithTags("run1", now.minus(40, ChronoUnit.DAYS), "production")); // Excluded
-        runs.add(createMockRunWithTags("run2", now.minus(35, ChronoUnit.DAYS), "critical")); // Excluded
-        runs.add(createMockRunWithTags("run3", now.minus(40, ChronoUnit.DAYS), "test")); // Should be cleaned
-        runs.add(createMockRunWithTags("run4", now.minus(35, ChronoUnit.DAYS), "dev")); // Should be cleaned
+        runs.add(createMockRunWithTags("run1", now.minus(40, ChronoUnit.DAYS), "production"));
+        runs.add(createMockRunWithTags("run2", now.minus(35, ChronoUnit.DAYS), "critical"));
+        runs.add(createMockRunWithTags("run3", now.minus(40, ChronoUnit.DAYS), "test"));
+        runs.add(createMockRunWithTags("run4", now.minus(35, ChronoUnit.DAYS), "dev"));
         
         MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
         MockIResultArchiveStore ras = new MockIResultArchiveStore();
@@ -162,10 +163,10 @@ public class TestRasRunCleanup {
         
         // Create old runs with different users
         List<IRunResult> runs = new ArrayList<>();
-        runs.add(createMockRunWithUser("run1", now.minus(40, ChronoUnit.DAYS), "admin")); // Excluded
-        runs.add(createMockRunWithUser("run2", now.minus(35, ChronoUnit.DAYS), "system")); // Excluded
-        runs.add(createMockRunWithUser("run3", now.minus(40, ChronoUnit.DAYS), "developer")); // Should be cleaned
-        runs.add(createMockRunWithUser("run4", now.minus(35, ChronoUnit.DAYS), "tester")); // Should be cleaned
+        runs.add(createMockRunWithUser("run1", now.minus(40, ChronoUnit.DAYS), "admin"));
+        runs.add(createMockRunWithUser("run2", now.minus(35, ChronoUnit.DAYS), "system"));
+        runs.add(createMockRunWithUser("run3", now.minus(40, ChronoUnit.DAYS), "developer"));
+        runs.add(createMockRunWithUser("run4", now.minus(35, ChronoUnit.DAYS), "tester"));
         
         MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
         MockIResultArchiveStore ras = new MockIResultArchiveStore();
@@ -191,20 +192,20 @@ public class TestRasRunCleanup {
     }
 
     @Test
-    public void testRunExcludesRunsWithMatchingBundle() throws Exception {
+    public void testRunExcludesRunsWithMatchingResult() throws Exception {
         // Given...
         Instant now = Instant.now();
         int maxAgeDays = 30;
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
-        cpsProperties.put("test.run.exclude.bundle", "dev.galasa.important.tests");
+        cpsProperties.put("test.run.exclude.result", Result.HUNG);
         MockCPSStore cps = createMockCPSStore(cpsProperties);
         
-        // Create old runs with different bundles
+        // Create old runs with different results
         List<IRunResult> runs = new ArrayList<>();
-        runs.add(createMockRunWithBundle("run1", now.minus(40, ChronoUnit.DAYS), "dev.galasa.important.tests")); // Excluded
-        runs.add(createMockRunWithBundle("run2", now.minus(35, ChronoUnit.DAYS), "dev.galasa.other.tests")); // Should be cleaned
+        runs.add(createMockRunWithResult("run1", now.minus(40, ChronoUnit.DAYS), Result.HUNG));
+        runs.add(createMockRunWithResult("run2", now.minus(35, ChronoUnit.DAYS), "another result"));
         
         MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
         MockIResultArchiveStore ras = new MockIResultArchiveStore();
@@ -221,8 +222,8 @@ public class TestRasRunCleanup {
         MockRunResult run1 = (MockRunResult) runs.get(0);
         MockRunResult run2 = (MockRunResult) runs.get(1);
         
-        assertThat(run1.isDiscarded()).as("Run from important bundle should be excluded from cleanup").isFalse();
-        assertThat(run2.isDiscarded()).as("Run from other bundle should be cleaned up").isTrue();
+        assertThat(run1.isDiscarded()).as("Run from important result should be excluded from cleanup").isFalse();
+        assertThat(run2.isDiscarded()).as("Run from other result should be cleaned up").isTrue();
     }
 
     @Test
@@ -239,9 +240,9 @@ public class TestRasRunCleanup {
         
         // Create old runs
         List<IRunResult> runs = new ArrayList<>();
-        runs.add(createMockRunWithTagsAndUser("run1", now.minus(40, ChronoUnit.DAYS), "production", "developer")); // Excluded by tag
-        runs.add(createMockRunWithTagsAndUser("run2", now.minus(35, ChronoUnit.DAYS), "test", "admin")); // Excluded by user
-        runs.add(createMockRunWithTagsAndUser("run3", now.minus(40, ChronoUnit.DAYS), "test", "developer")); // Should be cleaned
+        runs.add(createMockRunWithTagsAndUser("run1", now.minus(40, ChronoUnit.DAYS), "production", "developer"));
+        runs.add(createMockRunWithTagsAndUser("run2", now.minus(35, ChronoUnit.DAYS), "test", "admin"));
+        runs.add(createMockRunWithTagsAndUser("run3", now.minus(40, ChronoUnit.DAYS), "test", "developer"));
         
         MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
         MockIResultArchiveStore ras = new MockIResultArchiveStore();
@@ -299,13 +300,13 @@ public class TestRasRunCleanup {
         
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.age.max.days", String.valueOf(maxAgeDays));
-        cpsProperties.put("test.run.exclude.tags", " production , critical "); // With whitespace
+        cpsProperties.put("test.run.exclude.tags", " production , critical ");
         MockCPSStore cps = createMockCPSStore(cpsProperties);
         
         // Create old runs
         List<IRunResult> runs = new ArrayList<>();
-        runs.add(createMockRunWithTags("run1", now.minus(40, ChronoUnit.DAYS), "production")); // Should be excluded
-        runs.add(createMockRunWithTags("run2", now.minus(35, ChronoUnit.DAYS), "critical")); // Should be excluded
+        runs.add(createMockRunWithTags("run1", now.minus(40, ChronoUnit.DAYS), "production"));
+        runs.add(createMockRunWithTags("run2", now.minus(35, ChronoUnit.DAYS), "critical"));
         
         MockResultArchiveStoreDirectoryService directoryService = new MockResultArchiveStoreDirectoryService(runs);
         MockIResultArchiveStore ras = new MockIResultArchiveStore();
@@ -364,19 +365,19 @@ public class TestRasRunCleanup {
         return createMockRun(runId, startTime, null, user);
     }
 
-    private IRunResult createMockRunWithBundle(String runId, Instant startTime, String bundle) {
-        return createMockRun(runId, startTime, bundle, null);
+    private IRunResult createMockRunWithResult(String runId, Instant startTime, String result) {
+        return createMockRun(runId, startTime, result, null);
     }
 
     private IRunResult createMockRunWithTagsAndUser(String runId, Instant startTime, String tag, String user) {
         return createMockRun(runId, startTime, null, user, tag);
     }
 
-    private IRunResult createMockRun(String runId, Instant startTime, String bundle, String user, String... tags) {
+    private IRunResult createMockRun(String runId, Instant startTime, String result, String user, String... tags) {
         TestStructure testStructure = new TestStructure();
         testStructure.setRunName(runId);
         testStructure.setStartTime(startTime);
-        testStructure.setBundle(bundle != null ? bundle : "dev.galasa.test");
+        testStructure.setResult(result);
         testStructure.setTestName("TestClass");
         
         if (user != null) {

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanupResourceManagementProvider.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanupResourceManagementProvider.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal.rascleanup;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.HashMap;
+
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.MockCPSStore;
+import dev.galasa.framework.mocks.MockEnvironment;
+import dev.galasa.framework.mocks.MockFramework;
+import dev.galasa.framework.mocks.MockRASStoreService;
+import dev.galasa.framework.mocks.MockTimeService;
+import dev.galasa.framework.resource.management.internal.mocks.MockResourceManagement;
+import dev.galasa.framework.resource.management.internal.mocks.MockScheduledExecutorService;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+
+public class TestRasRunCleanupResourceManagementProvider {
+
+    @Test
+    public void testCanInstantiateProvider() throws Exception {
+        // Given...
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+
+        // When...
+        RasRunCleanupResourceManagementProvider provider = new RasRunCleanupResourceManagementProvider(timeService, env);
+
+        // Then...
+        assertThat(provider).as("Provider should be instantiated").isNotNull();
+    }
+
+    @Test
+    public void testInitialiseReturnsTrue() throws Exception {
+        // Given...
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+        RasRunCleanupResourceManagementProvider provider = new RasRunCleanupResourceManagementProvider(timeService, env);
+
+        MockFramework framework = createMockFramework();
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+
+        // When...
+        boolean result = provider.initialise(framework, resourceManagement);
+
+        // Then...
+        assertThat(result).as("Initialise should return true").isTrue();
+    }
+
+    @Test
+    public void testInitialiseCreatesScheduler() throws Exception {
+        // Given...
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+
+        env.setenv(RasRunCleanupResourceManagementProvider.TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR, "24");
+        env.setenv(RasRunCleanupResourceManagementProvider.TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR, "30");
+
+        RasRunCleanupResourceManagementProvider provider = new RasRunCleanupResourceManagementProvider(timeService, env);
+
+        MockFramework framework = createMockFramework();
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+
+        // When...
+        provider.initialise(framework, resourceManagement);
+
+        // Then...
+        // Scheduler should be created internally (we can verify this by calling start)
+        provider.start();
+        assertThat(resourceManagement.getScheduledExecutorService().scheduleWithFixedDelayCallCount)
+            .as("Scheduler should be created and started")
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void testInitialiseHandlesFrameworkException() throws Exception {
+        // Given...
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+        RasRunCleanupResourceManagementProvider provider = new RasRunCleanupResourceManagementProvider(timeService, env);
+
+        MockFramework framework = new MockFramework(null, null) {
+            @Override
+            public MockCPSStore getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                throw new ConfigurationPropertyStoreException("Test exception");
+            }
+        };
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+
+        // When...
+        boolean result = provider.initialise(framework, resourceManagement);
+
+        // Then...
+        assertThat(result).as("Initialise should still return true even with exception").isTrue();
+        
+        // Start should not schedule anything since scheduler creation failed
+        provider.start();
+        assertThat(resourceManagement.getScheduledExecutorService().scheduleWithFixedDelayCallCount)
+            .as("No scheduler should be started when initialisation fails")
+            .isEqualTo(0);
+    }
+
+    @Test
+    public void testStartSchedulesCleanupTask() throws Exception {
+        // Given...
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+
+        env.setenv(RasRunCleanupResourceManagementProvider.TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR, "24");
+        env.setenv(RasRunCleanupResourceManagementProvider.TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR, "30");
+
+        RasRunCleanupResourceManagementProvider provider = new RasRunCleanupResourceManagementProvider(timeService, env);
+
+        MockFramework framework = createMockFramework();
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockScheduledExecutorService executorService = resourceManagement.getScheduledExecutorService();
+
+        provider.initialise(framework, resourceManagement);
+
+        // When...
+        provider.start();
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should be scheduled once").isEqualTo(1);
+        assertThat(executorService.lastDelay).as("Delay should be 5 minutes").isEqualTo(5);
+    }
+
+    @Test
+    public void testStartWithoutInitialiseDoesNotSchedule() throws Exception {
+        // Given...
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+        RasRunCleanupResourceManagementProvider provider = new RasRunCleanupResourceManagementProvider(timeService, env);
+
+        // When...
+        provider.start();
+
+        // Then...
+        // No exception should be thrown, and nothing should happen
+    }
+
+    @Test
+    public void testStartWithFailedInitialiseDoesNotSchedule() throws Exception {
+        // Given...
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+        RasRunCleanupResourceManagementProvider provider = new RasRunCleanupResourceManagementProvider(timeService, env);
+
+        MockFramework framework = new MockFramework(null, null) {
+            @Override
+            public MockCPSStore getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                throw new ConfigurationPropertyStoreException("Test exception");
+            }
+        };
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockScheduledExecutorService executorService = resourceManagement.getScheduledExecutorService();
+
+        provider.initialise(framework, resourceManagement);
+
+        // When...
+        provider.start();
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount)
+            .as("Task should not be scheduled when scheduler is null")
+            .isEqualTo(0);
+    }
+
+    @Test
+    public void testShutdownDoesNotThrowException() throws Exception {
+        // Given...
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+        RasRunCleanupResourceManagementProvider provider = new RasRunCleanupResourceManagementProvider(timeService, env);
+
+        MockFramework framework = createMockFramework();
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+
+        provider.initialise(framework, resourceManagement);
+        provider.start();
+
+        // When...
+        provider.shutdown();
+
+        // Then...
+        // Should not throw any exception
+    }
+
+    @Test
+    public void testRunFinishedOrDeletedDoesNotThrowException() throws Exception {
+        // Given...
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+        RasRunCleanupResourceManagementProvider provider = new RasRunCleanupResourceManagementProvider(timeService, env);
+
+        MockFramework framework = createMockFramework();
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+
+        provider.initialise(framework, resourceManagement);
+
+        // When...
+        provider.runFinishedOrDeleted("test-run-123");
+
+        // Then...
+        // Should not throw any exception
+    }
+
+    @Test
+    public void testMultipleStartCallsScheduleMultipleTimes() throws Exception {
+        // Given...
+        MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+
+        env.setenv(RasRunCleanupResourceManagementProvider.TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR, "24");
+        env.setenv(RasRunCleanupResourceManagementProvider.TEST_RUN_CLEANUP_MAX_AGE_DAYS_ENV_VAR, "30");
+
+        RasRunCleanupResourceManagementProvider provider = new RasRunCleanupResourceManagementProvider(timeService, env);
+
+        MockFramework framework = createMockFramework();
+        MockResourceManagement resourceManagement = new MockResourceManagement();
+        MockScheduledExecutorService executorService = resourceManagement.getScheduledExecutorService();
+
+        provider.initialise(framework, resourceManagement);
+
+        // When...
+        provider.start();
+        provider.start();
+        provider.start();
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount)
+            .as("Each start call should schedule a task")
+            .isEqualTo(3);
+    }
+
+    private MockFramework createMockFramework() {
+        MockCPSStore cps = new MockCPSStore(new HashMap<>());
+        MockFramework framework = new MockFramework(cps, null);
+        framework.setMockRas(new MockRASStoreService(new HashMap<>()));
+        return framework;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanupScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanupScheduler.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.resource.management.internal.rascleanup;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.MockCPSStore;
+import dev.galasa.framework.mocks.MockFramework;
+import dev.galasa.framework.mocks.MockRASStoreService;
+import dev.galasa.framework.mocks.MockTimeService;
+import dev.galasa.framework.resource.management.internal.mocks.MockScheduledExecutorService;
+import dev.galasa.framework.resource.management.internal.mocks.MockScheduledFuture;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+
+public class TestRasRunCleanupScheduler {
+
+    @Test
+    public void testCanInstantiateScheduler() throws Exception {
+        // Given...
+        MockFramework framework = createMockFramework(new HashMap<>());
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        // When...
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // Then...
+        assertThat(scheduler).as("Scheduler should be instantiated").isNotNull();
+    }
+
+    @Test
+    public void testRunWithNoIntervalDoesNotScheduleTask() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        // No interval property set
+        MockFramework framework = createMockFramework(cpsProperties);
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // When...
+        scheduler.run();
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should not be scheduled when interval is not set").isEqualTo(0);
+    }
+
+    @Test
+    public void testRunWithZeroIntervalDoesNotScheduleTask() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "0");
+        MockFramework framework = createMockFramework(cpsProperties);
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // When...
+        scheduler.run();
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should not be scheduled when interval is zero").isEqualTo(0);
+    }
+
+    @Test
+    public void testRunWithNegativeIntervalDoesNotScheduleTask() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "-5");
+        MockFramework framework = createMockFramework(cpsProperties);
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // When...
+        scheduler.run();
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should not be scheduled when interval is negative").isEqualTo(0);
+    }
+
+    @Test
+    public void testRunWithValidIntervalSchedulesTask() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "24");
+        MockFramework framework = createMockFramework(cpsProperties);
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // When...
+        scheduler.run();
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should be scheduled once").isEqualTo(1);
+        assertThat(executorService.lastDelay).as("Delay should be 24 hours").isEqualTo(24);
+    }
+
+    @Test
+    public void testRunWithSameIntervalDoesNotReschedule() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "12");
+        MockFramework framework = createMockFramework(cpsProperties);
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // When...
+        scheduler.run();
+        scheduler.run();
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should only be scheduled once when interval hasn't changed").isEqualTo(1);
+    }
+
+    @Test
+    public void testRunWithChangedIntervalReschedulesTask() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "12");
+        MockFramework framework = createMockFramework(cpsProperties);
+
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // When...
+        scheduler.run();
+        MockScheduledFuture firstFuture = executorService.lastScheduledFuture;
+        
+        // Change the interval
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "24");
+        scheduler.run();
+        MockScheduledFuture secondFuture = executorService.lastScheduledFuture;
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should be rescheduled when interval changes").isEqualTo(2);
+        assertThat(firstFuture.isCancelled()).as("Previous task should be cancelled").isTrue();
+        assertThat(secondFuture.isCancelled()).as("New task should not be cancelled").isFalse();
+        assertThat(executorService.lastDelay).as("New delay should be 24 hours").isEqualTo(24);
+    }
+
+    @Test
+    public void testRunWithInvalidIntervalDoesNotScheduleTask() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "not-a-number");
+        MockFramework framework = createMockFramework(cpsProperties);
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // When...
+        scheduler.run();
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should not be scheduled when interval is invalid").isEqualTo(0);
+    }
+
+    @Test
+    public void testRunCancelsExistingTaskBeforeRescheduling() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "6");
+        MockFramework framework = createMockFramework(cpsProperties);
+
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // When...
+        scheduler.run();
+        MockScheduledFuture firstFuture = executorService.lastScheduledFuture;
+        
+        // Change interval to trigger rescheduling
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "12");
+        scheduler.run();
+
+        // Then...
+        assertThat(firstFuture.isCancelled()).as("Previous task should be cancelled before rescheduling").isTrue();
+    }
+
+    @Test
+    public void testRunHandlesExceptionGracefully() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        MockCPSStore cps = new MockCPSStore(cpsProperties) {
+            @Override
+            public String getProperty(String prefix, String suffix, String... infixes) throws ConfigurationPropertyStoreException {
+                throw new ConfigurationPropertyStoreException("CPS error");
+            }
+        };
+        MockFramework framework = new MockFramework(cps, null);
+        framework.setMockRas(new MockRASStoreService(new HashMap<>()));
+
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // When...
+        scheduler.run();
+
+        // Then...
+        // Should not throw exception and should not schedule task
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should not be scheduled when exception occurs").isEqualTo(0);
+    }
+
+    @Test
+    public void testRunWithMultipleIntervalChanges() throws Exception {
+        // Given...
+        Map<String, String> cpsProperties = new HashMap<>();
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "6");
+        MockCPSStore cps = new MockCPSStore(cpsProperties);
+        MockFramework framework = new MockFramework(cps, null);
+        framework.setMockRas(new MockRASStoreService(new HashMap<>()));
+
+        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
+        MockTimeService timeService = new MockTimeService(Instant.now());
+
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+
+        // When...
+        scheduler.run();
+        MockScheduledFuture firstFuture = executorService.lastScheduledFuture;
+        
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "12");
+        scheduler.run();
+        MockScheduledFuture secondFuture = executorService.lastScheduledFuture;
+        
+        cpsProperties.put("ras.cleanup.test.run.interval.hours", "24");
+        scheduler.run();
+
+        // Then...
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should be scheduled three times").isEqualTo(3);
+        assertThat(firstFuture.isCancelled()).as("First task should be cancelled").isTrue();
+        assertThat(secondFuture.isCancelled()).as("Second task should be cancelled").isTrue();
+        assertThat(executorService.lastDelay).as("Final delay should be 24 hours").isEqualTo(24);
+    }
+
+    private MockFramework createMockFramework(Map<String, String> cpsProperties) {
+        MockCPSStore cps = new MockCPSStore(cpsProperties);
+        MockFramework framework = new MockFramework(cps, null);
+        framework.setMockRas(new MockRASStoreService(new HashMap<>()));
+        return framework;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanupScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanupScheduler.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import org.junit.Test;
 
 import dev.galasa.framework.mocks.MockCPSStore;
-import dev.galasa.framework.mocks.MockEnvironment;
 import dev.galasa.framework.mocks.MockFramework;
 import dev.galasa.framework.mocks.MockRASStoreService;
 import dev.galasa.framework.mocks.MockTimeService;
@@ -30,10 +29,11 @@ public class TestRasRunCleanupScheduler {
         MockFramework framework = createMockFramework(new HashMap<>());
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
-        MockEnvironment env = new MockEnvironment();
+        long initialRunCleanupIntervalHours = 24;
+        int initialRunCleanupMaxAgeDays = 30;
 
         // When...
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, initialRunCleanupIntervalHours, initialRunCleanupMaxAgeDays, timeService);
 
         // Then...
         assertThat(scheduler).as("Scheduler should be instantiated").isNotNull();
@@ -47,10 +47,10 @@ public class TestRasRunCleanupScheduler {
         MockFramework framework = createMockFramework(cpsProperties);
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
-        MockEnvironment env = new MockEnvironment();
-        env.setenv(RasRunCleanupScheduler.TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR, "0");
+        long initialRunCleanupIntervalHours = 0;
+        int initialRunCleanupMaxAgeDays = 30;
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, initialRunCleanupIntervalHours, initialRunCleanupMaxAgeDays, timeService);
 
         // When...
         scheduler.run();
@@ -62,14 +62,16 @@ public class TestRasRunCleanupScheduler {
     @Test
     public void testRunWithNegativeIntervalDoesNotScheduleTask() throws Exception {
         // Given...
+        long initialRunCleanupIntervalHours = 24;
+        int initialRunCleanupMaxAgeDays = 30;
+
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.interval.hours", "-5");
         MockFramework framework = createMockFramework(cpsProperties);
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
-        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, initialRunCleanupIntervalHours, initialRunCleanupMaxAgeDays, timeService);
 
         // When...
         scheduler.run();
@@ -81,14 +83,16 @@ public class TestRasRunCleanupScheduler {
     @Test
     public void testRunWithValidIntervalSchedulesTask() throws Exception {
         // Given...
+        long initialRunCleanupIntervalHours = 20;
+        int initialRunCleanupMaxAgeDays = 30;
+
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.interval.hours", "24");
         MockFramework framework = createMockFramework(cpsProperties);
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
-        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, initialRunCleanupIntervalHours, initialRunCleanupMaxAgeDays, timeService);
 
         // When...
         scheduler.run();
@@ -101,14 +105,16 @@ public class TestRasRunCleanupScheduler {
     @Test
     public void testRunWithSameIntervalDoesNotReschedule() throws Exception {
         // Given...
+        long initialRunCleanupIntervalHours = 24;
+        int initialRunCleanupMaxAgeDays = 30;
+
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.interval.hours", "12");
         MockFramework framework = createMockFramework(cpsProperties);
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
-        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, initialRunCleanupIntervalHours, initialRunCleanupMaxAgeDays, timeService);
 
         // When...
         scheduler.run();
@@ -121,15 +127,17 @@ public class TestRasRunCleanupScheduler {
     @Test
     public void testRunWithChangedIntervalReschedulesTask() throws Exception {
         // Given...
+        long initialRunCleanupIntervalHours = 24;
+        int initialRunCleanupMaxAgeDays = 30;
+
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.interval.hours", "12");
         MockFramework framework = createMockFramework(cpsProperties);
 
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
-        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, initialRunCleanupIntervalHours, initialRunCleanupMaxAgeDays, timeService);
 
         // When...
         scheduler.run();
@@ -150,15 +158,16 @@ public class TestRasRunCleanupScheduler {
     @Test
     public void testRunWithInvalidIntervalInCpsUsesDefault() throws Exception {
         // Given...
+        long initialRunCleanupIntervalHours = 10;
+        int initialRunCleanupMaxAgeDays = 30;
+
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.interval.hours", "not-a-number");
         MockFramework framework = createMockFramework(cpsProperties);
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
-        MockEnvironment env = new MockEnvironment();
-        env.setenv(RasRunCleanupScheduler.TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR, "10");
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, initialRunCleanupIntervalHours, initialRunCleanupMaxAgeDays, timeService);
 
         // When...
         scheduler.run();
@@ -171,15 +180,17 @@ public class TestRasRunCleanupScheduler {
     @Test
     public void testRunCancelsExistingTaskBeforeRescheduling() throws Exception {
         // Given...
+        long initialRunCleanupIntervalHours = 10;
+        int initialRunCleanupMaxAgeDays = 30;
+
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.interval.hours", "6");
         MockFramework framework = createMockFramework(cpsProperties);
 
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
-        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, initialRunCleanupIntervalHours, initialRunCleanupMaxAgeDays, timeService);
 
         // When...
         scheduler.run();
@@ -196,6 +207,9 @@ public class TestRasRunCleanupScheduler {
     @Test
     public void testRunHandlesExceptionGracefully() throws Exception {
         // Given...
+        long initialRunCleanupIntervalHours = 10;
+        int initialRunCleanupMaxAgeDays = 30;
+
         Map<String, String> cpsProperties = new HashMap<>();
         MockCPSStore cps = new MockCPSStore(cpsProperties) {
             @Override
@@ -208,9 +222,8 @@ public class TestRasRunCleanupScheduler {
 
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
-        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, initialRunCleanupIntervalHours, initialRunCleanupMaxAgeDays, timeService);
 
         // When...
         scheduler.run();
@@ -223,6 +236,9 @@ public class TestRasRunCleanupScheduler {
     @Test
     public void testRunWithMultipleIntervalChanges() throws Exception {
         // Given...
+        long initialRunCleanupIntervalHours = 24;
+        int initialRunCleanupMaxAgeDays = 30;
+
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.interval.hours", "6");
         MockCPSStore cps = new MockCPSStore(cpsProperties);
@@ -231,9 +247,8 @@ public class TestRasRunCleanupScheduler {
 
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
-        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, initialRunCleanupIntervalHours, initialRunCleanupMaxAgeDays, timeService);
 
         // When...
         scheduler.run();

--- a/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanupScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.resource.management/src/test/java/dev/galasa/framework/resource/management/internal/rascleanup/TestRasRunCleanupScheduler.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import dev.galasa.framework.mocks.MockCPSStore;
+import dev.galasa.framework.mocks.MockEnvironment;
 import dev.galasa.framework.mocks.MockFramework;
 import dev.galasa.framework.mocks.MockRASStoreService;
 import dev.galasa.framework.mocks.MockTimeService;
@@ -29,42 +30,27 @@ public class TestRasRunCleanupScheduler {
         MockFramework framework = createMockFramework(new HashMap<>());
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
 
         // When...
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
 
         // Then...
         assertThat(scheduler).as("Scheduler should be instantiated").isNotNull();
     }
 
     @Test
-    public void testRunWithNoIntervalDoesNotScheduleTask() throws Exception {
+    public void testRunWithZeroIntervalDoesNotScheduleTask() throws Exception {
         // Given...
         Map<String, String> cpsProperties = new HashMap<>();
         // No interval property set
         MockFramework framework = createMockFramework(cpsProperties);
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+        env.setenv(RasRunCleanupScheduler.TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR, "0");
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
-
-        // When...
-        scheduler.run();
-
-        // Then...
-        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should not be scheduled when interval is not set").isEqualTo(0);
-    }
-
-    @Test
-    public void testRunWithZeroIntervalDoesNotScheduleTask() throws Exception {
-        // Given...
-        Map<String, String> cpsProperties = new HashMap<>();
-        cpsProperties.put("ras.cleanup.test.run.interval.hours", "0");
-        MockFramework framework = createMockFramework(cpsProperties);
-        MockScheduledExecutorService executorService = new MockScheduledExecutorService();
-        MockTimeService timeService = new MockTimeService(Instant.now());
-
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
 
         // When...
         scheduler.run();
@@ -81,8 +67,9 @@ public class TestRasRunCleanupScheduler {
         MockFramework framework = createMockFramework(cpsProperties);
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
 
         // When...
         scheduler.run();
@@ -99,8 +86,9 @@ public class TestRasRunCleanupScheduler {
         MockFramework framework = createMockFramework(cpsProperties);
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
 
         // When...
         scheduler.run();
@@ -118,8 +106,9 @@ public class TestRasRunCleanupScheduler {
         MockFramework framework = createMockFramework(cpsProperties);
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
 
         // When...
         scheduler.run();
@@ -138,8 +127,9 @@ public class TestRasRunCleanupScheduler {
 
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
 
         // When...
         scheduler.run();
@@ -158,21 +148,24 @@ public class TestRasRunCleanupScheduler {
     }
 
     @Test
-    public void testRunWithInvalidIntervalDoesNotScheduleTask() throws Exception {
+    public void testRunWithInvalidIntervalInCpsUsesDefault() throws Exception {
         // Given...
         Map<String, String> cpsProperties = new HashMap<>();
         cpsProperties.put("ras.cleanup.test.run.interval.hours", "not-a-number");
         MockFramework framework = createMockFramework(cpsProperties);
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
+        env.setenv(RasRunCleanupScheduler.TEST_RUN_CLEANUP_INTERVAL_HOURS_ENV_VAR, "10");
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
 
         // When...
         scheduler.run();
 
         // Then...
-        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should not be scheduled when interval is invalid").isEqualTo(0);
+        assertThat(executorService.scheduleWithFixedDelayCallCount).as("Task should have been scheduled").isEqualTo(1);
+        assertThat(executorService.lastDelay).as("Task should be scheduled using the default interval").isEqualTo(10);
     }
 
     @Test
@@ -184,8 +177,9 @@ public class TestRasRunCleanupScheduler {
 
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
 
         // When...
         scheduler.run();
@@ -214,8 +208,9 @@ public class TestRasRunCleanupScheduler {
 
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
 
         // When...
         scheduler.run();
@@ -236,8 +231,9 @@ public class TestRasRunCleanupScheduler {
 
         MockScheduledExecutorService executorService = new MockScheduledExecutorService();
         MockTimeService timeService = new MockTimeService(Instant.now());
+        MockEnvironment env = new MockEnvironment();
 
-        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService);
+        RasRunCleanupScheduler scheduler = new RasRunCleanupScheduler(framework, executorService, timeService, env);
 
         // When...
         scheduler.run();

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaQueuedFrom.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaQueuedFrom.java
@@ -23,22 +23,22 @@ public class RasSearchCriteriaQueuedFrom implements IRasSearchCriteria {
 	public boolean criteriaMatched(@NotNull TestStructure structure) {
 		
 		if(structure == null) {
-			return Boolean.FALSE;	
+			return true;	
 		}
 		
-		if(structure.getStartTime() == null) {
-			return Boolean.FALSE;
+		if(structure.getQueued() == null) {
+			return false;
 		}
 		
 		if(from == null) {
-			return Boolean.FALSE;
+			return false;
 		}
 		
-		if(from.equals(structure.getStartTime()) || from.isBefore(structure.getStartTime())) {
-			return Boolean.TRUE;
+		if(from.equals(structure.getQueued()) || from.isBefore(structure.getQueued())) {
+			return true;
 		}
 		
-		return Boolean.FALSE;
+		return false;
 	}
 
     public Instant getFrom() {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaQueuedTo.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaQueuedTo.java
@@ -24,22 +24,22 @@ public class RasSearchCriteriaQueuedTo implements IRasSearchCriteria {
 	public boolean criteriaMatched(@NotNull TestStructure structure) {
 		
 		if(structure == null) {
-			return Boolean.FALSE;	
+			return false;	
 		}
 		
-		if(structure.getEndTime() == null) {
-			return Boolean.FALSE;
+		if(structure.getQueued() == null) {
+			return false;
 		}
 		
 		if(to == null) {
-			return Boolean.FALSE;
+			return false;
 		}
 		
-		if(to.equals(structure.getEndTime()) || to.isAfter(structure.getEndTime())) {
-			return Boolean.TRUE;
+		if(to.equals(structure.getQueued()) || to.isAfter(structure.getQueued())) {
+			return true;
 		}
 		
-		return Boolean.FALSE;
+		return false;
 	}
 
     public Instant getTo() {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaRequestor.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaRequestor.java
@@ -22,18 +22,18 @@ public class RasSearchCriteriaRequestor implements IRasSearchCriteria {
 	public boolean criteriaMatched(@NotNull TestStructure structure) {
 		
 		if(structure == null) {
-			return Boolean.FALSE;	
+			return false;	
 		}
 		
 		if(requestors != null) {
 			for(String requestor : requestors) {
-				if(requestor.equals(structure.getRequestor())){
-					return Boolean.TRUE;
+				if(requestor.equalsIgnoreCase(structure.getRequestor())){
+					return true;
 				}
 			}
 		}
 		
-		return Boolean.FALSE;
+		return false;
 	}
 
     public String[] getRequestors() {

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaResult.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaResult.java
@@ -22,18 +22,18 @@ public class RasSearchCriteriaResult implements IRasSearchCriteria {
    public boolean criteriaMatched(@NotNull TestStructure structure) {
       
       if(structure == null) {
-         return Boolean.FALSE;
+         return false;
       }
       
       if(results != null) {
          for(String result : results) {
-             if(result.equals(structure.getResult())){
-                 return Boolean.TRUE;
+             if(result.equalsIgnoreCase(structure.getResult())){
+                 return true;
              }
          }
      }
       
-      return Boolean.FALSE;
+      return false;
       
       
    }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaStatus.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaStatus.java
@@ -26,7 +26,7 @@ public class RasSearchCriteriaStatus implements IRasSearchCriteria {
    public boolean criteriaMatched(@NotNull TestStructure structure) {
       
       for(TestRunLifecycleStatus status : statuses) {
-            if(status.toString().equals(structure.getStatus())){
+            if(status.toString().equalsIgnoreCase(structure.getStatus())){
                return true;
             }
       }

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaUser.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSearchCriteriaUser.java
@@ -29,7 +29,7 @@ public class RasSearchCriteriaUser implements IRasSearchCriteria {
         if (users != null) {
             for (String user : users) {
                 // When searching by user, match on either the test user or requestor.
-                if (user.equals(structure.getUser()) || user.equals(structure.getRequestor())) {
+                if (user.equalsIgnoreCase(structure.getUser()) || user.equalsIgnoreCase(structure.getRequestor())) {
                     return true;
                 }
             }


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2506.

## Changes
- [x] Added a new RAS cleanup process that deletes test runs older than a given amount of days from the RAS based on the CPS property `framework.ras.cleanup.test.run.age.max.days`
- [x] Added CPS property `framework.ras.cleanup.test.run.interval.hours` to configure how frequently the RAS cleanup process runs (this is done at runtime, no need to re-deploy the Galasa service to reschedule the process)
- [x] Added a new IResourceManagementProvider implementation that starts the RAS cleanup process **scheduler**, and this scheduler then handles the scheduling and rescheduling of the actual RAS cleanup process if the interval changes
- [x] Added support for a set of CPS properties in the form `framework.ras.cleanup.test.run.exclude.[FIELD_NAME]` that can be set to keep test runs from being deleted (e.g. `framework.ras.cleanup.test.run.exclude.tags` can be used to exclude runs by tag)
- [x] The RAS cleanup process can be disabled by setting the `GALASA_TEST_RUN_CLEANUP_INTERVAL_HOURS` or `GALASA_TEST_RUN_CLEANUP_MAX_AGE_DAYS` environment variables to 0 (or by not setting them) - these environment variables are used in the Helm chart (see https://github.com/galasa-dev/helm/pull/120)
- [x] Unit tests (if applicable)
- [x] Documentation updates (if applicable)
- [x] Release notes updates (if applicable)
