### PR TITLE
Add GH Actions workflow that runs a credentials store test on Windows

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -188,6 +188,12 @@ jobs:
           name: cli
           path: modules/cli/repo
 
+      - name: Upload CLI binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-binaries
+          path: modules/cli/bin
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -134,7 +134,7 @@ jobs:
 
   deploy-docs-pr-preview-to-github-pages:
 
-    if: ${{ (github.ref_name == 'main') }}
+    if: ${{ github.ref_name == 'main' && github.repository_owner == 'galasa-dev' }}
 
     # Add a dependency to the build job
     needs: build-docs

--- a/.github/workflows/pr-cli.yaml
+++ b/.github/workflows/pr-cli.yaml
@@ -253,6 +253,12 @@ jobs:
         run : |
           make all
 
+      - name: Upload CLI binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-binaries
+          path: modules/cli/bin
+
       # Generate the CLI syntax markdown documentation into a zip, published to maven
       - name: Package and publish the CLI syntax documentation
         working-directory: ./modules/cli

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -403,9 +403,17 @@ jobs:
       changed: ${{ needs.get-changed-modules.outputs.cli_changed }}
       artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
 
+  pr-test-creds-store:
+    name: Test credentials store implementations
+    needs: [find-artifacts, download-artifacts-for-codeql, pr-build-cli]
+    uses: ./.github/workflows/test-creds-store.yaml
+    secrets: inherit
+    with:
+      artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
+
   pr-build-docs:
     name: Build the 'docs' module
-    needs: [get-changed-modules, find-artifacts, pr-build-cli]
+    needs: [get-changed-modules, find-artifacts, pr-build-cli, pr-test-creds-store]
     uses: ./.github/workflows/pr-docs.yaml
     secrets: inherit
 
@@ -417,7 +425,7 @@ jobs:
   # This job is set in the branch protection rules as required to merge a Pull Request.
   end-pull-request-build:
     name: Pull Request build was successful
-    needs: [pr-build-ivts, pr-build-docs, detect-secrets]
+    needs: [pr-build-ivts, pr-test-creds-store, pr-build-docs, detect-secrets]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -403,17 +403,9 @@ jobs:
       changed: ${{ needs.get-changed-modules.outputs.cli_changed }}
       artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
 
-  pr-test-creds-store:
-    name: Test credentials store implementations
-    needs: [find-artifacts, download-artifacts-for-codeql, pr-build-cli]
-    uses: ./.github/workflows/test-creds-store.yaml
-    secrets: inherit
-    with:
-      artifact-id: ${{ needs.find-artifacts.outputs.workflow_for_artifact_download_id }}
-
   pr-build-docs:
     name: Build the 'docs' module
-    needs: [get-changed-modules, find-artifacts, pr-build-cli, pr-test-creds-store]
+    needs: [get-changed-modules, find-artifacts, pr-build-cli]
     uses: ./.github/workflows/pr-docs.yaml
     secrets: inherit
 
@@ -425,7 +417,7 @@ jobs:
   # This job is set in the branch protection rules as required to merge a Pull Request.
   end-pull-request-build:
     name: Pull Request build was successful
-    needs: [pr-build-ivts, pr-test-creds-store, pr-build-docs, detect-secrets]
+    needs: [pr-build-ivts, pr-build-docs, detect-secrets]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -249,9 +249,15 @@ jobs:
     uses: ./.github/workflows/cli.yaml
     secrets: inherit
 
+  test-creds-store:
+    name: Test credentials store implementations
+    needs: [build-ivts, build-cli]
+    uses: ./.github/workflows/test-creds-store.yaml
+    secrets: inherit
+
   build-docs:
-    name: Build the Galasa documentation 
-    needs: [build-cli]
+    name: Build the Galasa documentation
+    needs: [build-cli, test-creds-store]
     uses: ./.github/workflows/docs.yaml
     secrets: inherit
 

