### PR TITLE
Iss2576 - Bump httpclient5 dependency

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -216,7 +216,7 @@ dependencies {
         api 'org.apache.felix:org.apache.felix.http.servlet-api:2.1.0'
         api 'org.apache.felix:org.apache.felix.scr:2.1.14' // If updating, also update in galasa-boot build.gradle.
 
-        api 'org.apache.httpcomponents.client5:httpclient5:5.6'
+        api 'org.apache.httpcomponents.client5:httpclient5:5.6.1'
         api 'org.apache.httpcomponents.core5:httpcore5:5.4'
         api 'org.apache.httpcomponents.core5:httpcore5-h2:5.4'
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2578

## Changes
- [x] Bump httpclient5 dependency from 5.6 to 5.6.1 to remove High vulnerability.
