### PR TITLE
Iss2571 - Improve CouchDB Users and Tokens Views Performance

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
@@ -254,7 +254,13 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
 
         try {
             // Get all of the documents in the tokens database with include_docs=true
-            tokenDocuments = getAllDocsByLoginId(TOKENS_DATABASE_NAME, lowercaseLoginId, TOKENS_DB_VIEW_NAME, true);
+            ViewResponse viewResponse = getDocumentsFromDatabaseViewByKey(
+                TOKENS_DATABASE_NAME,
+                TOKENS_DB_VIEW_NAME,
+                lowercaseLoginId,
+                true
+            );
+            tokenDocuments = viewResponse.rows;
 
             // Build up a list of all the tokens using the documents from the view response
             for (ViewRow row : tokenDocuments) {
@@ -403,7 +409,13 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
             String lowerCaseLoginId = loginId.toLowerCase();
             
             // Fetch documents matching the lowercase loginId using the lowercase view with include_docs=true
-            userDocument = getAllDocsByLoginId(USERS_DATABASE_NAME, lowerCaseLoginId, USERS_DB_VIEW_NAME, true);
+            ViewResponse viewResponse = getDocumentsFromDatabaseViewByKey(
+                USERS_DATABASE_NAME,
+                USERS_DB_VIEW_NAME,
+                lowerCaseLoginId,
+                true
+            );
+            userDocument = viewResponse.rows;
 
             // Since loginIds are unique (case-insensitive), there should be only one document.
             if (userDocument != null && !userDocument.isEmpty()) {
@@ -439,53 +451,6 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
         UserImpl userImpl = new UserImpl(user);
         updateUser(httpClient, storeUri, userImpl);
         return userImpl;
-    }
-
-    /**
-     * Sends a GET request to CouchDB's
-     * /{db}/_design/docs/_view/loginId-view?key={loginId} endpoint and returns the
-     * "rows" list in the response,
-     * which corresponds to the list of documents within the given database.
-     *
-     * @param dbName  the name of the database to retrieve the documents of
-     * @param loginId the loginId of the user to retrieve the documents of
-     * @param viewName the name of the view to query
-     * @param includeDocs whether to include the full document in the response using include_docs=true
-     * @return a list of rows corresponding to documents within the database
-     * @throws CouchdbException if there was a problem accessing the
-     *                          CouchDB store or its response
-     */
-    protected List<ViewRow> getAllDocsByLoginId(String dbName, String loginId, String viewName, boolean includeDocs)
-            throws CouchdbException {
-        List<ViewRow> viewRows = null;
-
-        String viewRequestUriStr = storeUri + "/" + dbName + "/_design/docs/_view/" + viewName;
-        // String encodedLoginId = URLEncoder.encode("\"" + loginId + "\"", StandardCharsets.UTF_8);
-        
-        try {
-            URIBuilder uriBuilder = new URIBuilder(viewRequestUriStr);
-            uriBuilder.addParameter("key", '"' + loginId + '"');
-            if (includeDocs) {
-                uriBuilder.addParameter("include_docs", "true");
-            }
-    
-            HttpGet getDocs = httpRequestFactory.getHttpGetRequest(uriBuilder.build().toString());
-            getDocs.addHeader("Content-Type", "application/json");
-    
-            String responseEntity = sendHttpRequest(getDocs, HttpStatus.SC_OK);
-    
-            ViewResponse docByLoginId = gson.fromJson(responseEntity, ViewResponse.class);
-            viewRows = docByLoginId.rows;
-    
-            if (viewRows == null) {
-                String errorMessage = ERROR_FAILED_TO_GET_DOCUMENTS_FROM_DATABASE.getMessage(dbName);
-                throw new CouchdbException(errorMessage);
-            }
-        } catch (URISyntaxException e) {
-            String errorMessage = ERROR_URI_IS_INVALID.getMessage(viewRequestUriStr);
-            throw new CouchdbException(errorMessage, e);
-        }
-        return viewRows;
     }
 
     private void updateUser(CloseableHttpClient httpClient, URI couchdbUri, UserImpl user)

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
@@ -9,6 +9,7 @@ import static dev.galasa.extensions.common.Errors.*;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -21,6 +22,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 
@@ -251,12 +253,13 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
         String lowercaseLoginId = loginId.toLowerCase();
 
         try {
-            // Get all of the documents in the tokens database
-            tokenDocuments = getAllDocsByLoginId(TOKENS_DATABASE_NAME, lowercaseLoginId, TOKENS_DB_VIEW_NAME);
+            // Get all of the documents in the tokens database with include_docs=true
+            tokenDocuments = getAllDocsByLoginId(TOKENS_DATABASE_NAME, lowercaseLoginId, TOKENS_DB_VIEW_NAME, true);
 
-            // Build up a list of all the tokens using the document IDs
+            // Build up a list of all the tokens using the documents from the view response
             for (ViewRow row : tokenDocuments) {
-                tokens.add(getAuthTokenFromDocument(row.id));
+                CouchdbAuthToken token = gson.fromJson(gson.toJson(row.doc), CouchdbAuthToken.class);
+                tokens.add(token);
             }
 
             logger.info("Tokens retrieved from CouchDB OK");
@@ -399,15 +402,14 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
             // Convert the loginId to lowercase for the lookup
             String lowerCaseLoginId = loginId.toLowerCase();
             
-            // Fetch documents matching the lowercase loginId using the lowercase view
-            userDocument = getAllDocsByLoginId(USERS_DATABASE_NAME, lowerCaseLoginId, USERS_DB_VIEW_NAME);
+            // Fetch documents matching the lowercase loginId using the lowercase view with include_docs=true
+            userDocument = getAllDocsByLoginId(USERS_DATABASE_NAME, lowerCaseLoginId, USERS_DB_VIEW_NAME, true);
 
             // Since loginIds are unique (case-insensitive), there should be only one document.
             if (userDocument != null && !userDocument.isEmpty()) {
                 ViewRow row = userDocument.get(0); // Get the first entry since loginId is unique
 
-                // Fetch the user document from the CouchDB using the ID from the row
-                UserDoc fetchedUser = getUserFromDocument(row.id);
+                UserDoc fetchedUser = gson.fromJson(gson.toJson(row.doc), UserDoc.class);
 
                 if (row.value != null) {
                     AuthDBNameViewDesign nameViewDesign = gson.fromJson(gson.toJson(row.value),
@@ -446,30 +448,43 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
      * which corresponds to the list of documents within the given database.
      *
      * @param dbName  the name of the database to retrieve the documents of
-     * @param loginId the loginId of the user to retrieve the doucemnts of
+     * @param loginId the loginId of the user to retrieve the documents of
+     * @param viewName the name of the view to query
+     * @param includeDocs whether to include the full document in the response using include_docs=true
      * @return a list of rows corresponding to documents within the database
      * @throws CouchdbException if there was a problem accessing the
      *                          CouchDB store or its response
      */
-    protected List<ViewRow> getAllDocsByLoginId(String dbName, String loginId, String viewName)
+    protected List<ViewRow> getAllDocsByLoginId(String dbName, String loginId, String viewName, boolean includeDocs)
             throws CouchdbException {
+        List<ViewRow> viewRows = null;
 
-        String encodedLoginId = URLEncoder.encode("\"" + loginId + "\"", StandardCharsets.UTF_8);
-        String url = storeUri + "/" + dbName + "/_design/docs/_view/" + viewName + "?key=" + encodedLoginId;
-
-        HttpGet getDocs = httpRequestFactory.getHttpGetRequest(url);
-        getDocs.addHeader("Content-Type", "application/json");
-
-        String responseEntity = sendHttpRequest(getDocs, HttpStatus.SC_OK);
-
-        ViewResponse docByLoginId = gson.fromJson(responseEntity, ViewResponse.class);
-        List<ViewRow> viewRows = docByLoginId.rows;
-
-        if (viewRows == null) {
-            String errorMessage = ERROR_FAILED_TO_GET_DOCUMENTS_FROM_DATABASE.getMessage(dbName);
-            throw new CouchdbException(errorMessage);
+        String viewRequestUriStr = storeUri + "/" + dbName + "/_design/docs/_view/" + viewName;
+        // String encodedLoginId = URLEncoder.encode("\"" + loginId + "\"", StandardCharsets.UTF_8);
+        
+        try {
+            URIBuilder uriBuilder = new URIBuilder(viewRequestUriStr);
+            uriBuilder.addParameter("key", '"' + loginId + '"');
+            if (includeDocs) {
+                uriBuilder.addParameter("include_docs", "true");
+            }
+    
+            HttpGet getDocs = httpRequestFactory.getHttpGetRequest(uriBuilder.build().toString());
+            getDocs.addHeader("Content-Type", "application/json");
+    
+            String responseEntity = sendHttpRequest(getDocs, HttpStatus.SC_OK);
+    
+            ViewResponse docByLoginId = gson.fromJson(responseEntity, ViewResponse.class);
+            viewRows = docByLoginId.rows;
+    
+            if (viewRows == null) {
+                String errorMessage = ERROR_FAILED_TO_GET_DOCUMENTS_FROM_DATABASE.getMessage(dbName);
+                throw new CouchdbException(errorMessage);
+            }
+        } catch (URISyntaxException e) {
+            String errorMessage = ERROR_URI_IS_INVALID.getMessage(viewRequestUriStr);
+            throw new CouchdbException(errorMessage, e);
         }
-
         return viewRows;
     }
 

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStoreValidator.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStoreValidator.java
@@ -42,8 +42,10 @@ public class CouchdbAuthStoreValidator extends CouchdbBaseValidator {
     private final LogFactory logFactory;
 
     // A couchDB view, it gets all the access tokens of a the user based on the loginId provided.
-    public static final String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), doc); } }";
-    public static final String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), doc); } }";
+    // Views emit null as the value to avoid storing duplicate document copies in the view index.
+    // Use include_docs=true query parameter when full documents are needed.
+    public static final String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), null); } }";
+    public static final String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), null); } }";
 
     public CouchdbAuthStoreValidator() {
         this(new LogFactory(){

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStore.java
@@ -210,33 +210,24 @@ public class TestCouchdbAuthStore {
         URI authStoreUri = URI.create("couchdb:https://my-auth-store");
         MockLogFactory logFactory = new MockLogFactory();
 
+        Instant now = Instant.now();
+        Instant expiry = now.plus(90, java.time.temporal.ChronoUnit.DAYS);
+        CouchdbAuthToken mockToken = new CouchdbAuthToken("token1", "dex-client", "my test token", now, expiry,
+                        new CouchdbUser("johndoe", "dex-user-id"));
+
         ViewRow tokenDoc = new ViewRow();
         tokenDoc.id = "token1";
+        tokenDoc.doc = mockToken;  // Document is included in the view response when include_docs=true
         List<ViewRow> mockDocs = List.of(tokenDoc);
 
         ViewResponse mockAllDocsResponse = new ViewResponse();
         mockAllDocsResponse.rows = mockDocs;
 
-        Instant now = Instant.now();
-        Instant expiry = now.plus(90, java.time.temporal.ChronoUnit.DAYS);
-        CouchdbAuthToken mockToken = new CouchdbAuthToken("token1", "dex-client", "my test token", now, expiry,
-                        new CouchdbUser("johndoe", "dex-user-id"));
-        Instant now2 = Instant.now();
-        Instant expiry2 = now2.plus(90, java.time.temporal.ChronoUnit.DAYS);
-        CouchdbAuthToken mockToken2 = new CouchdbAuthToken("token2", "dex-client", "my test token",
-                        now2, expiry2,
-                        new CouchdbUser("notJohnDoe", "dex-user-id"));
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         addMigrationMockInteractions(interactions, authStoreUri.getSchemeSpecificPart());
         interactions.add(new GetAllDocumentsInteraction(
-                        "https://my-auth-store/galasa_tokens/_design/docs/_view/loginId-view?key=%22johndoe%22",
+                        "https://my-auth-store/galasa_tokens/_design/docs/_view/loginId-view?key=%22johndoe%22&include_docs=true",
                         HttpStatus.SC_OK, mockAllDocsResponse));
-        interactions.add(new GetDocumentInteraction<CouchdbAuthToken>(
-                        "https://my-auth-store/galasa_tokens/token1",
-                        HttpStatus.SC_OK, mockToken));
-        interactions.add(new GetDocumentInteraction<CouchdbAuthToken>(
-                        "https://my-auth-store/galasa_tokens/token1",
-                        HttpStatus.SC_OK, mockToken2));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 
@@ -264,7 +255,7 @@ public class TestCouchdbAuthStore {
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         addMigrationMockInteractions(interactions, authStoreUri.getSchemeSpecificPart());
         interactions.add(new GetAllDocumentsInteraction(
-                "https://my-auth-store/galasa_tokens/_design/docs/_view/loginId-view?key=%22johndoe%22",
+                "https://my-auth-store/galasa_tokens/_design/docs/_view/loginId-view?key=%22johndoe%22&include_docs=true",
                 HttpStatus.SC_INTERNAL_SERVER_ERROR, null));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
@@ -631,28 +622,21 @@ public class TestCouchdbAuthStore {
         URI authStoreUri = URI.create("couchdb:https://my-auth-store");
         MockLogFactory logFactory = new MockLogFactory();
 
-        ViewRow userDoc1 = new ViewRow();
+        UserDoc mockUser = new UserDoc("johndoe", List.of(new FrontEndClient("web-ui", Instant.now())), "2");
 
+        ViewRow userDoc1 = new ViewRow();
         userDoc1.id = "user1";
+        userDoc1.doc = mockUser;  // Document is included when include_docs=true
         List<ViewRow> mockDocs = List.of(userDoc1);
 
         ViewResponse mockAllDocsResponse = new ViewResponse();
         mockAllDocsResponse.rows = mockDocs;
 
-        FrontEndClient client = new FrontEndClient();
-
-        client.setClientName("web-ui");
-        client.setLastLogin(Instant.now());
-
-        UserDoc mockUser = new UserDoc("johndoe", List.of(client), "2");
-
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         addMigrationMockInteractions(interactions, authStoreUri.getSchemeSpecificPart());
         interactions.add(new GetAllDocumentsInteraction(
-                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22user1%22",
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22user1%22&include_docs=true",
                 HttpStatus.SC_OK, mockAllDocsResponse));
-        interactions.add(new GetDocumentInteraction<UserDoc>("https://my-auth-store/galasa_users/user1",
-                HttpStatus.SC_OK, mockUser));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 
@@ -675,23 +659,21 @@ public class TestCouchdbAuthStore {
         URI authStoreUri = URI.create("couchdb:https://my-auth-store");
         MockLogFactory logFactory = new MockLogFactory();
 
-        ViewRow userDoc1 = new ViewRow();
+        UserDoc mockUser = new UserDoc("johndoe", List.of(new FrontEndClient("web-ui", Instant.now())), "2");
 
+        ViewRow userDoc1 = new ViewRow();
         userDoc1.id = "user1";
+        userDoc1.doc = mockUser;  // Document is included when include_docs=true
         List<ViewRow> mockDocs = List.of(userDoc1);
 
         ViewResponse mockAllDocsResponse = new ViewResponse();
         mockAllDocsResponse.rows = mockDocs;
 
-        UserDoc mockUser = new UserDoc("johndoe", List.of(new FrontEndClient("web-ui", Instant.now())), "2");
-
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         addMigrationMockInteractions(interactions, authStoreUri.getSchemeSpecificPart());
         interactions.add(new GetAllDocumentsInteraction(
-                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22notjohndoe%22",
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22notjohndoe%22&include_docs=true",
                 HttpStatus.SC_OK, mockAllDocsResponse));
-        interactions.add(new GetDocumentInteraction<UserDoc>("https://my-auth-store/galasa_users/user1",
-                HttpStatus.SC_OK, mockUser));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 
@@ -713,27 +695,22 @@ public class TestCouchdbAuthStore {
         URI authStoreUri = URI.create("couchdb:https://my-auth-store");
         MockLogFactory logFactory = new MockLogFactory();
 
+        UserDoc mockUser = new UserDoc("JohnDoe", List.of(new FrontEndClient("web-ui", Instant.now())), "2");
+
         ViewRow userDoc1 = new ViewRow();
         userDoc1.id = "user1";
+        userDoc1.doc = mockUser;  // Document is included when include_docs=true
         List<ViewRow> mockDocs = List.of(userDoc1);
 
         ViewResponse mockAllDocsResponse = new ViewResponse();
         mockAllDocsResponse.rows = mockDocs;
 
-        FrontEndClient client = new FrontEndClient();
-        client.setClientName("web-ui");
-        client.setLastLogin(Instant.now());
-
-        UserDoc mockUser = new UserDoc("JohnDoe", List.of(client), "2");
-
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         addMigrationMockInteractions(interactions, authStoreUri.getSchemeSpecificPart());
         // The lowercase view should be queried with the lowercase version of the loginId
         interactions.add(new GetAllDocumentsInteraction(
-                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22johndoe%22",
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22johndoe%22&include_docs=true",
                 HttpStatus.SC_OK, mockAllDocsResponse));
-        interactions.add(new GetDocumentInteraction<UserDoc>("https://my-auth-store/galasa_users/user1",
-                HttpStatus.SC_OK, mockUser));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 
@@ -758,27 +735,22 @@ public class TestCouchdbAuthStore {
         URI authStoreUri = URI.create("couchdb:https://my-auth-store");
         MockLogFactory logFactory = new MockLogFactory();
 
+        UserDoc mockUser = new UserDoc("JohnDoe", List.of(new FrontEndClient("web-ui", Instant.now())), "2");
+
         ViewRow userDoc1 = new ViewRow();
         userDoc1.id = "user1";
+        userDoc1.doc = mockUser;  // Document is included when include_docs=true
         List<ViewRow> mockDocs = List.of(userDoc1);
 
         ViewResponse mockAllDocsResponse = new ViewResponse();
         mockAllDocsResponse.rows = mockDocs;
 
-        FrontEndClient client = new FrontEndClient();
-        client.setClientName("web-ui");
-        client.setLastLogin(Instant.now());
-
-        UserDoc mockUser = new UserDoc("JohnDoe", List.of(client), "2");
-
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         addMigrationMockInteractions(interactions, authStoreUri.getSchemeSpecificPart());
         // The lowercase view should be queried with the lowercase version of the loginId
         interactions.add(new GetAllDocumentsInteraction(
-                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22johndoe%22",
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22johndoe%22&include_docs=true",
                 HttpStatus.SC_OK, mockAllDocsResponse));
-        interactions.add(new GetDocumentInteraction<UserDoc>("https://my-auth-store/galasa_users/user1",
-                HttpStatus.SC_OK, mockUser));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 
@@ -803,23 +775,22 @@ public class TestCouchdbAuthStore {
         URI authStoreUri = URI.create("couchdb:https://my-auth-store");
         MockLogFactory logFactory = new MockLogFactory();
 
+        UserDoc mockUser = new UserDoc("admin", List.of(new FrontEndClient("web-ui", Instant.now())), "2");
+
         ViewRow userDoc1 = new ViewRow();
         userDoc1.id = "user1";
+        userDoc1.doc = mockUser;  // Document is included when include_docs=true
         List<ViewRow> mockDocs = List.of(userDoc1);
 
         ViewResponse mockAllDocsResponse = new ViewResponse();
         mockAllDocsResponse.rows = mockDocs;
 
-        UserDoc mockUser = new UserDoc("admin", List.of(new FrontEndClient("web-ui", Instant.now())), "2");
-
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         addMigrationMockInteractions(interactions, authStoreUri.getSchemeSpecificPart());
         // The lowercase view should be queried with the lowercase version of the loginId
         interactions.add(new GetAllDocumentsInteraction(
-                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22admin%22",
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22admin%22&include_docs=true",
                 HttpStatus.SC_OK, mockAllDocsResponse));
-        interactions.add(new GetDocumentInteraction<UserDoc>("https://my-auth-store/galasa_users/user1",
-                HttpStatus.SC_OK, mockUser));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 
@@ -850,7 +821,7 @@ public class TestCouchdbAuthStore {
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         addMigrationMockInteractions(interactions, authStoreUri.getSchemeSpecificPart());
         interactions.add(new GetAllDocumentsInteraction(
-                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22nonexistent%22",
+                "https://my-auth-store/galasa_users/_design/docs/_view/loginId-view?key=%22nonexistent%22&include_docs=true",
                 HttpStatus.SC_OK, mockEmptyResponse));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStoreValidator.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/internal/TestCouchdbAuthStoreValidator.java
@@ -137,7 +137,7 @@ public class TestCouchdbAuthStoreValidator {
         //   "language": "javascript"
         // }
         AuthStoreDBLoginView view = new AuthStoreDBLoginView();
-        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), doc);\n  }\n}";
+        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), null);\n  }\n}";
         AuthStoreDBViews views = new AuthStoreDBViews();
         views.loginIdView = view;
         AuthDBNameViewDesign designDocToPassBack = new AuthDBNameViewDesign();
@@ -210,7 +210,7 @@ public class TestCouchdbAuthStoreValidator {
         interactions.add(new CreateDatabaseInteraction(couchdbUriStr + "/" + usersDatabaseName, HttpStatus.SC_CREATED));
 
         AuthStoreDBLoginView view = new AuthStoreDBLoginView();
-        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), doc);\n  }\n}";
+        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), null);\n  }\n}";
         AuthStoreDBViews views = new AuthStoreDBViews();
         views.loginIdView = view;
         AuthDBNameViewDesign designDocToPassBack = new AuthDBNameViewDesign();
