### PR TITLE
build an offline OBR for galasa uber

### DIFF
--- a/modules/cli/pkg/cmd/runsCleanupLocal.go
+++ b/modules/cli/pkg/cmd/runsCleanupLocal.go
@@ -100,9 +100,10 @@ func (cmd *RunsCleanupLocalCommand) createCobraCmd(
 		"the version of galasa you want to use. This should match the version of the galasa obr you built your resource cleanup providers against.")
 
 	runsCleanupLocalCobraCmd.Flags().StringSliceVar(&cmd.values.runsCleanupLocalCmdParams.RemoteMavenRepos, "remoteMaven",
-		[]string{"https://repo.maven.apache.org/maven2"},
+		[]string{},
 		"the urls of the remote maven repositories where galasa bundles can be loaded from. "+
-			"Defaults to maven central.")
+			"If not specified, no remote Maven repositories will be used and mvn: URIs in OBRs will fail to resolve. "+
+			"Multiple repositories can be specified by using this flag multiple times.")
 
 	runsCleanupLocalCobraCmd.Flags().StringVar(&cmd.values.runsCleanupLocalCmdParams.LocalMaven, "localMaven", "",
 		"The url of a local maven repository are where galasa bundles can be loaded from on your local file system. Defaults to your home .m2/repository file. Please note that this should be in a URL form e.g. 'file:///Users/myuserid/.m2/repository', or 'file://C:/Users/myuserid/.m2/repository'")

--- a/modules/cli/pkg/cmd/runsSubmitLocal.go
+++ b/modules/cli/pkg/cmd/runsSubmitLocal.go
@@ -99,9 +99,9 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 	//currentUserName := runs.GetCurrentSystemUserName()
 
 	runsSubmitLocalCobraCmd.Flags().StringVar(&cmd.values.runsSubmitLocalCmdParams.RemoteMaven, "remoteMaven",
-		"https://repo.maven.apache.org/maven2",
-		"the url of the remote maven where galasa bundles can be loaded from. "+
-			"Defaults to maven central.")
+		"",
+		"the url of the remote maven repository where galasa bundles can be loaded from. "+
+			"If not specified, no remote Maven repository will be used and mvn: URIs in OBRs will fail to resolve.")
 
 	runsSubmitLocalCobraCmd.Flags().StringVar(&cmd.values.runsSubmitLocalCmdParams.LocalMaven, "localMaven", "",
 		"The url of a local maven repository are where galasa bundles can be loaded from on your local file system. Defaults to your home .m2/repository file. Please note that this should be in a URL form e.g. 'file:///Users/myuserid/.m2/repository', or 'file://C:/Users/myuserid/.m2/repository'")

