### PR TITLE
Add authenticated IVTs image and build the image in the IVTs workflow

### DIFF
--- a/.github/workflows/ivts.yaml
+++ b/.github/workflows/ivts.yaml
@@ -166,7 +166,7 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/ivts-maven-artefacts
-    
+
       - name: Build IVTs image for development Maven registry
         id: build
         uses: docker/build-push-action@v5
@@ -180,25 +180,6 @@ jobs:
             baseVersion=latest
             dockerRepository=${{ env.REGISTRY }}
             branch=${{ env.BRANCH }}
-    
-      - name: Build Authenticated IVTs image for development Maven registry
-        id: build
-        uses: docker/build-push-action@v5
-        env:
-          MAVEN_REPO_USERNAME: ${{ secrets.GALASA_MAVEN_REPO_USERNAME }}
-          MAVEN_REPO_PASSWORD: ${{ secrets.GALASA_MAVEN_REPO_PASSWORD }}
-        with:
-          context: modules/ivts
-          file: modules/ivts/dockerfiles/dockerfile.ivts-auth
-          push: true
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels }}
-          build-args: |
-            baseVersion=latest
-            dockerRepository=${{ env.REGISTRY }}
-            branch=${{ env.BRANCH }}
-            mavenUsername=${{ env.MAVEN_REPO_USERNAME }}
-            mavenPassword=${{ env.MAVEN_REPO_PASSWORD }}
 
       - name: Recycle 'ivts' application in ArgoCD
         # Skip this job for forks
@@ -221,27 +202,6 @@ jobs:
           echo "ArgoCD still uncontactable after 10 attempts."
           exit 1
 
-      - name: Recycle 'ivts-auth' application in ArgoCD
-        # Skip this job for forks
-        if: ${{ github.repository_owner == 'galasa-dev' }}
-        env:
-          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
-        run: |
-          for i in {1..10}; do
-            docker run \
-            --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} \
-            --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main \
-            app actions run ${{ env.BRANCH }}-ivts-auth restart \
-            --kind Deployment \
-            --resource-name ivts-auth-${{ env.BRANCH }} \
-            --server argocd.galasa.dev \
-            --grpc-web \
-            && exit 0 || sleep 10
-          done
-
-          echo "ArgoCD still uncontactable after 10 attempts."
-          exit 1
-
       - name: Wait for 'ivts' application health in ArgoCD
         # Skip this job for forks
         if: ${{ github.repository_owner == 'galasa-dev' }}
@@ -255,6 +215,52 @@ jobs:
             app wait ${{ env.BRANCH }}-ivts \
             --resource apps:Deployment:ivts-${{ env.BRANCH }} \
             --health \
+            --server argocd.galasa.dev \
+            --grpc-web \
+            && exit 0 || sleep 10
+          done
+
+          echo "ArgoCD still uncontactable after 10 attempts."
+          exit 1
+
+      - name: Extract metadata for authenticated IVTs
+        id: metadata-ivts-auth
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/ivts-auth-maven-artefacts
+    
+      - name: Build Authenticated IVTs image for development Maven registry
+        id: build
+        uses: docker/build-push-action@v5
+        env:
+          MAVEN_REPO_USERNAME: ${{ secrets.GALASA_MAVEN_REPO_USERNAME }}
+          MAVEN_REPO_PASSWORD: ${{ secrets.GALASA_MAVEN_REPO_PASSWORD }}
+        with:
+          context: modules/ivts
+          file: modules/ivts/dockerfiles/dockerfile.ivts-auth
+          push: true
+          tags: ${{ steps.metadata-ivts-auth.outputs.tags }}
+          labels: ${{ steps.metadata-ivts-auth.outputs.labels }}
+          build-args: |
+            baseVersion=latest
+            dockerRepository=${{ env.REGISTRY }}
+            branch=${{ env.BRANCH }}
+            mavenUsername=${{ env.MAVEN_REPO_USERNAME }}
+            mavenPassword=${{ env.MAVEN_REPO_PASSWORD }}
+
+      - name: Recycle 'ivts-auth' application in ArgoCD
+        # Skip this job for forks
+        if: ${{ github.repository_owner == 'galasa-dev' }}
+        env:
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          for i in {1..10}; do
+            docker run \
+            --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} \
+            --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main \
+            app actions run ${{ env.BRANCH }}-ivts-auth restart \
+            --kind Deployment \
+            --resource-name ivts-auth-${{ env.BRANCH }} \
             --server argocd.galasa.dev \
             --grpc-web \
             && exit 0 || sleep 10

--- a/.github/workflows/ivts.yaml
+++ b/.github/workflows/ivts.yaml
@@ -180,6 +180,25 @@ jobs:
             baseVersion=latest
             dockerRepository=${{ env.REGISTRY }}
             branch=${{ env.BRANCH }}
+    
+      - name: Build Authenticated IVTs image for development Maven registry
+        id: build
+        uses: docker/build-push-action@v5
+        env:
+          MAVEN_REPO_USERNAME: ${{ secrets.GALASA_MAVEN_REPO_USERNAME }}
+          MAVEN_REPO_PASSWORD: ${{ secrets.GALASA_MAVEN_REPO_PASSWORD }}
+        with:
+          context: modules/ivts
+          file: modules/ivts/dockerfiles/dockerfile.ivts-auth
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            baseVersion=latest
+            dockerRepository=${{ env.REGISTRY }}
+            branch=${{ env.BRANCH }}
+            mavenUsername=${{ env.MAVEN_REPO_USERNAME }}
+            mavenPassword=${{ env.MAVEN_REPO_PASSWORD }}
 
       - name: Recycle 'ivts' application in ArgoCD
         # Skip this job for forks