@@ -448,7 +448,7 @@ public class TestCouchdbAuthStoreValidator {
         //   "language": "javascript"
         // }
         AuthStoreDBLoginView view = new AuthStoreDBLoginView();
-        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), doc);\n  }\n}";
+        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), null);\n  }\n}";
         AuthStoreDBViews views = new AuthStoreDBViews();
         views.loginIdView = view;
         AuthDBNameViewDesign designDocToPassBack = new AuthDBNameViewDesign();
@@ -499,7 +499,7 @@ public class TestCouchdbAuthStoreValidator {
         //   "language": "javascript"
         // }
         AuthStoreDBLoginView view = new AuthStoreDBLoginView();
-        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), doc);\n  }\n}";
+        view.map = "function (doc) {\n  if (doc.owner && doc.owner.loginId) {\n    emit(doc.owner.loginId.toLowerCase(), null);\n  }\n}";
         AuthStoreDBViews views = new AuthStoreDBViews();
         views.loginIdView = view;
         AuthDBNameViewDesign designDocToPassBack = new AuthDBNameViewDesign();
@@ -534,7 +534,7 @@ public class TestCouchdbAuthStoreValidator {
 
         boolean isUpdated = validator.updateDesignDocToDesiredDesignDoc(tableDesign, dbName);
 
-        String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), doc); } }";
+        String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), null); } }";
 
         assertTrue(isUpdated);
         assertNotNull(tableDesign.views);
