### PR TITLE
Allow query parameters with no values to be supplied in the HTTP manager

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2637,7 +2637,7 @@
         "hashed_secret": "b9cace31dbaa773a8d8e41921ec40be3a9e4d072",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 64,
+        "line_number": 71,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2645,7 +2645,7 @@
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 128,
+        "line_number": 135,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2653,7 +2653,7 @@
         "hashed_secret": "7c685245c889dc1bb5128c7d430197b2be0969af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 149,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.http/src/main/java/dev/galasa/ivts/http/HttpManagerIVT.java
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.http/src/main/java/dev/galasa/ivts/http/HttpManagerIVT.java
@@ -227,27 +227,17 @@ public class HttpManagerIVT {
     }
     
     @Test
-    public void buildURITest() {
-    	HttpClientException expected = null;
-    	
-    	try {
-    		// dummy request
-    		client.getText("http://httpbin.org/anything?should==fail");
-    	} catch (HttpClientException e) {
-    		logger.info("Caught expected exception: " + e.getMessage());
-    		expected = e;
-    	}
-    	assertThat(expected).isNotNull();
-    	
-    	expected = null;
-    	try {
-    		// dummy request
-    		client.getText("http://httpbin.org/anything?thisparam=ok&&oops=yes");
-    	} catch (HttpClientException e) {
-    		logger.info("Caught expected exception: " + e.getMessage());
-    		expected = e;
-    	}
-    	assertThat(expected).isNotNull();
+    public void buildURITest() throws Exception {
+    	// Query parameter with double equals: "should==fail"
+    	// This is valid - parsed as parameter "should" with value "=fail"
+    	HttpClientResponse<String> response1 = client.getText("http://httpbin.org/anything?should==fail");
+    	assertThat(response1.getStatusCode()).isEqualTo(200);
+    	logger.info("Successfully handled query parameter with double equals");
+
+    	// Query parameter with double ampersand: "thisparam=ok&&oops=yes"
+    	// This is valid - parsed as "thisparam=ok", empty parameter, then "oops=yes"
+    	HttpClientResponse<String> response2 = client.getText("http://httpbin.org/anything?thisparam=ok&&oops=yes");
+    	assertThat(response2.getStatusCode()).isEqualTo(200);
+    	logger.info("Successfully handled query parameter with double ampersand");
     }
-    
 }

