### PR TITLE
Revert preemptive auth cache on the HttpClient

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
@@ -734,19 +734,10 @@ public class HttpClientImpl implements IHttpClient {
         builder.setDefaultRequestConfig(requestBuilder.build());
         httpClient = builder.build();
 
-        AuthCache existingAuthCache = null;
-        if (httpContext != null) {
-            existingAuthCache = httpContext.getAuthCache();
-        }
-        
         httpContext = ContextBuilder.create()
             .useCookieStore(cookieStore)
             .useCredentialsProvider(credentialsProvider)
             .build();
-
-        if (existingAuthCache != null) {
-            httpContext.setAuthCache(existingAuthCache);
-        }
 
         return this;
     }


### PR DESCRIPTION
## Why?

Reverts changes made in #597 as it broke some user tests involving the HTTP Manager. This will once again break the BatchAccountsOpenTest and WebAppIntegrationTest so we'll fix authentication in those separately.

## Changes
- [ ] Unit tests (if applicable)
- [ ] Documentation updates (if applicable)
- [ ] Release notes updates (if applicable)