@@ -553,7 +553,7 @@ public class TestCouchdbAuthStoreValidator {
 
         boolean isUpdated = validator.updateDesignDocToDesiredDesignDoc(tableDesign, dbName);
 
-        String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), doc); } }";
+        String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), null); } }";
 
         assertTrue(isUpdated);
         assertNotNull(tableDesign.views);
@@ -567,7 +567,7 @@ public class TestCouchdbAuthStoreValidator {
         AuthDBNameViewDesign tableDesign = new AuthDBNameViewDesign();
         tableDesign.views = new AuthStoreDBViews();
         tableDesign.views.loginIdView = new AuthStoreDBLoginView();
-        // Set an old map function
+        // Set an old map function (emitting doc instead of null)
         tableDesign.views.loginIdView.map = "function (doc) { emit(doc.owner.loginId, doc); }";
         tableDesign.language = "javascript";
         
@@ -576,7 +576,7 @@ public class TestCouchdbAuthStoreValidator {
 
         boolean isUpdated = validator.updateDesignDocToDesiredDesignDoc(tableDesign, dbName);
 
-        String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), doc); } }";
+        String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), null); } }";
 
         assertTrue("View should be updated when map function is different", isUpdated);
         assertNotNull(tableDesign.views);
@@ -590,7 +590,7 @@ public class TestCouchdbAuthStoreValidator {
         AuthDBNameViewDesign tableDesign = new AuthDBNameViewDesign();
         tableDesign.views = new AuthStoreDBViews();
         tableDesign.views.loginIdView = new AuthStoreDBLoginView();
-        // Set an old map function
+        // Set an old map function (emitting doc instead of null)
         tableDesign.views.loginIdView.map = "function (doc) { if (doc['login-id']) { emit(doc['login-id'], doc); } }";
         tableDesign.language = "javascript";
         
@@ -599,7 +599,7 @@ public class TestCouchdbAuthStoreValidator {
 
         boolean isUpdated = validator.updateDesignDocToDesiredDesignDoc(tableDesign, dbName);
 
-        String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), doc); } }";
+        String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), null); } }";
 
         assertTrue("View should be updated when map function is different", isUpdated);
         assertNotNull(tableDesign.views);
