### PR TITLE
Pre-compute priority scores before sorting to avoid timeService calls from breaking comparator contract

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/scheduling/PrioritySchedulingService.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/scheduling/PrioritySchedulingService.java
@@ -78,7 +78,15 @@ public class PrioritySchedulingService implements IPrioritySchedulingService {
         // repeatedly query the CPS when sorting the queued runs.
         Map<String, Tag> queuedRunTags = getAllQueuedRunTagsFromCps(queuedRuns);
 
-        queuedRuns.sort(getPriorityComparator(queuedRunTags));
+        // Pre-compute each run's total priority score once, before sorting begins.
+        Map<String, Double> queuedRunScores = new HashMap<>();
+        for (IRun run : queuedRuns) {
+            double score = getQueuedRunTotalPriorityPoints(run, queuedRunTags);
+            queuedRunScores.put(run.getName(), score);
+            logger.trace("Scheduling: run '" + run.getName() + "' pre-computed priority score: " + score);
+        }
+
+        queuedRuns.sort(getPriorityComparator(queuedRunScores));
         return queuedRuns;
     }
 
@@ -102,8 +110,8 @@ public class PrioritySchedulingService implements IPrioritySchedulingService {
         return tagsFromCps;
     }
 
-    private Comparator<IRun> getPriorityComparator(Map<String, Tag> queuedRunTags) {
-        return (a, b) -> Double.compare(getQueuedRunTotalPriorityPoints(b, queuedRunTags), getQueuedRunTotalPriorityPoints(a, queuedRunTags));
+    private Comparator<IRun> getPriorityComparator(Map<String, Double> queuedRunScores) {
+        return (a, b) -> Double.compare(queuedRunScores.get(b.getName()), queuedRunScores.get(a.getName()));
     }
 
     private List<IRun> getQueuedRemoteRuns() throws FrameworkException {
@@ -120,9 +128,16 @@ public class PrioritySchedulingService implements IPrioritySchedulingService {
     }
 
     double getQueuedRunTotalPriorityPoints(IRun run, Map<String, Tag> queuedRunTags) {
-        double totalPriorityPoints = getPriorityPointsFromQueuedTime(run.getQueued());
-        totalPriorityPoints += getRequestorPriorityPoints(run.getRequestor());
-        totalPriorityPoints += getPriorityPointsFromTags(run.getTags(), queuedRunTags);
+        double timePoints = getPriorityPointsFromQueuedTime(run.getQueued());
+        double requestorPoints = getRequestorPriorityPoints(run.getRequestor());
+        double tagPoints = getPriorityPointsFromTags(run.getTags(), queuedRunTags);
+        double totalPriorityPoints = timePoints + requestorPoints + tagPoints;
+
+        logger.trace("Scheduling: run '" + run.getName() + "' score breakdown:"
+            + " time=" + timePoints
+            + " requestor=" + requestorPoints
+            + " tags=" + tagPoints
+            + " total=" + totalPriorityPoints);
 
         return totalPriorityPoints;
     }

--- a/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/scheduling/PrioritySchedulingServiceTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/scheduling/PrioritySchedulingServiceTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 
@@ -29,6 +30,7 @@ import dev.galasa.framework.mocks.MockUser;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.rbac.BuiltInAction;
 import dev.galasa.framework.spi.tags.Tag;
+import dev.galasa.framework.spi.utils.ITimeService;
 
 public class PrioritySchedulingServiceTest {
 
@@ -452,5 +454,49 @@ public class PrioritySchedulingServiceTest {
         // Then...
         // Check that both tag priorities have been added to the run's total priority
         assertThat(runPriority).isEqualTo(220);
+    }
+
+    @Test
+    public void testSortDoesNotThrowWhenClockAdvancesBetweenComparisons() throws Exception {
+        // Given...
+        // A time service whose now() advances by 1 second on every call.
+        Instant startTime = Instant.EPOCH;
+        AtomicLong callCount = new AtomicLong(0);
+        ITimeService advancingTimeService = new ITimeService() {
+            @Override
+            public Instant now() {
+                return startTime.plusSeconds(callCount.getAndIncrement());
+            }
+            @Override
+            public void sleepMillis(long millisToSleep) throws InterruptedException {}
+        };
+
+        Instant queuedBase = Instant.EPOCH.minusSeconds(300);
+        List<IRun> runs = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            MockRun run = new MockRun(null, null, "run" + i, null, null, null, null, false);
+            run.setQueued(queuedBase.plusSeconds(i * 10));
+            run.setStatus(TestRunLifecycleStatus.QUEUED.toString());
+            runs.add(run);
+        }
+
+        MockFrameworkRuns mockFrameworkRuns = new MockFrameworkRuns(runs);
+        MockIConfigurationPropertyStoreService mockCps = new MockIConfigurationPropertyStoreService();
+        MockRBACService mockRBACService = FilledMockRBACService.createTestRBACService();
+        MockTagsService mockTagsService = new MockTagsService();
+
+        PrioritySchedulingService schedulingService = new PrioritySchedulingService(
+            mockFrameworkRuns, mockCps, mockRBACService, advancingTimeService, mockTagsService);
+
+        // When...
+        List<IRun> runsGotBack = schedulingService.getPrioritisedTestRunsToSchedule();
+
+        // Then...
+        // run0 was queued earliest so has the most elapsed time and highest priority
+        assertThat(runsGotBack).hasSize(10);
+        assertThat(runsGotBack.get(0).getName()).isEqualTo("run0");
+
+        // run9 was queued latest so has the least elapsed time and lowest priority
+        assertThat(runsGotBack.get(9).getName()).isEqualTo("run9");
     }
 }


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2611

As part of the priority scheduling code, every run comparison call goes through:

```
getQueuedRunTotalPriorityPoints() -> getPriorityPointsFromQueuedTime() -> timeService.now()
```

This likely means that the clock advances between comparisons during a sort, and in turn, means the score for the same run object can return a different value in successive calls. This violates Java's comparator contract (transitivity/antisymmetry), hence the `IllegalArgumentException`.

This PR solves this problem by pre-computing the priority score values for the queued test runs, so that the priority scores cannot change during sorting.


## Changes
- [x] Updated the priority scheduling code to pre-compute queued run priority points and pass the pre-computed values in the sort, rather than computing the priority points during sorting
- [x] Unit tests (if applicable)
