### PR TITLE
Make test-creds-store workflow wait for all maven artifacts to be uploaded before starting

### DIFF
--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -251,7 +251,7 @@ jobs:
 
   test-creds-store:
     name: Test credentials store implementations
-    needs: [build-ivts, build-cli]
+    needs: [build-ivts, build-cli, download-artifacts-for-codeql]
     uses: ./.github/workflows/test-creds-store.yaml
     secrets: inherit
 


### PR DESCRIPTION
## Why?

The main build failed in https://github.com/galasa-dev/galasa/actions/runs/27613767640/job/81648483616 because `all-artifacts` was not uploaded by the time the `test-creds-store` job started. This PR fixes that by making sure the `download-artifacts-for-codeql` workflow is complete (which is where the `all-artifacts` artifact gets uploaded)

## Changes
- [x] Added `download-artifacts-for-codeql` to the `needs` array for the `test-creds-store` job

