### PR TITLE
Bump log4j-core, log4j-slf4j-impl, log4j-layout-template-json

### DIFF
--- a/modules/framework/galasa-parent/galasa-boot/build.gradle
+++ b/modules/framework/galasa-parent/galasa-boot/build.gradle
@@ -56,13 +56,13 @@ dependencies {
     //
     // Without this, the framework would complain about not being able to find templates
     // on the classpath.
-    embedImplementation 'org.apache.logging.log4j:log4j-layout-template-json:2.25.3'
+    embedImplementation 'org.apache.logging.log4j:log4j-layout-template-json:2.25.4'
 
     bundleDependency 'org.apache.felix:org.apache.felix.bundlerepository:2.0.10'
     bundleDependency 'org.apache.felix:org.apache.felix.scr:2.1.14'
-    bundleDependency 'org.apache.logging.log4j:log4j-api:2.25.3'
-    bundleDependency 'org.apache.logging.log4j:log4j-core:2.25.3'
-    bundleDependency 'org.apache.logging.log4j:log4j-layout-template-json:2.25.3'
+    bundleDependency 'org.apache.logging.log4j:log4j-api:2.25.4'
+    bundleDependency 'org.apache.logging.log4j:log4j-core:2.25.4'
+    bundleDependency 'org.apache.logging.log4j:log4j-layout-template-json:2.25.4'
     bundleDependency project (':dev.galasa.framework.log4j2.bridge')
     bundleDependency project (':dev.galasa.framework.maven.repository')
     bundleDependency project (':dev.galasa.framework.maven.repository.spi')

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -233,10 +233,10 @@ dependencies {
         api 'org.apache.kafka:kafka-clients:3.9.0'
         api 'org.apache.kafka:kafka-server-common:3.9.0'
 
-        api 'org.apache.logging.log4j:log4j-api:2.25.3' // If updating, also update in galasa-boot build.gradle.
-        api 'org.apache.logging.log4j:log4j-core:2.25.3' // If updating, also update in galasa-boot build.gradle.
-        api 'org.apache.logging.log4j:log4j-layout-template-json:2.25.3' // If updating, also update in galasa-boot build.gradle.
-        api 'org.apache.logging.log4j:log4j-slf4j-impl:2.25.3'
+        api 'org.apache.logging.log4j:log4j-api:2.25.4' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.logging.log4j:log4j-core:2.25.4' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.logging.log4j:log4j-layout-template-json:2.25.4' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.logging.log4j:log4j-slf4j-impl:2.25.4'
 
         api 'org.apache.maven:maven-core:3.9.9'
         api 'org.apache.maven:maven-artifact:3.9.6'


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2574.

Bumps the log4j-core, log4j-slf4j-impl, log4j-layout-template-json used in galasa-boot, dev.galasa.framework and dev.galasa.framework.lod4j2.bridge to 2.25.4 from 2.25.3 to remove a Medium vulnerabiliy. 2.25.4 is the latest vulnerability free version without a major version upgrade. A PR to uplift these same dependencies in Simplatform will follow.

## Changes
- [x] Bumps the log4j-core, log4j-slf4j-impl, log4j-layout-template-json to 2.25.4
- [x] Bumps log4j-api to 2.25.4 also to keep consistency across the group
