### PR TITLE
Add Windows Credential Manager store implementation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1891,7 +1891,7 @@
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 53,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1779,7 +1779,7 @@
         "hashed_secret": "ad87109bfff0765f4dd8cf4943b04d16a4070fea",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 57,
+        "line_number": 61,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1787,7 +1787,7 @@
         "hashed_secret": "bbccdf2efb33b52e6c9d0a14dd70b2d415fbea6e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 67,
+        "line_number": 71,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1795,7 +1795,7 @@
         "hashed_secret": "05d97e6e9834ccf063c552e404b9ecafc5e4d662",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 76,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1803,15 +1803,7 @@
         "hashed_secret": "412800d02feedc405fa4f0ee31c0b9a6d6b8e84a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 75,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a2bb53c8d273742309cceb21ecf8efae45b2490f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 90,
+        "line_number": 79,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1819,7 +1811,15 @@
         "hashed_secret": "23467f1d326d6dcf0f4c3396f0c6173df8c1502f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 145,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a2bb53c8d273742309cceb21ecf8efae45b2490f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 170,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1827,7 +1827,7 @@
         "hashed_secret": "85dba0fbccdb8f0a39321bb6f164eaa8c88a76ac",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 150,
+        "line_number": 211,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1882,6 +1882,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 474,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManagerTest.java": [
+      {
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 87,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/README.md
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/README.md
@@ -6,7 +6,7 @@ This extension provides OS-native credentials store implementations for Galasa, 
 
 The OS credentials store extension enables Galasa to read credentials from:
 - **macOS**: Keychain Access (fully implemented)
-- **Windows**: Windows Credential Manager (planned)
+- **Windows**: Windows Credential Manager (fully implemented)
 - **Linux**: Secret Service API (planned)
 
 ## Architecture
@@ -21,6 +21,10 @@ The OS credentials store extension enables Galasa to read credentials from:
 ### macOS Implementation
 
 - **`MacOsKeychainStore`**: Implements `ICredentialsStore` using the macOS `security` CLI tool to manage credentials in the Keychain.
+
+### Windows Implementation
+
+- **`WindowsCredentialManagerStore`**: Implements `ICredentialsStore` using JNA to access the Windows Credential Manager API.
 
 ## How It Works
 
@@ -39,13 +43,13 @@ The `os:` URI scheme triggers the registration of this credentials store. The va
 
 Credentials are stored in the OS's native credential manager with a consistent format:
 
-- **Keychain Item Name**: `galasa.credentials.{CREDENTIALS-ID}`
-- **Account Name**: Varies by credential type (see below)
+- **Service/Target Name**: `galasa.credentials.{CREDENTIALS-ID}`
+- **Account/User Name**: Varies by credential type (see below)
 - **Password**: The actual password or token value
 
 #### Credential Types
 
-The macOS Keychain store supports multiple credential types, distinguished by the account name format:
+Both macOS and Windows implementations support multiple credential types, distinguished by the account/username format:
 
 1. **Username + Password**:
    - Account Name: Plain username (e.g., `IBMUSER`)
@@ -153,6 +157,65 @@ Using Keychain Access.app:
 ```bash
 base64 -i mykeystore.jks | tr -d '\n'
 ```
+
+### Adding Credentials (Windows)
+
+#### Username + Password
+
+Using Windows Credential Manager GUI:
+1. Open Control Panel → User Accounts → Credential Manager
+2. Click "Add a generic credential"
+3. Set "Internet or network address": `galasa.credentials.SIMBANK`
+4. Set "User name": `IBMUSER`
+5. Set "Password": `SYS1`
+6. Click "OK"
+
+Using command line (cmdkey):
+```cmd
+cmdkey /generic:galasa.credentials.SIMBANK /user:IBMUSER /pass:SYS1
+```
+
+#### Username Only
+
+Using command line:
+```cmd
+cmdkey /generic:galasa.credentials.MYUSER /user:username:IBMUSER /pass:""
+```
+
+#### Token Only
+
+Using command line:
+```cmd
+cmdkey /generic:galasa.credentials.GITHUB /user:token /pass:ghp_abc123xyz789
+```
+
+#### Username + Token
+
+Using command line:
+```cmd
+cmdkey /generic:galasa.credentials.GITLAB /user:username-token:myuser /pass:glpat-abc123xyz789
+```
+
+#### KeyStore (JSON Format)
+
+Using command line:
+```cmd
+cmdkey /generic:galasa.credentials.MYKEYSTORE /user:JSON /pass:"{\"keystore\":\"base64-content\",\"password\":\"keystorepass\",\"type\":\"JKS\"}"
+```
+
+Using Windows Credential Manager GUI:
+1. Open Control Panel → User Accounts → Credential Manager
+2. Click "Add a generic credential"
+3. Set "Internet or network address": `galasa.credentials.MYKEYSTORE`
+4. Set "User name": `JSON`
+5. Set "Password": `{"keystore":"base64-encoded-keystore","password":"keystorepass","type":"JKS"}`
+6. Click "OK"
+
+**Note**: The keystore content must be base64-encoded. You can encode a keystore file using:
+```powershell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("mykeystore.jks"))
+```
+
 
 ## Implementation Notes
 

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/bnd.bnd
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/bnd.bnd
@@ -9,3 +9,5 @@ Import-Package: \
     dev.galasa.framework.spi,\
     dev.galasa.framework.spi.creds,\
     org.apache.commons.logging
+-includeresource: jna-platform-*.jar; lib:=true,\
+    jna-*.jar; lib:=true

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/build.gradle
@@ -7,6 +7,8 @@ description = 'Galasa OS Credentials Store - Provides credentials from OS-native
 
 dependencies {
     implementation ('com.google.code.gson:gson')
+    implementation ('net.java.dev.jna:jna')
+    implementation ('net.java.dev.jna:jna-platform')
     testImplementation(testFixtures(project(':dev.galasa.extensions.common')))
 }
 

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/OsCredentialsStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/OsCredentialsStore.java
@@ -6,9 +6,11 @@
 package dev.galasa.creds.os.internal;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import dev.galasa.ICredentials;
 import dev.galasa.creds.os.internal.macos.MacOsKeychainStore;
+import dev.galasa.creds.os.internal.windows.WindowsCredentialManagerStore;
 import dev.galasa.framework.spi.creds.CredentialsException;
 import dev.galasa.framework.spi.creds.ICredentialsStore;
 
@@ -17,12 +19,19 @@ import dev.galasa.framework.spi.creds.ICredentialsStore;
  */
 public class OsCredentialsStore implements ICredentialsStore {
 
+    /**
+     * Pattern for validating credential names.
+     * Allows alphanumeric characters, dots, underscores, hyphens, and @ symbols.
+     */
+    public static final Pattern VALID_CREDENTIAL_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9._@-]+$");
+
     private final ICredentialsStore delegate;
     private final OperatingSystem os;
 
+
     /**
      * Creates an OS credentials store for the specified operating system.
-     * 
+     *
      * @param os the operating system to use
      * @throws OsCredentialsException if the operating system is not supported
      */
@@ -31,14 +40,24 @@ public class OsCredentialsStore implements ICredentialsStore {
         this.delegate = createDelegate(os);
     }
 
+    /**
+     * Creates an OS credentials store with a specific delegate.
+     * Package-private constructor for testing.
+     *
+     * @param os the operating system
+     * @param delegate the credentials store delegate
+     */
+    OsCredentialsStore(OperatingSystem os, ICredentialsStore delegate) {
+        this.os = os;
+        this.delegate = delegate;
+    }
+
     private ICredentialsStore createDelegate(OperatingSystem os) throws OsCredentialsException {
         switch (os) {
             case MACOS:
                 return new MacOsKeychainStore();
             case WINDOWS:
-                throw new OsCredentialsException(
-                    "Windows Credential Manager is not yet implemented. " +
-                    "Please use a different credentials store.");
+                return new WindowsCredentialManagerStore();
             case LINUX:
                 throw new OsCredentialsException(
                     "Linux Secret Service is not yet implemented. " +
@@ -47,7 +66,7 @@ public class OsCredentialsStore implements ICredentialsStore {
             default:
                 throw new OsCredentialsException(
                     "Unsupported operating system: " + os.getDisplayName() + ". " +
-                    "Supported operating systems are: macOS");
+                    "Supported operating systems are: macOS, Windows");
         }
     }
 

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/OsCredentialsStoreFactory.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/OsCredentialsStoreFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal;
+
+/**
+ * Factory for creating OS-specific credentials stores.
+ * This allows for dependency injection in tests.
+ */
+public class OsCredentialsStoreFactory {
+
+    /**
+     * Creates an OS credentials store for the specified operating system.
+     * 
+     * @param os the operating system
+     * @return the credentials store
+     * @throws OsCredentialsException if the store cannot be created
+     */
+    public OsCredentialsStore createStore(OperatingSystem os) throws OsCredentialsException {
+        return new OsCredentialsStore(os);
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/OsCredentialsStoreRegistration.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/OsCredentialsStoreRegistration.java
@@ -33,14 +33,23 @@ import dev.galasa.framework.spi.creds.ICredentialsStoreRegistration;
 public class OsCredentialsStoreRegistration implements ICredentialsStoreRegistration {
 
     private final OperatingSystemDetector osDetector;
+    private final OsCredentialsStoreFactory storeFactory;
 
     public OsCredentialsStoreRegistration() {
         this.osDetector = new OperatingSystemDetector();
+        this.storeFactory = new OsCredentialsStoreFactory();
     }
 
     // Package-private constructor for testing
     OsCredentialsStoreRegistration(OperatingSystemDetector osDetector) {
         this.osDetector = osDetector;
+        this.storeFactory = new OsCredentialsStoreFactory();
+    }
+
+    // Package-private constructor for testing with custom factory
+    OsCredentialsStoreRegistration(OperatingSystemDetector osDetector, OsCredentialsStoreFactory storeFactory) {
+        this.osDetector = osDetector;
+        this.storeFactory = storeFactory;
     }
 
     @Override
@@ -56,7 +65,7 @@ public class OsCredentialsStoreRegistration implements ICredentialsStoreRegistra
                     "Supported values are: auto, macOS, windows, linux");
             }
 
-            OsCredentialsStore store = new OsCredentialsStore(os);
+            OsCredentialsStore store = storeFactory.createStore(os);
             frameworkInitialisation.registerCredentialsStore(store);
         }
     }

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/macos/SecurityCommand.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/macos/SecurityCommand.java
@@ -7,9 +7,9 @@ package dev.galasa.creds.os.internal.macos;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import dev.galasa.creds.os.internal.OsCredentialsException;
+import dev.galasa.creds.os.internal.OsCredentialsStore;
 
 /**
  * A class that provides functions to exceute macOS security command-line tool commands.
@@ -19,8 +19,6 @@ public class SecurityCommand {
     public static final int SECURITY_CLI_SUCCESS_CODE = 0;
     public static final int SECURITY_CLI_ERROR_ITEM_NOT_FOUND_CODE = 44;
     public static final int SECURITY_CLI_ERROR_USER_CANCELLED_CODE = 128;
-
-    private static final Pattern VALID_SERVICE_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9._@-]+$");
 
     private final CommandExecutor commandExecutor;
 
@@ -57,7 +55,7 @@ public class SecurityCommand {
             throw new OsCredentialsException("Service name cannot be null or empty");
         }
 
-        if (!VALID_SERVICE_NAME_PATTERN.matcher(serviceName).matches()) {
+        if (!OsCredentialsStore.VALID_CREDENTIAL_NAME_PATTERN.matcher(serviceName).matches()) {
             throw new OsCredentialsException(
                 "Credentials ID contains invalid characters. "+
                 "Only alphanumeric characters, dots (.), underscores (_), hyphens (_), and at symbols (@) are allowed");

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/CredentialItem.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/CredentialItem.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal.windows;
+
+/**
+ * Data class representing a credential item retrieved from Windows Credential Manager.
+ * Contains the username and password/secret data.
+ */
+public class CredentialItem {
+    private final String username;
+    private final String password;
+
+    /**
+     * Creates a new credential item.
+     * 
+     * @param username the username from the credential
+     * @param password the password/secret from the credential
+     */
+    public CredentialItem(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    /**
+     * Gets the username from the credential.
+     * 
+     * @return the username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Gets the password/secret from the credential.
+     * 
+     * @return the password
+     */
+    public String getPassword() {
+        return password;
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/CredentialManagerJNA.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/CredentialManagerJNA.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal.windows;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.WString;
+import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.win32.StdCallLibrary;
+
+/**
+ * JNA interface to Windows Credential Manager API (Advapi32.dll).
+ * 
+ * <p>This interface provides access to the Windows credential management functions
+ * needed to read credentials from the Windows Credential Manager.
+ * 
+ * <p>Key functions:
+ * <ul>
+ *   <li>{@link #CredReadW(WString, int, int, PointerByReference)} - Read a credential</li>
+ *   <li>{@link #CredFree(Pointer)} - Free credential memory</li>
+ * </ul>
+ * 
+ * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/wincred/">Windows Credential Management Functions</a>
+ */
+public interface CredentialManagerJNA extends StdCallLibrary {
+
+    /**
+     * Singleton instance of the JNA interface.
+     */
+    CredentialManagerJNA INSTANCE = Native.load("Advapi32", CredentialManagerJNA.class);
+
+    /**
+     * Generic credential type constant.
+     * Used for credentials that are not associated with a specific logon session.
+     */
+    int CRED_TYPE_GENERIC = 1;
+
+    /**
+     * Reads a credential from the user's credential set.
+     * 
+     * <p>The credential set used is the one associated with the logon session of the current token.
+     * The token must not have the user's SID disabled.
+     * 
+     * @param targetName the name of the credential to read (wide string)
+     * @param type the type of the credential to read (use {@link #CRED_TYPE_GENERIC})
+     * @param flags reserved and must be zero
+     * @param credential pointer to receive the credential structure pointer
+     * @return true if successful, false otherwise (use Kernel32.GetLastError() for error code)
+     * 
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/wincred/nf-wincred-credreadw">CredReadW function</a>
+     */
+    boolean CredReadW(WString targetName, int type, int flags, PointerByReference credential);
+
+    /**
+     * Frees memory allocated by credential management functions.
+     *
+     * <p>This function must be called to free the memory allocated by {@link #CredReadW}.
+     * Failure to call this function will result in memory leaks.
+     *
+     * @param buffer pointer to the buffer to free
+     *
+     * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/wincred/nf-wincred-credfree">CredFree function</a>
+     */
+    void CredFree(Pointer buffer);
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/ICredentialManager.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/ICredentialManager.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal.windows;
+
+import dev.galasa.creds.os.internal.OsCredentialsException;
+
+/**
+ * An interface to the Windows Credential Manager API operations.
+ */
+public interface ICredentialManager {
+
+    /**
+     * Reads a credential from Windows Credential Manager.
+     *
+     * @param targetName the target name of the credential to read
+     * @return the credential item, or null if not found
+     * @throws OsCredentialsException if there's an error reading the credential
+     */
+    CredentialItem readCredential(String targetName) throws OsCredentialsException;
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/WindowsCredential.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/WindowsCredential.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal.windows;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.WString;
+import com.sun.jna.platform.win32.WinBase.FILETIME;
+
+/**
+ * JNA mapping of the Windows CREDENTIAL structure.
+ * 
+ * <p>This structure contains information about a credential stored in the Windows Credential Manager.
+ * It maps to the CREDENTIALW structure in the Windows API.
+ * 
+ * <p>Key fields:
+ * <ul>
+ *   <li>{@link #TargetName} - The credential identifier</li>
+ *   <li>{@link #UserName} - The username associated with the credential</li>
+ *   <li>{@link #CredentialBlob} - Pointer to the password/secret data</li>
+ *   <li>{@link #CredentialBlobSize} - Size of the credential blob in bytes</li>
+ * </ul>
+ * 
+ * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/wincred/ns-wincred-credentialw">CREDENTIALW structure</a>
+ */
+public class WindowsCredential extends Structure {
+
+    /**
+     * Creates a CREDENTIAL structure from a pointer.
+     *
+     * @param pointer pointer to the native CREDENTIAL structure
+     */
+    public WindowsCredential(Pointer pointer) {
+        super(pointer);
+    }
+
+    /**
+     * Default constructor for creating an empty CREDENTIAL structure.
+     */
+    public WindowsCredential() {
+        super();
+    }
+
+    /**
+     * Flags for the credential.
+     */
+    public int Flags;
+
+    /**
+     * Type of the credential (e.g., CRED_TYPE_GENERIC).
+     */
+    public int Type;
+
+    /**
+     * The name of the credential (target name).
+     */
+    public WString TargetName;
+
+    /**
+     * Optional comment string.
+     */
+    public WString Comment;
+
+    /**
+     * Time stamp of the last modification.
+     */
+    public FILETIME LastWritten;
+
+    /**
+     * Size of the CredentialBlob in bytes.
+     */
+    public int CredentialBlobSize;
+
+    /**
+     * Pointer to the credential data (password/secret).
+     */
+    public Pointer CredentialBlob;
+
+    /**
+     * Persistence of the credential.
+     */
+    public int Persist;
+
+    /**
+     * Number of attributes.
+     */
+    public int AttributeCount;
+
+    /**
+     * Pointer to attributes array.
+     */
+    public Pointer Attributes;
+
+    /**
+     * Alias for the target name.
+     */
+    public WString TargetAlias;
+
+    /**
+     * Username associated with the credential.
+     */
+    public WString UserName;
+
+    /**
+     * Defines the field order for JNA structure mapping.
+     * This must match the order of fields in the Windows CREDENTIALW structure.
+     * 
+     * @return list of field names in the correct order
+     */
+    @Override
+    protected List<String> getFieldOrder() {
+        return Arrays.asList(
+            "Flags",
+            "Type",
+            "TargetName",
+            "Comment",
+            "LastWritten",
+            "CredentialBlobSize",
+            "CredentialBlob",
+            "Persist",
+            "AttributeCount",
+            "Attributes",
+            "TargetAlias",
+            "UserName"
+        );
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManager.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManager.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal.windows;
+
+import java.nio.charset.StandardCharsets;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.WString;
+import com.sun.jna.ptr.PointerByReference;
+
+import dev.galasa.creds.os.internal.OsCredentialsException;
+import dev.galasa.creds.os.internal.OsCredentialsStore;
+
+/**
+ * Wrapper for Windows Credential Manager JNA calls with error handling and validation.
+ */
+public class WindowsCredentialManager implements ICredentialManager {
+
+    /**
+     * Windows error code: The system cannot find the file specified.
+     */
+    public static final int ERROR_NOT_FOUND = 1168;
+
+    /**
+     * Windows error code: No such logon session exists.
+     */
+    public static final int ERROR_NO_SUCH_LOGON_SESSION = 1312;
+
+    /**
+     * Windows error code: The parameter is incorrect.
+     */
+    public static final int ERROR_INVALID_PARAMETER = 87;
+
+    private final CredentialManagerJNA credManager;
+
+    /**
+     * Creates a new CredentialManagerCommand with the default JNA instance.
+     */
+    public WindowsCredentialManager() {
+        this(CredentialManagerJNA.INSTANCE);
+    }
+
+    /**
+     * Creates a new CredentialManagerCommand with the given JNA instance.
+     * @param credManager the JNA instance to use for the calls.
+     */
+    public WindowsCredentialManager(CredentialManagerJNA credManager) {
+        this.credManager = credManager;
+    }
+
+    @Override
+    public synchronized CredentialItem readCredential(String targetName) throws OsCredentialsException {
+        validateTargetName(targetName);
+
+        PointerByReference credentialRef = new PointerByReference();
+        WString targetNameWide = new WString(targetName);
+
+        boolean isReadSuccessful = credManager.CredReadW(
+            targetNameWide,
+            CredentialManagerJNA.CRED_TYPE_GENERIC,
+            0,
+            credentialRef
+        );
+
+        if (!isReadSuccessful) {
+            int errorCode = getLastErrorCode();
+            return handleReadError(errorCode, targetName);
+        }
+
+        Pointer credentialPointer = credentialRef.getValue();
+        if (credentialPointer == null) {
+            throw new OsCredentialsException("CredReadW returned success but credential pointer is null");
+        }
+
+        try {
+            WindowsCredential credential = new WindowsCredential(credentialPointer);
+            credential.read();
+
+            String username = extractUsername(credential);
+            String password = extractPassword(credential);
+
+            return new CredentialItem(username, password);
+
+        } finally {
+            credManager.CredFree(credentialPointer);
+        }
+    }
+
+    int getLastErrorCode() {
+        int errorCode = Native.getLastError();
+        return errorCode;
+    }
+
+    /**
+     * Validates that a target name contains only safe characters.
+     * 
+     * @param targetName the target name to validate
+     * @throws OsCredentialsException if the target name is invalid
+     */
+    private void validateTargetName(String targetName) throws OsCredentialsException {
+        if (targetName == null || targetName.trim().isEmpty()) {
+            throw new OsCredentialsException("Target name cannot be null or empty");
+        }
+
+        if (!OsCredentialsStore.VALID_CREDENTIAL_NAME_PATTERN.matcher(targetName).matches()) {
+            throw new OsCredentialsException(
+                "Credentials ID contains invalid characters. " +
+                "Only alphanumeric characters, dots (.), underscores (_), hyphens (-), and at symbols (@) are allowed"
+            );
+        }
+    }
+
+    /**
+     * Handles errors from CredReadW.
+     * 
+     * @param errorCode the Windows error code
+     * @param targetName the target name that was being read
+     * @return null if credential not found
+     * @throws OsCredentialsException for other errors
+     */
+    private CredentialItem handleReadError(int errorCode, String targetName) throws OsCredentialsException {
+        if (errorCode == ERROR_NOT_FOUND) {
+            return null;
+        }
+
+        if (errorCode == ERROR_NO_SUCH_LOGON_SESSION) {
+            throw new OsCredentialsException(
+                "No logon session exists. Please ensure you are logged in to Windows."
+            );
+        }
+
+        if (errorCode == ERROR_INVALID_PARAMETER) {
+            throw new OsCredentialsException(
+                "Invalid parameter when reading credential. Target name: " + targetName
+            );
+        }
+
+        throw new OsCredentialsException(
+            "Failed to read credential from Windows Credential Manager. Error code: " + errorCode
+        );
+    }
+
+    /**
+     * Extracts the username from a CREDENTIAL structure.
+     *
+     * @param credential the credential structure
+     * @return the username, or empty string if null
+     */
+    private String extractUsername(WindowsCredential credential) {
+        WString username = credential.UserName;
+        if (username == null) {
+            return "";
+        }
+        return username.toString();
+    }
+
+    /**
+     * Extracts the password from a CREDENTIAL structure.
+     *
+     * <p>The password is stored as a byte array in the CredentialBlob field.
+     * This method converts it to a UTF-16LE string (Windows native encoding).
+     *
+     * @param credential the credential structure
+     * @return the password, or empty string if null or empty
+     */
+    private String extractPassword(WindowsCredential credential) {
+        Pointer credentialBlobPointer = credential.CredentialBlob;
+        int credentialBlobSize = credential.CredentialBlobSize;
+        if (credentialBlobPointer == null || credentialBlobSize == 0) {
+            return "";
+        }
+
+        byte[] passwordBytes = credentialBlobPointer.getByteArray(0, credentialBlobSize);
+
+        return new String(passwordBytes, StandardCharsets.UTF_16LE);
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManagerStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/main/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManagerStore.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal.windows;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
+import dev.galasa.ICredentials;
+import dev.galasa.creds.os.internal.OsCredentialsException;
+import dev.galasa.creds.os.internal.parsers.JsonCredentialParser;
+import dev.galasa.creds.os.internal.parsers.KeyStoreJsonParser;
+import dev.galasa.framework.spi.creds.CredentialType;
+import dev.galasa.framework.spi.creds.CredentialsException;
+import dev.galasa.framework.spi.creds.CredentialsToken;
+import dev.galasa.framework.spi.creds.CredentialsUsername;
+import dev.galasa.framework.spi.creds.CredentialsUsernamePassword;
+import dev.galasa.framework.spi.creds.CredentialsUsernameToken;
+import dev.galasa.framework.spi.creds.ICredentialsStore;
+
+/**
+ * Windows Credential Manager implementation of the credentials store using JNA
+ * to access the Windows Credential Manager API.
+ *
+ * <p>This store supports the following credential types, determined by the username format:
+ * <ul>
+ *   <li><b>CredentialsUsernamePassword</b>: Username = plain username, Password = password</li>
+ *   <li><b>CredentialsUsername</b>: Username = "username:{username}", Password = empty</li>
+ *   <li><b>CredentialsToken</b>: Username = "token", Password = token value</li>
+ *   <li><b>CredentialsUsernameToken</b>: Username = "username-token:{username}", Password = token value</li>
+ *   <li><b>JSON-based credentials</b>: Username = "JSON", Password = JSON object with credential properties</li>
+ * </ul>
+ *
+ * <p><b>Creating credentials manually in Windows Credential Manager:</b>
+ * <ol>
+ *   <li>Open Control Panel → User Accounts → Credential Manager</li>
+ *   <li>Click "Add a generic credential"</li>
+ *   <li>Set "Internet or network address" to: galasa.credentials.{CREDENTIALS-ID}</li>
+ *   <li>Set "User name" and "Password" according to the credential type</li>
+ * </ol>
+ *
+ * <p>The implementation automatically detects the credential type when retrieving
+ * credentials based on the username format and password presence.
+ */
+public class WindowsCredentialManagerStore implements ICredentialsStore {
+
+    private static final String TARGET_PREFIX = "galasa.credentials.";
+    private static final String USERNAME_PREFIX = "username:";
+    private static final String USERNAME_TOKEN_PREFIX = "username-token:";
+    private static final String TOKEN_USERNAME = "token";
+    private static final String JSON_USERNAME = "JSON";
+
+    private final List<JsonCredentialParser> jsonParsers;
+    private final ICredentialManager credentialManager;
+
+    /**
+     * Creates a new Windows Credential Manager store with the default command executor.
+     */
+    public WindowsCredentialManagerStore() {
+        this(new WindowsCredentialManager());
+    }
+
+    /**
+     * Creates a new Windows Credential Manager store with a custom command executor.
+     *
+     * @param credentialManager the credential manager command executor
+     */
+    public WindowsCredentialManagerStore(ICredentialManager credentialManager) {
+        this.credentialManager = credentialManager;
+        this.jsonParsers = initializeJsonParsers();
+    }
+
+    /**
+     * Initializes the list of JSON credential parsers.
+     * New parser implementations should be added here.
+     *
+     * @return list of JSON credential parsers
+     */
+    private List<JsonCredentialParser> initializeJsonParsers() {
+        List<JsonCredentialParser> parsers = new ArrayList<>();
+        parsers.add(new KeyStoreJsonParser());
+        return parsers;
+    }
+
+    @Override
+    public ICredentials getCredentials(String credsId) throws CredentialsException {
+        if (credsId == null || credsId.trim().isEmpty()) {
+            throw new OsCredentialsException("Credentials ID cannot be null or empty");
+        }
+
+        String targetName = TARGET_PREFIX + credsId;
+        ICredentials credentialsToReturn = null;
+
+        CredentialItem item = credentialManager.readCredential(targetName);
+        if (item != null) {
+            String username = item.getUsername();
+            String password = item.getPassword();
+
+            if (JSON_USERNAME.equalsIgnoreCase(username)) {
+                credentialsToReturn = parseJsonCredentials(password);
+            } else {
+                CredentialType type = detectCredentialType(username, password);
+
+                switch (type) {
+                    case TOKEN:
+                        credentialsToReturn = new CredentialsToken(password);
+                        break;
+
+                    case USERNAME:
+                        String extractedUsername = extractUsername(username);
+                        credentialsToReturn = new CredentialsUsername(extractedUsername);
+                        break;
+
+                    case USERNAME_TOKEN:
+                        String usernameForToken = extractUsername(username);
+                        credentialsToReturn = new CredentialsUsernameToken(usernameForToken, password);
+                        break;
+
+                    case USERNAME_PASSWORD:
+                    default:
+                        credentialsToReturn = new CredentialsUsernamePassword(username, password);
+                        break;
+                }
+            }
+        }
+
+        return credentialsToReturn;
+    }
+
+    @Override
+    public Map<String, ICredentials> getAllCredentials() throws CredentialsException {
+        throw new OsCredentialsException("Getting all credentials is not enabled for OS credentials stores");
+    }
+
+    @Override
+    public void setCredentials(String credsId, ICredentials credentials) throws CredentialsException {
+        throw new OsCredentialsException("Setting credentials is not enabled for OS credentials stores");
+    }
+
+    @Override
+    public void deleteCredentials(String credsId) throws CredentialsException {
+        throw new OsCredentialsException("Deleting credentials is not enabled for OS credentials stores");
+    }
+
+    @Override
+    public void shutdown() throws CredentialsException {
+        // No resources to clean up
+    }
+
+    /**
+     * Detects the credential type based on the username format and password presence.
+     *
+     * @param username the username from the credential item
+     * @param password the password from the credential item
+     * @return the detected credential type
+     */
+    private CredentialType detectCredentialType(String username, String password) {
+        CredentialType type = CredentialType.USERNAME_PASSWORD;
+
+        if (TOKEN_USERNAME.equalsIgnoreCase(username)) {
+            type = CredentialType.TOKEN;
+        } else if (username.startsWith(USERNAME_TOKEN_PREFIX)) {
+            type = CredentialType.USERNAME_TOKEN;
+        } else if (username.startsWith(USERNAME_PREFIX)) {
+            type = CredentialType.USERNAME;
+        }
+
+        return type;
+    }
+
+    /**
+     * Extracts the username from a username field that has a prefix.
+     *
+     * @param username the username field (e.g., "username:myuser" or "username-token:myuser")
+     * @return the extracted username (e.g., "myuser")
+     */
+    private String extractUsername(String username) {
+        String extractedUsername = username;
+        if (username.startsWith(USERNAME_TOKEN_PREFIX)) {
+            extractedUsername = username.substring(USERNAME_TOKEN_PREFIX.length());
+        } else if (username.startsWith(USERNAME_PREFIX)) {
+            extractedUsername = username.substring(USERNAME_PREFIX.length());
+        }
+        return extractedUsername;
+    }
+
+    /**
+     * Parses JSON-based credentials from the password field using registered parsers.
+     *
+     * <p>This method iterates through all registered JSON credential parsers
+     * and uses the first one that can handle the JSON structure.
+     *
+     * <p>To add support for new JSON credential types:
+     * <ol>
+     *   <li>Create a new class implementing {@link JsonCredentialParser} interface</li>
+     *   <li>Add an instance of your parser to the {@link #initializeJsonParsers()} method</li>
+     * </ol>
+     *
+     * @param jsonPassword the JSON string containing credential data
+     * @return the parsed credentials object
+     * @throws CredentialsException if JSON parsing fails or no parser can handle the structure
+     */
+    private ICredentials parseJsonCredentials(String jsonPassword) throws CredentialsException {
+        if (jsonPassword == null || jsonPassword.trim().isEmpty()) {
+            throw new OsCredentialsException("JSON credentials cannot be empty");
+        }
+
+        try {
+            JsonObject json = JsonParser.parseString(jsonPassword).getAsJsonObject();
+
+            for (JsonCredentialParser parser : jsonParsers) {
+                if (parser.canParse(json)) {
+                    return parser.parse(json);
+                }
+            }
+
+            List<String> supportedTypes = jsonParsers.stream()
+                .map(parser -> parser.getCredentialType())
+                .collect(Collectors.toList());
+
+            throw new OsCredentialsException(
+                "Unknown JSON credential structure. Supported types: " + String.join(", ", supportedTypes)
+            );
+
+        } catch (JsonSyntaxException e) {
+            throw new OsCredentialsException("Invalid JSON in credentials: " + e.getMessage(), e);
+        } catch (IllegalStateException e) {
+            throw new OsCredentialsException("Invalid JSON structure in credentials: " + e.getMessage(), e);
+        }
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/OsCredentialsStoreRegistrationTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/OsCredentialsStoreRegistrationTest.java
@@ -12,6 +12,8 @@ import java.net.URI;
 
 import org.junit.Test;
 
+import dev.galasa.creds.os.internal.windows.MockCredentialManager;
+import dev.galasa.creds.os.internal.windows.WindowsCredentialManagerStore;
 import dev.galasa.extensions.common.mocks.MockEnvironment;
 import dev.galasa.extensions.common.mocks.MockFrameworkInitialisation;
 import dev.galasa.framework.spi.creds.ICredentialsStore;
@@ -103,16 +105,32 @@ public class OsCredentialsStoreRegistrationTest {
     public void testInitialiseWithWindowsUri() throws Exception {
         // Given
         OperatingSystemDetector detector = new OperatingSystemDetector();
+        
+        // Create a mock factory that returns a Windows store with mock command
+        OsCredentialsStoreFactory mockFactory = new OsCredentialsStoreFactory() {
+            @Override
+            public OsCredentialsStore createStore(OperatingSystem os) throws OsCredentialsException {
+                MockCredentialManager mockCredManager = new MockCredentialManager();
+                WindowsCredentialManagerStore mockWindowsStore = new WindowsCredentialManagerStore(mockCredManager);
+                return new OsCredentialsStore(os, mockWindowsStore);
+            }
+        };
+        
         URI uri = new URI("os:windows");
         MockFrameworkInitialisation mockInit = new MockFrameworkInitialisation();
         mockInit.setCredentialsStoreUri(uri);
-        OsCredentialsStoreRegistration registration = new OsCredentialsStoreRegistration(detector);
+        OsCredentialsStoreRegistration registration = new OsCredentialsStoreRegistration(detector, mockFactory);
 
-        // When/Then
-        assertThatThrownBy(() -> registration.initialise(mockInit))
-            .as("Should throw exception for unsupported Windows")
-            .isInstanceOf(OsCredentialsException.class)
-            .hasMessageContaining("Windows Credential Manager is not yet implemented");
+        // When
+        registration.initialise(mockInit);
+
+        // Then
+        ICredentialsStore registeredStore = mockInit.getRegisteredCredentialsStore();
+        assertThat(registeredStore).as("Credentials store should be registered").isNotNull();
+        assertThat(registeredStore).as("Should be OsCredentialsStore").isInstanceOf(OsCredentialsStore.class);
+
+        OsCredentialsStore osStore = (OsCredentialsStore) registeredStore;
+        assertThat(osStore.getOperatingSystem()).as("Should be Windows").isEqualTo(OperatingSystem.WINDOWS);
     }
 
     @Test

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/MockCredentialManager.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/MockCredentialManager.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal.windows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.galasa.creds.os.internal.OsCredentialsException;
+
+/**
+ * Mock implementation of the Windows Credential Manager for testing.
+ * Simulates Windows Credential Manager behavior without requiring actual Windows API calls.
+ */
+public class MockCredentialManager implements ICredentialManager {
+
+    private final Map<String, CredentialItem> storage = new HashMap<>();
+    private boolean shouldFail = false;
+
+    @Override
+    public CredentialItem readCredential(String targetName) throws OsCredentialsException {
+        if (shouldFail) {
+            throw new OsCredentialsException("simulating an error");
+        }
+
+        return storage.get(targetName);
+    }
+
+    // Test helper methods
+
+    /**
+     * Adds a credential to the mock storage.
+     *
+     * @param targetName the target name of the credential
+     * @param username the username
+     * @param password the password
+     */
+    public void addCredential(String targetName, String username, String password) {
+        storage.put(targetName, new CredentialItem(username, password));
+    }
+
+    /**
+     * Removes a credential from the mock storage.
+     *
+     * @param targetName the target name of the credential
+     */
+    public void removeCredential(String targetName) {
+        storage.remove(targetName);
+    }
+
+    /**
+     * Checks if a credential exists in the mock storage.
+     *
+     * @param targetName the target name of the credential
+     * @return true if the credential exists
+     */
+    public boolean hasCredential(String targetName) {
+        return storage.containsKey(targetName);
+    }
+
+    /**
+     * Simulates a "no logon session" error on the next read operation.
+     *
+     * @param shouldFail true to simulate the error
+     */
+    public void setShouldFail(boolean shouldFail) {
+        this.shouldFail = shouldFail;
+    }
+
+    /**
+     * Clears all stored credentials and resets the error flag.
+     */
+    public void clear() {
+        storage.clear();
+        shouldFail = false;
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/MockCredentialManagerJNA.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/MockCredentialManagerJNA.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal.windows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
+import com.sun.jna.WString;
+import com.sun.jna.platform.win32.WinBase.FILETIME;
+import com.sun.jna.ptr.PointerByReference;
+
+/**
+ * Mock implementation of CredentialManagerJNA for testing.
+ * Simulates Windows Credential Manager behavior without requiring native libraries.
+ */
+public class MockCredentialManagerJNA implements CredentialManagerJNA {
+
+    private final Map<String, CredentialItem> credentials = new HashMap<>();
+    private final Map<String, Memory> allocatedMemory = new HashMap<>();
+    private int lastError = 0;
+    private boolean shouldFail = false;
+    private boolean isMemoryFreed = false;
+
+    /**
+     * Adds a credential to the mock store.
+     * 
+     * @param targetName the credential target name
+     * @param username the username
+     * @param password the password
+     */
+    public void addCredential(String targetName, String username, String password) {
+        credentials.put(targetName, new CredentialItem(username, password));
+    }
+
+    /**
+     * Sets the error code that will be returned by GetLastError.
+     * 
+     * @param errorCode the error code
+     */
+    public void setLastError(int errorCode) {
+        this.lastError = errorCode;
+        this.shouldFail = true;
+    }
+
+    /**
+     * Clears all credentials and resets error state.
+     * Removes references to allocated memory, making them eligible for garbage collection.
+     */
+    public void clear() {
+        // Clear the map to remove strong references to Memory objects
+        // This makes them eligible for garbage collection by JNA
+        allocatedMemory.clear();
+        credentials.clear();
+        lastError = 0;
+        shouldFail = false;
+        isMemoryFreed = false;
+    }
+
+    /**
+     * Gets the last error code.
+     * 
+     * @return the last error code
+     */
+    public int getLastError() {
+        return lastError;
+    }
+
+    @Override
+    public boolean CredReadW(WString targetName, int type, int flags, PointerByReference credential) {
+        if (shouldFail) {
+            return false;
+        }
+
+        String target = targetName.toString();
+        CredentialItem item = credentials.get(target);
+
+        if (item == null) {
+            lastError = WindowsCredentialManager.ERROR_NOT_FOUND;
+            return false;
+        }
+
+        // Create a mock WindowsCredential structure in memory
+        WindowsCredential cred = new WindowsCredential();
+        
+        // Set the target name
+        cred.TargetName = new WString(target);
+        
+        // Set the username
+        if (item.getUsername() != null && !item.getUsername().isEmpty()) {
+            cred.UserName = new WString(item.getUsername());
+        }
+        
+        // Set the password as a byte array in UTF-16LE encoding
+        if (item.getPassword() != null && !item.getPassword().isEmpty()) {
+            byte[] passwordBytes = item.getPassword().getBytes(StandardCharsets.UTF_16LE);
+            // Allocate memory and keep reference to prevent garbage collection
+            Memory passwordMemory = new Memory(passwordBytes.length);
+            passwordMemory.write(0, passwordBytes, 0, passwordBytes.length);
+            allocatedMemory.put(target, passwordMemory);
+            cred.CredentialBlob = passwordMemory;
+            cred.CredentialBlobSize = passwordBytes.length;
+        } else {
+            cred.CredentialBlob = null;
+            cred.CredentialBlobSize = 0;
+        }
+        
+        // Set other required fields
+        cred.Type = CRED_TYPE_GENERIC;
+        cred.Flags = 0;
+        cred.Persist = 2; // CRED_PERSIST_LOCAL_MACHINE
+        cred.AttributeCount = 0;
+        cred.LastWritten = new FILETIME();
+        
+        // Write the structure to memory
+        cred.write();
+        
+        // Set the credential pointer
+        credential.setValue(cred.getPointer());
+        
+        return true;
+    }
+
+    @Override
+    public void CredFree(Pointer buffer) {
+        // In the mock, we don't need to actually free memory
+        // JNA will handle memory cleanup via garbage collection
+        isMemoryFreed = true;
+    }
+
+    public boolean isMemoryFreed() {
+        return isMemoryFreed;
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManagerStoreTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManagerStoreTest.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal.windows;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayOutputStream;
+import java.security.KeyStore;
+import java.util.Base64;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import dev.galasa.ICredentials;
+import dev.galasa.ICredentialsKeyStore;
+import dev.galasa.creds.os.internal.OsCredentialsException;
+import dev.galasa.framework.spi.creds.CredentialsKeyStore;
+import dev.galasa.framework.spi.creds.CredentialsToken;
+import dev.galasa.framework.spi.creds.CredentialsUsername;
+import dev.galasa.framework.spi.creds.CredentialsUsernamePassword;
+import dev.galasa.framework.spi.creds.CredentialsUsernameToken;
+import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
+
+/**
+ * Unit tests for WindowsCredentialManagerStore.
+ */
+public class WindowsCredentialManagerStoreTest {
+
+    private MockCredentialManager mockCredentialManager;
+    private WindowsCredentialManagerStore store;
+    private Gson gson;
+
+    @Before
+    public void setUp() {
+        mockCredentialManager = new MockCredentialManager();
+        store = new WindowsCredentialManagerStore(mockCredentialManager);
+        gson = new GalasaGsonBuilder(false).getGson();
+    }
+
+    @After
+    public void tearDown() {
+        mockCredentialManager.clear();
+    }
+
+    /**
+     * Creates a valid base64-encoded keystore for testing.
+     *
+     * @param type The keystore type (JKS or PKCS12)
+     * @param password The keystore password
+     * @return Base64-encoded keystore bytes
+     */
+    private String createTestKeyStore(String type, String password) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(type);
+        keyStore.load(null, password.toCharArray());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        keyStore.store(baos, password.toCharArray());
+
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    /**
+     * Creates a JSON object for KeyStore credentials and converts it to a string.
+     *
+     * @param keystoreBase64 The base64-encoded keystore content
+     * @param password The keystore password
+     * @param type The keystore type (JKS or PKCS12)
+     * @return JSON string representation
+     */
+    private String createKeystoreJson(String keystoreBase64, String password, String type) {
+        JsonObject json = new JsonObject();
+        json.addProperty("keystore", keystoreBase64);
+        json.addProperty("password", password);
+        json.addProperty("type", type);
+        return gson.toJson(json);
+    }
+
+    // ========== getCredentials() tests ==========
+
+    @Test
+    public void testGetCredentialsWithNullId() {
+        assertThatThrownBy(() -> store.getCredentials(null))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Credentials ID cannot be null or empty");
+    }
+
+    @Test
+    public void testGetCredentialsWithEmptyId() {
+        assertThatThrownBy(() -> store.getCredentials(""))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Credentials ID cannot be null or empty");
+    }
+
+    @Test
+    public void testGetCredentialsNotFound() throws Exception {
+        // When...
+        ICredentials credentials = store.getCredentials("NONEXISTENT");
+
+        // Then...
+        assertThat(credentials).isNull();
+    }
+
+    @Test
+    public void testGetCredentialsUsernamePassword() throws Exception {
+        // Given...
+        String targetName = "galasa.credentials.SIMBANK";
+        mockCredentialManager.addCredential(targetName, "IBMUSER", "SYS1");
+
+        // When...
+        ICredentials credentials = store.getCredentials("SIMBANK");
+
+        // Then...
+        assertThat(credentials).isNotNull();
+        assertThat(credentials).isInstanceOf(CredentialsUsernamePassword.class);
+
+        CredentialsUsernamePassword creds = (CredentialsUsernamePassword) credentials;
+        assertThat(creds.getUsername()).isEqualTo("IBMUSER");
+        assertThat(creds.getPassword()).isEqualTo("SYS1");
+    }
+
+    @Test
+    public void testGetCredentialsUsernameOnly() throws Exception {
+        // Given...
+        String targetName = "galasa.credentials.MYUSER";
+        mockCredentialManager.addCredential(targetName, "username:IBMUSER", "");
+
+        // When...
+        ICredentials credentials = store.getCredentials("MYUSER");
+
+        // Then...
+        assertThat(credentials).isNotNull();
+        assertThat(credentials).isInstanceOf(CredentialsUsername.class);
+
+        CredentialsUsername creds = (CredentialsUsername) credentials;
+        assertThat(creds.getUsername()).isEqualTo("IBMUSER");
+    }
+
+    @Test
+    public void testGetCredentialsTokenOnly() throws Exception {
+        // Given...
+        String targetName = "galasa.credentials.GITHUB";
+        mockCredentialManager.addCredential(targetName, "token", "ghp_abc123xyz789");
+
+        // When...
+        ICredentials credentials = store.getCredentials("GITHUB");
+
+        // Then...
+        assertThat(credentials).isNotNull();
+        assertThat(credentials).isInstanceOf(CredentialsToken.class);
+
+        CredentialsToken creds = (CredentialsToken) credentials;
+        assertThat(creds.getToken()).isEqualTo("ghp_abc123xyz789".getBytes());
+    }
+
+    @Test
+    public void testGetCredentialsUsernameToken() throws Exception {
+        // Given...
+        String targetName = "galasa.credentials.GITLAB";
+        mockCredentialManager.addCredential(targetName, "username-token:myuser", "glpat-abc123xyz789");
+
+        // When...
+        ICredentials credentials = store.getCredentials("GITLAB");
+
+        // Then...
+        assertThat(credentials).isNotNull();
+        assertThat(credentials).isInstanceOf(CredentialsUsernameToken.class);
+
+        CredentialsUsernameToken creds = (CredentialsUsernameToken) credentials;
+        assertThat(creds.getUsername()).isEqualTo("myuser");
+        assertThat(creds.getToken()).isEqualTo("glpat-abc123xyz789".getBytes());
+    }
+
+    @Test
+    public void testGetCredentialsJsonKeyStoreJKS() throws Exception {
+        // Given...
+        String keystoreBase64 = createTestKeyStore("JKS", "keystorepass");
+        String jsonPassword = createKeystoreJson(keystoreBase64, "keystorepass", "JKS");
+
+        String targetName = "galasa.credentials.MYKEYSTORE";
+        mockCredentialManager.addCredential(targetName, "JSON", jsonPassword);
+
+        // When...
+        ICredentials credentials = store.getCredentials("MYKEYSTORE");
+
+        // Then...
+        assertThat(credentials).isNotNull();
+        assertThat(credentials).isInstanceOf(CredentialsKeyStore.class);
+
+        ICredentialsKeyStore creds = (ICredentialsKeyStore) credentials;
+        assertThat(creds.getKeyStore()).isNotNull();
+        assertThat(creds.getKeyStore().getType()).isEqualTo("JKS");
+    }
+
+    @Test
+    public void testGetCredentialsJsonKeyStorePKCS12() throws Exception {
+        // Given...
+        String keystoreBase64 = createTestKeyStore("PKCS12", "keystorepass");
+        String jsonPassword = createKeystoreJson(keystoreBase64, "keystorepass", "PKCS12");
+
+        String targetName = "galasa.credentials.MYKEYSTORE";
+        mockCredentialManager.addCredential(targetName, "json", jsonPassword); // Test case-insensitive
+
+        // When...
+        ICredentials credentials = store.getCredentials("MYKEYSTORE");
+
+        // Then...
+        assertThat(credentials).isNotNull();
+        assertThat(credentials).isInstanceOf(CredentialsKeyStore.class);
+
+        ICredentialsKeyStore creds = (ICredentialsKeyStore) credentials;
+        assertThat(creds.getKeyStore()).isNotNull();
+        assertThat(creds.getKeyStore().getType()).isEqualTo("PKCS12");
+    }
+
+    @Test
+    public void testGetCredentialsJsonInvalidStructure() {
+        // Given...
+        String targetName = "galasa.credentials.INVALID";
+        mockCredentialManager.addCredential(targetName, "JSON", "{\"unknown\":\"field\"}");
+
+        // When/Then...
+        assertThatThrownBy(() -> store.getCredentials("INVALID"))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Unknown JSON credential structure");
+    }
+
+    @Test
+    public void testGetCredentialsJsonInvalidSyntax() {
+        // Given...
+        String targetName = "galasa.credentials.INVALID";
+        mockCredentialManager.addCredential(targetName, "JSON", "not valid json");
+
+        // When/Then...
+        assertThatThrownBy(() -> store.getCredentials("INVALID"))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Invalid JSON in credentials");
+    }
+
+    @Test
+    public void testGetCredentialsJsonEmpty() {
+        // Given...
+        String targetName = "galasa.credentials.EMPTY";
+        mockCredentialManager.addCredential(targetName, "JSON", "");
+
+        // When/Then...
+        assertThatThrownBy(() -> store.getCredentials("EMPTY"))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("JSON credentials cannot be empty");
+    }
+
+    // ========== Error handling tests ==========
+
+    @Test
+    public void testGetCredentialsWithSimulatedErrorFailsCorrectly() {
+        // Given...
+        mockCredentialManager.setShouldFail(true);
+
+        // When/Then...
+        assertThatThrownBy(() -> store.getCredentials("TEST"))
+            .isInstanceOf(OsCredentialsException.class);
+    }
+
+    // ========== Unsupported operations tests ==========
+
+    @Test
+    public void testGetAllCredentialsThrowsException() {
+        assertThatThrownBy(() -> store.getAllCredentials())
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Getting all credentials is not enabled for OS credentials stores");
+    }
+
+    @Test
+    public void testSetCredentialsThrowsException() {
+        // Given...
+        CredentialsUsernamePassword creds = new CredentialsUsernamePassword("user", "pass");
+
+        // When/Then...
+        assertThatThrownBy(() -> store.setCredentials("TEST", creds))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Setting credentials is not enabled for OS credentials stores");
+    }
+
+    @Test
+    public void testDeleteCredentialsThrowsException() {
+        assertThatThrownBy(() -> store.deleteCredentials("TEST"))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Deleting credentials is not enabled for OS credentials stores");
+    }
+
+    @Test
+    public void testShutdownDoesNotThrow() throws Exception {
+        store.shutdown(); // Should complete without error
+    }
+
+    // ========== Credential type detection tests ==========
+
+    @Test
+    public void testCredentialTypeDetectionPrefixOrdering() throws Exception {
+        // Given...
+        // Test that username-token: is checked before username:
+        String targetName = "galasa.credentials.TEST";
+        mockCredentialManager.addCredential(targetName, "username-token:testuser", "token123");
+
+        // When...
+        ICredentials credentials = store.getCredentials("TEST");
+
+        // Then...
+        assertThat(credentials).isInstanceOf(CredentialsUsernameToken.class);
+        CredentialsUsernameToken creds = (CredentialsUsernameToken) credentials;
+        assertThat(creds.getUsername()).isEqualTo("testuser");
+    }
+
+    @Test
+    public void testCredentialTypeDetectionTokenCaseInsensitive() throws Exception {
+        // Given...
+        String targetName = "galasa.credentials.TEST";
+        mockCredentialManager.addCredential(targetName, "TOKEN", "mytoken");
+
+        // When...
+        ICredentials credentials = store.getCredentials("TEST");
+
+        // Then...
+        assertThat(credentials).isInstanceOf(CredentialsToken.class);
+    }
+
+    @Test
+    public void testCredentialTypeDetectionJsonCaseInsensitive() throws Exception {
+        // Given...
+        String keystoreBase64 = createTestKeyStore("JKS", "pass");
+        String jsonPassword = createKeystoreJson(keystoreBase64, "pass", "JKS");
+
+        String targetName = "galasa.credentials.TEST";
+        mockCredentialManager.addCredential(targetName, "Json", jsonPassword);
+
+        // When...
+        ICredentials credentials = store.getCredentials("TEST");
+
+        // Then...
+        assertThat(credentials).isInstanceOf(CredentialsKeyStore.class);
+    }
+}

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManagerTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManagerTest.java
@@ -64,40 +64,6 @@ public class WindowsCredentialManagerTest {
     }
 
     @Test
-    public void testReadCredentialWithUsernameOnly() throws OsCredentialsException {
-        // Given
-        String targetName = "galasa.credentials.USERONLY";
-        String username = "testuser";
-        mockJNA.addCredential(targetName, username, "");
-
-        // When
-        CredentialItem result = credentialManager.readCredential(targetName);
-
-        // Then
-        assertThat(result).isNotNull();
-        assertThat(result.getUsername()).isEqualTo(username);
-        assertThat(result.getPassword()).isEmpty();
-        assertThat(mockJNA.isMemoryFreed()).isTrue();
-    }
-
-    @Test
-    public void testReadCredentialWithPasswordOnly() throws OsCredentialsException {
-        // Given
-        String targetName = "galasa.credentials.PASSONLY";
-        String password = "testpass";
-        mockJNA.addCredential(targetName, "", password);
-
-        // When
-        CredentialItem result = credentialManager.readCredential(targetName);
-
-        // Then
-        assertThat(result).isNotNull();
-        assertThat(result.getUsername()).isEmpty();
-        assertThat(result.getPassword()).isEqualTo(password);
-        assertThat(mockJNA.isMemoryFreed()).isTrue();
-    }
-
-    @Test
     public void testReadCredentialNotFound() throws OsCredentialsException {
         // Given
         String targetName = "galasa.credentials.NOTFOUND";

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManagerTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.creds.os/src/test/java/dev/galasa/creds/os/internal/windows/WindowsCredentialManagerTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.creds.os.internal.windows;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import dev.galasa.creds.os.internal.OsCredentialsException;
+
+public class WindowsCredentialManagerTest {
+
+    private MockCredentialManagerJNA mockJNA;
+    private TestableWindowsCredentialManager credentialManager;
+
+    class TestableWindowsCredentialManager extends WindowsCredentialManager {
+        private final MockCredentialManagerJNA mockJNA;
+
+        public TestableWindowsCredentialManager(MockCredentialManagerJNA mockJNA) {
+            super(mockJNA);
+            this.mockJNA = mockJNA;
+        }
+
+        @Override
+        int getLastErrorCode() {
+            // Return the mock error code instead of calling Native.getLastError()
+            return mockJNA.getLastError();
+        }
+    }
+
+    @Before
+    public void setUp() {
+        mockJNA = new MockCredentialManagerJNA();
+        credentialManager = new TestableWindowsCredentialManager(mockJNA);
+    }
+
+    @After
+    public void tearDown() {
+        mockJNA.clear();
+    }
+
+    @Test
+    public void testReadCredentialWithUsernameAndPassword() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.TEST";
+        String username = "testuser";
+        String password = "testpass";
+        mockJNA.addCredential(targetName, username, password);
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo(username);
+        assertThat(result.getPassword()).isEqualTo(password);
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadCredentialWithUsernameOnly() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.USERONLY";
+        String username = "testuser";
+        mockJNA.addCredential(targetName, username, "");
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo(username);
+        assertThat(result.getPassword()).isEmpty();
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadCredentialWithPasswordOnly() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.PASSONLY";
+        String password = "testpass";
+        mockJNA.addCredential(targetName, "", password);
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEmpty();
+        assertThat(result.getPassword()).isEqualTo(password);
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadCredentialNotFound() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.NOTFOUND";
+        // No credential added
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void testReadCredentialWithSpecialCharactersInPassword() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.SPECIAL";
+        String username = "user";
+        String password = "p@ssw0rd!#$%^&*()";
+        mockJNA.addCredential(targetName, username, password);
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo(username);
+        assertThat(result.getPassword()).isEqualTo(password);
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadCredentialWithLongPassword() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.LONG";
+        String username = "user";
+        String password = "a".repeat(1000); // 1000 character password
+        mockJNA.addCredential(targetName, username, password);
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo(username);
+        assertThat(result.getPassword()).isEqualTo(password);
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadCredentialWithNullTargetName() {
+        // When/Then
+        assertThatThrownBy(() -> credentialManager.readCredential(null))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Target name cannot be null or empty");
+    }
+
+    @Test
+    public void testReadCredentialWithEmptyTargetName() {
+        // When/Then
+        assertThatThrownBy(() -> credentialManager.readCredential(""))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Target name cannot be null or empty");
+    }
+
+    @Test
+    public void testReadCredentialWithWhitespaceTargetName() {
+        // When/Then
+        assertThatThrownBy(() -> credentialManager.readCredential("   "))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Target name cannot be null or empty");
+    }
+
+    @Test
+    public void testReadCredentialWithInvalidCharacters() {
+        // When/Then
+        assertThatThrownBy(() -> credentialManager.readCredential("galasa/credentials/TEST"))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Credentials ID contains invalid characters");
+    }
+
+    @Test
+    public void testReadCredentialWithInvalidCharactersBackslash() {
+        // When/Then
+        assertThatThrownBy(() -> credentialManager.readCredential("galasa\\credentials\\TEST"))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Credentials ID contains invalid characters");
+    }
+
+    @Test
+    public void testReadCredentialWithInvalidCharactersSpace() {
+        // When/Then
+        assertThatThrownBy(() -> credentialManager.readCredential("galasa credentials TEST"))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Credentials ID contains invalid characters");
+    }
+
+    @Test
+    public void testReadCredentialWithValidSpecialCharacters() throws OsCredentialsException {
+        // Given - dots, underscores, hyphens, and @ symbols are allowed
+        String targetName = "galasa.credentials.TEST-USER_123@domain";
+        String username = "user";
+        String password = "pass";
+        mockJNA.addCredential(targetName, username, password);
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo(username);
+        assertThat(result.getPassword()).isEqualTo(password);
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadCredentialWithNoLogonSession() {
+        // Given
+        String targetName = "galasa.credentials.TEST";
+        mockJNA.setLastError(WindowsCredentialManager.ERROR_NO_SUCH_LOGON_SESSION);
+
+        // When/Then
+        assertThatThrownBy(() -> credentialManager.readCredential(targetName))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("No logon session exists");
+    }
+
+    @Test
+    public void testReadCredentialWithInvalidParameter() {
+        // Given
+        String targetName = "galasa.credentials.TEST";
+        mockJNA.setLastError(WindowsCredentialManager.ERROR_INVALID_PARAMETER);
+
+        // When/Then
+        assertThatThrownBy(() -> credentialManager.readCredential(targetName))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Invalid parameter when reading credential");
+    }
+
+    @Test
+    public void testReadCredentialWithUnknownError() {
+        // Given
+        String targetName = "galasa.credentials.TEST";
+        mockJNA.setLastError(999); // Unknown error code
+
+        // When/Then
+        assertThatThrownBy(() -> credentialManager.readCredential(targetName))
+            .isInstanceOf(OsCredentialsException.class)
+            .hasMessageContaining("Failed to read credential from Windows Credential Manager")
+            .hasMessageContaining("Error code: 999");
+    }
+
+    @Test
+    public void testReadCredentialWithEmptyUsername() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.EMPTYUSER";
+        mockJNA.addCredential(targetName, "", "password");
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEmpty();
+        assertThat(result.getPassword()).isEqualTo("password");
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadCredentialWithEmptyPassword() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.EMPTYPASS";
+        mockJNA.addCredential(targetName, "username", "");
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo("username");
+        assertThat(result.getPassword()).isEmpty();
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadCredentialMultipleTimes() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.MULTI";
+        String username = "user";
+        String password = "pass";
+        mockJNA.addCredential(targetName, username, password);
+
+        // When - read the same credential multiple times
+        CredentialItem result1 = credentialManager.readCredential(targetName);
+        CredentialItem result2 = credentialManager.readCredential(targetName);
+        CredentialItem result3 = credentialManager.readCredential(targetName);
+
+        // Then - all reads should succeed and memory should be freed each time
+        assertThat(result1).isNotNull();
+        assertThat(result1.getUsername()).isEqualTo(username);
+        assertThat(result1.getPassword()).isEqualTo(password);
+
+        assertThat(result2).isNotNull();
+        assertThat(result2.getUsername()).isEqualTo(username);
+        assertThat(result2.getPassword()).isEqualTo(password);
+
+        assertThat(result3).isNotNull();
+        assertThat(result3.getUsername()).isEqualTo(username);
+        assertThat(result3.getPassword()).isEqualTo(password);
+
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadDifferentCredentials() throws OsCredentialsException {
+        // Given
+        mockJNA.addCredential("galasa.credentials.CRED1", "user1", "pass1");
+        mockJNA.addCredential("galasa.credentials.CRED2", "user2", "pass2");
+        mockJNA.addCredential("galasa.credentials.CRED3", "user3", "pass3");
+
+        // When
+        CredentialItem result1 = credentialManager.readCredential("galasa.credentials.CRED1");
+        CredentialItem result2 = credentialManager.readCredential("galasa.credentials.CRED2");
+        CredentialItem result3 = credentialManager.readCredential("galasa.credentials.CRED3");
+
+        // Then
+        assertThat(result1.getUsername()).isEqualTo("user1");
+        assertThat(result1.getPassword()).isEqualTo("pass1");
+
+        assertThat(result2.getUsername()).isEqualTo("user2");
+        assertThat(result2.getPassword()).isEqualTo("pass2");
+
+        assertThat(result3.getUsername()).isEqualTo("user3");
+        assertThat(result3.getPassword()).isEqualTo("pass3");
+
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadCredentialWithNumericUsername() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.NUMERIC";
+        String username = "12345";
+        String password = "pass";
+        mockJNA.addCredential(targetName, username, password);
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo(username);
+        assertThat(result.getPassword()).isEqualTo(password);
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+
+    @Test
+    public void testReadCredentialWithNumericPassword() throws OsCredentialsException {
+        // Given
+        String targetName = "galasa.credentials.NUMPASS";
+        String username = "user";
+        String password = "123456789";
+        mockJNA.addCredential(targetName, username, password);
+
+        // When
+        CredentialItem result = credentialManager.readCredential(targetName);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo(username);
+        assertThat(result.getPassword()).isEqualTo(password);
+        assertThat(mockJNA.isMemoryFreed()).isTrue();
+    }
+}

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -194,7 +194,8 @@ dependencies {
 
         api 'net.bytebuddy:byte-buddy:1.18.3'
 
-        api 'net.java.dev.jna:jna:5.12.1' // bnd.bnd only
+        api 'net.java.dev.jna:jna:5.18.1'
+        api 'net.java.dev.jna:jna-platform:5.18.1'
 
         api 'org.apache.bcel:bcel:6.11.0'
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2592

## Changes
- [x] Added an implementation of the credentials store that uses the Windows Credential Manager, allowing for read-only access to credentials in tests
  - Note: this implementation uses JNA to access the Windows APIs rather than spawning a new shell process to run commands, which can be expensive and slow
- [x] Unit tests (if applicable)
