### PR TITLE
Bump jackson-databind and jackson-core to 3.1.4 to fix vulnerability in client-java and kafka-clients wrapping bundles

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation ('com.google.code.gson:gson')
     
     // Not required for compile,  but required to force the download of the jars to embed by bnd
-    implementation('tools.jackson.core:jackson-core')
+    implementation('com.fasterxml.jackson.core:jackson-core')
     implementation('com.google.api.grpc:proto-google-common-protos:2.59.2')
     implementation('com.google.guava:failureaccess')
     implementation('com.google.guava:guava')

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation ('com.google.code.gson:gson')
     
     // Not required for compile,  but required to force the download of the jars to embed by bnd
-    implementation('com.fasterxml.jackson.core:jackson-core')
+    implementation('tools.jackson.core:jackson-core')
     implementation('com.google.api.grpc:proto-google-common-protos:2.59.2')
     implementation('com.google.guava:failureaccess')
     implementation('com.google.guava:guava')

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -37,8 +37,8 @@ dependencies {
         api 'com.auth0:java-jwt:4.4.0' // used by wrapper.
         
         api 'com.fasterxml.jackson.core:jackson-annotations:2.21' // used by wrapper.
-        api 'com.fasterxml.jackson.core:jackson-core:2.21.2' // used by wrapper.
-        api 'com.fasterxml.jackson.core:jackson-databind:2.21.2' // used by wrapper.
+        api 'tools.jackson.core:jackson-core:3.1.4' // used by wrapper.
+        api 'tools.jackson.core:jackson-databind:3.1.4' // used by wrapper.
 
         api 'com.github.docker-java:docker-java-api:3.2.14' // bnd.bnd only
         api 'com.github.docker-java:docker-java-core:3.2.14'

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -37,8 +37,8 @@ dependencies {
         api 'com.auth0:java-jwt:4.4.0' // used by wrapper.
         
         api 'com.fasterxml.jackson.core:jackson-annotations:2.21' // used by wrapper.
-        api 'tools.jackson.core:jackson-core:3.1.4' // used by wrapper.
-        api 'tools.jackson.core:jackson-databind:3.1.4' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-core:2.21.4' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-databind:2.21.4' // used by wrapper.
 
         api 'com.github.docker-java:docker-java-api:3.2.14' // bnd.bnd only
         api 'com.github.docker-java:docker-java-core:3.2.14'

--- a/modules/wrapping/dev.galasa.wrapping.io.kubernetes.client-java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.io.kubernetes.client-java/pom.xml
@@ -19,6 +19,20 @@
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
+
+            <!-- Security fix: Exclude transitive jackson-databind version -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Security fix: Override transitive jackson-databind version to address CVE -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- Security fix: Override transitive netty-codec version to address CVE -->

--- a/modules/wrapping/dev.galasa.wrapping.io.kubernetes.client-java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.io.kubernetes.client-java/pom.xml
@@ -31,7 +31,7 @@
 
         <!-- Security fix: Override transitive jackson-databind version to address CVE -->
         <dependency>
-            <groupId>tools.jackson.core</groupId>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
@@ -23,6 +23,18 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-server-common</artifactId>
+
+            <!-- Security fix: Exclude transitive jackson-core and jackson-databind -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -31,9 +43,15 @@
 		</dependency>
         <!-- Security fix: Override transitive jackson-core version from kafka-server-common to address CVE -->
         <dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
+			<groupId>tools.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 		</dependency>
+
+        <!-- Security fix: Override transitive jackson-databind version from kafka-server-common to address CVE -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
@@ -43,13 +43,13 @@
 		</dependency>
         <!-- Security fix: Override transitive jackson-core version from kafka-server-common to address CVE -->
         <dependency>
-			<groupId>tools.jackson.core</groupId>
+			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 		</dependency>
 
         <!-- Security fix: Override transitive jackson-databind version from kafka-server-common to address CVE -->
         <dependency>
-            <groupId>tools.jackson.core</groupId>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 	</dependencies>


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2614

Resolves a reported vulnerability in dev.galasa.wrapping.io.kubernetes.client-java and dev.galasa.wrapping.kafka.clients bundles by bumping jackson-databind and jackson-core 2.21.2 to 3.1.4

## Changes
- [x] Bumped jackson-databind and jackson-core to 3.1.4
