### PR TITLE
chore(deps): Uplift jackson-core dependency

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     implementation 'org.apache.commons:commons-compress'
     implementation 'org.bouncycastle:bcpkix-jdk18on'
     implementation 'org.bouncycastle:bcprov-jdk18on'
+    // Security fix: Override transitive jackson-core version from docker-java-core to address CVE
+    implementation 'com.fasterxml.jackson.core:jackson-core'
 }
 
 // Note: These values are consumed by the parent build process

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -37,8 +37,8 @@ dependencies {
         api 'com.auth0:java-jwt:4.4.0' // used by wrapper.
         
         api 'com.fasterxml.jackson.core:jackson-annotations:2.21' // used by wrapper.
-        api 'com.fasterxml.jackson.core:jackson-core:2.21.1' // used by wrapper.
-        api 'com.fasterxml.jackson.core:jackson-databind:2.21.1' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-core:2.21.2' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-databind:2.21.2' // used by wrapper.
 
         api 'com.github.docker-java:docker-java-api:3.2.14' // bnd.bnd only
         api 'com.github.docker-java:docker-java-core:3.2.14'

--- a/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
@@ -29,6 +29,11 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.36</version>
 		</dependency>
+        <!-- Security fix: Override transitive jackson-core version from kafka-server-common to address CVE -->
+        <dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
## Why?

Uplifts the version of the jackson-core dependencies from 2.21.1 to 2.21.2 to remove several vulnerabilities found by Snyk (see [report](https://github.com/galasa-dev/galasa/security/code-scanning?query=jackson+is%3Aopen+branch%3Amain+tool%3A%22Snyk+Open+Source%22+))

Also adds a dependency into the dev.galasa.wrapping.kafka.clients pom.xml to force this wrapping bundle to use the version stated by the platform.

Also adds a dependency into the dev.galasa.framework.docker.controller build.gradle to force this package to use the version stated by the platform.

## Changes
- [ ] Unit tests (if applicable)
- [ ] Documentation updates (if applicable)
- [ ] Release notes updates (if applicable)
