### PR TITLE
Add support for loading test artifacts from basic auth-protected maven repos for local runs via bootstrap props and env variables

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2844,6 +2844,42 @@
         "verified_result": null
       }
     ],
+    "modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/test/java/dev/galasa/framework/maven/repository/internal/GalasaMavenUrlHandlerServiceTest.java": [
+      {
+        "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 52,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7c685245c889dc1bb5128c7d430197b2be0969af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7a1550db1f35d711f4b160e5be20e14ca55182e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "modules/framework/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java": [
+      {
+        "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 370,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "modules/framework/run-locally.sh": [
       {
         "hashed_secret": "8cbd3af3de67a89adedc45b1e3d99b7b135a8ca4",

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository.spi/src/main/java/dev/galasa/framework/maven/repository/spi/IMavenRepository.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository.spi/src/main/java/dev/galasa/framework/maven/repository/spi/IMavenRepository.java
@@ -18,4 +18,16 @@ public interface IMavenRepository {
 
     void addRemoteRepository(URL remoteRepository);
 
+    /**
+     * Set credentials for basic maven repository authentication.
+     *
+     * @param username The maven repository username
+     * @param password The maven repository password
+     */
+    void setCredentials(String username, String password);
+
+    String getUsername();
+
+    String getPassword();
+
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation 'org.codehaus.plexus:plexus-xml'
 
     testImplementation(testFixtures(project(':dev.galasa.framework')))
+    testImplementation project(':dev.galasa.framework.maven.repository.spi')
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/main/java/dev/galasa/framework/maven/repository/internal/GalasaMavenRepository.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/main/java/dev/galasa/framework/maven/repository/internal/GalasaMavenRepository.java
@@ -19,6 +19,8 @@ public class GalasaMavenRepository implements IMavenRepository {
     private URL       localRepository;
     private List<URL> remoteRepositories = new ArrayList<URL>();
 
+    private MavenCredentials mavenCredentials = new MavenCredentials();
+
     @Override
     public URL getLocalRepository() {
         return this.localRepository;
@@ -38,5 +40,21 @@ public class GalasaMavenRepository implements IMavenRepository {
     @Override
     public void addRemoteRepository(URL remoteRepository) {
         this.remoteRepositories.add(0, remoteRepository);
+    }
+
+    @Override
+    public void setCredentials(String username, String password) {
+        mavenCredentials.setUsername(username);
+        mavenCredentials.setPassword(password);
+    }
+
+    @Override
+    public String getUsername() {
+        return mavenCredentials.getUsername();
+    }
+
+    @Override
+    public String getPassword() {
+        return mavenCredentials.getPassword();
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/main/java/dev/galasa/framework/maven/repository/internal/GalasaMavenUrlHandlerService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/main/java/dev/galasa/framework/maven/repository/internal/GalasaMavenUrlHandlerService.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -19,6 +20,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,8 +46,35 @@ public class GalasaMavenUrlHandlerService extends AbstractURLStreamHandlerServic
             .getLog(GalasaMavenUrlHandlerService.class);
     private static final DateTimeFormatter dtf                   = DateTimeFormatter.ofPattern("uuuuMMddHHmmss");
 
+    private static final int FIVE_MINUTES_IN_MS_UNITS = 3000000;
+
     @Reference
     private IMavenRepository               galasaRepository;
+
+    public GalasaMavenUrlHandlerService() {
+    }
+
+    public GalasaMavenUrlHandlerService(IMavenRepository mavenRepository) {
+        this.galasaRepository = mavenRepository;
+    }
+
+    /**
+     * Adds Basic Authentication header to URLConnection if credentials are available
+     *
+     * @param connection The URLConnection to add authentication to
+     */
+    void addAuthenticationIfRequired(URLConnection connection) {
+        String username = galasaRepository.getUsername();
+        String password = galasaRepository.getPassword();
+
+        if (username != null && password != null) {
+            String auth = username + ":" + password;
+            String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+            connection.setRequestProperty("Authorization", "Basic " + encodedAuth);
+            logger.trace("Added Basic Authentication header for Maven repository");
+        }
+    }
+
 
     @Override
     public URLConnection openConnection(URL arg0) throws IOException {
@@ -255,10 +284,7 @@ public class GalasaMavenUrlHandlerService extends AbstractURLStreamHandlerServic
                 buildArtifactFilename(artifactid, snapshotSuffix, type));
         logger.debug("Attempting to download snapshot" + urlRemoteFile);
 
-        URLConnection connection = urlRemoteFile.openConnection();
-        connection.setConnectTimeout(300000);
-        connection.setReadTimeout(300000);
-        connection.setDoOutput(false);
+        URLConnection connection = createConnection(urlRemoteFile);
         connection.connect();
 
         try {
@@ -280,10 +306,7 @@ public class GalasaMavenUrlHandlerService extends AbstractURLStreamHandlerServic
           URL urlRemoteFile = buildArtifactUrl(repository, groupid, artifactid, version, "maven-metadata.xml");
           logger.debug("Attempting to download temporary metadata " + urlRemoteFile);
 
-          URLConnection connection = urlRemoteFile.openConnection();
-          connection.setConnectTimeout(300000);
-          connection.setReadTimeout(300000);
-          connection.setDoOutput(false);
+          URLConnection connection = createConnection(urlRemoteFile);
           connection.connect();
           Files.copy(connection.getInputStream(), tempMetadata, StandardCopyOption.REPLACE_EXISTING);
       } catch (FileNotFoundException e) {
@@ -291,6 +314,18 @@ public class GalasaMavenUrlHandlerService extends AbstractURLStreamHandlerServic
           return null;
       }
       return tempMetadata;
+    }
+
+
+    private URLConnection createConnection(URL urlRemoteFile) throws IOException {
+        URLConnection connection = urlRemoteFile.openConnection();
+
+        connection.setConnectTimeout(FIVE_MINUTES_IN_MS_UNITS);
+        connection.setReadTimeout(FIVE_MINUTES_IN_MS_UNITS);
+        connection.setDoOutput(false);
+        addAuthenticationIfRequired(connection);
+
+        return connection;
     }
 
     private URL fetchReleaseArtifact(Path localArtifact, String groupid, String artifactid, String version, String type)
@@ -309,8 +344,6 @@ public class GalasaMavenUrlHandlerService extends AbstractURLStreamHandlerServic
         return null;
     }
 
-    private static final int FIVE_MINUTES_IN_MS_UNITS = 3000000;
-
     private boolean getArtifact(URL repository, Path localArtifact, String groupid, String artifactid,
             String version) throws IOException {
         logger.debug("Checking " + repository);
@@ -324,11 +357,7 @@ public class GalasaMavenUrlHandlerService extends AbstractURLStreamHandlerServic
                     " with connection timeout of "+Integer.toString(connectionTimeoutMilliSecs)+"ms "+
                     "and read timeout of "+Integer.toString(readTimeoutMilliSecs)+"ms "
                     );
-        URLConnection connection = urlRemoteFile.openConnection();
-        connection.setDoOutput(false);
-
-        connection.setConnectTimeout(connectionTimeoutMilliSecs);
-        connection.setReadTimeout(readTimeoutMilliSecs);
+        URLConnection connection = createConnection(urlRemoteFile);
 
         try {
             logger.debug("Connecting now...");

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/main/java/dev/galasa/framework/maven/repository/internal/MavenCredentials.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/main/java/dev/galasa/framework/maven/repository/internal/MavenCredentials.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.maven.repository.internal;
+
+/**
+ * Represents authentication credentials for accessing a Maven repository.
+ * Currently, this class only supports basic authentication.
+ */
+public class MavenCredentials {
+    
+    private String username;
+    private String password;
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return this.username;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/test/java/dev/galasa/framework/maven/repository/internal/GalasaMavenUrlHandlerServiceTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/test/java/dev/galasa/framework/maven/repository/internal/GalasaMavenUrlHandlerServiceTest.java
@@ -8,7 +8,13 @@ package dev.galasa.framework.maven.repository.internal;
 import static org.assertj.core.api.Assertions.*;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import org.junit.Test;
+
+import dev.galasa.framework.maven.repository.internal.mocks.MockMavenRepository;
+import dev.galasa.framework.maven.repository.internal.mocks.MockURLConnection;
 
 public class GalasaMavenUrlHandlerServiceTest {
 
@@ -38,5 +44,141 @@ public class GalasaMavenUrlHandlerServiceTest {
         URL url = service.buildArtifactUrl(repositoryUrl, "myGroupId", "myArtifactId", "0.myVersion.0", "myFileName");
 
         assertThat(url.toString()).doesNotContain("//myGroupId");
+    }
+
+    @Test
+    public void testAuthenticationHeaderAddedWhenCredentialsProvided() throws Exception {
+        String username = "testuser";
+        String password = "testpassword";
+        
+        MockMavenRepository mockRepo = new MockMavenRepository();
+        mockRepo.setCredentials(username, password);
+        
+        GalasaMavenUrlHandlerService service = new GalasaMavenUrlHandlerService(mockRepo);
+        MockURLConnection mockConnection = new MockURLConnection(new URL("http://example.com"));
+        
+        service.addAuthenticationIfRequired(mockConnection);
+        
+        String expectedAuth = username + ":" + password;
+        String expectedEncodedAuth = Base64.getEncoder().encodeToString(expectedAuth.getBytes(StandardCharsets.UTF_8));
+        String expectedHeader = "Basic " + expectedEncodedAuth;
+        
+        assertThat(mockConnection.getRequestProperty("Authorization")).isEqualTo(expectedHeader);
+    }
+
+    @Test
+    public void testAuthenticationHeaderNotAddedWhenNoCredentials() throws Exception {
+        MockMavenRepository mockRepo = new MockMavenRepository();
+        
+        GalasaMavenUrlHandlerService service = new GalasaMavenUrlHandlerService(mockRepo);
+        MockURLConnection mockConnection = new MockURLConnection(new URL("http://example.com"));
+        
+        service.addAuthenticationIfRequired(mockConnection);
+        
+        assertThat(mockConnection.getRequestProperty("Authorization")).isNull();
+    }
+
+    @Test
+    public void testAuthenticationHeaderNotAddedWhenOnlyUsernameProvided() throws Exception {
+        MockMavenRepository mockRepo = new MockMavenRepository();
+        mockRepo.setUsername("testuser");
+        
+        GalasaMavenUrlHandlerService service = new GalasaMavenUrlHandlerService(mockRepo);
+        MockURLConnection mockConnection = new MockURLConnection(new URL("http://example.com"));
+        
+        service.addAuthenticationIfRequired(mockConnection);
+        
+        assertThat(mockConnection.getRequestProperty("Authorization")).isNull();
+    }
+
+    @Test
+    public void testAuthenticationHeaderNotAddedWhenOnlyPasswordProvided() throws Exception {
+        MockMavenRepository mockRepo = new MockMavenRepository();
+        mockRepo.setPassword("testpassword");
+        
+        GalasaMavenUrlHandlerService service = new GalasaMavenUrlHandlerService(mockRepo);
+        MockURLConnection mockConnection = new MockURLConnection(new URL("http://example.com"));
+        
+        service.addAuthenticationIfRequired(mockConnection);
+        
+        assertThat(mockConnection.getRequestProperty("Authorization")).isNull();
+    }
+
+    @Test
+    public void testAuthenticationEncodesCredentialsCorrectlyWithSpecialCharacters() throws Exception {
+        String username = "user@example.com";
+        String password = "p@ssw0rd!#$%";
+        
+        MockMavenRepository mockRepo = new MockMavenRepository();
+        mockRepo.setCredentials(username, password);
+        
+        GalasaMavenUrlHandlerService service = new GalasaMavenUrlHandlerService(mockRepo);
+        MockURLConnection mockConnection = new MockURLConnection(new URL("http://example.com"));
+        
+        service.addAuthenticationIfRequired(mockConnection);
+        
+        String authHeader = mockConnection.getRequestProperty("Authorization");
+        assertThat(authHeader).isNotNull();
+        assertThat(authHeader).startsWith("Basic ");
+        
+        String encodedPart = authHeader.substring(6);
+        String decoded = new String(Base64.getDecoder().decode(encodedPart), StandardCharsets.UTF_8);
+        assertThat(decoded).isEqualTo(username + ":" + password);
+    }
+
+    @Test
+    public void testAuthenticationHandlesColonsInCredentials() throws Exception {
+        String username = "user:with:colons";
+        String password = "pass:word:too";
+        
+        MockMavenRepository mockRepo = new MockMavenRepository();
+        mockRepo.setCredentials(username, password);
+        
+        GalasaMavenUrlHandlerService service = new GalasaMavenUrlHandlerService(mockRepo);
+        MockURLConnection mockConnection = new MockURLConnection(new URL("http://example.com"));
+        
+        service.addAuthenticationIfRequired(mockConnection);
+        
+        String authHeader = mockConnection.getRequestProperty("Authorization");
+        assertThat(authHeader).isNotNull();
+        
+        String encodedPart = authHeader.substring(6);
+        String decoded = new String(Base64.getDecoder().decode(encodedPart), StandardCharsets.UTF_8);
+        assertThat(decoded).isEqualTo(username + ":" + password);
+    }
+
+    @Test
+    public void testAuthenticationWithEmptyStringCredentialsTreatedAsNull() throws Exception {
+        MockMavenRepository mockRepo = new MockMavenRepository();
+        mockRepo.setUsername("");
+        mockRepo.setPassword("");
+        
+        GalasaMavenUrlHandlerService service = new GalasaMavenUrlHandlerService(mockRepo);
+        MockURLConnection mockConnection = new MockURLConnection(new URL("http://example.com"));
+        
+        service.addAuthenticationIfRequired(mockConnection);
+        
+        assertThat(mockConnection.getRequestProperty("Authorization")).isNull();
+    }
+
+    @Test
+    public void testAuthenticationWithVeryLongCredentials() throws Exception {
+        String username = "a".repeat(1000);
+        String password = "b".repeat(1000);
+        
+        MockMavenRepository mockRepo = new MockMavenRepository();
+        mockRepo.setCredentials(username, password);
+        
+        GalasaMavenUrlHandlerService service = new GalasaMavenUrlHandlerService(mockRepo);
+        MockURLConnection mockConnection = new MockURLConnection(new URL("http://example.com"));
+        
+        service.addAuthenticationIfRequired(mockConnection);
+        
+        String authHeader = mockConnection.getRequestProperty("Authorization");
+        assertThat(authHeader).isNotNull();
+        
+        String encodedPart = authHeader.substring(6);
+        String decoded = new String(Base64.getDecoder().decode(encodedPart), StandardCharsets.UTF_8);
+        assertThat(decoded).isEqualTo(username + ":" + password);
     }
 }

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/test/java/dev/galasa/framework/maven/repository/internal/mocks/MockMavenRepository.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/test/java/dev/galasa/framework/maven/repository/internal/mocks/MockMavenRepository.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.maven.repository.internal.mocks;
+
+import java.net.URL;
+import java.util.List;
+
+import dev.galasa.framework.maven.repository.spi.IMavenRepository;
+
+/**
+ * Mock implementation of IMavenRepository for testing
+ */
+public class MockMavenRepository implements IMavenRepository {
+    private String username;
+    private String password;
+
+    @Override
+    public void setCredentials(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public String getUsername() {
+        return (username != null && !username.isEmpty()) ? username : null;
+    }
+
+    @Override
+    public String getPassword() {
+        return (password != null && !password.isEmpty()) ? password : null;
+    }
+
+    @Override
+    public URL getLocalRepository() {
+        throw new UnsupportedOperationException("Unimplemented method 'getLocalRepository'");
+    }
+
+    @Override
+    public List<URL> getRemoteRepositories() {
+        throw new UnsupportedOperationException("Unimplemented method 'getRemoteRepositories'");
+    }
+
+    @Override
+    public void setRepositories(URL localRepository, List<URL> remoteRepositories) {
+        throw new UnsupportedOperationException("Unimplemented method 'setRepositories'");
+    }
+
+    @Override
+    public void addRemoteRepository(URL remoteRepository) {
+        throw new UnsupportedOperationException("Unimplemented method 'addRemoteRepository'");
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/test/java/dev/galasa/framework/maven/repository/internal/mocks/MockURLConnection.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.maven.repository/src/test/java/dev/galasa/framework/maven/repository/internal/mocks/MockURLConnection.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.maven.repository.internal.mocks;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mock URLConnection that stores request properties for verification
+ */
+public class MockURLConnection extends URLConnection {
+    private Map<String, String> requestProperties = new HashMap<>();
+
+    public MockURLConnection(URL url) {
+        super(url);
+    }
+
+    @Override
+    public void connect() throws IOException {
+    }
+
+    @Override
+    public void setRequestProperty(String key, String value) {
+        requestProperties.put(key, value);
+    }
+
+    @Override
+    public String getRequestProperty(String key) {
+        return requestProperties.get(key);
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockMavenRepository.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/testFixtures/java/dev/galasa/framework/mocks/MockMavenRepository.java
@@ -34,5 +34,20 @@ public class MockMavenRepository implements IMavenRepository {
     public void addRemoteRepository(URL remoteRepository) {
         remoteRepoUrls.add(remoteRepository);
     }
+
+    @Override
+    public void setCredentials(String username, String password) {
+        throw new UnsupportedOperationException("Unimplemented method 'setBootstrapCredentials'");
+    }
+
+    @Override
+    public String getUsername() {
+        throw new UnsupportedOperationException("Unimplemented method 'getUsername'");
+    }
+
+    @Override
+    public String getPassword() {
+        throw new UnsupportedOperationException("Unimplemented method 'getPassword'");
+    }
     
 }

--- a/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -49,6 +49,9 @@ import dev.galasa.boot.felix.FelixFramework;
  */
 public class Launcher {
 
+    public static final String MAVEN_USERNAME_BOOTSTRAP_PROPERTY = "maven.repository.username";
+    public static final String MAVEN_PASSWORD_BOOTSTRAP_PROPERTY = "maven.repository.password";
+
     private static final String LOG4J2_PROPERTIES_FILE_OPTION = "log4j2-properties-file";
     private static final String LOG4J2_CONFIGURATION_FILE_PROPERTY_NAME = "log4j2.configurationFile";
     
@@ -345,6 +348,7 @@ public class Launcher {
         checkForBootstrap(commandLine);
         setStoresFromEnvironmentVariables(env,bootstrapProperties);
         setExtraBundlesFromEnvironment(env, bootstrapProperties);
+        setMavenCredentialsFromEnvironment(env, bootstrapProperties);
         checkForOverrides(commandLine);
         checkForBundles(commandLine);
         checkForMetricsPort(commandLine);
@@ -767,6 +771,25 @@ public class Launcher {
             extraBundles = extraBundles.trim();
             logger.info(String.format("Environment variable: %s used to set extra bundles", EXTRA_BUNDLES_ENV_VAR));
             bootstrap.setProperty("framework.extra.bundles", extraBundles);
+        }
+    }
+
+    void setMavenCredentialsFromEnvironment(Environment env, Properties bootstrap) {
+        String MAVEN_USERNAME_ENV_VAR = "GALASA_MAVEN_USERNAME";
+        String MAVEN_PASSWORD_ENV_VAR = "GALASA_MAVEN_PASSWORD";
+
+        String mavenUsername = env.getenv(MAVEN_USERNAME_ENV_VAR);
+        if ((mavenUsername != null) && (!mavenUsername.trim().isEmpty())) {
+            mavenUsername = mavenUsername.trim();
+            logger.info(String.format("Environment variable: %s used to set maven username", MAVEN_USERNAME_ENV_VAR));
+            bootstrap.setProperty(MAVEN_USERNAME_BOOTSTRAP_PROPERTY, mavenUsername);
+        }
+
+        String mavenPassword = env.getenv(MAVEN_PASSWORD_ENV_VAR);
+        if ((mavenPassword != null) && (!mavenPassword.trim().isEmpty())) {
+            mavenPassword = mavenPassword.trim();
+            logger.info(String.format("Environment variable: %s used to set maven password", MAVEN_PASSWORD_ENV_VAR));
+            bootstrap.setProperty(MAVEN_PASSWORD_BOOTSTRAP_PROPERTY, mavenPassword);
         }
     }
 }

--- a/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -39,6 +39,7 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.framework.launch.Framework;
 
 import dev.galasa.boot.BootLogger;
+import dev.galasa.boot.Launcher;
 import dev.galasa.boot.LauncherException;
 import dev.galasa.boot.ResourceManagementConfiguration;
 
@@ -119,7 +120,7 @@ public class FelixFramework {
 
             installBundle("dev.galasa.framework.maven.repository.spi.jar", true);
             installBundle("dev.galasa.framework.maven.repository.jar", true);
-            loadMavenRepositories(localMavenRepo, remoteMavenRepos);
+            loadMavenRepositories(localMavenRepo, remoteMavenRepos, boostrapProperties);
 
             // Install and start the Felix OBR bundle
             obrBundle = installBundle("org.apache.felix.bundlerepository.jar", true);
@@ -166,7 +167,7 @@ public class FelixFramework {
         }
     }
 
-    private void loadMavenRepositories(URL localMavenRepo, List<URL> remoteMavenRepos) throws LauncherException {
+    private void loadMavenRepositories(URL localMavenRepo, List<URL> remoteMavenRepos, Properties bootstrapProperties) throws LauncherException {
 
         // Get the framework bundle
         Bundle frameWorkBundle = getBundle("dev.galasa.framework.maven.repository");
@@ -189,18 +190,41 @@ public class FelixFramework {
         }
 
         // Get the GalasaMavenRepositoryr#setRepositories() method
-        Method runTestMethod;
+        Method setRepositoriesMethod;
         try {
-            runTestMethod = service.getClass().getMethod("setRepositories", URL.class, List.class);
+            setRepositoriesMethod = service.getClass().getMethod("setRepositories", URL.class, List.class);
         } catch (NoSuchMethodException | SecurityException e) {
-            throw new LauncherException("Unable to get Framework Maven Repository method", e);
+            throw new LauncherException("Unable to get Framework Maven Repository setRepositories method", e);
         }
 
         // Invoke the setRepositories method
         try {
-            runTestMethod.invoke(service, localMavenRepo, remoteMavenRepos);
+            setRepositoriesMethod.invoke(service, localMavenRepo, remoteMavenRepos);
         } catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
             throw new LauncherException(e.getCause());
+        }
+
+        setMavenCredentialsIfProvided(bootstrapProperties, service);
+    }
+
+    private void setMavenCredentialsIfProvided(Properties bootstrapProperties, Object service) throws LauncherException {
+        String mavenUsername = bootstrapProperties.getProperty(Launcher.MAVEN_USERNAME_BOOTSTRAP_PROPERTY);
+        String mavenPassword = bootstrapProperties.getProperty(Launcher.MAVEN_PASSWORD_BOOTSTRAP_PROPERTY);
+
+        if (mavenUsername != null && mavenPassword != null) {
+            logger.info("Configuring bootstrap Maven repository credentials");
+            Method setCredentialsMethod;
+            try {
+                setCredentialsMethod = service.getClass().getMethod("setCredentials", String.class, String.class);
+            } catch (NoSuchMethodException | SecurityException e) {
+                throw new LauncherException("Unable to get Framework Maven Repository setCredentials method", e);
+            }
+
+            try {
+                setCredentialsMethod.invoke(service, mavenUsername, mavenPassword);
+            } catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
+                throw new LauncherException("Failed to set bootstrap Maven credentials", e.getCause());
+            }
         }
     }
 

--- a/modules/framework/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
+++ b/modules/framework/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
@@ -331,4 +331,66 @@ public class TestLauncher {
 
         assertThat(mockEnv.getExitCode()).isEqualTo(-1);
     }
+
+    @Test
+    public void testCanSetMavenUsernameFromEnvironmentVariable() {
+        Launcher launcher  = new Launcher();
+        MockEnvironment mockEnv = new MockEnvironment();
+        Properties bootstrap = new Properties();
+
+        String mavenUsername = "myuser";
+        mockEnv.setenv("GALASA_MAVEN_USERNAME", mavenUsername);
+
+        launcher.setMavenCredentialsFromEnvironment(mockEnv, bootstrap);
+
+        assertThat(bootstrap.getProperty("maven.repository.username")).isEqualTo(mavenUsername);
+    }
+
+    @Test
+    public void testCanSetMavenPasswordFromEnvironmentVariable() {
+        Launcher launcher  = new Launcher();
+        MockEnvironment mockEnv = new MockEnvironment();
+        Properties bootstrap = new Properties();
+
+        String mavenPassword = "mypassword";
+        mockEnv.setenv("GALASA_MAVEN_PASSWORD", mavenPassword);
+
+        launcher.setMavenCredentialsFromEnvironment(mockEnv, bootstrap);
+
+        assertThat(bootstrap.getProperty("maven.repository.password")).isEqualTo(mavenPassword);
+    }
+
+    @Test
+    public void testMavenCredentialsCanBeLoadedFromEnvironmentVariables() {
+        Launcher launcher  = new Launcher();
+        MockEnvironment mockEnv = new MockEnvironment();
+        Properties bootstrap = new Properties();
+
+        String mavenUsername = "myuser";
+        String mavenPassword = "mypassword";
+        mockEnv.setenv("GALASA_MAVEN_USERNAME", mavenUsername);
+        mockEnv.setenv("GALASA_MAVEN_PASSWORD", mavenPassword);
+
+        launcher.setMavenCredentialsFromEnvironment(mockEnv, bootstrap);
+
+        assertThat(bootstrap.getProperty("maven.repository.username")).isEqualTo(mavenUsername);
+        assertThat(bootstrap.getProperty("maven.repository.password")).isEqualTo(mavenPassword);
+    }
+
+    @Test
+    public void testMavenCredentialsLoadedFromEnvironmentVariableAreTrimmed() {
+        Launcher launcher  = new Launcher();
+        MockEnvironment mockEnv = new MockEnvironment();
+        Properties bootstrap = new Properties();
+
+        String mavenUsername = "    myuser   ";
+        String mavenPassword = "mypassword     ";
+        mockEnv.setenv("GALASA_MAVEN_USERNAME", mavenUsername);
+        mockEnv.setenv("GALASA_MAVEN_PASSWORD", mavenPassword);
+
+        launcher.setMavenCredentialsFromEnvironment(mockEnv, bootstrap);
+
+        assertThat(bootstrap.getProperty("maven.repository.username")).isEqualTo(mavenUsername.trim());
+        assertThat(bootstrap.getProperty("maven.repository.password")).isEqualTo(mavenPassword.trim());
+    }
 }


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/1572 

This PR adds the initial changes required to allow local runs to be able to authenticate with password-protected Maven repos by pulling credentials from bootstrap.properties or environment variables (doc changes to follow in a separate PR). 

The credentials store could not be used to retrieve credentials because the dev.galasa.framework bundle is loaded from a Maven repository when the felix framework gets built, so the framework is unavailable at the point where the launcher contacts the configured Maven repositories.

## Changes
- [x] Local runs can now contact username/password-protected maven repositories via bootstrap properties and env variables
- [x] Unit tests (if applicable)
