### PR TITLE
Remove unused imports/objects from the Managers module

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/ras/RASByteChannelTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/ras/RASByteChannelTest.java
@@ -14,8 +14,6 @@ import java.nio.channels.ClosedChannelException;
 import org.junit.Assert;
 import org.junit.Test;
 
-import dev.galasa.framework.spi.ras.ResultArchiveStoreByteChannel;
-
 public class RASByteChannelTest {
 
     @Test

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/ras/RASFileStoreTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/ras/RASFileStoreTest.java
@@ -12,8 +12,6 @@ import java.nio.file.attribute.FileStoreAttributeView;
 import org.junit.Assert;
 import org.junit.Test;
 
-import dev.galasa.framework.spi.ras.ResultArchiveStoreFileStore;
-
 public class RASFileStoreTest {
 
     @Test

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager/src/main/java/dev/galasa/cicsts/cemt/internal/CemtImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager/src/main/java/dev/galasa/cicsts/cemt/internal/CemtImpl.java
@@ -10,8 +10,6 @@ import java.util.regex.Pattern;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import dev.galasa.cicsts.CemtException;
 import dev.galasa.cicsts.CemtManagerException;
 import dev.galasa.cicsts.CicstsHashMap;
@@ -27,8 +25,6 @@ import dev.galasa.zos3270.TimeoutException;
 import dev.galasa.zos3270.spi.NetworkException;
 
 public class CemtImpl implements ICemt {
-
-    private static final Log logger = LogFactory.getLog(CemtImpl.class);
     
     private ICicsRegion cicsRegion;
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerLeaveRunning.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerLeaveRunning.java
@@ -5,8 +5,6 @@
  */
 package dev.galasa.docker.internal.properties;
 
-import java.util.Map;
-
 import dev.galasa.docker.DockerManagerException;
 import dev.galasa.docker.internal.DockerContainerImpl;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;

--- a/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxSecurityGroups.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxSecurityGroups.java
@@ -12,7 +12,6 @@ import dev.galasa.framework.spi.cps.CpsProperties;
 import dev.galasa.openstack.manager.OpenstackManagerException;
 
 import java.util.List;
-import java.util.Arrays;
 
 /**
  * OpenStack Linux Security Groups

--- a/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/src/main/java/dev/galasa/db2/Db2Instance.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/src/main/java/dev/galasa/db2/Db2Instance.java
@@ -9,7 +9,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.sql.ResultSet;
 
 import dev.galasa.framework.spi.ValidAnnotatedFields;
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/src/main/java/dev/galasa/db2/internal/Db2InstanceImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/src/main/java/dev/galasa/db2/internal/Db2InstanceImpl.java
@@ -5,24 +5,11 @@
  */
 package dev.galasa.db2.internal;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.ICredentialsUsernamePassword;
 import dev.galasa.db2.Db2ManagerException;
@@ -45,8 +32,6 @@ import dev.galasa.framework.spi.creds.CredentialsException;
  */
 public class Db2InstanceImpl implements IDb2Instance{
 	private Connection 			conn;
-	
-	private static final Log  	logger = LogFactory.getLog(Db2InstanceImpl.class);
 	
 	public Db2InstanceImpl(IFramework framework, Db2ManagerImpl manager, String tag) throws Db2ManagerException{
 		String instance = Db2DSEInstanceName.get(tag);

--- a/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/src/main/java/dev/galasa/db2/internal/Db2ManagerImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/src/main/java/dev/galasa/db2/internal/Db2ManagerImpl.java
@@ -9,7 +9,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/src/main/java/dev/galasa/db2/internal/Db2SchemaImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/src/main/java/dev/galasa/db2/internal/Db2SchemaImpl.java
@@ -20,7 +20,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;

--- a/modules/managers/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/src/main/java/dev/galasa/elasticlog/internal/properties/ElasticLogLocalRun.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/src/main/java/dev/galasa/elasticlog/internal/properties/ElasticLogLocalRun.java
@@ -6,7 +6,6 @@
 package dev.galasa.elasticlog.internal.properties;
 
 import dev.galasa.elasticlog.internal.ElasticLogManagerException;
-import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.cps.CpsProperties;
 
 /**

--- a/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/src/main/java/dev/galasa/selenium/internal/SeleniumGridSessionMonitor.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/src/main/java/dev/galasa/selenium/internal/SeleniumGridSessionMonitor.java
@@ -9,7 +9,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/src/main/java/dev/galasa/selenium/internal/WebPageImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/src/main/java/dev/galasa/selenium/internal/WebPageImpl.java
@@ -29,7 +29,6 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 
 import dev.galasa.ResultArchiveStoreContentType;
 import dev.galasa.SetContentType;
-import dev.galasa.framework.spi.IFramework;
 import dev.galasa.selenium.IWebPage;
 import dev.galasa.selenium.SeleniumManagerException;
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerFileDatasetIVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerFileDatasetIVT.java
@@ -19,7 +19,6 @@ import dev.galasa.artifact.TestBundleResourceException;
 import dev.galasa.core.manager.CoreManager;
 import dev.galasa.core.manager.ICoreManager;
 import dev.galasa.core.manager.Logger;
-import dev.galasa.core.manager.TestProperty;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 import dev.galasa.zosbatch.IZosBatch;

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerFileVSAMIVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerFileVSAMIVT.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 
 import org.apache.commons.logging.Log;
 
-import dev.galasa.ICredentialsUsernamePassword;
 import dev.galasa.Test;
 import dev.galasa.artifact.BundleResources;
 import dev.galasa.artifact.IBundleResources;

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zos/internal/properties/PoolPorts.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zos/internal/properties/PoolPorts.java
@@ -11,7 +11,6 @@ import javax.validation.constraints.NotNull;
 
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.cps.CpsProperties;
-import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosManagerException;
 
 public class PoolPorts extends CpsProperties {

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zosfile/IZosUNIXFile.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zosfile/IZosUNIXFile.java
@@ -11,8 +11,6 @@ import java.util.SortedMap;
 
 import javax.validation.constraints.NotNull;
 
-import dev.galasa.zosfile.IZosDataset.DatasetDataType;
-
 /**
  * Representation of a UNIX file or directory.
  *

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/src/main/java/dev/galasa/zos3270/manager/ivt/Zos3270IVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/src/main/java/dev/galasa/zos3270/manager/ivt/Zos3270IVT.java
@@ -9,10 +9,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.commons.logging.Log;
 
-import dev.galasa.ICredentialsUsernamePassword;
+// import dev.galasa.ICredentialsUsernamePassword;
 import dev.galasa.Test;
 import dev.galasa.core.manager.CoreManager;
-import dev.galasa.core.manager.CoreManagerException;
+// import dev.galasa.core.manager.CoreManagerException;
 import dev.galasa.core.manager.ICoreManager;
 import dev.galasa.core.manager.Logger;
 import dev.galasa.core.manager.RunName;
@@ -28,8 +28,8 @@ import dev.galasa.zos3270.TextNotFoundException;
 import dev.galasa.zos3270.TimeoutException;
 import dev.galasa.zos3270.Zos3270Exception;
 import dev.galasa.zos3270.Zos3270Terminal;
-import dev.galasa.zos3270.spi.Colour;
-import dev.galasa.zos3270.spi.Highlight;
+// import dev.galasa.zos3270.spi.Colour;
+// import dev.galasa.zos3270.spi.Highlight;
 import dev.galasa.zos3270.spi.NetworkException;
 
 @Test

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/Zos3270ManagerImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/Zos3270ManagerImpl.java
@@ -9,7 +9,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import javax.validation.constraints.NotNull;
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosrseapi.manager/src/main/java/dev/galasa/zosrseapi/IRseapi.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosrseapi.manager/src/main/java/dev/galasa/zosrseapi/IRseapi.java
@@ -9,8 +9,6 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
-import java.net.HttpURLConnection;
-
 import org.apache.http.HttpStatus;
 
 import com.google.gson.JsonObject;

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosrseapi.manager/src/main/java/dev/galasa/zosrseapi/IRseapiRestApiProcessor.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosrseapi.manager/src/main/java/dev/galasa/zosrseapi/IRseapiRestApiProcessor.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import javax.validation.constraints.NotNull;
 
-import dev.galasa.zosbatch.ZosBatchException;
 import dev.galasa.zosrseapi.IRseapi.RseapiRequestType;
 
 public interface IRseapiRestApiProcessor {    

--- a/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosrseapi.manager/src/main/java/dev/galasa/zosrseapi/internal/RseapiRestApiProcessor.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosrseapi.manager/src/main/java/dev/galasa/zosrseapi/internal/RseapiRestApiProcessor.java
@@ -22,7 +22,6 @@ import org.apache.http.HttpStatus;
 
 import com.google.gson.JsonObject;
 
-import dev.galasa.zosbatch.ZosBatchException;
 import dev.galasa.zosrseapi.IRseapi;
 import dev.galasa.zosrseapi.IRseapiResponse;
 import dev.galasa.zosrseapi.IRseapiRestApiProcessor;


### PR DESCRIPTION
## Why?

Removing unused imports from the Managers module to reduce noisy warnings from VSCode.
