### PR TITLE
Bump jackson-databind and jackson-core

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -37,8 +37,8 @@ dependencies {
         api 'com.auth0:java-jwt:4.4.0' // used by wrapper.
         
         api 'com.fasterxml.jackson.core:jackson-annotations:2.21' // used by wrapper.
-        api 'com.fasterxml.jackson.core:jackson-core:2.21.2' // used by wrapper.
-        api 'com.fasterxml.jackson.core:jackson-databind:2.21.2' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-core:2.21.4' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-databind:2.21.4' // used by wrapper.
 
         api 'com.github.docker-java:docker-java-api:3.2.14' // bnd.bnd only
         api 'com.github.docker-java:docker-java-core:3.2.14'

--- a/modules/wrapping/dev.galasa.wrapping.io.kubernetes.client-java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.io.kubernetes.client-java/pom.xml
@@ -19,6 +19,20 @@
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
+
+            <!-- Security fix: Exclude transitive jackson-databind version -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Security fix: Override transitive jackson-databind version to address CVE -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- Security fix: Override transitive netty-codec version to address CVE -->

--- a/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
@@ -23,6 +23,18 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-server-common</artifactId>
+
+            <!-- Security fix: Exclude transitive jackson-core and jackson-databind -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -34,6 +46,12 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 		</dependency>
+
+        <!-- Security fix: Override transitive jackson-databind version from kafka-server-common to address CVE -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
## Why? 

For https://github.com/galasa-dev/projectmanagement/issues/2614

Bumps jackson-core and jackson-databind to 2.21.4 since 3.1.4 features breaking changes that the kubernetes client-java and kafka clients libraries don't yet support.

## Changes
- [x] Bumped jackson-core and jackson-databind to 2.21.4