### PR TITLE
Iss2594 - Update build workflows to trigger Isolated build after Docs has completed

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -346,20 +346,6 @@ jobs:
           echo "ArgoCD still uncontactable after 10 attempts."
           exit 1
 
-  trigger-next-workflow:
-    # Skip this job for forks
-    if: ${{ github.repository_owner == 'galasa-dev' }}
-    name: Trigger next workflow in the build chain
-    needs: [log-github-ref, build-cli]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Triggering isolated build
-        env:
-            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          gh workflow run build.yaml --repo https://github.com/galasa-dev/isolated --ref ${{ env.BRANCH }}
-
   report-failure:
     # Skip this job for forks
     if: ${{ failure() && github.repository_owner == 'galasa-dev' }}

--- a/.github/workflows/obr.yaml
+++ b/.github/workflows/obr.yaml
@@ -861,46 +861,12 @@ jobs:
             dockerRepository=${{ env.REGISTRY }}
             jdkImage=ghcr.io/galasa-dev/openjdk:17
 
-  trigger-next-workflows:
-    # Skip this job for forks
-    if: ${{ github.repository_owner == 'galasa-dev' }}
-    name: Trigger next workflows in the build chain
-    needs: [build-obr, build-obr-generic, build-obr-javadocs, build-obr-galasabld-image]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Triggering helm build (github.ref is main)
-        if: ${{ env.BRANCH == 'main' }}
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation --ref ${{ env.BRANCH }}
-
-      - name: Triggering integratedtests build (github.ref is main)
-        if: ${{ env.BRANCH == 'main' }}
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          gh workflow run build.yaml --repo https://github.com/galasa-dev/integratedtests --ref ${{ env.BRANCH }}
-
-      - name: Triggering simplatform build
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          gh workflow run build.yaml --repo https://github.com/galasa-dev/simplatform --ref ${{ env.BRANCH }}
-
-      - name: Triggering webui build
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          gh workflow run build.yaml --repo https://github.com/galasa-dev/webui --ref ${{ env.BRANCH }}
-
   report-failure:
     # Skip this job for forks
     if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
     name: Report failure in workflow
     runs-on: ubuntu-latest
-    needs: [log-github-ref, build-obr, build-obr-javadocs, build-obr-generic, trigger-next-workflows]
+    needs: [log-github-ref, build-obr, build-obr-javadocs, build-obr-generic]
 
     steps:
       - name: Report failure in workflow to Slack

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -10,6 +10,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  BRANCH: ${{ github.ref_name }}
+
 jobs:
 
   set-build-properties:
@@ -101,6 +104,40 @@ jobs:
     secrets: inherit
     with:
       galasa-version: "${{ needs.set-build-properties.outputs.galasa-version }}"
+
+  trigger-next-workflows:
+    # Skip this job for forks
+    if: ${{ github.repository_owner == 'galasa-dev' }}
+    name: Trigger next workflows
+    needs: [build-obr]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Triggering helm build (github.ref is main)
+        if: ${{ env.BRANCH == 'main' }}
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation --ref ${{ env.BRANCH }}
+
+      - name: Triggering integratedtests build (github.ref is main)
+        if: ${{ env.BRANCH == 'main' }}
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/integratedtests --ref ${{ env.BRANCH }}
+
+      - name: Triggering simplatform build
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/simplatform --ref ${{ env.BRANCH }}
+
+      - name: Triggering webui build
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/webui --ref ${{ env.BRANCH }}
 
   # The IVTs are built after the OBR as they require the galasa-bom to get dependencies.
   build-ivts:
@@ -217,3 +254,16 @@ jobs:
     needs: [build-cli]
     uses: ./.github/workflows/docs.yaml
     secrets: inherit
+
+  trigger-isolated:
+    # Skip this job for forks
+    if: ${{ github.repository_owner == 'galasa-dev' }}
+    name: Trigger Isolated
+    needs: [build-docs]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Triggering Isolated
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/isolated --ref ${{ env.BRANCH }}

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -25,6 +25,9 @@ on:
         - 'true'
         - 'false'
 
+env:
+  BRANCH: ${{ github.ref_name }}
+
 jobs:
 
   set-build-properties:
@@ -139,6 +142,25 @@ jobs:
     with:
       galasa-version: "${{ needs.set-build-properties.outputs.galasa-version }}"
 
+  trigger-next-workflows:
+    # Skip this job for forks
+    if: ${{ github.repository_owner == 'galasa-dev' }}
+    name: Trigger next workflows
+    needs: [build-obr]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Triggering simplatform build
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/simplatform --ref ${{ env.BRANCH }}
+
+      - name: Triggering webui build
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/webui --ref ${{ env.BRANCH }}
+
   build-cli:
     name: Build the 'cli' module
     needs: [build-obr]
@@ -150,3 +172,16 @@ jobs:
     needs: [build-cli]
     uses: ./.github/workflows/docs.yaml
     secrets: inherit
+
+  trigger-isolated:
+    # Skip this job for forks
+    if: ${{ github.repository_owner == 'galasa-dev' }}
+    name: Trigger Isolated
+    needs: [build-docs]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Triggering Isolated
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/isolated --ref ${{ env.BRANCH }}


### PR DESCRIPTION
## Why?

Fixes https://github.com/galasa-dev/projectmanagement/issues/2594

I discovered during the v0.48.0 release process that the Isolated and MVP zips contain a back-level version of the galasa-docs-site HTML (i.e., for the v0.48.0 release, they contained v0.47.0 docs).

This was due to a timing condition in the workflows where the Isolated build was being called immediately after the CLI build completed. This is incorrect as the Isolated build should wait for the Docs build to complete and upload the galasa-docs-site artifact. In the previous few releases, the galasa-docs-site artifact from the previous release was pulled in.

This PR moves the trigger for the Isolated build to after the Docs build has completed to remove this timing condition. It also moves all triggers to next workflows to the orchestrator workflow so they are more visible in the GitHub Actions workflow run UI (this will be visible as a job in the left-hand sidebar).

## Changes
- [ ] Unit tests (if applicable)
- [ ] Documentation updates (if applicable)
- [ ] Release notes updates (if applicable)
