### PR TITLE
Allow multiple --class flags in runs submit local commands

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1507,7 +1507,7 @@
         "hashed_secret": "c042bdfc4bc5516ec716afe9e85c173b614ff9f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 900,
+        "line_number": 970,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/docs/content/releases/posts/v1.0.0.md
+++ b/docs/content/releases/posts/v1.0.0.md
@@ -11,3 +11,4 @@ links:
 
 - Windows Credential Manager support added to the OS Credentials Store extension. Galasa can now securely read test credentials from Windows Credential Manager, providing a more secure alternative to storing credentials in plain text configuration files. See [Windows Credential Manager Store](../../docs/configuring-local-credentials/windows-credential-manager-store.md) for more details.
 
+- Fixed an issue where multiple Galasa test classes could not be run in one `galasactl runs submit local` command. You can now supply multiple `--class` flags to run multiple test classes sequentially.

--- a/modules/cli/docs/generated/galasactl_runs_submit_local.md
+++ b/modules/cli/docs/generated/galasactl_runs_submit_local.md
@@ -24,6 +24,7 @@ galasactl runs submit local [flags]
       --methods strings        Optional. The names of the Java test methods from the test class provided via the --class option that you wish to run. Method names must start with a letter (a-z, A-Z), can contain letters, numbers, and underscores, and must not be a Java reserved keyword. If not specified, all methods in the given class are run. Method names are case sensitive. This option can only be used alongside --class and cannot be used with --gherkin.
       --obr strings            The maven coordinates of the obr bundle(s) which refer to your test bundles. The format of this parameter is 'mvn:${TEST_OBR_GROUP_ID}/${TEST_OBR_ARTIFACT_ID}/${TEST_OBR_VERSION}/obr' Multiple instances of this flag can be used to describe multiple obr bundles.
       --remoteMaven string     the url of the remote maven where galasa bundles can be loaded from. Defaults to maven central. (default "https://repo.maven.apache.org/maven2")
+      --throttle int           how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 1)
 ```
 
 ### Options inherited from parent commands
@@ -45,7 +46,6 @@ galasactl runs submit local [flags]
       --reportyaml string                     yaml file to record the final results in
       --requesttype string                    the type of request, used to allocate a run name. Defaults to CLI. (default "CLI")
       --tags strings                          tagging metadata to be associated with the submitted runs. This can be specified as a comma-separated list of tag strings, or by repeating the --tags parameter, or both.
-      --throttle int                          how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 3)
       --throttlefile string                   a file where the current throttle is stored. Periodically the throttle value is read from the file used. Someone with edit access to the file can change it which dynamically takes effect. Long-running large portfolios can be throttled back to nothing (paused) using this mechanism (if throttle is set to 0). And they can be resumed (un-paused) if the value is set back. This facility can allow the tests to not show a failure when the system under test is taken out of service for maintainence.Optional. If not specified, no throttle file is used.
       --trace                                 Trace to be enabled on the test runs
 ```

--- a/modules/cli/pkg/cmd/runsSubmitLocal.go
+++ b/modules/cli/pkg/cmd/runsSubmitLocal.go
@@ -153,6 +153,9 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 	runsSubmitLocalCobraCmd.MarkFlagsOneRequired("class", "gherkin")
 	runsSubmitLocalCobraCmd.MarkFlagsMutuallyExclusive("methods", "gherkin")
 
+	runsSubmitLocalCobraCmd.Flags().IntVar(&runsSubmitCmd.Values().(*utils.RunsSubmitCmdValues).Throttle, "throttle", runs.DEFAULT_LOCAL_THROTTLE_TESTS_AT_ONCE,
+		"how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially.")
+
 	runsSubmitCmd.CobraCommand().AddCommand(runsSubmitLocalCobraCmd)
 
 	return runsSubmitLocalCobraCmd, err

--- a/modules/cli/pkg/launcher/jvmLauncher.go
+++ b/modules/cli/pkg/launcher/jvmLauncher.go
@@ -471,7 +471,7 @@ func (launcher *JvmLauncher) GetRunsByGroup(groupName string) (*galasaapi.TestRu
 
 	log.Printf("JvmLauncher: GetRunsByGroup(groupName=%s) exiting. isComplete:%v testRuns returned:%v\n", groupName, *testRuns.Complete, len(testRuns.Runs))
 	for _, testRun := range testRuns.Runs {
-		log.Printf("JvmLauncher: GetRunsByGroup test name:%s status:%s result:%s\n", *testRun.Name, *testRun.Status, *testRun.Result)
+		log.Printf("JvmLauncher: GetRunsByGroup test name:%s status:%s result:%s\n", testRun.GetName(), testRun.GetStatus(), testRun.GetResult())
 	}
 	return &testRuns, nil
 }