--- a/modules/cli/pkg/launcher/jvmLauncher.go
+++ b/modules/cli/pkg/launcher/jvmLauncher.go
@@ -603,7 +603,6 @@ func (launcher *JvmLauncher) IsLocal() bool {
 // --remotemaven $REMOTE_MAVEN \
 // --bootstrap file:${HOME}/.galasa/bootstrap.properties \
 // --overrides file:${HOME}/.galasa/overrides.properties \
-// --obr mvn:dev.galasa/dev.galasa.uber.obr/${OBR_VERSION}/obr \
 // --obr mvn:${TEST_OBR_GROUP_ID}/${TEST_OBR_ARTIFACT_ID}/${TEST_OBR_VERSION}/obr \
 // --test ${TEST_BUNDLE}/${TEST_JAVA_CLASS} | tee jvm-log.txt | grep "[*][*][*]" | grep -v "[*][*][*][*]" | sed -e "s/[--]*//g"
 //
@@ -614,7 +613,6 @@ func (launcher *JvmLauncher) IsLocal() bool {
 //	    --remotemaven https://development.galasa.dev/main/maven-repo/obr/ \
 //	    --bootstrap file:/Users/mcobbett/.galasa/bootstrap.properties \
 //	    --overrides file:/Users/mcobbett/.galasa/overrides.properties \
-//	    --obr mvn:dev.galasa/dev.galasa.uber.obr/0.26.0/obr \
 //	    --obr mvn:dev.galasa.example.banking/dev.galasa.example.banking.obr/0.0.1-SNAPSHOT/obr \
 //	    --test dev.galasa.example.banking.payee/dev.galasa.example.banking.payee.TestPayee
 func getCommandSyntax(

--- a/modules/cli/pkg/launcher/jvmLauncherUtils.go
+++ b/modules/cli/pkg/launcher/jvmLauncherUtils.go
@@ -103,11 +103,6 @@ func getBaseCommandSyntax(
 			args = append(args, obrMvnPath)
 		}
 
-		// --obr mvn:dev.galasa/dev.galasa.uber.obr/${OBR_VERSION}/obr
-		args = append(args, "--obr")
-		galasaUberObrPath := "mvn:dev.galasa/dev.galasa.uber.obr/" + galasaVersionToRun + "/obr"
-		args = append(args, galasaUberObrPath)
-
 		if isTraceEnabled {
 			args = append(args, "--trace")
 		}

--- a/modules/cli/pkg/launcher/resourceCleanupJvmLauncher.go
+++ b/modules/cli/pkg/launcher/resourceCleanupJvmLauncher.go
@@ -192,7 +192,6 @@ func (launcher *ResourceCleanupJvmLauncher) RunResourceCleanup() error {
 // --localmaven file:${M2_PATH}/repository/ \
 // --remotemaven $REMOTE_MAVEN \
 // --bootstrap file:${HOME}/.galasa/bootstrap.properties \
-// --obr mvn:dev.galasa/dev.galasa.uber.obr/${OBR_VERSION}/obr \
 // --obr mvn:${OBR_GROUP_ID}/${OBR_ARTIFACT_ID}/${OBR_VERSION}/obr \
 // --includes-monitor-pattern "dev.galasa.*"
 // --excludes-monitor-pattern "*MyUnwantedCleanupJob"

--- a/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -445,7 +445,7 @@ public class Launcher {
                     this.remoteMavenRepos.add(new URL(option.replaceFirst("/*$", "")));
                 }
             }
-            this.remoteMavenRepos.add(new URL("https://repo.maven.apache.org/maven2"));
+            // No longer automatically adding Maven Central - users must explicitly opt-in via --remotemaven
         } catch (MalformedURLException e) {
             logger.error("invalid remote maven urls", e);
             commandLineError(null);

--- a/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildOBRResources.java
+++ b/modules/maven/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/galasa/BuildOBRResources.java
@@ -8,8 +8,11 @@ package dev.galasa.maven.plugin.galasa;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -39,7 +42,8 @@ public class BuildOBRResources extends AbstractMojo {
 
     public enum OBR_URL_TYPE {
         file,
-        mvn
+        mvn,
+        relative
     }
 
     @Parameter(defaultValue = "${project}", readonly = true)
@@ -56,6 +60,12 @@ public class BuildOBRResources extends AbstractMojo {
 
     @Parameter(defaultValue = "false", property = "includeSelf", required = false)
     private boolean      includeSelf;
+
+    @Parameter(defaultValue = "false", property = "copyBundles", required = false)
+    private boolean      copyBundles;
+
+    @Parameter(defaultValue = "bundles", property = "bundlesDir", required = false)
+    private String       bundlesDir;
 
     private Field requirementsField;
 
@@ -223,6 +233,17 @@ public class BuildOBRResources extends AbstractMojo {
                     name = new URI("mvn:" + artifact.getGroupId() + "/" + artifact.getArtifactId() + "/"
                             + artifact.getBaseVersion() + "/" + artifact.getType());
                     break;
+                case relative:
+                    // Include group ID to prevent collisions
+                    String fileName = buildBundleFileName(artifact);
+                    name = new URI(bundlesDir + "/" + fileName);
+                    
+                    // Copy the bundle if requested
+                    if (copyBundles) {
+                        File bundlesDirectory = new File(outputDirectory, bundlesDir);
+                        copyBundleToDirectory(artifact, fileName, bundlesDirectory);
+                    }
+                    break;
                 case file:
                 default:
                     name = artifact.getFile().toURI();
@@ -237,6 +258,38 @@ public class BuildOBRResources extends AbstractMojo {
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to process dependency " + artifact.getGroupId() + ":"
                     + artifact.getArtifactId() + ":" + artifact.getVersion(), e);
+        }
+    }
+
+    private String buildBundleFileName(DefaultArtifact artifact) {
+        // Include group ID to prevent collisions
+        return artifact.getGroupId() + "." +
+               artifact.getArtifactId() + "-" +
+               artifact.getBaseVersion() + "." +
+               artifact.getType();
+    }
+
+    private void copyBundleToDirectory(DefaultArtifact artifact, String fileName, File bundlesDirectory)
+            throws MojoExecutionException {
+        try {
+            if (!bundlesDirectory.exists()) {
+                bundlesDirectory.mkdirs();
+                getLog().info("BuildOBRResources: Created bundles directory: " + bundlesDirectory.getAbsolutePath());
+            }
+            
+            File sourceFile = artifact.getFile();
+            File targetFile = new File(bundlesDirectory, fileName);
+            
+            Files.copy(sourceFile.toPath(), targetFile.toPath(),
+                      StandardCopyOption.REPLACE_EXISTING);
+            
+            getLog().info("BuildOBRResources: Copied bundle: " + fileName + " to " + bundlesDirectory.getName() + "/");
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to copy bundle " +
+                                            artifact.getId() + " to bundles directory", e);
+        } catch (SecurityException e) {
+            throw new MojoExecutionException("Security exception while copying bundle " +
+                                            artifact.getId() + " to bundles directory", e);
         }
     }
 

--- a/modules/obr/dev.galasa.uber.obr/pom.template
+++ b/modules/obr/dev.galasa.uber.obr/pom.template
@@ -80,6 +80,11 @@
 				<artifactId>galasa-maven-plugin</artifactId>
 				<version>{{.Release}}</version>
 				<extensions>true</extensions>
+				<configuration>
+					<obrUrlType>relative</obrUrlType>
+					<copyBundles>true</copyBundles>
+					<bundlesDir>bundles</bundlesDir>
+				</configuration>
 				<executions>
 					<execution>
 						<id>deploy-testcatalog</id>


### PR DESCRIPTION
Example of an approach you could take to build a strictly offline version of the Galasa Uber OBR that could be run on airgapped systems without access to Maven Central

I also removed the hard-coded Galasa Uber OBR from the CLI, and the hard-coded Maven Central repo from both the CLI and the launcher, so that it can be tested without any reference to a remote repo in the configuration.  This probably need a bit more thought as it's a bit heavy-handed!