--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.http/src/main/java/dev/galasa/ivts/http/HttpManagerIVT.java
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.http/src/main/java/dev/galasa/ivts/http/HttpManagerIVT.java
@@ -228,15 +228,15 @@ public class HttpManagerIVT {
     
     @Test
     public void buildURITest() throws Exception {
-    	// Query parameter with double equals: "should==fail"
-    	// This is valid - parsed as parameter "should" with value "=fail"
-    	HttpClientResponse<String> response1 = client.getText("http://httpbin.org/anything?should==fail");
+    	// Query parameter with double equals
+    	// This is valid - parsed as parameter "should" with value "=pass"
+    	HttpClientResponse<String> response1 = client.getText("http://httpbin.org/anything?should==pass");
     	assertThat(response1.getStatusCode()).isEqualTo(200);
     	logger.info("Successfully handled query parameter with double equals");
 
-    	// Query parameter with double ampersand: "thisparam=ok&&oops=yes"
-    	// This is valid - parsed as "thisparam=ok", empty parameter, then "oops=yes"
-    	HttpClientResponse<String> response2 = client.getText("http://httpbin.org/anything?thisparam=ok&&oops=yes");
+    	// Query parameter with double ampersand
+    	// This is valid - parsed as "thisparam=ok", empty parameter, then "thisisfine=yes"
+    	HttpClientResponse<String> response2 = client.getText("http://httpbin.org/anything?thisparam=ok&&thisisfine=yes");
     	assertThat(response2.getStatusCode()).isEqualTo(200);
     	logger.info("Successfully handled query parameter with double ampersand");
     }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/src/main/java/dev/galasa/http/manager/ivt/HttpManagerIVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/src/main/java/dev/galasa/http/manager/ivt/HttpManagerIVT.java
@@ -227,27 +227,18 @@ public class HttpManagerIVT {
     }
     
     @Test
-    public void buildURITest() {
-    	HttpClientException expected = null;
-    	
-    	try {
-    		// dummy request
-    		client.getText("http://httpbin.org/anything?should==fail");
-    	} catch (HttpClientException e) {
-    		logger.info("Caught expected exception: " + e.getMessage());
-    		expected = e;
-    	}
-    	assertThat(expected).isNotNull();
-    	
-    	expected = null;
-    	try {
-    		// dummy request
-    		client.getText("http://httpbin.org/anything?thisparam=ok&&oops=yes");
-    	} catch (HttpClientException e) {
-    		logger.info("Caught expected exception: " + e.getMessage());
-    		expected = e;
-    	}
-    	assertThat(expected).isNotNull();
+    public void buildURITest() throws Exception {
+    	// Query parameter with double equals: "should==fail"
+    	// This is valid - parsed as parameter "should" with value "=fail"
+    	HttpClientResponse<String> response1 = client.getText("http://httpbin.org/anything?should==fail");
+    	assertThat(response1.getStatusCode()).isEqualTo(200);
+    	logger.info("Successfully handled query parameter with double equals");
+
+    	// Query parameter with double ampersand: "thisparam=ok&&oops=yes"
+    	// This is valid - parsed as "thisparam=ok", empty parameter, then "oops=yes"
+    	HttpClientResponse<String> response2 = client.getText("http://httpbin.org/anything?thisparam=ok&&oops=yes");
+    	assertThat(response2.getStatusCode()).isEqualTo(200);
+    	logger.info("Successfully handled query parameter with double ampersand");
     }
     
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/src/main/java/dev/galasa/http/manager/ivt/HttpManagerIVT.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/src/main/java/dev/galasa/http/manager/ivt/HttpManagerIVT.java
@@ -228,15 +228,15 @@ public class HttpManagerIVT {
     
     @Test
     public void buildURITest() throws Exception {
-    	// Query parameter with double equals: "should==fail"
-    	// This is valid - parsed as parameter "should" with value "=fail"
-    	HttpClientResponse<String> response1 = client.getText("http://httpbin.org/anything?should==fail");
+    	// Query parameter with double equals
+    	// This is valid - parsed as parameter "should" with value "=pass"
+    	HttpClientResponse<String> response1 = client.getText("http://httpbin.org/anything?should==pass");
     	assertThat(response1.getStatusCode()).isEqualTo(200);
     	logger.info("Successfully handled query parameter with double equals");
 
-    	// Query parameter with double ampersand: "thisparam=ok&&oops=yes"
-    	// This is valid - parsed as "thisparam=ok", empty parameter, then "oops=yes"
-    	HttpClientResponse<String> response2 = client.getText("http://httpbin.org/anything?thisparam=ok&&oops=yes");
+    	// Query parameter with double ampersand
+    	// This is valid - parsed as "thisparam=ok", empty parameter, then "thisisfine=yes"
+    	HttpClientResponse<String> response2 = client.getText("http://httpbin.org/anything?thisparam=ok&&thisisfine=yes");
     	assertThat(response2.getStatusCode()).isEqualTo(200);
     	logger.info("Successfully handled query parameter with double ampersand");
     }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
@@ -24,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManagerFactory;
@@ -102,14 +99,21 @@ public class HttpClientImpl implements IHttpClient {
     private HttpClientContext   httpContext          = null;
     private Set<Integer>        okResponseCodes      = new HashSet<>();
 
+    private IHttpRequestExecutor httpRequestExecutor;
+
     private Log                 logger;
 
     private SSLTLSContextNameSelector nameSelector = new SSLTLSContextNameSelector();
 
     public HttpClientImpl(int timeout, Log log) {
+        this(timeout, log, new HttpRequestExecutor());
+    }
+
+    public HttpClientImpl(int timeout, Log log, IHttpRequestExecutor httpRequestExecutor) {
         this.timeout = timeout;
         this.logger = log;
         this.cookieStore = new BasicCookieStore();
+        this.httpRequestExecutor = httpRequestExecutor;
     }
 
     /**
@@ -726,55 +730,32 @@ public class HttpClientImpl implements IHttpClient {
     }
 
     private URI buildUri(String path, Map<String, String> queryParams) throws HttpClientException {
-
-        if (queryParams == null) {
-            queryParams = new HashMap<>();
-        }
-
-        // Create a multi-valued map since we can have more than one value for each
-        // param in the path
-        Map<String, List<String>> multiMap = new HashMap<>();
-        for (Entry<String, String> entry : queryParams.entrySet()) {
-            List<String> list = new ArrayList<>();
-            list.add(entry.getValue());
-            multiMap.put(entry.getKey(), list);
-        }
-
-        Pattern p = Pattern.compile("^(.*)\\?((?:.+=.*&?)+)$", Pattern.MULTILINE);
-        Matcher m = p.matcher(path);
-        if (m.find()) {
-            path = m.group(1);
-
-            String[] pairs = m.group(2).split("&");
-            for (String pair : pairs) {
-                String[] parts = pair.split("=");
-                if (parts.length != 2) {
-                    throw new HttpClientException("Illegal query parameter found: '" + pair + "'");
-                }
-
-                String param = URLDecoder.decode(parts[0], StandardCharsets.UTF_8);
-                String value = URLDecoder.decode(parts[1], StandardCharsets.UTF_8);
-                if (multiMap.containsKey(param)) {
-                    multiMap.get(param).add(value);
-                } else {
-                    List<String> list = new ArrayList<>();
-                    list.add(value);
-                    multiMap.put(param, list);
-                }
-            }
-        }
-
-        URIBuilder ub = new URIBuilder(host);
-        appendPath(ub, path);
-
-        // Iterate through the multi-value map to add all the parameters
-        for (Entry<String, List<String>> entry : multiMap.entrySet()) {
-            for (String value : entry.getValue()) {
-                ub.addParameter(entry.getKey(), value);
-            }
-        }
-
         try {
+            // Parse the path (which may contain a query string) into a temporary URIBuilder
+            URIBuilder tempBuilder = new URIBuilder(path);
+            
+            // Check if the path contains a complete URI (scheme + host)
+            // If so, use it directly; otherwise combine with the host field
+            URIBuilder ub;
+            if (tempBuilder.getScheme() != null && tempBuilder.getHost() != null) {
+                // Path contains a complete URI, use it as the base
+                ub = tempBuilder;
+            } else {
+                // Path is relative, combine with the host field
+                ub = new URIBuilder(host);
+                appendPath(ub, tempBuilder.getPath());
+                
+                // Add existing query parameters from the path
+                ub.addParameters(tempBuilder.getQueryParams());
+            }
+            
+            // Add additional query parameters if provided
+            if (queryParams != null) {
+                for (Entry<String, String> entry : queryParams.entrySet()) {
+                    ub.addParameter(entry.getKey(), entry.getValue());
+                }
+            }
+            
             return ub.build();
         } catch (URISyntaxException e) {
             throw new HttpClientException("Cannot construct URI using path: '" + path + "'", e);
@@ -932,11 +913,7 @@ public class HttpClientImpl implements IHttpClient {
 
     private ClassicHttpResponse execute(ClassicHttpRequest request) throws HttpClientException {
         this.build();
-        try {
-            return httpClient.executeOpen(null, request, httpContext);
-        } catch (IOException e) {
-            throw new HttpClientException("Error executing http request", e);
-        }
+        return httpRequestExecutor.execute(httpClient, httpContext, request);
     }
 
     @Override

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpRequestExecutor.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpRequestExecutor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.http.internal;
+
+import java.io.IOException;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+
+import dev.galasa.http.HttpClientException;
+
+public class HttpRequestExecutor implements IHttpRequestExecutor {
+
+    @Override
+    public ClassicHttpResponse execute(CloseableHttpClient httpClient, HttpClientContext httpContext, ClassicHttpRequest request) throws HttpClientException {
+        try {
+            return httpClient.executeOpen(null, request, httpContext);
+        } catch (IOException e) {
+            throw new HttpClientException("Error executing http request", e);
+        }
+    }
+    
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpRequestExecutor.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpRequestExecutor.java
@@ -14,6 +14,11 @@ import org.apache.hc.core5.http.ClassicHttpResponse;
 
 import dev.galasa.http.HttpClientException;
 
+/**
+ * Executes HTTP requests using Apache HttpClient.
+ * This class wraps the execution of HTTP requests and handles any IO exceptions
+ * by converting them to HttpClientException.
+ */
 public class HttpRequestExecutor implements IHttpRequestExecutor {
 
     @Override

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/IHttpRequestExecutor.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/IHttpRequestExecutor.java
@@ -12,6 +12,20 @@ import org.apache.hc.core5.http.ClassicHttpResponse;
 
 import dev.galasa.http.HttpClientException;
 
+/**
+ * An executor for HTTP requests. This interface was primarily added to make
+ * unit testing easier by allowing the execution of HTTP requests to be mocked out.
+ */
 public interface IHttpRequestExecutor {
+    /**
+     * Executes an HTTP request using the given HTTP client and context.
+     *
+     * @param httpClient  the HTTP client to use for executing the request
+     * @param httpContext the HTTP client context containing request-specific
+     *                    settings
+     * @param request     the HTTP request to execute
+     * @return the HTTP response from executing the request
+     * @throws HttpClientException if an error occurs while executing the request
+     */
     ClassicHttpResponse execute(CloseableHttpClient httpClient, HttpClientContext httpContext, ClassicHttpRequest request) throws HttpClientException;
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/IHttpRequestExecutor.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/IHttpRequestExecutor.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.http.internal;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+
+import dev.galasa.http.HttpClientException;
+
+public interface IHttpRequestExecutor {
+    ClassicHttpResponse execute(CloseableHttpClient httpClient, HttpClientContext httpContext, ClassicHttpRequest request) throws HttpClientException;
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/test/java/dev/galasa/http/internal/HttpClientImplTest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/test/java/dev/galasa/http/internal/HttpClientImplTest.java
@@ -8,10 +8,15 @@ package dev.galasa.http.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
+import java.util.List;
 
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 import org.junit.Before;
 import org.junit.Test;
 
+import dev.galasa.http.mocks.MockHttpRequestExecutor;
 import dev.galasa.http.mocks.MockLog;
 
 /**
@@ -20,13 +25,15 @@ import dev.galasa.http.mocks.MockLog;
 public class HttpClientImplTest {
 
     private HttpClientImpl httpClient;
-    private MockLog mockLog;
+    private MockHttpRequestExecutor mockHttpRequestExecutor;
     private static final int DEFAULT_TIMEOUT = 5000;
 
     @Before
     public void setUp() throws Exception {
-        mockLog = new MockLog();
-        httpClient = new HttpClientImpl(DEFAULT_TIMEOUT, mockLog);
+        MockLog mockLog = new MockLog();
+        mockHttpRequestExecutor = new MockHttpRequestExecutor();
+
+        httpClient = new HttpClientImpl(DEFAULT_TIMEOUT, mockLog, mockHttpRequestExecutor);
         httpClient.setURI(new URI("http://example.com"));
     }
 
@@ -174,7 +181,6 @@ public class HttpClientImplTest {
         httpClient.close();
 
         // Then - should not throw exception
-        assertThat(true).as("Close should complete without exception").isTrue();
     }
 
     @Test
@@ -183,7 +189,393 @@ public class HttpClientImplTest {
         httpClient.close();
 
         // Then - should not throw exception
-        assertThat(true).as("Close should complete without exception when not built").isTrue();
+    }
+
+    @Test
+    public void testCanBuildUriWithSingleKeyValueQueryParameter() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/helloworld?key1=value1");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getQuery()).isEqualTo("key1=value1");
+    }
+
+    @Test
+    public void testCanBuildUriWithSingleKeyQueryParameter() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/helloworld?key1");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getQuery()).isEqualTo("key1");
+    }
+
+    @Test
+    public void testCanBuildUriWithMultipleKeyValueQueryParameters() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/api/users?status=active&role=admin&limit=10");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getQuery()).contains("status=active");
+        assertThat(uri.getQuery()).contains("role=admin");
+        assertThat(uri.getQuery()).contains("limit=10");
+    }
+
+    @Test
+    public void testCanBuildUriWithEncodedQueryParameters() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/api/search?q=hello%20world&email=user%40example.com");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getRawQuery()).contains("q=hello%20world");
+        assertThat(uri.getRawQuery()).contains("email=user%40example.com");
+    }
+
+    @Test
+    public void testCanBuildUriWithMultipleValuesForSameParameter() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/api/users?id=1&id=2&id=3");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        String query = uri.getQuery();
+        assertThat(query).contains("id=1");
+        assertThat(query).contains("id=2");
+        assertThat(query).contains("id=3");
+    }
+
+    @Test
+    public void testCanBuildUriWithMixedKeyAndKeyValueParameters() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/api/users?active&status=verified&limit=5");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        String query = uri.getQuery();
+        assertThat(query).contains("active");
+        assertThat(query).contains("status=verified");
+        assertThat(query).contains("limit=5");
+    }
+
+    @Test
+    public void testCanBuildUriWithEmptyPath() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getPath()).isNotNull();
+    }
+
+    @Test
+    public void testCanBuildUriWithRootPath() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getPath()).isEqualTo("/");
+    }
+
+    @Test
+    public void testCanBuildUriWithPathNotStartingWithSlash() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("api/users");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getPath()).startsWith("/");
+        assertThat(uri.getPath()).contains("api/users");
+    }
+
+    @Test
+    public void testCanBuildUriWithComplexPath() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/api/v1/organizations/123/projects/456/users");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getPath()).isEqualTo("/api/v1/organizations/123/projects/456/users");
+    }
+
+    @Test
+    public void testCanBuildUriWithSpecialCharactersInPath() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/api/users/john.doe@example.com");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getPath()).contains("john.doe@example.com");
+    }
+
+    @Test
+    public void testCanBuildUriWithQueryParameterContainingAmpersand() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/api/search?q=foo%26bar");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getRawQuery()).isEqualTo("q=foo%26bar");
+    }
+
+    @Test
+    public void testCanBuildUriWithQueryParameterContainingEquals() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/api/search?filter=type%3Duser");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getRawQuery()).isEqualTo("filter=type%3Duser");
+    }
+
+    @Test
+    public void testCanBuildUriWithPlusSignInQueryParameter() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/api/search?name=John+Doe");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getQuery()).isEqualTo("name=John+Doe");
+    }
+
+    @Test
+    public void testCanBuildUriWithEmptyQueryParameterValue() throws Exception {
+        // Given...
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        httpClient.getText("/api/users?status=&role=admin");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        String query = uri.getQuery();
+        assertThat(query).contains("status=");
+        assertThat(query).contains("role=admin");
+    }
+
+    @Test
+    public void testBuildUriWithCompleteUrlInPath() throws Exception {
+        // Given...
+        // Create a client WITHOUT setting a host (host is null)
+        httpClient.build();
+
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        // Pass a complete URL in the path parameter
+        httpClient.getText("http://example.com/api/users");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getScheme()).isEqualTo("http");
+        assertThat(uri.getHost()).isEqualTo("example.com");
+        assertThat(uri.getPath()).isEqualTo("/api/users");
+    }
+
+    @Test
+    public void testBuildUriWithCompleteUrlAndQueryParams() throws Exception {
+        // Given...
+        // Create a client WITHOUT setting a host (host is null)
+        MockLog mockLog = new MockLog();
+        HttpClientImpl client = new HttpClientImpl(DEFAULT_TIMEOUT, mockLog, mockHttpRequestExecutor);
+
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        // Pass a complete URL with query parameters in the path
+        client.getText("https://api.example.com:8080/api/users?status=active&role=admin");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        assertThat(uri.getScheme()).isEqualTo("https");
+        assertThat(uri.getHost()).isEqualTo("api.example.com");
+        assertThat(uri.getPort()).isEqualTo(8080);
+        assertThat(uri.getPath()).isEqualTo("/api/users");
+        
+        String query = uri.getQuery();
+        assertThat(query).contains("status=active");
+        assertThat(query).contains("role=admin");
+    }
+
+    @Test
+    public void testBuildUriWithCompleteUrlOverridesHost() throws Exception {
+        // Given...
+        // Create a client WITH a host set
+        httpClient.setURI(URI.create("http://default-host.com"));
+
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        // Pass a complete URL that should override the default host
+        httpClient.getText("http://override-host.com/api/data");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        // The complete URL in path should override the default host
+        assertThat(uri.getHost()).isEqualTo("override-host.com");
+        assertThat(uri.getPath()).isEqualTo("/api/data");
+    }
+
+    @Test
+    public void testBuildUriWithRelativePathUsesDefaultHost() throws Exception {
+        // Given...
+        httpClient.setURI(URI.create("http://default-host.com"));
+        httpClient.build();
+
+        ClassicHttpResponse mockResponse = new BasicClassicHttpResponse(200);
+        mockHttpRequestExecutor.setMockResponse(mockResponse);
+
+        // When...
+        // Pass a relative path (no scheme/host)
+        httpClient.getText("/api/users?id=123");
+
+        // Then...
+        List<ClassicHttpRequest> requests = mockHttpRequestExecutor.getRequests();
+        assertThat(requests).hasSize(1);
+
+        ClassicHttpRequest request = requests.get(0);
+        URI uri = request.getUri();
+        // Should use the default host
+        assertThat(uri.getHost()).isEqualTo("default-host.com");
+        assertThat(uri.getPath()).isEqualTo("/api/users");
+        
+        String query = uri.getQuery();
+        assertThat(query).isEqualTo("id=123");
     }
 }
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/test/java/dev/galasa/http/mocks/MockHttpRequestExecutor.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/test/java/dev/galasa/http/mocks/MockHttpRequestExecutor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.http.mocks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+
+import dev.galasa.http.HttpClientException;
+import dev.galasa.http.internal.IHttpRequestExecutor;
+
+public class MockHttpRequestExecutor implements IHttpRequestExecutor {
+
+    private ClassicHttpResponse mockResponse;
+    private List<ClassicHttpRequest> requests = new ArrayList<>();
+
+    public List<ClassicHttpRequest> getRequests() {
+        return requests;
+    }
+
+    public void setMockResponse(ClassicHttpResponse mockResponse) {
+        this.mockResponse = mockResponse;
+    }
+
+    @Override
+    public ClassicHttpResponse execute(CloseableHttpClient httpClient, HttpClientContext httpContext,
+            ClassicHttpRequest request) throws HttpClientException {
+        requests.add(request);
+        return mockResponse;
+    }
+}


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2575. 

The HTTP manager no longer requires query parameters to be in the form `key=value` and will now allow query parameters with no values to be supplied without throwing exceptions.

## Changes
- [x] Updated the `buildUri` method in the HTTP manager to use the URIBuilder to build request URIs rather than regex which also allows query parameters to be supplied without values
- [x] Updated the HttpManagerIVT's `buildURITest` test case assertions to expect valid responses from httpbin
  - Previously, the test believed `?should==fail` was invalid, but this is a valid query parameter which has the value `=fail` and similarly, it thought that `thisparam=ok&&oops=yes` was invalid due to the `&&`, but this is fine because this just means that there's an empty query parameter is ignored
- [x] Unit tests (if applicable)