@@ -523,7 +523,7 @@ func createRunFromLocalTest(localTest *LocalTest) (*galasaapi.Run, error) {
 		err = fmt.Errorf("createRunFromLocalTest - Don't have enough information to find the structure.json in the RAS folder")
 		log.Printf("%v", err.Error())
 	} else {
-		jsonFilePath := strings.TrimPrefix(localTest.rasFolderPathUrl, "file:///") + "/" + localTest.runId + "/structure.json"
+		jsonFilePath := fileUrlToPath(localTest.rasFolderPathUrl) + "/" + localTest.runId + "/structure.json"
 		log.Printf("createRunFromLocalTest - Reading latest test status from '%s'\n", jsonFilePath)
 
 		err = setTestStructureFromRasFile(run, jsonFilePath, localTest.fileSystem)

--- a/modules/cli/pkg/launcher/jvmLauncher_test.go
+++ b/modules/cli/pkg/launcher/jvmLauncher_test.go
@@ -428,6 +428,76 @@ func TestCanGetRunGroupStatus(t *testing.T) {
 	}
 }
 
+func TestGetRunsByGroupRetainsRunNameWhenStructureJsonAbsent(t *testing.T) {
+	// Given...
+	env := utils.NewMockEnv()
+	env.EnvVars["JAVA_HOME"] = "/java"
+
+	fs := files.NewMockFileSystem()
+	utils.AddJavaRuntimeToMock(fs, "/java")
+
+	galasaHome, _ := utils.NewGalasaHome(fs, env, "")
+
+	jvmLaunchParams := getBasicJvmLaunchParams()
+	timeService := utils.NewMockTimeService()
+
+	mockProcess := NewMockProcess()
+	mockProcessFactory := NewMockProcessFactory(mockProcess)
+
+	bootstrapProps := getBasicBootstrapProperties()
+
+	mockFactory := &utils.MockFactory{
+		Env:         env,
+		FileSystem:  fs,
+		TimeService: timeService,
+	}
+
+	launcher, err := NewJVMLauncher(
+		mockFactory,
+		bootstrapProps, embedded.GetReadOnlyFileSystem(),
+		jvmLaunchParams, mockProcessFactory, galasaHome, utils.NewRealTimedSleeper(),
+	)
+	if err != nil {
+		assert.Fail(t, "Launcher should have been created OK")
+	}
+
+	isTraceEnabled := true
+	var overrides map[string]interface{} = make(map[string]interface{})
+	var tags []string
+
+	launcher.SubmitTestRun(
+		"myGroup",
+		"galasa.dev.example.banking.account/galasa.dev.example.banking.account.TestAccount",
+		"myRequestType-UnitTest",
+		"myRequestor",
+		"myRequestor",
+		"unitTestStream",
+		"mvn:myGroup/myArtifact/myClassifier/obr",
+		isTraceEnabled,
+		"", // No Gherkin URL supplied
+		"", // No Gherkin Feature supplied
+		overrides,
+		tags,
+	)
+
+	// Simulate the JVM process exiting WITHOUT writing structure.json to disk
+	mockProcess.Wait()
+
+	// structure.json is deliberately NOT written to fs here.
+
+	// When...
+	testRuns, err := launcher.GetRunsByGroup("myGroup")
+
+	// Then...
+	assert.Nil(t, err, "GetRunsByGroup should not return an error")
+	assert.NotNil(t, testRuns, "Returned test runs should not be nil")
+	assert.Len(t, testRuns.Runs, 1, "Should have exactly one run")
+
+	// The run name must be the one allocated by the JVM ("L12345"), not "".
+	assert.Equal(t, "L12345", testRuns.Runs[0].GetName(),
+		"Run name must be preserved even when structure.json has not been written yet")
+}
+
 func TestJvmLauncherSetsRASStoreOverride(t *testing.T) {
 	overrides := make(map[string]interface{})
 	fs := files.NewMockFileSystem()

--- a/modules/cli/pkg/launcher/localTest.go
+++ b/modules/cli/pkg/launcher/localTest.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -16,6 +17,30 @@ import (
 	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/spi"
 )
+
+// windowsDrivePattern matches one or more leading slashes followed by a Windows
+// drive letter and colon, e.g. "/C:/" or "//C:/".
+var windowsDrivePattern = regexp.MustCompile(`^/+([A-Za-z]:/.*)`)
+
+// fileUrlToPath converts a file:// URL string to a native filesystem path that
+// works on both Unix and Windows regardless of how many slashes the JVM emits
+// after "file:".
+//
+//   - Unix:    "file:///home/user/.galasa/ras"   →  "/home/user/.galasa/ras"
+//   - Unix:    "file:////home/user/.galasa/ras"  →  "/home/user/.galasa/ras"
+//   - Windows: "file:///C:/Users/.galasa/ras"    →  "C:/Users/.galasa/ras"
+func fileUrlToPath(fileUrl string) string {
+	// Strip the scheme, leaving one or more leading slashes.
+	path := strings.TrimPrefix(fileUrl, "file:")
+	// On Windows the path looks like "///C:/..." — strip all leading slashes and
+	// return the drive-letter path (e.g. "C:/...").
+	if m := windowsDrivePattern.FindStringSubmatch(path); m != nil {
+		return m[1]
+	}
+	// On Unix collapse any run of leading slashes down to a single "/".
+	path = "/" + strings.TrimLeft(path, "/")
+	return path
+}
 
 // A local test which gets run.
 type LocalTest struct {
@@ -201,13 +226,13 @@ func (localTest *LocalTest) updateTestStatusFromRasFile() error {
 		log.Printf("Don't have enough information to find the structure.json in the RAS folder yet. Test JVM is starting up.\n")
 	} else {
 
-		jsonFilePath := strings.TrimPrefix(localTest.rasFolderPathUrl, "file:///") + "/" + localTest.runId + "/structure.json"
+		jsonFilePath := fileUrlToPath(localTest.rasFolderPathUrl) + "/" + localTest.runId + "/structure.json"
 		log.Printf("Reading latest test status from '%s'\n", jsonFilePath)
 
 		var testRun *galasaapi.TestRun
 		testRun, err = readTestRunFromJsonFile(localTest.fileSystem, jsonFilePath)
 
-		if err == nil {
+		if err == nil && testRun != nil {
 			localTest.testRun = testRun
 		}
 	}

--- a/modules/cli/pkg/launcher/testRun.go
+++ b/modules/cli/pkg/launcher/testRun.go
@@ -7,7 +7,6 @@ package launcher
 
 import (
 	"encoding/json"
-	"net/url"
 
 	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/spi"
@@ -60,54 +59,50 @@ func readTestRunFromJsonFile(
 	log.Printf("readTestRunFromJsonFile entered. Reading file '%s'\n", jsonFilePath)
 
 	var testRunData *galasaapi.TestRun = nil
-	url, err := url.Parse(jsonFilePath)
+	var err error
+
+	isExists, err := fileSystem.Exists(jsonFilePath)
 	if err != nil {
-		log.Printf("Failed to parse json file path '%s' into a URL.", jsonFilePath)
+		log.Printf("Failed to check whether the file '%s' exists. Can't read status.", jsonFilePath)
 	} else {
-		var isExists bool
-		isExists, err = fileSystem.Exists(url.Path)
-		if err != nil {
-			log.Printf("Failed to check whether the file '%s' exists. Can't read status.", url.Path)
+		if !isExists {
+			log.Printf("readTestRunFromJsonFile file '%s' does not exist.", jsonFilePath)
 		} else {
-			if !isExists {
-				log.Printf("readTestRunFromJsonFile file '%s' does not exist.", url.Path)
+			var jsonContent string
+			jsonContent, err = fileSystem.ReadTextFile(jsonFilePath)
+			if err != nil {
+				log.Printf("readTestRunFromJsonFile file '%s' could not be read.", jsonFilePath)
 			} else {
-				var jsonContent string
-				jsonContent, err = fileSystem.ReadTextFile(url.Path)
-				if err != nil {
-					log.Printf("readTestRunFromJsonFile file '%s' could not be read.", url.Path)
+				if len(jsonContent) <= 0 {
+					log.Printf("readTestRunFromJsonFile file '%s' is empty. Status could not be read.", jsonFilePath)
 				} else {
-					if len(jsonContent) <= 0 {
-						log.Printf("readTestRunFromJsonFile file '%s' is empty. Status could not be read.", url.Path)
+					var f interface{}
+					err = json.Unmarshal([]byte(jsonContent), &f)
+
+					if err != nil {
+						log.Printf("readTestRunFromJsonFile file '%s' could not be parsed from json. status could not be read.", jsonFilePath)
 					} else {
-						var f interface{}
-						err = json.Unmarshal([]byte(jsonContent), &f)
+						fields := f.(map[string]interface{})
 
-						if err != nil {
-							log.Printf("readTestRunFromJsonFile file '%s' could not be parsed from json. status could not be read.", jsonFilePath)
-						} else {
-							fields := f.(map[string]interface{})
+						testRunData = galasaapi.NewTestRun()
 
-							testRunData = galasaapi.NewTestRun()
+						testRunData.Name = getStringField(fields, "runName")
+						testRunData.Test = getStringField(fields, "testShortName")
+						testRunData.BundleName = getStringField(fields, "bundle")
+						testRunData.TestName = getStringField(fields, "testName")
+						testRunData.Status = getStringField(fields, "status")
+						testRunData.Result = getStringField(fields, "result")
+						testRunData.Queued = getStringField(fields, "queued")
+						testRunData.Requestor = getStringField(fields, "requestor")
+						testRunData.User = getStringField(fields, "user")
+						testRunData.RasRunId = getStringField(fields, "runName")
 
-							testRunData.Name = getStringField(fields, "runName")
-							testRunData.Test = getStringField(fields, "testShortName")
-							testRunData.BundleName = getStringField(fields, "bundle")
-							testRunData.TestName = getStringField(fields, "testName")
-							testRunData.Status = getStringField(fields, "status")
-							testRunData.Result = getStringField(fields, "result")
-							testRunData.Queued = getStringField(fields, "queued")
-							testRunData.Requestor = getStringField(fields, "requestor")
-							testRunData.User = getStringField(fields, "user")
-							testRunData.RasRunId = getStringField(fields, "runName")
-
-							log.Printf("readTestRunFromJsonFile Test %s status %s result %s\n", *testRunData.Name, *testRunData.Status, *testRunData.Result)
-							// testRunData.Stream = stream
-							// testRunData.Local = isLocal
-							// testRunData.Trace = isTraceEnabled
-							// testRunData.Type = testType
-							// testRunData.Group = group
-						}
+						log.Printf("readTestRunFromJsonFile Test %s status %s result %s\n", *testRunData.Name, *testRunData.Status, *testRunData.Result)
+						// testRunData.Stream = stream
+						// testRunData.Local = isLocal
+						// testRunData.Trace = isTraceEnabled
+						// testRunData.Type = testType
+						// testRunData.Group = group
 					}
 				}
 			}

--- a/modules/cli/pkg/runs/runTypes.go
+++ b/modules/cli/pkg/runs/runTypes.go
@@ -47,4 +47,5 @@ const (
 	MAX_INT                                  int = int(^uint(0) >> 1)
 	DEFAULT_PROGRESS_REPORT_INTERVAL_MINUTES int = 5
 	DEFAULT_THROTTLE_TESTS_AT_ONCE           int = 3
+	DEFAULT_LOCAL_THROTTLE_TESTS_AT_ONCE     int = 1
 )

--- a/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/modules/framework/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.UUID;
 import java.text.*;
 
 import org.apache.commons.io.FileUtils;
@@ -82,9 +83,10 @@ public class FelixFramework {
         logger.debug("Building Felix Framework...");
 
         File galasaDirectory = new File(galasaHome);
-        String cacheDirectory = "felix-cache";
-        
-        this.felixCache = new File(galasaDirectory, cacheDirectory);
+        File cacheParent = new File(galasaDirectory, "cache");
+        String cacheDirectory = "felix-cache-" + UUID.randomUUID().toString();
+
+        this.felixCache = new File(cacheParent, cacheDirectory);
         try {
             FileUtils.deleteDirectory(felixCache);
             


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2610

## Changes
- [x] The framework now creates `felix-cache` directories under a common `cache` folder within the Galasa home directory
- [x] The CLI no longer "loses" test runs when multiple `--class` flags are given
- [x] `runs submit local` now sets a default throttle of 1 to avoid JVMs from competing with each other over resources and DSS changes
- [x] Unit tests (if applicable)
- [x] Release notes updates (if applicable)