@@ -614,7 +614,7 @@ public class TestCouchdbAuthStoreValidator {
         tableDesign.views = new AuthStoreDBViews();
         tableDesign.views.loginIdView = new AuthStoreDBLoginView();
         // Set the correct map function
-        String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), doc); } }";
+        String DB_TABLE_TOKENS_DESIGN = "function (doc) { if (doc.owner && doc.owner.loginId) {emit(doc.owner.loginId.toLowerCase(), null); } }";
         tableDesign.views.loginIdView.map = DB_TABLE_TOKENS_DESIGN;
         tableDesign.language = "javascript";
         
@@ -633,7 +633,7 @@ public class TestCouchdbAuthStoreValidator {
         tableDesign.views = new AuthStoreDBViews();
         tableDesign.views.loginIdView = new AuthStoreDBLoginView();
         // Set the correct map function
-        String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), doc); } }";
+        String DB_TABLE_USERS_DESIGN = "function (doc) { if (doc['login-id']) { emit(doc['login-id'].toLowerCase(), null); } }";
         tableDesign.views.loginIdView.map = DB_TABLE_USERS_DESIGN;
         tableDesign.language = "javascript";
         

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/src/main/java/dev/galasa/extensions/common/couchdb/CouchdbStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.extensions.common.couchdb/src/main/java/dev/galasa/extensions/common/couchdb/CouchdbStore.java
@@ -167,6 +167,18 @@ public abstract class CouchdbStore {
         return response;
     }
 
