### PR TITLE
Add istio sidecar to test pods if istio is enabled in the Galasa service

### DIFF
--- a/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
+++ b/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
@@ -298,6 +298,135 @@ When a nominated owner logs into the Galasa Ecosystem, they are granted the `own
 
 ### Optional Configurations
 
+#### Istio Service Mesh
+
+The Galasa service supports integration with [Istio](https://istio.io) service mesh to automatically encrypt all pod-to-pod traffic using mutual TLS (mTLS).
+
+**Prerequisites:**
+- Istio 1.29+ installed in your Kubernetes cluster
+- See [Istio installation guide](https://istio.io/latest/docs/setup/getting-started/)
+
+**Basic Configuration (Internal Traffic Only):**
+
+To enable mTLS for internal pod-to-pod traffic:
+
+```yaml
+istio:
+  enabled: true
+  mtls:
+    mode: "STRICT"  # Recommended for production
+```
+
+**External Traffic Routing:**
+
+Istio can also handle external traffic routing. Choose one option:
+
+**Option 1: Istio with Kubernetes Gateway API (Recommended)**
+
+```yaml
+istio:
+  enabled: true
+  mtls:
+    mode: "STRICT"
+
+gatewayApi:
+  enabled: true
+  gatewayClassName: "istio"  # Use Istio's Gateway implementation
+
+```
+
+**Option 2: Istio with Kubernetes Ingress**
+
+First, create an Istio IngressClass:
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: istio
+spec:
+  controller: istio.io/ingress-controller
+EOF
+```
+
+Then configure the chart's values:
+
+```yaml
+istio:
+  enabled: true
+  mtls:
+    mode: "STRICT"
+
+ingress:
+  enabled: true
+  ingressClassName: "istio"  # Use Istio's Ingress controller
+
+```
+
+**Note:** When using Istio for external traffic, Istio handles both external ingress and internal mTLS encryption.
+
+**Configuration Options:**
+
+- `istio.enabled`: Enable or disable Istio integration (default: `false`)
+- `istio.mtls.mode`: mTLS enforcement mode
+  - `STRICT`: Only mTLS traffic allowed (recommended for production)
+  - `PERMISSIVE`: Both mTLS and plaintext allowed (useful for migration)
+  - `DISABLE`: mTLS disabled
+
+**How It Works:**
+
+When Istio is enabled:
+1. All Galasa service pods receive an Istio sidecar proxy
+2. The sidecar automatically encrypts all pod-to-pod traffic using mTLS
+3. Application code continues to use HTTP URLs - encryption is transparent
+4. Test pods launched by the Engine Controller also receive Istio sidecars
+
+**Migration Strategy:**
+
+For existing deployments, use a gradual migration approach:
+
+1. **Enable with PERMISSIVE mode:**
+   ```yaml
+   istio:
+     enabled: true
+     mtls:
+       mode: "PERMISSIVE"
+   ```
+
+2. **Upgrade your deployment:**
+   ```bash
+   helm upgrade my-galasa galasa/ecosystem -f values.yaml --wait
+   ```
+
+3. **Verify all services are working:**
+   ```bash
+   # Check that all pods have Istio sidecars (should show 2 containers per pod)
+   kubectl get pods
+   
+   # Verify mTLS is enabled by checking Istio proxy config
+   istioctl proxy-status 
+   ```
+
+4. **Switch to STRICT mode:**
+   ```yaml
+   istio:
+     enabled: true
+     mtls:
+       mode: "STRICT"
+   ```
+
+5. **Upgrade again:**
+   ```bash
+   helm upgrade my-galasa galasa/ecosystem -f values.yaml --wait
+   ```
+
+**Troubleshooting:**
+
+- **Pods not getting sidecars:** Verify Istio is installed with `kubectl get pods -n istio-system`
+- **Connection failures:** Use PERMISSIVE mode during migration, then switch to STRICT
+- **Check Istio proxy logs:** `kubectl logs <pod-name> -c istio-proxy`
+
 #### Storage Class
 
 If your cluster requires a specific StorageClass for persistent volumes:

