### PR TITLE
HTTP Manager: TLS + postForm + timeout + clearcookie + redirectstrategy

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/bnd.bnd
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/bnd.bnd
@@ -17,16 +17,20 @@ Import-Package: com.google.gson,\
     org.apache.commons.logging,\
     org.apache.hc.core5.http,\
     org.apache.hc.core5.http.io.entity,\
+    org.apache.hc.core5.http.io.support,\
     org.apache.hc.core5.http.message,\
     org.apache.hc.core5.http.protocol,\
+    org.apache.hc.core5.http.ssl,\
     org.apache.hc.core5.net,\
     org.apache.hc.core5.util,\
+    org.apache.hc.client5.http,\
     org.apache.hc.client5.http.auth,\
     org.apache.hc.client5.http.classic.methods,\
     org.apache.hc.client5.http.config,\
     org.apache.hc.client5.http.cookie,\
     org.apache.hc.client5.http.entity,\
     org.apache.hc.client5.http.entity.mime,\
+    org.apache.hc.client5.http.impl,\
     org.apache.hc.client5.http.impl.auth,\
     org.apache.hc.client5.http.impl.classic,\
     org.apache.hc.client5.http.impl.io,\

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/ContentType.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/ContentType.java
@@ -18,6 +18,8 @@ public enum ContentType {
     APPLICATION_FORM_URLENCODED(org.apache.hc.core5.http.ContentType.APPLICATION_FORM_URLENCODED),
     TEXT_PLAIN(org.apache.hc.core5.http.ContentType.TEXT_PLAIN),
     TEXT_HTML(org.apache.hc.core5.http.ContentType.TEXT_HTML),
+    TEXT_MARKDOWN(org.apache.hc.core5.http.ContentType.TEXT_MARKDOWN),
+    TEXT_EVENT_STREAM(org.apache.hc.core5.http.ContentType.TEXT_EVENT_STREAM),
     TEXT_XML(org.apache.hc.core5.http.ContentType.TEXT_XML),
     RDF_XML("application/rdf+xml"),
     SOAP_XML("application/soap+xml");

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/HttpClient.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/HttpClient.java
@@ -26,4 +26,8 @@ import dev.galasa.http.internal.HttpManagerField;
 @ValidAnnotatedFields({ IHttpClient.class })
 public @interface HttpClient {
 
+    /**
+     * The length of time a connection or response will timeout (in milliseconds). Optional.
+     */
+    int timeout() default 0;
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/IHttpClient.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/IHttpClient.java
@@ -208,6 +208,28 @@ public interface IHttpClient {
     HttpClientResponse<String> postText(String url, String text) throws HttpClientException;
 
     /**
+     * Issue an HTTP POST to the provided URL, sending form-encoded data
+     * and receiving a {@link String} in the response.
+     *
+     * <p>
+     * This is a convenience method for posting form data (e.g., login credentials).
+     * The data is encoded as application/x-www-form-urlencoded, which is the standard
+     * format for HTML form submissions.
+     * </p>
+     *
+     * <p>
+     * This method is commonly used for form-based authentication where credentials
+     * are posted as form fields (e.g., j_username, j_password for Java EE security).
+     * </p>
+     *
+     * @param url - URL path
+     * @param fields - Form fields as key-value pairs
+     * @return - {@link HttpClientResponse} with a {@link String} content type
+     * @throws HttpClientException if the request fails
+     */
+    HttpClientResponse<String> postForm(String url, Map<String, String> fields) throws HttpClientException;
+
+    /**
      * Issue an HTTP PUT to the provided URL, sending the provided {@link String}
      * and receiving a {@link String} in the response.
      * 
@@ -413,6 +435,24 @@ public interface IHttpClient {
     void addOkResponseCode(int responseCode);
 
     /**
+     * Set the socket timeout in seconds.
+     * This is the timeout for waiting for data after connection is established.
+     * Must be called before {@link #build()}.
+     *
+     * @param seconds - timeout in seconds
+     */
+    void setSocketTimeout(int seconds);
+
+    /**
+     * Set the connection timeout in seconds.
+     * This is the timeout for establishing the connection.
+     * Must be called before {@link #build()}.
+     *
+     * @param seconds - timeout in seconds
+     */
+    void setConnectTimeout(int seconds);
+
+    /**
      * Build the client
      * 
      * @return the built client
@@ -508,5 +548,18 @@ public interface IHttpClient {
      * @param host
      */
     void setURI(URI host);
+    
+    /**
+     * Clear the cookie store
+     */
+    void clearCookies();
+    
+    /**
+     * Set TLS versions required.
+     *
+     * @param tlsVersions
+     *            TLS versions
+     */
+    void setTlsVersions(String[] tlsVersions);
 
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/IHttpClient.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/IHttpClient.java
@@ -560,6 +560,6 @@ public interface IHttpClient {
      * @param tlsVersions
      *            TLS versions
      */
-    void setTlsVersions(String[] tlsVersions);
+    void setTlsVersions(TLS[] tlsVersions);
 
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/TLS.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/TLS.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.http;
+
+public enum TLS {
+
+    v1_0(org.apache.hc.core5.http.ssl.TLS.V_1_0),
+    v1_1(org.apache.hc.core5.http.ssl.TLS.V_1_1),
+    v1_2(org.apache.hc.core5.http.ssl.TLS.V_1_2),
+    v1_3(org.apache.hc.core5.http.ssl.TLS.V_1_3);
+
+
+    private final org.apache.hc.core5.http.ssl.TLS tls;
+
+    TLS(org.apache.hc.core5.http.ssl.TLS tls) {
+        this.tls = tls;
+    }
+
+    public org.apache.hc.core5.http.ssl.TLS getTls() {
+        return tls;
+    }
+
+}

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManagerFactory;
@@ -93,6 +94,8 @@ import dev.galasa.http.HttpClientException;
 import dev.galasa.http.HttpClientResponse;
 import dev.galasa.http.HttpFileResponse;
 import dev.galasa.http.IHttpClient;
+import dev.galasa.http.TLS;
+
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.annotation.XmlType;
@@ -105,7 +108,7 @@ public class HttpClientImpl implements IHttpClient {
     protected URI               host                 = null;
 
     private final List<Header>  commonHeaders        = new ArrayList<>();
-    private String[]            tlsVersions;
+    private TLS[]               tlsVersions;
 
     private final int           timeout;
     private Timeout             socketTimeout    = null;
@@ -135,7 +138,7 @@ public class HttpClientImpl implements IHttpClient {
         this.timeout = timeout;
         this.logger = log;
         this.cookieStore = new BasicCookieStore();
-        this.tlsVersions = new String[] { "TLSv1.2" };
+        this.tlsVersions = new TLS[] { TLS.v1_2 };
         this.httpRequestExecutor = httpRequestExecutor;
     }
 
@@ -658,8 +661,7 @@ public class HttpClientImpl implements IHttpClient {
      * @param seconds - timeout in seconds
      */
     @Override
-    public void setSocketTimeout(int seconds)
-    {
+    public void setSocketTimeout(int seconds) 
         this.socketTimeout = Timeout.ofSeconds(seconds);
     }
 
@@ -670,8 +672,7 @@ public class HttpClientImpl implements IHttpClient {
      * @param seconds - timeout in seconds
      */
     @Override
-    public void setConnectTimeout(int seconds)
-    {
+    public void setConnectTimeout(int seconds) {
         this.connectTimeout = Timeout.ofSeconds(seconds);
     }
 
@@ -702,8 +703,13 @@ public class HttpClientImpl implements IHttpClient {
         PoolingHttpClientConnectionManagerBuilder cmBuilder = PoolingHttpClientConnectionManagerBuilder.create();
         
         if (sslContext != null) {
+            org.apache.hc.core5.http.ssl.TLS [] tlsApacheVersions = Arrays.asList(tlsVersions).stream()
+                .map(t -> t.getTls())
+                .collect(Collectors.toList())
+                .toArray(org.apache.hc.core5.http.ssl.TLS[]::new);
+            
             TlsSocketStrategy tlsStrategy = ClientTlsStrategyBuilder.create().setSslContext(sslContext)
-                .setTlsVersions(String.join(",", tlsVersions)).setHostnameVerifier(hostnameVerifier).buildClassic();
+                .setTlsVersions(tlsApacheVersions).setHostnameVerifier(hostnameVerifier).buildClassic();
             cmBuilder.setTlsSocketStrategy(tlsStrategy);
         }
         
@@ -1054,37 +1060,30 @@ public class HttpClientImpl implements IHttpClient {
     }
 
     @Override
-    public void setTlsVersions(String[] tlsVersions)
-    {
-        this.tlsVersions = Arrays.copyOf(tlsVersions, tlsVersions.length);
+    public void setTlsVersions(TLS[] tlsVersions) {
+        this.tlsVersions = tlsVersions;
     }
 
-    public String[] getTlsVersions()
-    {
+    public TLS[] getTlsVersions() {
         return tlsVersions;
     }
-
 
     /**
      * Custom redirect strategy that resolves relative redirect URIs against the base URI.
      * This ensures that redirects like "/" are resolved as "/myapp/" instead of just "/".
      */
-    private class BaseUriRedirectStrategy extends DefaultRedirectStrategy
-    {
+    private class BaseUriRedirectStrategy extends DefaultRedirectStrategy {
         @Override
         public URI getLocationURI(HttpRequest request, HttpResponse response, HttpContext context)
-            throws org.apache.hc.core5.http.HttpException
-        {
+            throws org.apache.hc.core5.http.HttpException {
             // Get the redirect location from the response
             URI locationUri = super.getLocationURI(request, response, context);
 
             if (locationUri.toString().replace(HttpClientImpl.this.host.toString(), "").trim().isBlank()) {
-                try
-                {
+                try {
                     locationUri = new URI(locationUri.toString() + "/");
                 }
-                catch (URISyntaxException e)
-                {
+                catch (URISyntaxException e) {
                     return locationUri;
                 }
             }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
@@ -18,6 +18,7 @@ import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -33,6 +34,7 @@ import javax.net.ssl.TrustManagerFactory;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
+import org.apache.hc.client5.http.ContextBuilder;
 import org.apache.hc.client5.http.auth.AuthCache;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -40,6 +42,7 @@ import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.StandardCookieSpec;
@@ -49,24 +52,36 @@ import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.auth.BasicScheme;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.InputStreamEntity;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.net.URIBuilder;
 import org.apache.hc.core5.util.Timeout;
 
@@ -90,8 +105,11 @@ public class HttpClientImpl implements IHttpClient {
     protected URI               host                 = null;
 
     private final List<Header>  commonHeaders        = new ArrayList<>();
+    private String[]            tlsVersions;
 
     private final int           timeout;
+    private Timeout             socketTimeout    = null;
+    private Timeout             connectTimeout   = null;
 
     private BasicCookieStore    cookieStore;
     private SSLContext          sslContext;
@@ -105,7 +123,10 @@ public class HttpClientImpl implements IHttpClient {
     private Log                 logger;
 
     private SSLTLSContextNameSelector nameSelector = new SSLTLSContextNameSelector();
-
+    
+    ContentType[] textContentTypes = new ContentType[] { ContentType.TEXT_PLAIN, ContentType.TEXT_EVENT_STREAM,
+        ContentType.TEXT_HTML, ContentType.TEXT_MARKDOWN, ContentType.TEXT_XML };
+    
     public HttpClientImpl(int timeout, Log log) {
         this(timeout, log, new HttpRequestExecutor());
     }
@@ -114,6 +135,7 @@ public class HttpClientImpl implements IHttpClient {
         this.timeout = timeout;
         this.logger = log;
         this.cookieStore = new BasicCookieStore();
+        this.tlsVersions = new String[] { "TLSv1.2" };
         this.httpRequestExecutor = httpRequestExecutor;
     }
 
@@ -256,7 +278,7 @@ public class HttpClientImpl implements IHttpClient {
     public HttpClientResponse<String> getText(String url) throws HttpClientException {
 
         HttpClientRequest request = HttpClientRequest.newGetRequest(buildUri(url, null).toString(),
-                new ContentType[] { ContentType.TEXT_PLAIN });
+            textContentTypes);
 
         return executeTextRequest(request);
     }
@@ -285,7 +307,7 @@ public class HttpClientImpl implements IHttpClient {
     public HttpClientResponse<String> putSOAP(String url, String xml) throws HttpClientException {
 
         HttpClientRequest request = HttpClientRequest.newPutRequest(buildUri(url, null).toString(),
-                new ContentType[] { ContentType.SOAP_XML }, ContentType.SOAP_XML);
+            new ContentType[] { ContentType.SOAP_XML }, ContentType.SOAP_XML);
         request.setBody(xml);
 
         return executeTextRequest(request);
@@ -295,7 +317,7 @@ public class HttpClientImpl implements IHttpClient {
     public HttpClientResponse<String> postSOAP(String url, String xml) throws HttpClientException {
 
         HttpClientRequest request = HttpClientRequest.newPostRequest(buildUri(url, null).toString(),
-                new ContentType[] { ContentType.SOAP_XML }, ContentType.SOAP_XML);
+            new ContentType[] { ContentType.SOAP_XML }, ContentType.SOAP_XML);
         request.setBody(xml);
 
         return executeTextRequest(request);
@@ -305,7 +327,7 @@ public class HttpClientImpl implements IHttpClient {
     public HttpClientResponse<String> putText(String url, String text) throws HttpClientException {
 
         HttpClientRequest request = HttpClientRequest.newPutRequest(buildUri(url, null).toString(),
-                new ContentType[] { ContentType.TEXT_PLAIN }, ContentType.TEXT_PLAIN);
+            textContentTypes, ContentType.TEXT_PLAIN);
         request.setBody(text);
 
         return executeTextRequest(request);
@@ -315,9 +337,17 @@ public class HttpClientImpl implements IHttpClient {
     public HttpClientResponse<String> postText(String url, String text) throws HttpClientException {
 
         HttpClientRequest request = HttpClientRequest.newPostRequest(buildUri(url, null).toString(),
-                new ContentType[] { ContentType.TEXT_PLAIN }, ContentType.TEXT_PLAIN);
+            textContentTypes, ContentType.TEXT_PLAIN);
         request.setBody(text);
 
+        return executeTextRequest(request);
+    }
+
+    @Override
+    public HttpClientResponse<String> postForm(String url, Map<String, String> fields) throws HttpClientException {
+        HttpClientRequest request = HttpClientRequest.newPostRequest(buildUri(url, null).toString(),
+            textContentTypes, ContentType.APPLICATION_FORM_URLENCODED);
+        request.setFormBody(fields);
         return executeTextRequest(request);
     }
 
@@ -325,7 +355,7 @@ public class HttpClientImpl implements IHttpClient {
     public HttpClientResponse<String> deleteText(String url) throws HttpClientException {
 
         HttpClientRequest request = HttpClientRequest.newDeleteRequest(buildUri(url, null).toString(),
-                new ContentType[] { ContentType.TEXT_PLAIN });
+            textContentTypes);
 
         return executeTextRequest(request);
     }
@@ -622,6 +652,30 @@ public class HttpClientImpl implements IHttpClient {
     }
 
     /**
+     * Set the socket timeout in seconds.
+     * This is the timeout for waiting for data after connection is established.
+     *
+     * @param seconds - timeout in seconds
+     */
+    @Override
+    public void setSocketTimeout(int seconds)
+    {
+        this.socketTimeout = Timeout.ofSeconds(seconds);
+    }
+
+    /**
+     * Set the connection timeout in seconds.
+     * This is the timeout for establishing the connection.
+     *
+     * @param seconds - timeout in seconds
+     */
+    @Override
+    public void setConnectTimeout(int seconds)
+    {
+        this.connectTimeout = Timeout.ofSeconds(seconds);
+    }
+
+    /**
      * Build the client
      * 
      * @return the built client
@@ -630,25 +684,52 @@ public class HttpClientImpl implements IHttpClient {
         RequestConfig.Builder requestBuilder = RequestConfig.custom();
         HttpClientBuilder builder = HttpClientBuilder.create();
         builder.setDefaultCookieStore(cookieStore);
+        builder.setRedirectStrategy(new BaseUriRedirectStrategy());
         requestBuilder.setCookieSpec(StandardCookieSpec.STRICT);
+        requestBuilder.setRedirectsEnabled(true);
+        requestBuilder.setCircularRedirectsAllowed(true);
         builder.setDefaultCredentialsProvider(credentialsProvider);
         builder.setDefaultHeaders(commonHeaders);
 
+        // Apply request-level timeouts if default timeout is set
         if (timeout > 0) {
             Timeout timeoutValue = Timeout.ofMilliseconds(timeout);
             requestBuilder.setConnectionRequestTimeout(timeoutValue)
                           .setResponseTimeout(timeoutValue);
         }
 
+        // Create connection manager and apply connection-level timeouts
+        PoolingHttpClientConnectionManagerBuilder cmBuilder = PoolingHttpClientConnectionManagerBuilder.create();
+        
         if (sslContext != null) {
-            TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(sslContext, hostnameVerifier);
-            HttpClientConnectionManager cm = PoolingHttpClientConnectionManagerBuilder.create()
-                    .setTlsSocketStrategy(tlsStrategy)
-                    .build();
-            builder.setConnectionManager(cm);
+            TlsSocketStrategy tlsStrategy = ClientTlsStrategyBuilder.create().setSslContext(sslContext)
+                .setTlsVersions(String.join(",", tlsVersions)).setHostnameVerifier(hostnameVerifier).buildClassic();
+            cmBuilder.setTlsSocketStrategy(tlsStrategy);
         }
+        
+        PoolingHttpClientConnectionManager connectionManager = cmBuilder.build();
+        
+        // Apply connection-level timeouts (socket and connect) if set
+        if (socketTimeout != null || connectTimeout != null) {
+            ConnectionConfig.Builder connConfigBuilder = ConnectionConfig.custom();
+            
+            if (socketTimeout != null) {
+                connConfigBuilder.setSocketTimeout(socketTimeout);
+            }
+            
+            if (connectTimeout != null) {
+                connConfigBuilder.setConnectTimeout(connectTimeout);
+            }
+            
+            connectionManager.setDefaultConnectionConfig(connConfigBuilder.build());
+        }
+        
+        builder.setConnectionManager(connectionManager);
         builder.setDefaultRequestConfig(requestBuilder.build());
         httpClient = builder.build();
+        
+        httpContext = ContextBuilder.create().useCookieStore(cookieStore).useCredentialsProvider(credentialsProvider)
+            .build();
 
         return this;
     }
@@ -806,7 +887,7 @@ public class HttpClientImpl implements IHttpClient {
             return;
         }
 
-        if (!path.startsWith("/")) {
+        if (!path.startsWith("/") && !ub.toString().endsWith("/")) {
             path = "/" + path;
         }
 
@@ -967,4 +1048,48 @@ public class HttpClientImpl implements IHttpClient {
 
     }
 
+    @Override
+    public void clearCookies() {
+        this.cookieStore.clear();
+    }
+
+    @Override
+    public void setTlsVersions(String[] tlsVersions)
+    {
+        this.tlsVersions = Arrays.copyOf(tlsVersions, tlsVersions.length);
+    }
+
+    public String[] getTlsVersions()
+    {
+        return tlsVersions;
+    }
+
+
+    /**
+     * Custom redirect strategy that resolves relative redirect URIs against the base URI.
+     * This ensures that redirects like "/" are resolved as "/myapp/" instead of just "/".
+     */
+    private class BaseUriRedirectStrategy extends DefaultRedirectStrategy
+    {
+        @Override
+        public URI getLocationURI(HttpRequest request, HttpResponse response, HttpContext context)
+            throws org.apache.hc.core5.http.HttpException
+        {
+            // Get the redirect location from the response
+            URI locationUri = super.getLocationURI(request, response, context);
+
+            if (locationUri.toString().replace(HttpClientImpl.this.host.toString(), "").trim().isBlank()) {
+                try
+                {
+                    locationUri = new URI(locationUri.toString() + "/");
+                }
+                catch (URISyntaxException e)
+                {
+                    return locationUri;
+                }
+            }
+
+            return locationUri;
+        }
+    }
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
@@ -661,7 +661,7 @@ public class HttpClientImpl implements IHttpClient {
      * @param seconds - timeout in seconds
      */
     @Override
-    public void setSocketTimeout(int seconds) 
+    public void setSocketTimeout(int seconds) {
         this.socketTimeout = Timeout.ofSeconds(seconds);
     }
 

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientRequest.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientRequest.java
@@ -10,7 +10,9 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -21,12 +23,15 @@ import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.FileEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.net.URIBuilder;
 import org.w3c.dom.Document;
 
@@ -206,6 +211,25 @@ public class HttpClientRequest {
      */
     public HttpClientRequest setJSONBody(JsonObject json) {
         return setBody(json.toString());
+    }
+
+    /**
+     * Set the body of the request as form-encoded data.
+     *
+     * <p>
+     * This method encodes the provided fields as application/x-www-form-urlencoded
+     * data, which is commonly used for HTML form submissions (e.g., login forms).
+     *
+     * @param fields - Map of form field names to values
+     * @return - the updated request
+     */
+    public HttpClientRequest setFormBody(Map<String, String> fields) {
+        List<NameValuePair> nvps = new ArrayList<>();
+        for (Entry<String, String> field : fields.entrySet()) {
+            nvps.add(new BasicNameValuePair(field.getKey(), field.getValue()));
+        }
+        this.content = new UrlEncodedFormEntity(nvps);
+        return this;
     }
 
     /**

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpManagerImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpManagerImpl.java
@@ -41,12 +41,10 @@ public class HttpManagerImpl extends AbstractManager implements IHttpManagerSpi 
         int timeout = annotationHttpClient.timeout();
 
         IHttpClient httpClient = null;
-        if (timeout > 0)
-        {
+        if (timeout > 0) {
             httpClient = newHttpClient(timeout);
         }
-        else
-        {
+        else {
             httpClient = newHttpClient();
         }
         return httpClient;

--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpManagerImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpManagerImpl.java
@@ -36,7 +36,20 @@ public class HttpManagerImpl extends AbstractManager implements IHttpManagerSpi 
 
     @GenerateAnnotatedField(annotation = HttpClient.class)
     public IHttpClient generateHttpClient(Field field, List<Annotation> annotations) {
-        return newHttpClient();
+        HttpClient annotationHttpClient = field.getAnnotation(HttpClient.class);
+
+        int timeout = annotationHttpClient.timeout();
+
+        IHttpClient httpClient = null;
+        if (timeout > 0)
+        {
+            httpClient = newHttpClient(timeout);
+        }
+        else
+        {
+            httpClient = newHttpClient();
+        }
+        return httpClient;
     }
 
     @Override


### PR DESCRIPTION
## Why?

This PR delivers a number of changes which have been required whilst migrating our tests over from using the v4 HTTP client, and our own internal v5 HTTP client, over to the new public httpclient5 HTTP manager delivered in 0.47.0.

The changes are:

1. New text content types available to support return types by springboot 4 applications
2. The ability to set the c**onnection request** + **response** timeout manually via annotation metadata
3. The ability to set the **socket** and **connection** timeout via helper functions
4. A new `postForm()` handler which makes working with encoded forms a lot easier (simply provide a url and a key-value map for the form)
5. Latest TLS versions supported for the connection
6. A helper to clear cookies, which can be handy when testing authentication scenarios.
7. Better redirect support. Firstly, to enable it, secondly, a redirect strategy to handle when a redirect after authentication may go back to `/`, however, the trailing `/` is lost and it simply goes back to the baseUrl, causing failures. 

## Changes
- [ ] Unit tests (if applicable)
- [ ] Documentation updates (if applicable)
- [ ] Release notes updates (if applicable)
