### PR TITLE
Updated CEMT manager

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager/src/main/java/dev/galasa/cicsts/cemt/internal/CemtImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager/src/main/java/dev/galasa/cicsts/cemt/internal/CemtImpl.java
@@ -601,5 +601,104 @@ public class CemtImpl implements ICemt {
         return this.inquireResource(terminal, resourceType, resourceName, " Ena ");
     }
 
+    @Override
+    public boolean setSystemProperty(ICicsTerminal terminal, String systemArea,
+            String propertyName, String newValue, String expectedResponse)
+            throws CemtException
+    {
+        if (expectedResponse == null)
+        {
+            throw new CemtException("Expected Response cannot be null");
+        }
 
+        if (cicsRegion != terminal.getCicsRegion())
+        {
+            throw new CemtException("Terminal provided does not match CICS region.");
+        }
+
+        if (!terminal.isClearScreen())
+        {
+            try
+            {
+                terminal.resetAndClear();
+            }
+            catch (CicstsManagerException e)
+            {
+                throw new CemtException("Problem reset and clearing screen for CEMT transaction", e);
+            }
+        }
+
+        String cemtCmd = "CEMT SET " + systemArea + " ";
+        cemtCmd += propertyName + "(" + newValue + ")";
+
+        try
+        {
+            terminal.type(cemtCmd).enter().waitForKeyboard();
+            boolean success = false;
+            String response = terminal.retrieveScreen();
+            if (response != null)
+            {
+                success = response.contains(expectedResponse);
+            }
+            terminal.reportScreen();
+            if (!success)
+            {
+                throw new CemtException("Expected Response from CEMT SET not found. Expected: " + expectedResponse);
+            }
+            return success;
+        }
+        catch (FieldNotFoundException | KeyboardLockedException | TerminalInterruptedException |
+               NetworkException | TimeoutException | CicstsManagerException e)
+        {
+            throw new CemtException(e);
+        }
+    }
+
+    @Override
+    public boolean setSystemProperty(ICicsTerminal terminal, String systemArea,
+            String setRequest, String expectedResponse) throws CemtException
+    {
+        if (expectedResponse == null)
+        {
+            throw new CemtException("Expected Response cannot be null");
+        }
+
+        if (cicsRegion != terminal.getCicsRegion())
+        {
+            throw new CemtException("Terminal provided does not match CICS region.");
+        }
+
+        if (!terminal.isClearScreen())
+        {
+            try
+            {
+                terminal.resetAndClear();
+            }
+            catch (CicstsManagerException e)
+            {
+                throw new CemtException("Problem reset and clearing screen for CEMT transaction", e);
+            }
+        }
+
+        String cemtCmd = "CEMT SET " + systemArea + " ";
+        cemtCmd += setRequest;
+
+        try
+        {
+            terminal.type(cemtCmd).enter().waitForKeyboard();
+            boolean success = terminal.searchText(expectedResponse);
+            terminal.reportScreen();
+            if (!success)
+            {
+                throw new CemtException("Expected Response from CEMT SET not found. Expected: " + expectedResponse);
+            }
+            return success;
+        }
+        catch (FieldNotFoundException | KeyboardLockedException | TerminalInterruptedException |
+               NetworkException | TimeoutException | CicstsManagerException e)
+        {
+            throw new CemtException(e);
+        }
+    }
+    
 }

--- a/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/ICemt.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/ICemt.java
@@ -194,4 +194,39 @@ public interface ICemt {
     boolean isResourceEnabled(ICicsTerminal terminal, String resourceType, String resourceName)
         throws CemtException;
 
+    /**
+     * Set a system property using CEMT SET command with property name and value.
+     * This method is useful for setting system-level properties that do not have specific resource names.
+     *
+     * @param cemtTerminal an {@link ICicsTerminal} object logged on to the CICS region.
+     * @param systemArea a {@link String} specifying the system area.
+     * @param propertyName a {@link String} specifying the property to set.
+     * @param newValue a {@link String} specifying the new value for the property.
+     * @param expectedResponse a {@link String} specifying the expected response text to validate success.
+     * @return boolean true if the expected response was found, false otherwise.
+     * @throws CemtException if the expected response is not found or if there is an error executing the command.
+     */
+    public boolean setSystemProperty(@NotNull ICicsTerminal cemtTerminal,
+                                     @NotNull String systemArea,
+                                     @NotNull String propertyName,
+                                     @NotNull String newValue,
+                                     @NotNull String expectedResponse) throws CemtException;
+
+    /**
+     * Set a system property using CEMT SET command with a complete set request.
+     * This method is useful for setting system-level properties like IRC, VTAM, etc.
+     * that do not have specific resource names.
+     *
+     * @param cemtTerminal an {@link ICicsTerminal} object logged on to the CICS region.
+     * @param systemArea a {@link String} specifying the system area (e.g., "IRC", "VTAM").
+     * @param setRequest a {@link String} specifying the complete set request (e.g., "OPEN").
+     * @param expectedResponse a {@link String} specifying the expected response text to validate success.
+     * @return boolean true if the expected response was found, false otherwise.
+     * @throws CemtException if the expected response is not found or if there is an error executing the command.
+     */
+    public boolean setSystemProperty(@NotNull ICicsTerminal cemtTerminal,
+                                     @NotNull String systemArea,
+                                     @NotNull String setRequest,
+                                     @NotNull String expectedResponse) throws CemtException;
+
 }


### PR DESCRIPTION
Two new overloaded setSystemProperty methods have been added to provide enhanced functionality for setting CICS system-level properties using CEMT SET commands. These methods are designed for system areas that don't have specific resource names (e.g., IRC, VTAM, DB2CONN).


Method 1: setSystemProperty (5 parameters)
Signature:
public boolean setSystemProperty(@NotNull ICicsTerminal cemtTerminal,
                                 @NotNull String systemArea,
                                 @NotNull String propertyName,
                                 @NotNull String newValue,
                                 @NotNull String expectedResponse) throws CemtException

Purpose:
Sets a system property using CEMT SET command with a property name and value pair.

Parameters:
cemtTerminal - An ICicsTerminal object logged on to the CICS region
systemArea - The system area to modify 
propertyName - The specific property to set within the system area
newValue - The new value to assign to the property
expectedResponse - Text expected in the terminal response to validate success

Implementation Details:
Validates that the terminal matches the CICS region
Resets and clears the terminal screen if needed
Constructs command: CEMT SET <systemArea> <propertyName>(<newValue>)
Executes the command and waits for keyboard
Validates response contains the expected text using retrieveScreen().contains()
Reports the screen output for debugging
Throws CemtException if expected response is not found


Method 2: setSystemProperty (4 parameters)
Signature:
public boolean setSystemProperty(@NotNull ICicsTerminal cemtTerminal,
                                 @NotNull String systemArea,
                                 @NotNull String setRequest,
                                 @NotNull String expectedResponse) throws CemtException

Purpose:
Sets a system property using CEMT SET command with a complete set request string.

Parameters:

cemtTerminal - An ICicsTerminal object logged on to the CICS region
systemArea - The system area to modify (e.g., "IRC", "VTAM")
setRequest - The complete set request string (e.g., "OPEN", "CLOSE", "AUTOCONNECT(YES)")
expectedResponse - Text expected in the terminal response to validate success

Implementation Details:
Validates that the terminal matches the CICS region
Resets and clears the terminal screen if needed
Constructs command: CEMT SET <systemArea> <setRequest>
Executes the command and waits for keyboard
Validates response contains the expected text using searchText()
Reports the screen output for debugging
Throws CemtException if expected response is not found
