### PR TITLE
Add --maven-secret-name flag to streams set and update CLI to use /testcatalog endpoint

### DIFF
--- a/modules/cli/docs/generated/errors-list.md
+++ b/modules/cli/docs/generated/errors-list.md
@@ -141,7 +141,7 @@ The `galasactl` tool can generate the following errors:
 - GAL1141E: Unable to compile the regex pattern for Galasa Property field '{}'. Reason: '{}'
 - GAL1142E: The {} field value, '{}', provided does not match formatting requirements. The {} field value must start with a character in the 'a-z' or 'A-Z' range, followed by any characters in the 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore) or '@' (at) ranges only.
 - GAL1143E: Could not query run results. Server returned a non-200 code ({})
-- GAL1144E: Could not use url '{}' to retrieve the contents of the test catalog from stream '{}'. Http error from the Galasa server is '{}'
+- GAL1144E: Could not retrieve the contents of the test catalog from stream '{}'. Check that your test stream is configured correctly. Http error from the Galasa server is '{}'
 - GAL1145E: Failed to create folder for bearer tokens at '{}'
 
 - GAL1146E: Could not get list of tokens from API server. Reason: '{}'. Ensure you have allocated a personal access token and configured your client program by setting your GALASA_TOKEN as an environment variable or by storing it in your galasactl.properties file

--- a/modules/cli/docs/generated/galasactl_streams_set.md
+++ b/modules/cli/docs/generated/galasactl_streams_set.md
@@ -13,12 +13,13 @@ galasactl streams set [flags]
 ### Options
 
 ```
-      --description string       the description to associate with the test stream being created or updated
-  -h, --help                     Displays the options for the 'streams set' command.
-      --maven-repo-url string    the URL to the Maven repository containing test material for the test stream to use. For example: https://my-maven-repository
-      --name string              A mandatory field indicating the name of a test stream.
-      --obr strings              The Maven coordinates of the OBR bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:{OBR_GROUP_ID}/{OBR_ARTIFACT_ID}/{OBR_VERSION}/obr'. Multiple instances of this flag can be used to describe multiple OBR bundles.
-      --testcatalog-url string   the URL to the test catalog for the test stream being created or updated. For example: https://my-maven-repository/path/to/testcatalog.json
+      --description string         the description to associate with the test stream being created or updated
+  -h, --help                       Displays the options for the 'streams set' command.
+      --maven-repo-url string      the URL to the Maven repository containing test material for the test stream to use. For example: https://my-maven-repository
+      --maven-secret-name string   the name of the Galasa secret containing the Maven credentials to use when accessing the test stream's Maven repository. For example: MY_MAVEN_SECRET
+      --name string                A mandatory field indicating the name of a test stream.
+      --obr strings                The Maven coordinates of the OBR bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:{OBR_GROUP_ID}/{OBR_ARTIFACT_ID}/{OBR_VERSION}/obr'. Multiple instances of this flag can be used to describe multiple OBR bundles.
+      --testcatalog-url string     the URL to the test catalog for the test stream being created or updated. For example: https://my-maven-repository/path/to/testcatalog.json
 ```
 
 ### Options inherited from parent commands

--- a/modules/cli/pkg/cmd/streamsSet.go
+++ b/modules/cli/pkg/cmd/streamsSet.go
@@ -20,6 +20,7 @@ type StreamsSetCmdValues struct {
 	description string
     testCatalogUrl string
     mavenRepositoryUrl string
+    mavenSecretName string
     obrs []string
 }
 