--- a/.github/workflows/test-creds-store.yaml
+++ b/.github/workflows/test-creds-store.yaml
@@ -1,0 +1,108 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Test Credentials Store Implementations
+
+on:
+  workflow_call:
+    inputs:
+      artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts to download'
+        required: false
+        type: string
+  workflow_dispatch:
+
+jobs:
+  test-windows-credentials-store:
+    name: Run TestCredentialsStoreAccess on Windows Runner
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            build.properties
+            modules/ivts
+
+      - name: Download CLI binaries from this workflow
+        id: download-cli-binaries
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-binaries
+          path: tools/galasactl
+
+      - name: Download CLI binaries from last successful workflow
+        if: ${{ steps.download-cli-binaries.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-binaries
+          path: tools/galasactl
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.artifact-id }}
+
+      - name: Download All 'dev.galasa' Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: all-artifacts
+          path: modules/artifacts/dev/galasa
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 9.0.0
+          cache-disabled: true
+
+      - name: Setup galasactl
+        shell: powershell
+        run: |
+          Copy-Item "tools/galasactl/galasactl-windows-x86_64.exe" "tools/galasactl/galasactl.exe"
+          Add-Content $env:GITHUB_PATH "$pwd\tools\galasactl"
+
+      - name: Create test credentials in Windows Credential Manager
+        shell: powershell
+        run: |
+          Write-Host "Creating test credentials in Windows Credential Manager..."
+
+          cmdkey /generic:"galasa.credentials.TEST_USERNAME_PASSWORD" /user:"testuser1" /pass:"testpass1"
+          cmdkey /generic:"galasa.credentials.TEST_USERNAME" /user:"username:useronly" /pass:""
+          cmdkey /generic:"galasa.credentials.TEST_TOKEN" /user:"token" /pass:"ghp_test123token456"
+          cmdkey /generic:"galasa.credentials.TEST_USERNAME_TOKEN" /user:"username-token:tokenuser" /pass:"tokenvalue123"
+
+          Write-Host "Test credentials created successfully"
+
+      - name: Initialise Galasa local environment
+        shell: powershell
+        run: |
+          galasactl.exe local init --development --log -
+
+      - name: Run TestCredentialsStoreAccess
+        shell: powershell
+        env:
+          GALASA_CREDENTIALS_STORE: os:auto
+          GALASA_EXTRA_BUNDLES: dev.galasa.creds.os
+        run: |
+          $galasaVersion = (Get-Content build.properties | Select-String '^GALASA_VERSION=').ToString().Split('=')[1]
+          galasactl.exe runs submit local --localMaven file:///${{ github.workspace }}/modules/artifacts --class dev.galasa.ivts/dev.galasa.ivts.framework.TestCredentialsStoreAccess --obr "mvn:dev.galasa/dev.galasa.ivts.obr/$galasaVersion/obr" --log -
+
+  report-failure:
+    if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [test-windows-credentials-store]
+
+    steps:
+      - name: Report failure in workflow to Slack
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "galasa" --module "ivts-windows-creds" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ github.ref_name }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/.github/workflows/test-creds-store.yaml
+++ b/.github/workflows/test-creds-store.yaml
@@ -95,7 +95,7 @@ jobs:
           galasactl.exe runs submit local --localMaven file:///${{ github.workspace }}/modules/artifacts --class dev.galasa.ivts/dev.galasa.ivts.framework.TestCredentialsStoreAccess --obr "mvn:dev.galasa/dev.galasa.ivts.obr/$galasaVersion/obr" --log -
 
   report-failure:
-    if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
+    if: ${{ failure() && github.repository_owner == 'galasa-dev' && github.event_name == 'push' }}
     name: Report failure in workflow
     runs-on: ubuntu-latest
     needs: [test-windows-credentials-store]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2132,6 +2132,26 @@
         "verified_result": null
       }
     ],