--- a/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
+++ b/docs/content/docs/ecosystem/ecosystem-installing-k8s.md
@@ -313,8 +313,7 @@ To enable mTLS for internal pod-to-pod traffic:
 ```yaml
 istio:
   enabled: true
-  mtls:
-    mode: "STRICT"  # Recommended for production
+  mtlsMode: "STRICT"  # Recommended for production
 ```
 
 **External Traffic Routing:**
@@ -326,8 +325,7 @@ Istio can also handle external traffic routing. Choose one option:
 ```yaml
 istio:
   enabled: true
-  mtls:
-    mode: "STRICT"
+  mtlsMode: "STRICT"
 
 gatewayApi:
   enabled: true
@@ -355,8 +353,7 @@ Then configure the chart's values:
 ```yaml
 istio:
   enabled: true
-  mtls:
-    mode: "STRICT"
+  mtlsMode: "STRICT"
 
 ingress:
   enabled: true
@@ -369,7 +366,7 @@ ingress:
 **Configuration Options:**
 
 - `istio.enabled`: Enable or disable Istio integration (default: `false`)
-- `istio.mtls.mode`: mTLS enforcement mode
+- `istio.mtlsMode`: mTLS enforcement mode
   - `STRICT`: Only mTLS traffic allowed (recommended for production)
   - `PERMISSIVE`: Both mTLS and plaintext allowed (useful for migration)
   - `DISABLE`: mTLS disabled
@@ -390,8 +387,7 @@ For existing deployments, use a gradual migration approach:
    ```yaml
    istio:
      enabled: true
-     mtls:
-       mode: "PERMISSIVE"
+     mtlsMode: "PERMISSIVE"
    ```
 
 2. **Upgrade your deployment:**
@@ -412,8 +408,7 @@ For existing deployments, use a gradual migration approach:
    ```yaml
    istio:
      enabled: true
-     mtls:
-       mode: "STRICT"
+     mtlsMode: "STRICT"
    ```
 
 5. **Upgrade again:**

--- a/docs/content/releases/posts/v0.48.0.md
+++ b/docs/content/releases/posts/v0.48.0.md
@@ -13,6 +13,10 @@ links:
   - By default, test runs older than 30 days are deleted and the cleanup process runs once every 24 hours.
   - For information on how to configure the cleanup process, including how to adjust the age threshold, cleanup frequency, and exclude specific test runs from cleanup, see [Configuring automatic cleanup of test runs](../../docs/manage-ecosystem/automatic-runs-cleanup.md).
 