@@ -202,6 +221,27 @@ jobs:
           echo "ArgoCD still uncontactable after 10 attempts."
           exit 1
 
+      - name: Recycle 'ivts-auth' application in ArgoCD
+        # Skip this job for forks
+        if: ${{ github.repository_owner == 'galasa-dev' }}
+        env:
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          for i in {1..10}; do
+            docker run \
+            --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} \
+            --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main \
+            app actions run ${{ env.BRANCH }}-ivts-auth restart \
+            --kind Deployment \
+            --resource-name ivts-auth-${{ env.BRANCH }} \
+            --server argocd.galasa.dev \
+            --grpc-web \
+            && exit 0 || sleep 10
+          done
+
+          echo "ArgoCD still uncontactable after 10 attempts."
+          exit 1
+
       - name: Wait for 'ivts' application health in ArgoCD
         # Skip this job for forks
         if: ${{ github.repository_owner == 'galasa-dev' }}
@@ -214,6 +254,27 @@ jobs:
             --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main \
             app wait ${{ env.BRANCH }}-ivts \
             --resource apps:Deployment:ivts-${{ env.BRANCH }} \
+            --health \
+            --server argocd.galasa.dev \
+            --grpc-web \
+            && exit 0 || sleep 10
+          done
+
+          echo "ArgoCD still uncontactable after 10 attempts."
+          exit 1
+
+      - name: Wait for 'ivts-auth' application health in ArgoCD
+        # Skip this job for forks
+        if: ${{ github.repository_owner == 'galasa-dev' }}
+        env:
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          for i in {1..10}; do
+            docker run \
+            --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} \
+            --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main \
+            app wait ${{ env.BRANCH }}-ivts-auth \
+            --resource apps:Deployment:ivts-auth-${{ env.BRANCH }} \
             --health \
             --server argocd.galasa.dev \
             --grpc-web \

--- a/modules/ivts/dockerfiles/dockerfile.ivts-auth
+++ b/modules/ivts/dockerfiles/dockerfile.ivts-auth
@@ -1,0 +1,21 @@
+ARG baseVersion
+ARG dockerRepository
+FROM ${dockerRepository}/galasa-dev/base-image:${baseVersion}
+
+ARG branch
+ARG mavenUsername
+ARG mavenPassword
+
+# Create password file using build arguments
+# Using bcrypt encryption (-B flag)
+RUN htpasswd -cb /usr/local/apache2/conf/.htpasswd ${mavenUsername} ${mavenPassword}
+
+# Copy the authenticated httpd configuration
+COPY dockerfiles/httpdconf/httpd-auth.conf /usr/local/apache2/conf/httpd.conf
+
+# Replace placeholders in the config
+RUN sed -i "s/--branchname--/${branch}/" /usr/local/apache2/conf/httpd.conf
+RUN sed -i 's/--repositoryname--/ivts-auth/' /usr/local/apache2/conf/httpd.conf
+
+# Copy the Maven repository content
+COPY repo/ /usr/local/apache2/htdocs/

--- a/modules/ivts/dockerfiles/httpdconf/httpd-auth.conf
+++ b/modules/ivts/dockerfiles/httpdconf/httpd-auth.conf
@@ -1,0 +1,94 @@
+#
+# Apache HTTP server configuration with Basic Authentication
+#
+ServerRoot "/usr/local/apache2"
+
+Listen 80
+
+# Load required modules
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+LoadModule filter_module modules/mod_filter.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule env_module modules/mod_env.so
+LoadModule headers_module modules/mod_headers.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule version_module modules/mod_version.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule alias_module modules/mod_alias.so
+
+<IfModule unixd_module>
+User daemon
+Group daemon
+</IfModule>
+
+ServerAdmin you@example.com
+
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+Alias "/${CONTEXTROOT}" "/usr/local/apache2/htdocs"
+
+DocumentRoot "/usr/local/apache2/htdocs"
+<Directory "/usr/local/apache2/htdocs">
+    Options Indexes FollowSymLinks
+    IndexOptions FancyIndexing
+    AllowOverride None
+    
+    # Enable Basic Authentication
+    AuthType Basic
+    AuthName "Maven Repository - Galasa Test"
+    AuthUserFile /usr/local/apache2/conf/.htpasswd
+    Require valid-user
+</Directory>
+
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+<Files ".ht*">
+    Require all denied
+</Files>
+
+ErrorLog /proc/self/fd/2
+LogLevel warn
+
+<IfModule log_config_module>
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+    CustomLog /proc/self/fd/1 common
+</IfModule>
+
+<IfModule alias_module>
+    ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
+</IfModule>
+
+<Directory "/usr/local/apache2/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule headers_module>
+    RequestHeader unset Proxy early
+</IfModule>
+
+<IfModule mime_module>
+    TypesConfig conf/mime.types
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+</IfModule>


### PR DESCRIPTION
## Why?
Refer to https://github.com/galasa-dev/projectmanagement/issues/1572. 

## Changes
- [x] Added a new Dockerfile to build an authenticated httpd server to serve up IVTs
- [x] Updated the ivts workflow to include steps to build the new authenticated IVTs image and then recycle the related ArgoCD app