+    "modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.core/src/main/java/dev/galasa/ivts/core/TestCredentialsStoreAccess.java": [
+      {
+        "hashed_secret": "f953298876f062f1e31ec1a795f2013db8825b00",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.framework/src/main/java/dev/galasa/ivts/framework/TestCredentialsStoreAccess.java": [
+      {
+        "hashed_secret": "f953298876f062f1e31ec1a795f2013db8825b00",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "modules/managers/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager.ivt/README.md": [
       {
         "hashed_secret": "79b50c37ca39ff0a232fe3e9ca102fa47a10c2b5",

--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.framework/bnd.bnd
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.framework/bnd.bnd
@@ -1,0 +1,8 @@
+-snapshot: ${tstamp}
+Bundle-Name: dev.galasa.ivts.framework
+Export-Package: dev.galasa.ivts.framework*
+Import-Package: !javax.validation.constraints,\
+                dev.galasa,\
+                dev.galasa.core.manager,\
+                org.apache.commons.logging,\
+                org.assertj.core.api

--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.framework/build.gradle
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.framework/build.gradle
@@ -1,0 +1,14 @@
+// This section tells gradle which gradle plugins to use to build this project.
+plugins {
+    id 'galasa.ivt'
+}
+
+// Set the variables which will control what the built OSGi bundle will be called
+// and the name it will be published under in the maven repository.
+description = 'Galasa Framework Validation IVTs'
+
+// What are the dependencies of the test code ? 
+// When more managers and dependencies are added, this list will need to grow.
+dependencies {
+    implementation 'dev.galasa:dev.galasa.core.manager'
+}

--- a/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.framework/src/main/java/dev/galasa/ivts/framework/TestCredentialsStoreAccess.java
+++ b/modules/ivts/galasa-ivts-parent/dev.galasa.ivts/dev.galasa.ivts.framework/src/main/java/dev/galasa/ivts/framework/TestCredentialsStoreAccess.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.ivts.framework;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.logging.Log;
+
+import dev.galasa.ICredentials;
+import dev.galasa.ICredentialsToken;
+import dev.galasa.ICredentialsUsername;
+import dev.galasa.ICredentialsUsernamePassword;
+import dev.galasa.ICredentialsUsernameToken;
+import dev.galasa.Summary;
+import dev.galasa.Tags;
+import dev.galasa.Test;
+import dev.galasa.core.manager.CoreManager;
+import dev.galasa.core.manager.ICoreManager;
+import dev.galasa.core.manager.Logger;
+
+@Test
+@Summary("Verify the core manager can retrieve credentials store entries")
+@Tags({"core","ivt"})
+public class TestCredentialsStoreAccess {
+
+    private static final String USERNAME_PASSWORD_CREDENTIALS_ID = "TEST_USERNAME_PASSWORD";
+    private static final String USERNAME_ONLY_CREDENTIALS_ID = "TEST_USERNAME";
+    private static final String TOKEN_ONLY_CREDENTIALS_ID = "TEST_TOKEN";
+    private static final String USERNAME_TOKEN_CREDENTIALS_ID = "TEST_USERNAME_TOKEN";
+
+    private static final String EXPECTED_USERNAME_PASSWORD_USERNAME = "testuser1";
+    private static final String EXPECTED_USERNAME_PASSWORD_PASSWORD = "testpass1";
+
+    private static final String EXPECTED_USERNAME_ONLY_USERNAME = "useronly";
+
+    private static final String EXPECTED_TOKEN_ONLY_TOKEN = "ghp_test123token456";
+
+    private static final String EXPECTED_USERNAME_TOKEN_USERNAME = "tokenuser";
+    private static final String EXPECTED_USERNAME_TOKEN_TOKEN = "tokenvalue123";
+
+    @Logger
+    public Log logger;
+
+    @CoreManager
+    public ICoreManager coreManager;
+
+    @Test
+    public void checkUsernamePasswordCredentials() throws Exception {
+        ICredentials credentials = coreManager.getCredentials(USERNAME_PASSWORD_CREDENTIALS_ID);
+
+        assertThat(credentials)
+                .as("Username and password credentials should be retrieved")
+                .isInstanceOf(ICredentialsUsernamePassword.class);
+
+        ICredentialsUsernamePassword usernamePasswordCredentials =
+                (ICredentialsUsernamePassword) credentials;
+
+        assertThat(usernamePasswordCredentials.getUsername())
+                .as("Username should match the expected username")
+                .isEqualTo(EXPECTED_USERNAME_PASSWORD_USERNAME);
+
+        assertThat(usernamePasswordCredentials.getPassword())
+                .as("Password should match the expected password")
+                .isEqualTo(EXPECTED_USERNAME_PASSWORD_PASSWORD);
+
+        ICredentialsUsernamePassword directUsernamePasswordCredentials =
+                coreManager.getUsernamePassword(USERNAME_PASSWORD_CREDENTIALS_ID);
+
+        assertThat(directUsernamePasswordCredentials.getUsername())
+                .as("Direct username and password lookup should return the expected username")
+                .isEqualTo(EXPECTED_USERNAME_PASSWORD_USERNAME);
+
+        assertThat(directUsernamePasswordCredentials.getPassword())
+                .as("Direct username and password lookup should return the expected password")
+                .isEqualTo(EXPECTED_USERNAME_PASSWORD_PASSWORD);
+
+        logger.info("Successfully verified username and password credentials");
+    }
+
+    @Test
+    public void checkUsernameOnlyCredentials() throws Exception {
+        ICredentials credentials = coreManager.getCredentials(USERNAME_ONLY_CREDENTIALS_ID);
+
+        assertThat(credentials)
+                .as("Username only credentials should be retrieved")
+                .isInstanceOf(ICredentialsUsername.class);
+
+        ICredentialsUsername usernameCredentials = (ICredentialsUsername) credentials;
+
+        assertThat(usernameCredentials.getUsername())
+                .as("Username only credential should match the expected username")
+                .isEqualTo(EXPECTED_USERNAME_ONLY_USERNAME);
+
+        logger.info("Successfully verified username only credentials");
+    }
+
+    @Test
+    public void checkTokenOnlyCredentials() throws Exception {
+        ICredentials credentials = coreManager.getCredentials(TOKEN_ONLY_CREDENTIALS_ID);
+
+        assertThat(credentials)
+                .as("Token only credentials should be retrieved")
+                .isInstanceOf(ICredentialsToken.class);
+
+        ICredentialsToken tokenCredentials = (ICredentialsToken) credentials;
+
+        assertThat(new String(tokenCredentials.getToken()))
+                .as("Token only credential should match the expected token")
+                .isEqualTo(EXPECTED_TOKEN_ONLY_TOKEN);
+
+        logger.info("Successfully verified token only credentials");
+    }
+
+    @Test
+    public void checkUsernameTokenCredentials() throws Exception {
+        ICredentials credentials = coreManager.getCredentials(USERNAME_TOKEN_CREDENTIALS_ID);
+
+        assertThat(credentials)
+                .as("Username and token credentials should be retrieved")
+                .isInstanceOf(ICredentialsUsernameToken.class);
+
+        ICredentialsUsernameToken usernameTokenCredentials = (ICredentialsUsernameToken) credentials;
+
+        assertThat(usernameTokenCredentials.getUsername())
+                .as("Username and token credential should return the expected username")
+                .isEqualTo(EXPECTED_USERNAME_TOKEN_USERNAME);
+
+        assertThat(new String(usernameTokenCredentials.getToken()))
+                .as("Username and token credential should return the expected token")
+                .isEqualTo(EXPECTED_USERNAME_TOKEN_TOKEN);
+
+        logger.info("Successfully verified username and token credentials");
+    }
+
+}

--- a/modules/ivts/galasa-ivts-parent/settings.gradle
+++ b/modules/ivts/galasa-ivts-parent/settings.gradle
@@ -22,6 +22,7 @@ include 'dev.galasa.ivts:dev.galasa.ivts.artifact'
 include 'dev.galasa.ivts:dev.galasa.ivts.compilation'
 include 'dev.galasa.ivts:dev.galasa.ivts.core'
 include 'dev.galasa.ivts:dev.galasa.ivts.docker'
+include 'dev.galasa.ivts:dev.galasa.ivts.framework'
 include 'dev.galasa.ivts:dev.galasa.ivts.http'
 
 include 'dev.galasa.zos.ivts:dev.galasa.zos.ivts.ceci'


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2592

The new Windows Credential Manager-based credentials store code needs to be exercised regularly, so this PR adds a GitHub Actions workflow as well as a generic IVT to test that the new credentials store implementation works as expected on a Windows runner.

## Changes
- [x] Added a GitHub Actions workflow that uses GitHub's Windows runner to run a test to check that the new credentials store works as expected
