### PR TITLE
Auto-embed transitive dependencies for httpclient5, jta, and kafka-clients wrapped bundles

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -211,10 +211,6 @@ dependencies {
         api 'org.apache.httpcomponents:httpcore-osgi:4.4.14' // If updating, also update in obr/release.yaml.
         api 'org.apache.httpcomponents:httpmime:4.5.14'
 
-        api 'org.apache.httpcomponents.httpclient:httpclient5:5.0.3' // bnd.bnd only
-
-        api 'org.apache.httpcomponents.core5:httpcore5:5.0.2' // bnd.bnd only
-
         api 'org.apache.kafka:kafka-clients:4.0.2'
         api 'org.apache.kafka:kafka-server-common:4.0.2'
 

--- a/modules/wrapping/dev.galasa.wrapping.httpclient5/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.httpclient5/pom.xml
@@ -20,16 +20,6 @@
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents.core5</groupId>
-            <artifactId>httpcore5</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents.core5</groupId>
-            <artifactId>httpcore5-h2</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -42,7 +32,8 @@
                     <supportedProjectTypes>bundle</supportedProjectTypes>
                     <instructions>
                         <Bundle-SymbolicName>dev.galasa.wrapping.httpclient5</Bundle-SymbolicName>
-                        <Embed-Dependency>*;scope=compile</Embed-Dependency>
+                        <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
                         <Import-Package>
                             javax.crypto,
                             javax.crypto.spec,

--- a/modules/wrapping/dev.galasa.wrapping.jta/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.jta/pom.xml
@@ -39,7 +39,8 @@
 					<supportedProjectTypes>bundle</supportedProjectTypes>
 					<instructions>
 						<Bundle-SymbolicName>dev.galasa.wrapping.jta</Bundle-SymbolicName>
-						<Embed-Dependency>*;scope=compile</Embed-Dependency>
+						<Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
+						<Embed-Transitive>true</Embed-Transitive>
 						<Export-Package>javax.transaction,
 							javax.transaction.*,
 							javax.enterprise.util,

--- a/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.kafka.clients/pom.xml
@@ -36,11 +36,7 @@
                 </exclusion>
             </exclusions>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.36</version>
-		</dependency>
+
         <!-- Security fix: Override transitive jackson-core version from kafka-server-common to address CVE -->
         <dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
@@ -64,7 +60,8 @@
 					<supportedProjectTypes>bundle</supportedProjectTypes>
 					<instructions>
 						<Bundle-SymbolicName>dev.galasa.wrapping.kafka.clients</Bundle-SymbolicName>
-						<Embed-Dependency>*;scope=compile</Embed-Dependency>
+						<Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
+						<Embed-Transitive>true</Embed-Transitive>
 						<Import-Package>
 						    org.ietf.jgss,
 							javax.management,


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2608

## Changes
- [x] Replaced the explicit transitive dependencies defined in the wrapping bundles for httpclient5, jta, and kafka-clients with the maven bundle plugin's `Embed-Transitive` instruction
- [x] Removed duplicate httpclient5 dependencies from the gradle platform