+- Added support for integrating the Galasa service with the [Istio](https://istio.io){target="_blank"} service mesh.
+  - When enabled, Galasa service pods start up with an Istio sidecar so that pod-to-pod traffic can be secured using mutual TLS (mTLS).
+  - For configuration details, see [Installing an Ecosystem using Helm](../../docs/ecosystem/ecosystem-installing-k8s.md#istio-service-mesh).
+
 ## Changes affecting tests running locally or on the Galasa Service
 
 - The artifacts.properties file containing information about a local test run's artifacts will no longer be created and stored in the local RAS. Instead, an artifacts.json file will be created to provide more flexibility in the amount of metadata that can be included for each artifact. artifacts.json was already provided for runs in a Galasa service so the artifacts.properties file will simply no longer be provided.

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/ISettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/ISettings.java
@@ -54,5 +54,7 @@ public interface ISettings {
     public long getInterruptedTestRunCleanupGracePeriodSeconds();
 
     public long getAllocatedTestRunTimeoutMinutes();
+
+    public boolean isIstioEnabled();
 }
 

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -35,6 +35,8 @@ public class Settings implements Runnable, ISettings {
     public static final int ALLOCATED_TEST_RUN_TIMEOUT_MINUTES_DEFAULT = 30;
     public static final String ALLOCATED_TEST_RUN_TIMEOUT_MINUTES_PROPERTY_NAME = "allocated_test_run_timeout_minutes";
 
+    public static final String IS_ISTIO_ENABLED_PROPERTY_NAME = "is_istio_enabled";
+
     private final Log         logger                      = LogFactory.getLog(getClass());
 
     private final K8sController controller;
@@ -57,6 +59,7 @@ public class Settings implements Runnable, ISettings {
     private String            nodePreferredAffinity       = "";
     private String            nodeRequiredAffinity        = "";
     private String            nodeTolerations             = "";
+    private boolean           isIstioEnabled              = false;
 
     // A fail-safe to make sure we never try to re-launch/re-create a pod for a testcase more than 
     // this number  of times.
@@ -110,6 +113,14 @@ public class Settings implements Runnable, ISettings {
     private String updateProperty(Map<String, String> configMapData, String key, String defaultValue, String oldValue) {
         String newValue = getPropertyFromData(configMapData, key, defaultValue);
         if (!newValue.equals(oldValue)) {
+            logger.info("Setting " + key + " from '" + oldValue + "' to '" + newValue + "'");
+        }
+        return newValue;
+    }
+
+    private boolean updateProperty(Map<String, String> configMapData, String key, boolean defaultValue, boolean oldValue) {
+        boolean newValue = Boolean.parseBoolean(getPropertyFromData(configMapData, key, String.valueOf(defaultValue)));
+        if (newValue != oldValue) {
             logger.info("Setting " + key + " from '" + oldValue + "' to '" + newValue + "'");
         }
         return newValue;
@@ -222,6 +233,7 @@ public class Settings implements Runnable, ISettings {
         this.encryptionKeysSecretName = updateProperty(configMapData, "encryption_keys_secret_name", "", this.encryptionKeysSecretName);
 
         this.maxTestPodRetryLimit = updateProperty(configMapData, MAX_TEST_POD_RETRY_LIMIT_CONFIG_MAP_PROPERTY_NAME, MAX_TEST_POD_RETRY_LIMIT_DEFAULT, this.maxTestPodRetryLimit);
+        this.isIstioEnabled = updateProperty(configMapData, IS_ISTIO_ENABLED_PROPERTY_NAME, false, this.isIstioEnabled);
     }
 
     private void setRunPoll(Map<String,String> configMapData) throws K8sControllerException {
@@ -406,5 +418,9 @@ public class Settings implements Runnable, ISettings {
 
     public long getAllocatedTestRunTimeoutMinutes() {
         return this.allocatedTestRunTimeoutMinutes;
+    }
+
+    public boolean isIstioEnabled() {
+        return this.isIstioEnabled;
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodKubeLabels.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodKubeLabels.java
@@ -24,7 +24,13 @@ public enum TestPodKubeLabels {
      * Test pods have a kube label with a value being the name of the engine controller
      * the pods were launched using
      */
-    ENGINE_CONTROLLER("galasa-engine-controller");
+    ENGINE_CONTROLLER("galasa-engine-controller"),
+
+    /**
+     * If secure internal pod communication is enabled, then test pods will be injected with
+     * an Istio sidecar and will have this kube label set to "true"
+     */
+    ISTIO_SIDECAR("sidecar.istio.io/inject");
     ;
 
     private String label;

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -261,6 +261,11 @@ public class TestPodScheduler implements Runnable {
         metadata.putLabelsItem(TestPodKubeLabels.ENGINE_CONTROLLER.toString(), this.settings.getEngineLabel());
         metadata.putLabelsItem(TestPodKubeLabels.GALASA_RUN.toString(), runName);
         metadata.putLabelsItem(TestPodKubeLabels.GALASA_SERVICE_NAME.toString(), kubeEngineFacade.getGalasaServiceInstallName());
+
+        if (settings.isIstioEnabled()) {
+            metadata.putLabelsItem(TestPodKubeLabels.ISTIO_SIDECAR.toString(), "true");
+        }
+
         logger.debug(metadata.toString());
 
         V1PodSpec podSpec = new V1PodSpec();

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/SettingsTest.java
@@ -148,4 +148,48 @@ public class SettingsTest {
 
         assertThat(gotBack).isEqualTo(300);
     }
+
+    @Test
+    public void testUsesDefaultIstioEnabledIfMissingFromConfigMap() throws Exception {
+        K8sController controller = new K8sController();
+        KubernetesEngineFacade kube = null;
+        Settings settings = new Settings(controller, kube, "myPod", "myConfigMapName");
+        Map<String, String> configMap = new HashMap<String, String>();
+
+        settings.updateConfigMapProperties(configMap);
+
+        boolean gotBack = settings.isIstioEnabled();
+
+        assertThat(gotBack).isFalse();
+    }
+
+    @Test
+    public void testCanReadIstioEnabledTrueIfPresentInConfigMap() throws Exception {
+        K8sController controller = new K8sController();
+        KubernetesEngineFacade kube = null;
+        Settings settings = new Settings(controller, kube, "myPod", "myConfigMapName");
+        Map<String, String> configMap = new HashMap<String, String>();
+        configMap.put(Settings.IS_ISTIO_ENABLED_PROPERTY_NAME, "true");
+
+        settings.updateConfigMapProperties(configMap);
+
+        boolean gotBack = settings.isIstioEnabled();
+
+        assertThat(gotBack).isTrue();
+    }
+
+    @Test
+    public void testCanReadIstioEnabledFalseIfPresentInConfigMap() throws Exception {
+        K8sController controller = new K8sController();
+        KubernetesEngineFacade kube = null;
+        Settings settings = new Settings(controller, kube, "myPod", "myConfigMapName");
+        Map<String, String> configMap = new HashMap<String, String>();
+        configMap.put(Settings.IS_ISTIO_ENABLED_PROPERTY_NAME, "false");
+
+        settings.updateConfigMapProperties(configMap);
+
+        boolean gotBack = settings.isIstioEnabled();
+
+        assertThat(gotBack).isFalse();
+    }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -294,6 +294,45 @@ public class TestPodSchedulerTest {
     }
 
     @Test
+    public void testCanCreateTestPodWithIstioSidecarLabelWhenIstioEnabled() throws Exception {
+        // Given...
+        MockEnvironment mockEnvironment = new MockEnvironment();
+
+        String encryptionKeysMountPath = "/encryption/encryption-keys.yaml";
+        mockEnvironment.setenv(FrameworkEncryptionService.ENCRYPTION_KEYS_PATH_ENV, encryptionKeysMountPath);
+
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(new ArrayList<>());
+
+        MockISettings settings = new MockISettings();
+        settings.setIsIstioEnabled(true);
+
+        MockCPSStore mockCPS = new MockCPSStore(null);
+
+        String galasaServiceInstallName = "myGalasaService";
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(null, "mynamespace", galasaServiceInstallName);
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
+
+        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, settings, facade, mockTimeService, prioritySchedulingService);
+
+        String runName = "run1";
+        String podName = settings.getEngineLabel() + "-" + runName;
+        boolean isTraceEnabled = false;
+
+        // When...
+        V1Pod pod = runPoll.createTestPodDefinition(runName, podName, isTraceEnabled);
+
+        // Then...
+        String expectedEncryptionKeysMountPath = "/encryption";
+        assertPodDetailsAreCorrect(pod, galasaServiceInstallName, runName, podName, expectedEncryptionKeysMountPath, settings);
+        assertThat(pod.getMetadata().getLabels()).containsKey(TestPodKubeLabels.ISTIO_SIDECAR.toString());
+    }
+
+    @Test
     public void testCanCreateTestPodWithoutNodeRequiredAffinity() throws Exception {
         // Given...
         MockEnvironment mockEnvironment = new MockEnvironment();

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -91,12 +91,16 @@ public class TestPodSchedulerTest {
         String expectedPodName,
         ISettings settings
     ) {
+        Map<String, String> expectedLabels = new HashMap<>();
+        expectedLabels.put(TestPodKubeLabels.GALASA_RUN.toString(), expectedRunName);
+        expectedLabels.put(TestPodKubeLabels.ENGINE_CONTROLLER.toString(), settings.getEngineLabel());
+        expectedLabels.put(TestPodKubeLabels.GALASA_SERVICE_NAME.toString(), expectedGalasaServiceName);
+        if (settings.isIstioEnabled()) {
+            expectedLabels.put(TestPodKubeLabels.ISTIO_SIDECAR.toString(), "true");
+        }
+
         V1ObjectMeta expectedMetadata = new V1ObjectMeta()
-            .labels(Map.of(
-                TestPodKubeLabels.GALASA_RUN.toString(), expectedRunName,
-                TestPodKubeLabels.ENGINE_CONTROLLER.toString(), settings.getEngineLabel(),
-                TestPodKubeLabels.GALASA_SERVICE_NAME.toString(), expectedGalasaServiceName
-            ))
+            .labels(expectedLabels)
             .name(expectedPodName);
 
         // Check the pod's metadata is as expected
@@ -248,6 +252,45 @@ public class TestPodSchedulerTest {
         // Then...
         String expectedEncryptionKeysMountPath = "/encryption";
         assertPodDetailsAreCorrect(pod, galasaServiceInstallName, runName, podName, expectedEncryptionKeysMountPath, settings);
+    }
+
+    @Test
+    public void testCanCreateTestPodWithoutIstioSidecarLabelWhenIstioDisabled() throws Exception {
+        // Given...
+        MockEnvironment mockEnvironment = new MockEnvironment();
+
+        String encryptionKeysMountPath = "/encryption/encryption-keys.yaml";
+        mockEnvironment.setenv(FrameworkEncryptionService.ENCRYPTION_KEYS_PATH_ENV, encryptionKeysMountPath);
+
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(new ArrayList<>());
+
+        MockISettings settings = new MockISettings();
+        settings.setIsIstioEnabled(false);
+
+        MockCPSStore mockCPS = new MockCPSStore(null);
+
+        String galasaServiceInstallName = "myGalasaService";
+        KubernetesEngineFacade facade = new KubernetesEngineFacade(null, "mynamespace", galasaServiceInstallName);
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService();
+        IPrioritySchedulingService prioritySchedulingService = new PrioritySchedulingService(mockFrameworkRuns, mockCPS, mockRBACService, mockTimeService, mockTagsService);
+
+        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, settings, facade, mockTimeService, prioritySchedulingService);
+
+        String runName = "run1";
+        String podName = settings.getEngineLabel() + "-" + runName;
+        boolean isTraceEnabled = false;
+
+        // When...
+        V1Pod pod = runPoll.createTestPodDefinition(runName, podName, isTraceEnabled);
+
+        // Then...
+        String expectedEncryptionKeysMountPath = "/encryption";
+        assertPodDetailsAreCorrect(pod, galasaServiceInstallName, runName, podName, expectedEncryptionKeysMountPath, settings);
+        assertThat(pod.getMetadata().getLabels()).doesNotContainKey(TestPodKubeLabels.ISTIO_SIDECAR.toString());
     }
 
     @Test

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockISettings.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/mocks/MockISettings.java
@@ -13,6 +13,7 @@ public class MockISettings implements ISettings {
     private int maxEngines = 5;
     private String nodeRequiredAffinity = "MyNodeRequiredAffinity=MyNodeRequiredAffinityValue:23";
     private String nodePreferredAffinity = "MyNodePreferredAffinity=MyNodePreferredAffinityValue:23";
+    private boolean isIstioEnabled = true;
 
     @Override
     public String getEngineLabel() {
@@ -124,6 +125,15 @@ public class MockISettings implements ISettings {
     @Override
     public long getAllocatedTestRunTimeoutMinutes() {
         return allocatedTestRunTimeoutMins;
+    }
+
+    @Override
+    public boolean isIstioEnabled() {
+        return isIstioEnabled;
+    }
+
+    public void setIsIstioEnabled(boolean isIstioEnabled) {
+        this.isIstioEnabled = isIstioEnabled;
     }
 
     @Override


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/1531. 
Relates to changes in https://github.com/galasa-dev/helm/pull/121

## Changes
- [x] Added galasa.dev docs on how to configure the Galasa service to use Istio and what's required in order to do so
- [x] Added the `is_istio_enabled` setting which is used to determine whether to inject an istio sidecar to test pods
- [x] Unit tests (if applicable)
- [x] Documentation updates (if applicable)
- [x] Release notes updates (if applicable)
