### PR TITLE
Iss2576 - Bump org.bouncycastle dependencies

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -259,9 +259,9 @@ dependencies {
 
         api 'org.bitbucket.b_c:jose4j:0.9.6'
 
-        api 'org.bouncycastle:bcpkix-jdk18on:1.83'
-        api 'org.bouncycastle:bcprov-jdk18on:1.83'
-        api 'org.bouncycastle:bcutil-jdk18on:1.83'
+        api 'org.bouncycastle:bcpkix-jdk18on:1.84'
+        api 'org.bouncycastle:bcprov-jdk18on:1.84'
+        api 'org.bouncycastle:bcutil-jdk18on:1.84'
 
         api 'org.checkerframework:checker-qual:3.43.0'
         api 'org.codehaus.mojo:animal-sniffer-annotations:1.24'


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2576

## Changes
- [x] Bump org.bouncycastle dependencies from 1.83 to 1.84 to remove High vulnerability.