### PR TITLE
Reimplement preemptive auth cache that was removed from the HTTP Manager

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
@@ -733,9 +733,20 @@ public class HttpClientImpl implements IHttpClient {
         builder.setConnectionManager(connectionManager);
         builder.setDefaultRequestConfig(requestBuilder.build());
         httpClient = builder.build();
+
+        AuthCache existingAuthCache = null;
+        if (httpContext != null) {
+            existingAuthCache = httpContext.getAuthCache();
+        }
         
-        httpContext = ContextBuilder.create().useCookieStore(cookieStore).useCredentialsProvider(credentialsProvider)
+        httpContext = ContextBuilder.create()
+            .useCookieStore(cookieStore)
+            .useCredentialsProvider(credentialsProvider)
             .build();
+
+        if (existingAuthCache != null) {
+            httpContext.setAuthCache(existingAuthCache);
+        }
 
         return this;
     }


### PR DESCRIPTION
## Why?

Fixes https://github.com/galasa-dev/projectmanagement/issues/2569, and changes needed to allow us to run the WebAppIntegrationTest which exercises the Selenium Manager, in order to start on https://github.com/galasa-dev/projectmanagement/issues/2589

The BatchAccountsOpenTest and WebAppIntegrationTest started failing again after changes made recently which removed the auth cache for preemptive basic authentication.

Prior to the changes in this PR to restore preemptive auth, the BatchAccountsOpenTest and WebAppIntegrationTest tests failed due to receiving 401s back from the ManagementFacilityListener in SimBank which simulates z/OS MF and requires basic authentication. After this change, both tests pass and the WebAppIntegrationTest opens Firefox using the configured web driver as expected.

## Changes
- [ ] Unit tests (if applicable)
- [ ] Documentation updates (if applicable)
- [ ] Release notes updates (if applicable)
