### PR TITLE
CouchdbAuthStoreValidator reapplies database views if missing or updated

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStoreValidator.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStoreValidator.java
@@ -131,14 +131,16 @@ public class CouchdbAuthStoreValidator extends CouchdbBaseValidator {
             tableDesign.views.loginIdView = new AuthStoreDBLoginView();
         }
 
-        if (tableDesign.views.loginIdView.map == null) {
+        String expectedMapFunction;
+        if (dbName.equals(CouchdbAuthStore.TOKENS_DATABASE_NAME)) {
+            expectedMapFunction = DB_TABLE_TOKENS_DESIGN;
+        } else {
+            expectedMapFunction = DB_TABLE_USERS_DESIGN;
+        }
+
+        if (tableDesign.views.loginIdView.map == null || !tableDesign.views.loginIdView.map.equals(expectedMapFunction)) {
             isUpdated = true;
-            if(dbName.equals(CouchdbAuthStore.TOKENS_DATABASE_NAME)){
-                tableDesign.views.loginIdView.map = DB_TABLE_TOKENS_DESIGN;
-            }
-            else{
-                tableDesign.views.loginIdView.map = DB_TABLE_USERS_DESIGN;
-            }
+            tableDesign.views.loginIdView.map = expectedMapFunction;
         }
 
         if (tableDesign.language == null || !tableDesign.language.equals("javascript")) {

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStoreValidator.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStoreValidator.java
@@ -561,5 +561,89 @@ public class TestCouchdbAuthStoreValidator {
         assertEquals(DB_TABLE_USERS_DESIGN, tableDesign.views.loginIdView.map);
         assertEquals("javascript", tableDesign.language);
     }
+
+    @Test
+    public void testOutdatedMapFunctionGetsUpdated_TokensDatabase() {
+        AuthDBNameViewDesign tableDesign = new AuthDBNameViewDesign();
+        tableDesign.views = new AuthStoreDBViews();
+        tableDesign.views.loginIdView = new AuthStoreDBLoginView();
+        // Set an old map function
+        tableDesign.views.loginIdView.map = "function (doc) { emit(doc.owner.loginId, doc); }";
+        tableDesign.language = "javascript";
+        
+        String dbName = CouchdbAuthStore.TOKENS_DATABASE_NAME;
+        CouchdbAuthStoreValidator validator = new CouchdbAuthStoreValidator();
+
+        boolean isUpdated = validator.updateDesignDocToDesiredDesignDoc(tableDesign, dbName);
+
+        String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), doc); } }";
+
+        assertTrue("View should be updated when map function is different", isUpdated);
+        assertNotNull(tableDesign.views);
+        assertNotNull(tableDesign.views.loginIdView);
+        assertEquals("Map function should be updated to the expected design", DB_TABLE_TOKENS_DESIGN, tableDesign.views.loginIdView.map);
+        assertEquals("javascript", tableDesign.language);
+    }
+
+    @Test
+    public void testOutdatedMapFunctionGetsUpdated_UsersDatabase() {
+        AuthDBNameViewDesign tableDesign = new AuthDBNameViewDesign();
+        tableDesign.views = new AuthStoreDBViews();
+        tableDesign.views.loginIdView = new AuthStoreDBLoginView();
+        // Set an old map function
+        tableDesign.views.loginIdView.map = "function (doc) { if (doc['login-id']) { emit(doc['login-id'], doc); } }";
+        tableDesign.language = "javascript";
+        
+        String dbName = CouchdbAuthStore.USERS_DATABASE_NAME;
+        CouchdbAuthStoreValidator validator = new CouchdbAuthStoreValidator();
+
+        boolean isUpdated = validator.updateDesignDocToDesiredDesignDoc(tableDesign, dbName);
+
+        String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), doc); } }";
+
+        assertTrue("View should be updated when map function is different", isUpdated);
+        assertNotNull(tableDesign.views);
+        assertNotNull(tableDesign.views.loginIdView);
+        assertEquals("Map function should be updated to the expected design", DB_TABLE_USERS_DESIGN, tableDesign.views.loginIdView.map);
+        assertEquals("javascript", tableDesign.language);
+    }
+
+    @Test
+    public void testCorrectMapFunctionNotUpdated_TokensDatabase() {
+        AuthDBNameViewDesign tableDesign = new AuthDBNameViewDesign();
+        tableDesign.views = new AuthStoreDBViews();
+        tableDesign.views.loginIdView = new AuthStoreDBLoginView();
+        // Set the correct map function
+        String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), doc); } }";
+        tableDesign.views.loginIdView.map = DB_TABLE_TOKENS_DESIGN;
+        tableDesign.language = "javascript";
+        
+        String dbName = CouchdbAuthStore.TOKENS_DATABASE_NAME;
+        CouchdbAuthStoreValidator validator = new CouchdbAuthStoreValidator();
+
+        boolean isUpdated = validator.updateDesignDocToDesiredDesignDoc(tableDesign, dbName);
+
+        assertThat(isUpdated).as("View should not be updated when map function is already correct").isFalse();
+        assertEquals("Map function should remain unchanged", DB_TABLE_TOKENS_DESIGN, tableDesign.views.loginIdView.map);
+    }
+
+    @Test
+    public void testCorrectMapFunctionNotUpdated_UsersDatabase() {
+        AuthDBNameViewDesign tableDesign = new AuthDBNameViewDesign();
+        tableDesign.views = new AuthStoreDBViews();
+        tableDesign.views.loginIdView = new AuthStoreDBLoginView();
+        // Set the correct map function
+        String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), doc); } }";
+        tableDesign.views.loginIdView.map = DB_TABLE_USERS_DESIGN;
+        tableDesign.language = "javascript";
+        
+        String dbName = CouchdbAuthStore.USERS_DATABASE_NAME;
+        CouchdbAuthStoreValidator validator = new CouchdbAuthStoreValidator();
+
+        boolean isUpdated = validator.updateDesignDocToDesiredDesignDoc(tableDesign, dbName);
+
+        assertThat(isUpdated).as("View should not be updated when map function is already correct").isFalse();
+        assertEquals("Map function should remain unchanged", DB_TABLE_USERS_DESIGN, tableDesign.views.loginIdView.map);
+    }
     
 }


### PR DESCRIPTION
## Why?

Fixes an issue introduced after #574 which changed the tokens and users view. The CouchdbAuthStoreValidator previously only applied the view if it was missing, but now it applies it if it's different to expected (what is defined in the code). This should fix code changes to the view function not being picked up and used by CouchDB.
