### PR TITLE
Uplift kafka-clients to v4.0.2

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -230,8 +230,8 @@ dependencies {
 
         api 'org.apache.httpcomponents.core5:httpcore5:5.0.2' // bnd.bnd only
 
-        api 'org.apache.kafka:kafka-clients:3.9.0'
-        api 'org.apache.kafka:kafka-server-common:3.9.0'
+        api 'org.apache.kafka:kafka-clients:4.0.2'
+        api 'org.apache.kafka:kafka-server-common:4.0.2'
 
         api 'org.apache.logging.log4j:log4j-api:2.25.4' // If updating, also update in galasa-boot build.gradle.
         api 'org.apache.logging.log4j:log4j-core:2.25.4' // If updating, also update in galasa-boot build.gradle.


### PR DESCRIPTION
## Why?

Fixes https://github.com/galasa-dev/projectmanagement/issues/2599

- Uplifts kafka-clients from 3.9.0 to 4.0.2 to remove direct vulnerabilities and transitive vulnerabilities from lz4-java 1.8.0
- Also uplifts kafka-server-common to 4.0.2 for consistency across this group

## Changes
- [ ] Unit tests (if applicable)
- [ ] Documentation updates (if applicable)
- [ ] Release notes updates (if applicable)
