### PR TITLE
Remove duplicate step ID and use build-ivts-auth instead

### DIFF
--- a/.github/workflows/ivts.yaml
+++ b/.github/workflows/ivts.yaml
@@ -230,7 +230,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/ivts-auth-maven-artefacts
     
       - name: Build Authenticated IVTs image for development Maven registry
-        id: build
+        id: build-ivts-auth
         uses: docker/build-push-action@v5
         env:
           MAVEN_REPO_USERNAME: ${{ secrets.GALASA_MAVEN_REPO_USERNAME }}


### PR DESCRIPTION
## Why?

Related to changes in https://github.com/galasa-dev/galasa/pull/608

## Changes
- [x] Fixed an issue where a duplicate step ID was being used which was causing a build error
