### PR TITLE
Add release note and docs on using the Windows Credential Manager creds store

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -182,6 +182,48 @@
         "verified_result": null
       }
     ],
+    "docs/content/docs/configuring-local-credentials/windows-credential-manager-store.md": [
+      {
+        "hashed_secret": "ad87109bfff0765f4dd8cf4943b04d16a4070fea",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 57,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bbccdf2efb33b52e6c9d0a14dd70b2d415fbea6e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 103,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "05d97e6e9834ccf063c552e404b9ecafc5e4d662",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 127,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c1d6eea14e37c1eda083790dc844c90c8154cb7d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 134,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "23467f1d326d6dcf0f4c3396f0c6173df8c1502f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 164,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "docs/content/docs/ecosystem/ecosystem-installing-k8s.md": [
       {
         "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",

--- a/docs/content/docs/configuring-local-credentials/index.md
+++ b/docs/content/docs/configuring-local-credentials/index.md
@@ -20,14 +20,15 @@ Starting from Galasa 0.47.0, the OS Credentials Store bundle (`dev.galasa.creds.
 To enable the OS Credentials Store, add the following properties to your `{GALASA_HOME}/bootstrap.properties` file:
 
 ```properties
-framework.credentials.store=os:[macOS|auto]
+framework.credentials.store=os:[macOS|windows|auto]
 framework.extra.bundles=dev.galasa.creds.os
 ```
 
-The `os:auto` value automatically detects your operating system and uses the appropriate credentials store implementation. At the moment, only a macOS Keychain implementation is available.
+The `os:auto` value automatically detects your operating system and uses the appropriate credentials store implementation.
 
 ### Platform-Specific Documentation
 
 See the platform-specific documentation for more information:
 
 - [macOS Keychain Store](./macos-keychain-store.md)
+- [Windows Credential Manager Store](./windows-credential-manager-store.md)

--- a/docs/content/docs/configuring-local-credentials/windows-credential-manager-store.md
+++ b/docs/content/docs/configuring-local-credentials/windows-credential-manager-store.md
@@ -1,0 +1,299 @@
+---
+title: Windows Credential Manager Store
+---
+
+The Windows Credential Manager Store extension allows Galasa to securely read test credentials from Windows Credential Manager, providing a more secure alternative to storing credentials in plain text configuration files.
+
+## Prerequisites
+
+- Windows 10 or later
+- Galasa 0.48.1 or later
+
+## Configuration
+
+### 1. Enable the OS Credentials Store
+
+Follow the [Enabling the OS Credentials Store](./index.md#enabling-the-os-credentials-store) instructions to enable the OS Credentials Store.
+
+### 2. Add Credentials to Windows Credential Manager
+
+Credentials must be added to Windows Credential Manager before Galasa can retrieve them. Each credential is stored as a generic credential with:
+
+- **Target Name**: `galasa.credentials.{CREDENTIALS-ID}`
+- **User Name**: Varies by credential type (see below)
+- **Password**: The actual password, token, or JSON data
+
+## Supported Credential Types
+
+### Username + Password
+
+**Format:**
+
+- User Name: The username (e.g., `MYUSER`)
+- Password: The password
+
+**Example using Control Panel:**
+
+1. Open Control Panel → User Accounts → Credential Manager
+2. Click "Windows Credentials" → "Add a generic credential"
+3. Set "Internet or network address" to: `galasa.credentials.SIMBANK`
+4. Set "User name" to: `MYUSER`
+5. Set "Password" to: `SYS1`
+6. Click "OK"
+
+**Example using PowerShell:**
+
+```powershell
+cmdkey /generic:"galasa.credentials.SIMBANK" /user:"MYUSER" /pass:"SYS1"
+```
+
+### Username Only
+
+For scenarios where only a username is needed (no password).
+
+**Format:**
+
+- User Name: `username:{actual-username}` (e.g., `username:MYUSER`)
+- Password: Empty string or any placeholder
+
+**Example using Control Panel:**
+
+1. Open Control Panel → User Accounts → Credential Manager
+2. Click "Windows Credentials" → "Add a generic credential"
+3. Set "Internet or network address" to: `galasa.credentials.USERNAME`
+4. Set "User name" to: `username:MYUSER`
+5. Set "Password" to any value (required by Windows)
+6. Click "OK"
+
+**Example using PowerShell:**
+
+```powershell
+cmdkey /generic:"galasa.credentials.USERNAME" /user:"username:MYUSER" /pass:" "
+```
+
+### Token Only
+
+For API tokens, personal access tokens, or other token-based authentication.
+
+**Format:**
+
+- User Name: `token`
+- Password: The token value
+
+**Example using Control Panel:**
+
+1. Open Control Panel → User Accounts → Credential Manager
+2. Click "Windows Credentials" → "Add a generic credential"
+3. Set "Internet or network address" to: `galasa.credentials.TOKEN`
+4. Set "User name" to: `token`
+5. Set "Password" to the token value
+6. Click "OK"
+
+**Example using PowerShell:**
+
+```powershell
+cmdkey /generic:"galasa.credentials.TOKEN" /user:"token" /pass:"abc123xyz789"
+```
+
+### Username + Token
+
+**Format:**
+
+- User Name: `username-token:{actual-username}` (e.g., `username-token:myuser`)
+- Password: The token value
+
+**Example using Control Panel:**
+
+1. Open Control Panel → User Accounts → Credential Manager
+2. Click "Windows Credentials" → "Add a generic credential"
+3. Set "Internet or network address" to: `galasa.credentials.USERNAMETOKEN`
+4. Set "User name" to: `username-token:myuser`
+5. Set "Password" to the token value
+6. Click "OK"
+
+**Example using PowerShell:**
+
+```powershell
+cmdkey /generic:"galasa.credentials.USERNAMETOKEN" /user:"username-token:myuser" /pass:"abc123xyz789"
+```
+
+### KeyStore (JSON Format)
+
+For Java KeyStore credentials containing SSL/TLS certificates and private keys.
+
+**Format:**
+
+- User Name: `JSON` (case-insensitive)
+- Password: JSON object with keystore properties
+
+**JSON Structure:**
+
+```json
+{
+  "keystore": "base64-encoded-keystore-content",
+  "password": "keystore-password",
+  "type": "JKS"
+}
+```
+
+**Supported KeyStore Types:**
+
+- `JKS` - Java KeyStore
+- `PKCS12` - PKCS#12 format
+
+**Example - Encoding a KeyStore:**
+
+```powershell
+# First, encode your keystore file to base64
+$bytes = [System.IO.File]::ReadAllBytes("mykeystore.jks")
+$base64 = [System.Convert]::ToBase64String($bytes)
+
+# Create the JSON (single line, no line breaks)
+$json = "{`"keystore`":`"$base64`",`"password`":`"keystorepass`",`"type`":`"JKS`"}"
+
+# Add to Credential Manager
+cmdkey /generic:"galasa.credentials.MYKEYSTORE" /user:"JSON" /pass:"$json"
+```
+
+**Example using Control Panel:**
+
+1. Open Control Panel → User Accounts → Credential Manager
+2. Click "Windows Credentials" → "Add a generic credential"
+3. Set "Internet or network address" to: `galasa.credentials.MYKEYSTORE`
+4. Set "User name" to: `JSON`
+5. Set "Password" to: `{"keystore":"base64-content","password":"keystorepass","type":"JKS"}` (must be a single-line JSON string)
+6. Click "OK"
+
+## Managing Credentials
+
+### Viewing Credentials
+
+**Using Control Panel:**
+
+1. Open Control Panel → User Accounts → Credential Manager
+2. Click "Windows Credentials"
+3. Look for credentials starting with `galasa.credentials.`
+
+**Using PowerShell:**
+
+```powershell
+# List all Galasa credentials
+cmdkey /list | Select-String "galasa.credentials"
+```
+
+### Updating Credentials
+
+**Using Control Panel:**
+
+1. Open Credential Manager
+2. Find the credential under "Windows Credentials"
+3. Click the arrow to expand
+4. Click "Edit"
+5. Update the values
+6. Click "Save"
+
+**Using PowerShell:**
+
+```powershell
+# Update by deleting and re-adding
+cmdkey /delete:"galasa.credentials.MYCRED"
+cmdkey /generic:"galasa.credentials.MYCRED" /user:"newuser" /pass:"newpass"
+```
+
+### Deleting Credentials
+
+**Using Control Panel:**
+
+1. Open Credential Manager
+2. Find the credential under "Windows Credentials"
+3. Click the arrow to expand
+4. Click "Remove"
+5. Confirm deletion
+
+**Using PowerShell:**
+
+```powershell
+cmdkey /delete:"galasa.credentials.MYCRED"
+```
+
+## Security Considerations
+
+### Credential Protection
+
+Windows Credential Manager stores credentials encrypted using the Windows Data Protection API (DPAPI):
+
+- Credentials are encrypted with your Windows user account
+- Only your user account can decrypt and access the credentials
+- Credentials are protected even if someone gains physical access to your hard drive
+
+### Best Practices
+
+1. **Regular audits**: Periodically review stored credentials in Credential Manager
+2. **Principle of least privilege**: Only store credentials that are actually needed
+3. **Shared systems**: Be cautious when using shared Windows systems - credentials are user-specific
+4. **Backup considerations**: Credentials are tied to your user profile and Windows installation
+
+## Troubleshooting
+
+### "Credentials not found" Error
+
+**Cause**: The credential doesn't exist in Credential Manager or the target name is incorrect.
+
+**Solution:**
+
+1. Verify the credential exists:
+   ```powershell
+   cmdkey /list | Select-String "galasa.credentials.MYCRED"
+   ```
+2. Check the target name format: must be `galasa.credentials.{ID}`
+3. Ensure the credential is stored as a "Generic Credential" (not "Windows Credential" or "Certificate-Based Credential")
+
+### "Access Denied" Error
+
+**Cause**: Insufficient permissions to access Credential Manager.
+
+**Solution:**
+
+1. Ensure you're running as the same user who created the credential
+2. Check Windows user account permissions
+3. Try running your application as administrator (not recommended for regular use)
+
+### Invalid JSON Error (KeyStore credentials)
+
+**Cause**: The JSON in the password field is malformed or missing required fields.
+
+**Solution:**
+
+1. Validate your JSON using a JSON validator
+2. Ensure all required fields are present: `keystore`, `password`, `type`
+3. Verify the keystore content is properly base64-encoded
+4. Ensure the JSON is a single line with no line breaks
+5. Check for special characters that might need escaping in PowerShell
+
+### KeyStore Loading Error
+
+**Cause**: The base64-encoded keystore content is invalid or corrupted.
+
+**Solution:**
+
+1. Re-encode the keystore file:
+   ```powershell
+   $bytes = [System.IO.File]::ReadAllBytes("keystore.jks")
+   $base64 = [System.Convert]::ToBase64String($bytes)
+   ```
+2. Verify the keystore is valid:
+   ```powershell
+   keytool -list -keystore keystore.jks
+   ```
+3. Ensure the keystore password in the JSON matches the actual keystore password
+
+### Credential Manager Not Available
+
+**Cause**: Credential Manager service is not running or disabled.
+
+**Solution:**
+
+1. Open Services (services.msc)
+2. Find "Credential Manager" service
+3. Ensure it's set to "Automatic" and is running
+4. If stopped, start the service

--- a/docs/content/docs/configuring-local-credentials/windows-credential-manager-store.md
+++ b/docs/content/docs/configuring-local-credentials/windows-credential-manager-store.md
@@ -7,7 +7,7 @@ The Windows Credential Manager Store extension allows Galasa to securely read te
 ## Prerequisites
 
 - Windows 10 or later
-- Galasa 0.48.1 or later
+- Galasa 1.0.0 or later
 
 ## Configuration
 

--- a/docs/content/releases/posts/v0.48.1.md
+++ b/docs/content/releases/posts/v0.48.1.md
@@ -12,3 +12,8 @@ links:
 - Username/password credentials used to authenticate with Maven repositories can be supplied to download test artifacts and OBRs from password-protected Maven repositories.
   - **For local test runs:** Credentials can be supplied in the `${GALASA_HOME}/bootstrap.properties` file using the `maven.repository.username` and `maven.repository.password` properties. Alternatively, credentials can be supplied as environment variables by setting `GALASA_MAVEN_USERNAME` and `GALASA_MAVEN_PASSWORD`. Values in environment variables take precedence over values in the `bootstrap.properties` file.
   - **For test runs on the Galasa Service:** Test streams can be configured with an optional `secretName` field that contains the name of an existing Galasa secret containing the credentials to use when authenticating with Maven repositories. The secret name can be set using the `galasactl streams set --name <stream-name> --maven-secret-name <secret-name>` command or via YAML files with the `galasactl resources apply` command (see [Test Streams as GalasaStream resources](../../docs/manage-ecosystem/test-streams.md) for more details).
+
+## Changes affecting tests running locally
+
+- Windows Credential Manager support added to the OS Credentials Store extension. Galasa can now securely read test credentials from Windows Credential Manager, providing a more secure alternative to storing credentials in plain text configuration files. See [Windows Credential Manager Store](../../docs/configuring-local-credentials/windows-credential-manager-store.md) for more details.
+

--- a/docs/content/releases/posts/v0.48.1.md
+++ b/docs/content/releases/posts/v0.48.1.md
@@ -12,8 +12,3 @@ links:
 - Username/password credentials used to authenticate with Maven repositories can be supplied to download test artifacts and OBRs from password-protected Maven repositories.
   - **For local test runs:** Credentials can be supplied in the `${GALASA_HOME}/bootstrap.properties` file using the `maven.repository.username` and `maven.repository.password` properties. Alternatively, credentials can be supplied as environment variables by setting `GALASA_MAVEN_USERNAME` and `GALASA_MAVEN_PASSWORD`. Values in environment variables take precedence over values in the `bootstrap.properties` file.
   - **For test runs on the Galasa Service:** Test streams can be configured with an optional `secretName` field that contains the name of an existing Galasa secret containing the credentials to use when authenticating with Maven repositories. The secret name can be set using the `galasactl streams set --name <stream-name> --maven-secret-name <secret-name>` command or via YAML files with the `galasactl resources apply` command (see [Test Streams as GalasaStream resources](../../docs/manage-ecosystem/test-streams.md) for more details).
-
-## Changes affecting tests running locally
-
-- Windows Credential Manager support added to the OS Credentials Store extension. Galasa can now securely read test credentials from Windows Credential Manager, providing a more secure alternative to storing credentials in plain text configuration files. See [Windows Credential Manager Store](../../docs/configuring-local-credentials/windows-credential-manager-store.md) for more details.
-

--- a/docs/content/releases/posts/v1.0.0.md
+++ b/docs/content/releases/posts/v1.0.0.md
@@ -1,0 +1,13 @@
+---
+slug: v1.0.0
+date: 2026-06-03
+links:
+  - v1.0.0 GitHub release: https://github.com/galasa-dev/galasa/releases/tag/v1.0.0
+---
+
+# 1.0.0 - Release Highlights
+
+## Changes affecting tests running locally
+
+- Windows Credential Manager support added to the OS Credentials Store extension. Galasa can now securely read test credentials from Windows Credential Manager, providing a more secure alternative to storing credentials in plain text configuration files. See [Windows Credential Manager Store](../../docs/configuring-local-credentials/windows-credential-manager-store.md) for more details.
+


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2592. 

Added a v1.0.0 release note and documentation about using Windows Credential Manager with the new credentials store implementation in https://github.com/galasa-dev/galasa/pull/627

## Changes
- [x] Documentation updates (if applicable)
- [x] Release notes updates (if applicable)