+    /**
+     * Sends a GET request to CouchDB's /{db}/_design/docs/_view/{viewName}?key={queryKey} endpoint
+     * and returns the ViewResponse containing the "rows" list, which corresponds to the list of
+     * documents within the given database that match the specified key.
+     *
+     * @param dbName      the name of the database to retrieve the documents from
+     * @param viewName    the name of the view to query
+     * @param queryKey    the key value to search for in the view
+     * @param includeDocs whether to include the full document in the response using include_docs=true parameter
+     * @return a ViewResponse containing the rows that match the query key
+     * @throws CouchdbException if there was a problem accessing the CouchDB store or its response
+     */
     public ViewResponse getDocumentsFromDatabaseViewByKey(String dbName, String viewName, String queryKey, boolean includeDocs)
             throws CouchdbException {
         ViewResponse viewResponse = null;
@@ -182,9 +194,9 @@ public abstract class CouchdbStore {
                 uriBuilder.addParameter("include_docs", "true");
             }
 
-            HttpGet getRunsRequest = httpRequestFactory.getHttpGetRequest(uriBuilder.build().toString());
+            HttpGet getDocumentsRequest = httpRequestFactory.getHttpGetRequest(uriBuilder.build().toString());
 
-            String responseEntity = sendHttpRequest(getRunsRequest, HttpStatus.SC_OK);
+            String responseEntity = sendHttpRequest(getDocumentsRequest, HttpStatus.SC_OK);
             viewResponse = gson.fromJson(responseEntity, ViewResponse.class);
 
             if (viewResponse.rows == null) {


### PR DESCRIPTION
## Why?

Fixes https://github.com/galasa-dev/projectmanagement/issues/2571

The User and Token Couchdb views will not emit the whole document unless the `include_docs=true` parameter is added to the request to avoid using excess disk space which could cause performance issues.

## Changes
- [x] Users and Tokens Couchdb Views updated
- [x] `getAllDocsByLoginId` takes a boolean parameter of whether to add the `include_docs=true` parameters to the request
- [x] Changes tested on Minikube with `galasactl users` and `auth tokens` commands
- [x] Verified that there are not duplicate views (old and new) in `_design/docs` for galasa_users and galasa_tokens in my Minikube system
- [x] Unit tests (if applicable)
- [ ] Documentation updates (if applicable)
- [ ] Release notes updates (if applicable)