@@ -97,16 +98,18 @@ func (cmd *StreamsSetCommand) createCobraCmd(
     descriptionFlag := "description"
     testCatalogUrlFlag := "testcatalog-url"
     mavenRepoUrlFlag := "maven-repo-url"
+    mavenSecretNameFlag := "maven-secret-name"
     obrFlag := "obr"
 
     streamsSetCobraCmd.Flags().StringVar(&cmd.values.description, descriptionFlag, "", "the description to associate with the test stream being created or updated")
     streamsSetCobraCmd.Flags().StringVar(&cmd.values.testCatalogUrl, testCatalogUrlFlag, "", "the URL to the test catalog for the test stream being created or updated. For example: https://my-maven-repository/path/to/testcatalog.json")
     streamsSetCobraCmd.Flags().StringVar(&cmd.values.mavenRepositoryUrl, mavenRepoUrlFlag, "", "the URL to the Maven repository containing test material for the test stream to use. For example: https://my-maven-repository")
+    streamsSetCobraCmd.Flags().StringVar(&cmd.values.mavenSecretName, mavenSecretNameFlag, "", "the name of the Galasa secret containing the Maven credentials to use when accessing the test stream's Maven repository. For example: MY_MAVEN_SECRET")
     streamsSetCobraCmd.Flags().StringSliceVar(&cmd.values.obrs, obrFlag, make([]string, 0), "The Maven coordinates of the OBR bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:{OBR_GROUP_ID}/{OBR_ARTIFACT_ID}/{OBR_VERSION}/obr'. "+
         "Multiple instances of this flag can be used to describe multiple OBR bundles.")
 
     // streams set requires the name flag as well as one of the following: --description --testcatalog, --maven-repo-url, --obr
-	streamsSetCobraCmd.MarkFlagsOneRequired(descriptionFlag, testCatalogUrlFlag, mavenRepoUrlFlag, obrFlag)
+	streamsSetCobraCmd.MarkFlagsOneRequired(descriptionFlag, testCatalogUrlFlag, mavenRepoUrlFlag, obrFlag, mavenSecretNameFlag)
 
     streamsCommand.CobraCommand().AddCommand(streamsSetCobraCmd)
 
@@ -153,6 +156,7 @@ func (cmd *StreamsSetCommand) executeStreamsSet(
                         streamsCmdValues.name,
                         cmd.values.description,
                         cmd.values.mavenRepositoryUrl,
+                        cmd.values.mavenSecretName,
                         cmd.values.testCatalogUrl,
                         cmd.values.obrs,
                         apiClient,

--- a/modules/cli/pkg/cmd/streamsSet_test.go
+++ b/modules/cli/pkg/cmd/streamsSet_test.go
@@ -86,5 +86,5 @@ func TestStreamsSetRequiresNameAndAtLeastOneOtherFlag(t *testing.T) {
 
 	// Then...
 	assert.NotNil(t, err)
-	assert.ErrorContains(t, err, "at least one of the flags in the group [description testcatalog-url maven-repo-url obr] is required")
+	assert.ErrorContains(t, err, "at least one of the flags in the group [description testcatalog-url maven-repo-url obr maven-secret-name] is required")
 }

--- a/modules/cli/pkg/errors/errorMessage.go
+++ b/modules/cli/pkg/errors/errorMessage.go
@@ -327,7 +327,7 @@ var (
 	GALASA_ERROR_INVALID_PROPERTY_FIELD_FORMAT          = NewMessageType("GAL1142E: The %s field value, '%s', provided does not match formatting requirements. "+
 		"The %s field value must start with a character in the 'a-z' or 'A-Z' range, followed by any characters in the 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore) or '@' (at) ranges only.", 1142, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_QUERY_RUNS_NON_OK_STATUS              = NewMessageType("GAL1143E: Could not query run results. Server returned a non-200 code (%s)", 1143, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_GET_TEST_CATALOG_CONTENTS_FAILED      = NewMessageType("GAL1144E: Could not use url '%s' to retrieve the contents of the test catalog from stream '%s'. Http error from the Galasa server is '%v'", 1144, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_GET_TEST_CATALOG_CONTENTS_FAILED      = NewMessageType("GAL1144E: Could not retrieve the contents of the test catalog from stream '%s'. Check that your test stream is configured correctly. Http error from the Galasa server is '%v'", 1144, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_FAILED_TO_CREATE_BEARER_TOKEN_FOLDER  = NewMessageType("GAL1145E: Failed to create folder for bearer tokens at '%s'\n", 1145, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_RETRIEVING_TOKEN_LIST_FROM_API_SERVER = NewMessageType("GAL1146E: Could not get list of tokens from API server. Reason: '%s'."+
 		" Ensure you have allocated a personal access token and configured your client program by setting your GALASA_TOKEN as an environment variable or by storing it in your galasactl.properties file", 1146, STACK_TRACE_WANTED)

--- a/modules/cli/pkg/launcher/remoteLauncher.go
+++ b/modules/cli/pkg/launcher/remoteLauncher.go
@@ -7,12 +7,9 @@ package launcher
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"log"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/embedded"
@@ -271,54 +268,29 @@ func (launcher *RemoteLauncher) GetTestCatalog(stream string) (TestCatalog, erro
 
 	var err error
 	var testCatalog TestCatalog
-	var cpsProperty []galasaapi.GalasaProperty
 	var restApiVersion string
 
 	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 
 	if err == nil {
-		var cpsResponse *http.Response
+		var testCatalogResponse *http.Response
 		err = launcher.commsClient.RunAuthenticatedCommandWithRateLimitRetries(func(apiClient *galasaapi.APIClient) error {
-			cpsProperty, cpsResponse, err = apiClient.ConfigurationPropertyStoreAPIApi.QueryCpsNamespaceProperties(context.TODO(), "framework").Prefix("test.stream." + stream).Suffix("location").ClientApiVersion(restApiVersion).Execute()
+			testCatalog, testCatalogResponse, err = apiClient.StreamsAPIApi.
+				GetStreamTestCatalog(context.TODO(), stream).
+				ClientApiVersion(restApiVersion).
+				Execute()
 
 			var statusCode int
-			if cpsResponse != nil {
-				defer cpsResponse.Body.Close()
-				statusCode = cpsResponse.StatusCode
+			if testCatalogResponse != nil {
+				defer testCatalogResponse.Body.Close()
+				statusCode = testCatalogResponse.StatusCode
 			}
 
 			if err != nil {
-				err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_PROPERTY_GET_FAILED, stream, err)
-			} else if len(cpsProperty) < 1 {
-				err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_CATALOG_NOT_FOUND, stream)
+				err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_GET_TEST_CATALOG_CONTENTS_FAILED, stream, err)
 			}
 			return err
 		})
-
-		if err == nil {
-			streamLocation := cpsProperty[0].Data.Value
-			catalogString := new(strings.Builder)
-			var resp *http.Response
-			resp, err = http.Get(*streamLocation)
-			if err != nil {
-				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_GET_TEST_CATALOG_CONTENTS_FAILED, *streamLocation, stream, err)
-			} else {
-				defer resp.Body.Close()
-
-				_, err = io.Copy(catalogString, resp.Body)
-				if err != nil {
-					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_CATALOG_COPY_FAILED, *streamLocation, stream, err)
-				}
-			}
-
-			if err == nil {
-				err = json.Unmarshal([]byte(catalogString.String()), &testCatalog)
-				if err != nil {
-					err = galasaErrors.NewGalasaError(
-						galasaErrors.GALASA_ERROR_CATALOG_UNMARSHAL_FAILED, *streamLocation, stream, err)
-				}
-			}
-		}
 	}
 	
 		return testCatalog, err

--- a/modules/cli/pkg/launcher/remoteLauncher_test.go
+++ b/modules/cli/pkg/launcher/remoteLauncher_test.go
@@ -11,8 +11,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
-	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -27,6 +28,42 @@ const (
 	// This is a dummy JWT that expires 1 hour after the Unix epoch
 	// This JWT has already expired if you compare it to the real time now.
 	mockExpiredJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjM2MDB9._j3Fchdx5IIqgGrdEGWXHxdgVyoBEyoD2-IBvhlxF1s" //pragma: allowlist secret
+
+	mockTestCatalogResponse = `
+{
+	"metadata": {
+		"generated": "2026-05-15T10:45:13.922391Z",
+		"name": "dev.galasa.ivts.obr"
+	},
+	"classes": {
+		"dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT": {
+			"name": "dev.galasa.ivts.core.CoreManagerIVT",
+			"bundle": "dev.galasa.ivts",
+			"shortName": "CoreManagerIVT",
+			"package": "dev.galasa.ivts.core",
+			"summary": "Ensure the basic functions are working in the Core Manager"
+		}
+	},
+	"packages": {
+		"dev.galasa.ivts.core": [
+			"dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT"
+		]
+	},
+	"bundles": {
+		"dev.galasa.ivts": {
+			"packages": {
+				"dev.galasa.ivts.core": [
+					"dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT"
+				]
+			}
+		}
+	},
+	"sharedEnvironments": {},
+	"gherkin": {},
+	"name": "dev.galasa.ivts.obr",
+	"build": "gradle",
+	"version": "0.48.0"
+}`
 )
 
 func createValidMockJwt() string {
@@ -95,37 +132,22 @@ func TestProcessingEmptyPropertiesListExtractsZeroStreamsOk(t *testing.T) {
 }
 
 func TestGetTestCatalogHttpErrorGetsReported(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("URL arrived at the mock test server: %s\n", r.RequestURI)
-		switch r.RequestURI {
-		case "/cps/framework/properties?prefix=test.stream.myStream&suffix=location":
 
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
+	streamName := "myStream"
+	getTestCatalogInteraction := utils.NewHttpInteraction("/streams/"+streamName+"/testcatalog", http.MethodGet)
+	
+	getTestCatalogInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusInternalServerError)
+		writer.Write([]byte(`{}`))
+	}
 
-			name := "mycpsPropName"
-			value := "a duff value" // This is intentionally duff, which will cause an HTTP error when the production code tries to GET using this as a URL.
-			payload := []galasaapi.GalasaProperty{
-				{
-					Metadata: &galasaapi.GalasaPropertyMetadata{
-						Name: &name,
-					},
-					Data: &galasaapi.GalasaPropertyData{
-						Value: &value,
-					},
-				},
-			}
-			payloadBytes, _ := json.Marshal(payload)
-			w.Write(payloadBytes)
-
-			fmt.Printf("mock server sending payload: %s\n", string(payloadBytes))
-
-		}
-	}))
-	defer server.Close()
+	interactions := []utils.HttpInteraction{getTestCatalogInteraction}
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
 
 	mockFactory := utils.NewMockFactory()
-	apiServerUrl := server.URL
+	apiServerUrl := server.Server.URL
 	apiClient := api.InitialiseAPI(apiServerUrl)
 	authenticator := utils.NewMockAuthenticatorWithAPIClient(apiClient)
 	mockFactory.Authenticator = authenticator
@@ -147,6 +169,55 @@ func TestGetTestCatalogHttpErrorGetsReported(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.ErrorContains(t, err, "GAL1144E") // Failed to get the test catalog.
+}
+
+func TestGetTestCatalogWithOkResponseReturnsCorrectJson(t *testing.T) {
+
+	streamName := "myStream"
+	getTestCatalogInteraction := utils.NewHttpInteraction("/streams/"+streamName+"/testcatalog", http.MethodGet)
+	
+	getTestCatalogInteraction.WriteHttpResponseFunc = func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(mockTestCatalogResponse))
+	}
+
+	interactions := []utils.HttpInteraction{getTestCatalogInteraction}
+	server := utils.NewMockHttpServer(t, interactions)
+	defer server.Server.Close()
+
+	mockFactory := utils.NewMockFactory()
+	apiServerUrl := server.Server.URL
+	apiClient := api.InitialiseAPI(apiServerUrl)
+	authenticator := utils.NewMockAuthenticatorWithAPIClient(apiClient)
+	mockFactory.Authenticator = authenticator
+
+	mockFileSystem := mockFactory.GetFileSystem()
+	mockEnvironment := mockFactory.GetEnvironment()
+	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+	mockFileSystem.WriteTextFile(mockGalasaHome.GetUrlFolderPath()+"/bootstrap.properties", "")
+
+	bootstrap := ""
+	maxAttempts := 3
+	retryBackoffSeconds := 1
+
+	commsClient, _ := api.NewAPICommsClient(bootstrap, maxAttempts, float64(retryBackoffSeconds), mockFactory, mockGalasaHome)
+
+	launcher := NewRemoteLauncher(commsClient)
+
+	testCatalog, err := launcher.GetTestCatalog("myStream")
+	testCatalogKeys := slices.Collect(maps.Keys(testCatalog))
+
+	assert.Nil(t, err)
+	assert.Contains(t, testCatalogKeys, "metadata")
+	assert.Contains(t, testCatalogKeys, "classes")
+	assert.Contains(t, testCatalogKeys, "packages")
+	assert.Contains(t, testCatalogKeys, "bundles")
+	assert.Contains(t, testCatalogKeys, "sharedEnvironments")
+	assert.Contains(t, testCatalogKeys, "gherkin")
+	assert.Contains(t, testCatalogKeys, "name")
+	assert.Contains(t, testCatalogKeys, "build")
+	assert.Contains(t, testCatalogKeys, "version")
 }
 
 func TestGetRunsByGroupWithInvalidBearerTokenGetsNewTokenOk(t *testing.T) {

--- a/modules/cli/pkg/secrets/secrets.go
+++ b/modules/cli/pkg/secrets/secrets.go
@@ -13,7 +13,7 @@ import (
 	"github.com/galasa-dev/cli/pkg/utils"
 )
 
-func validateSecretName(secretName string) (string, error) {
+func ValidateSecretName(secretName string) (string, error) {
     var err error
     secretName = strings.TrimSpace(secretName)
 

--- a/modules/cli/pkg/secrets/secretsDelete.go
+++ b/modules/cli/pkg/secrets/secretsDelete.go
@@ -25,7 +25,7 @@ func DeleteSecret(
 ) error {
     var err error
 
-    secretName, err = validateSecretName(secretName)
+    secretName, err = ValidateSecretName(secretName)
     if err == nil {
         log.Printf("Secret name validated OK")
         err = sendDeleteSecretRequest(secretName, apiClient, byteReader)

--- a/modules/cli/pkg/secrets/secretsGet.go
+++ b/modules/cli/pkg/secrets/secretsGet.go
@@ -69,7 +69,7 @@ func getSecretByName(
 ) (*galasaapi.GalasaSecret, error) {
 	var err error
 	var secret *galasaapi.GalasaSecret
-	secretName, err = validateSecretName(secretName)
+	secretName, err = ValidateSecretName(secretName)
 	if err == nil {
 		secret, err = getSecretFromRestApi(secretName, apiClient, byteReader)
 	}

--- a/modules/cli/pkg/secrets/secretsSet.go
+++ b/modules/cli/pkg/secrets/secretsSet.go
@@ -42,7 +42,7 @@ func SetSecret(
 ) error {
 	var err error
 
-	secretName, err = validateSecretName(secretName)
+	secretName, err = ValidateSecretName(secretName)
 	if err == nil {
 		log.Printf("Secret name validated OK")
 		if description != "" {

--- a/modules/cli/pkg/streams/streamsSet.go
+++ b/modules/cli/pkg/streams/streamsSet.go
@@ -14,6 +14,7 @@ import (
 	"github.com/galasa-dev/cli/pkg/embedded"
 	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
 	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/galasa-dev/cli/pkg/secrets"
 	"github.com/galasa-dev/cli/pkg/spi"
 	"github.com/galasa-dev/cli/pkg/utils"
 )
@@ -22,6 +23,7 @@ func SetStream(
 	streamName string,
 	description string,
 	mavenRepositoryUrl string,
+	mavenSecretName string,
 	testCatalogUrl string,
 	obrs []string,
 	apiClient *galasaapi.APIClient,
@@ -38,6 +40,10 @@ func SetStream(
 
 		if mavenRepositoryUrl != "" {
 			mavenRepositoryUrl, err = validateUrl(mavenRepositoryUrl)
+		}
+
+		if mavenSecretName != "" {
+			mavenSecretName, err = secrets.ValidateSecretName(mavenSecretName)
 		}
 
 		if testCatalogUrl != "" {
@@ -58,6 +64,7 @@ func SetStream(
 				streamName,
 				description,
 				mavenRepositoryUrl,
+				mavenSecretName,
 				testCatalogUrl,
 				streamObrs,
 				apiClient,
@@ -72,6 +79,7 @@ func sendStreamUpdateToRestApi(
 	streamName string,
 	description string,
 	mavenRepositoryUrl string,
+	mavenSecretName string,
 	testCatalogUrl string,
 	obrs []galasaapi.StreamOBRData,
 	apiClient *galasaapi.APIClient,
@@ -84,7 +92,7 @@ func sendStreamUpdateToRestApi(
 
 	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 
-	streamSetRequest := buildStreamUpdateRequest(description, mavenRepositoryUrl, testCatalogUrl, obrs)
+	streamSetRequest := buildStreamUpdateRequest(description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs)
 
 	apiCall := apiClient.StreamsAPIApi.UpdateStream(context, streamName).
 		StreamUpdateRequest(*streamSetRequest).
@@ -127,6 +135,7 @@ func sendStreamUpdateToRestApi(
 func buildStreamUpdateRequest(
 	description string,
 	mavenRepositoryUrl string,
+	mavenSecretName string,
 	testCatalogUrl string,
 	obrs []galasaapi.StreamOBRData,
 ) *galasaapi.StreamUpdateRequest {
@@ -136,9 +145,15 @@ func buildStreamUpdateRequest(
 		streamSetRequest.SetDescription(description)
 	}
 
+	repository := galasaapi.NewStreamUpdateRequestRepository()
 	if mavenRepositoryUrl != "" {
-		repository := galasaapi.NewStreamUpdateRequestRepository()
 		repository.SetUrl(mavenRepositoryUrl)
+
+		streamSetRequest.SetRepository(*repository)
+	}
+
+	if mavenSecretName != "" {
+		repository.SetSecretName(mavenSecretName)
 		streamSetRequest.SetRepository(*repository)
 	}
 

--- a/modules/cli/pkg/streams/streamsSet_test.go
+++ b/modules/cli/pkg/streams/streamsSet_test.go
@@ -33,6 +33,7 @@ func TestSetStreamWithInvalidNameReturnsError(t *testing.T) {
 	streamName := ""
 	description := ""
 	mavenRepositoryUrl := ""
+	mavenSecretName := ""
 	testCatalogUrl := ""
 	obrs := []string{}
 
@@ -45,7 +46,7 @@ func TestSetStreamWithInvalidNameReturnsError(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.NotNil(t, err)
@@ -58,6 +59,7 @@ func TestSetStreamWithInvalidDescriptionReturnsError(t *testing.T) {
 	streamName := "mystream"
 	description := "     "
 	mavenRepositoryUrl := ""
+	mavenSecretName := ""
 	testCatalogUrl := ""
 	obrs := []string{}
 
@@ -70,7 +72,7 @@ func TestSetStreamWithInvalidDescriptionReturnsError(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.NotNil(t, err)
@@ -83,6 +85,7 @@ func TestSetStreamWithInvalidMavenUrlReturnsError(t *testing.T) {
 	streamName := "mystream"
 	description := "my description"
 	mavenRepositoryUrl := "not a valid url"
+	mavenSecretName := ""
 	testCatalogUrl := ""
 	obrs := []string{}
 
@@ -95,7 +98,7 @@ func TestSetStreamWithInvalidMavenUrlReturnsError(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.NotNil(t, err)
@@ -108,6 +111,7 @@ func TestSetStreamWithInvalidTestCatalogUrlReturnsError(t *testing.T) {
 	streamName := "mystream"
 	description := "my description"
 	mavenRepositoryUrl := ""
+	mavenSecretName := ""
 	testCatalogUrl := "not a valid url"
 	obrs := []string{}
 
@@ -120,7 +124,7 @@ func TestSetStreamWithInvalidTestCatalogUrlReturnsError(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.NotNil(t, err)
@@ -133,6 +137,7 @@ func TestSetStreamSendsCorrectRequest(t *testing.T) {
 	streamName := "mystream"
 	description := "my stream's description"
 	mavenRepositoryUrl := "https://maven.example.com/repo"
+	mavenSecretName := "MAVEN_SECRET"
 	testCatalogUrl := "https://maven.example.com/repo/testcatalog.json"
 	obrs := []string{}
 
@@ -159,7 +164,8 @@ func TestSetStreamSendsCorrectRequest(t *testing.T) {
 			},
 			"data": {
 				"repository": {
-					"url": "https://maven.example.com/repo"
+					"url": "https://maven.example.com/repo",
+					"secretName": "MAVEN_SECRET"
 				},
 				"testCatalog": {
 					"url": "https://maven.example.com/repo/testcatalog.json"
@@ -184,7 +190,7 @@ func TestSetStreamSendsCorrectRequest(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.Nil(t, err)
@@ -195,6 +201,7 @@ func TestSetStreamWithObrsUpdatesObrData(t *testing.T) {
 	streamName := "mystream"
 	description := "my stream's description"
 	mavenRepositoryUrl := ""
+	mavenSecretName := ""
 	testCatalogUrl := ""
 	obrs := []string{"mvn:dev.galasa/dev.galasa.obr/0.1.0/obr"}
 
@@ -245,7 +252,7 @@ func TestSetStreamWithObrsUpdatesObrData(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.Nil(t, err)
@@ -256,6 +263,7 @@ func TestSetStreamWithTooManyObrPartsReturnsError(t *testing.T) {
 	streamName := "mystream"
 	description := "my stream's description"
 	mavenRepositoryUrl := ""
+	mavenSecretName := ""
 	testCatalogUrl := ""
 	obrs := []string{"mvn:/this/obr/has/too/many/parts/obr"}
 
@@ -269,7 +277,7 @@ func TestSetStreamWithTooManyObrPartsReturnsError(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.NotNil(t, err)
@@ -282,6 +290,7 @@ func TestSetStreamWithTooFewObrPartsReturnsError(t *testing.T) {
 	streamName := "mystream"
 	description := "my stream's description"
 	mavenRepositoryUrl := ""
+	mavenSecretName := ""
 	testCatalogUrl := ""
 	obrs := []string{"mvn:not-enough-parts/obr"}
 
@@ -295,7 +304,7 @@ func TestSetStreamWithTooFewObrPartsReturnsError(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.NotNil(t, err)
@@ -308,6 +317,7 @@ func TestSetStreamWithNoMavenPrefixReturnsError(t *testing.T) {
 	streamName := "mystream"
 	description := "my stream's description"
 	mavenRepositoryUrl := ""
+	mavenSecretName := ""
 	testCatalogUrl := ""
 	obrs := []string{"dev.galasa/dev.galasa.obr/0.1.0/obr"}
 
@@ -321,7 +331,7 @@ func TestSetStreamWithNoMavenPrefixReturnsError(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.NotNil(t, err)
@@ -334,6 +344,7 @@ func TestSetStreamWithNoObrSuffixReturnsError(t *testing.T) {
 	streamName := "mystream"
 	description := "my stream's description"
 	mavenRepositoryUrl := ""
+	mavenSecretName := ""
 	testCatalogUrl := ""
 	obrs := []string{"mvn:dev.galasa/dev.galasa.obr/0.1.0"}
 
@@ -347,7 +358,7 @@ func TestSetStreamWithNoObrSuffixReturnsError(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.NotNil(t, err)
@@ -360,6 +371,7 @@ func TestSetStreamWithServerFailureGivesCorrectMessage(t *testing.T) {
 	streamName := "mystream"
 	description := "my stream's description"
 	mavenRepositoryUrl := ""
+	mavenSecretName := ""
 	testCatalogUrl := ""
 	obrs := []string{}
 
@@ -386,7 +398,7 @@ func TestSetStreamWithServerFailureGivesCorrectMessage(t *testing.T) {
 	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	// When...
-	err := SetStream(streamName, description, mavenRepositoryUrl, testCatalogUrl, obrs, apiClient, mockByteReader)
+	err := SetStream(streamName, description, mavenRepositoryUrl, mavenSecretName, testCatalogUrl, obrs, apiClient, mockByteReader)
 
 	// Then...
 	assert.NotNil(t, err)


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/1572.

This PR adds a new (optional) `--maven-secret-name` flag to the `streams set` command allowing users to set the name of the Galasa secret containing credentials to use when authenticating with a test stream's maven repository.

The PR also updates the `runs submit` and `runs prepare` commands to get the testcatalog for a test stream using the API server's new `/streams/{streamName}/testcatalog` endpoint, rather than directly reaching out to the Maven repository configured in a test stream which may be password-protected. This way, the API server handles authentication with the Maven repository if needed.

## Changes
- [x] Added `--maven-secret-name` flag to `streams set`
- [x] Updated `GetTestCatalog` code to use the API server's `/testcatalog` endpoint
- [x] Unit tests (if applicable)
