### PR TITLE
Remove references to the unused Secret/Variable READ_GITHUB_PACKAGES-USERNAME/TOKEN

### DIFF
--- a/.github/workflows/check-required-secrets-configured.yaml
+++ b/.github/workflows/check-required-secrets-configured.yaml
@@ -23,16 +23,6 @@ on:
         required: false
         default: 'false'
         type: string
-      check_read_github_packages_username:
-        description: 'True if the secret READ_GITHUB_PACKAGES_USERNAME is needed for the calling workflow'
-        required: false
-        default: 'false'
-        type: string
-      check_read_github_packages_token:
-        description: 'True if the secret READ_GITHUB_PACKAGES_TOKEN is needed for the calling workflow'
-        required: false
-        default: 'false'
-        type: string
       check_gpg_key:
         description: 'True if the secret GPG_KEY is needed for the calling workflow'
         required: false
@@ -50,9 +40,6 @@ on:
         type: string
     secrets:
       WRITE_GITHUB_PACKAGES_TOKEN:
-        description: 'A GitHub token passed from the caller workflow to validate'
-        required: false
-      READ_GITHUB_PACKAGES_TOKEN:
         description: 'A GitHub token passed from the caller workflow to validate'
         required: false
       GPG_KEY:
@@ -98,34 +85,6 @@ jobs:
             echo "WRITE_GITHUB_PACKAGES_TOKEN is set."
           fi
         id: check-write-github-packages-token
-
-      - name: Check if READ_GITHUB_PACKAGES_USERNAME is set in this repository
-        if: ${{ inputs.check_read_github_packages_username == 'true' }}
-        continue-on-error: true
-        env:
-          READ_GITHUB_PACKAGES_USERNAME: ${{ vars.READ_GITHUB_PACKAGES_USERNAME }}
-        run: |
-          if [ -z "${READ_GITHUB_PACKAGES_USERNAME}" ] || [ "${READ_GITHUB_PACKAGES_USERNAME}" = "" ]; then
-            echo "READ_GITHUB_PACKAGES_USERNAME is not set. See the output of the 'Report missing repository secrets/variables' job below."
-            exit 1
-          else
-            echo "READ_GITHUB_PACKAGES_USERNAME is set."
-          fi
-        id: check-read-github-packages-username
-
-      - name: Check if READ_GITHUB_PACKAGES_TOKEN is set in this repository
-        if: ${{ inputs.check_read_github_packages_token == 'true' }}
-        continue-on-error: true
-        env:
-          READ_GITHUB_PACKAGES_TOKEN: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
-        run: |
-          if [ -z "${READ_GITHUB_PACKAGES_TOKEN}" ] || [ "${READ_GITHUB_PACKAGES_TOKEN}" = "" ]; then
-            echo "READ_GITHUB_PACKAGES_TOKEN is not set. See the output of the 'Report missing repository secrets/variables' job below."
-            exit 1
-          else
-            echo "READ_GITHUB_PACKAGES_TOKEN is set."
-          fi
-        id: check-read-github-packages-token
 
       - name: Check if GPG_KEY is set in this repository
         if: ${{ inputs.check_gpg_key == 'true' }}
@@ -173,8 +132,6 @@ jobs:
         if: ${{ 
           steps.check-write-github-packages-username.outcome == 'failure' || 
           steps.check-write-github-packages-token.outcome == 'failure' || 
-          steps.check-read-github-packages-username.outcome == 'failure' || 
-          steps.check-read-github-packages-token.outcome == 'failure' || 
           steps.check-gpg-key.outcome == 'failure' || 
           steps.check-gpg-keyid.outcome == 'failure' || 
           steps.check-gpg-passphrase.outcome == 'failure' 
@@ -187,15 +144,6 @@ jobs:
           if [[ ${{ steps.check-write-github-packages-token.outcome }} == 'failure' ]]; then
             echo "WRITE_GITHUB_PACKAGES_TOKEN is not set. Configure it in the repository secrets.\
             It must contain a GitHub Personal Access Token with write:packages scope\
-            that you want to use to log into GitHub Container Registry."
-          fi
-          if [[ ${{ steps.check-read-github-packages-username.outcome }} == 'failure' ]]; then
-            echo "READ_GITHUB_PACKAGES_USERNAME is not set. Configure it in the repository variables.\
-            It must contain the GitHub username you want to use to log into GitHub Container Registry."
-          fi
-          if [[ ${{ steps.check-read-github-packages-token.outcome }} == 'failure' ]]; then
-            echo "READ_GITHUB_PACKAGES_TOKEN is not set. Configure it in the repository secrets.\
-            It must contain a GitHub Personal Access Token with read:packages scope\
             that you want to use to log into GitHub Container Registry."
           fi
           if [[ ${{ steps.check-gpg-key.outcome }} == 'failure' ]]; then


### PR DESCRIPTION
## Why?

Removing references to the variable READ_GITHUB_PACKAGES_USERNAME and secret READ_GITHUB_PACKAGES_TOKEN which are no longer used.
