### PR TITLE
Revert velocity-engine-core wrapping removal to override commons-lang3 version and address CVE

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -146,6 +146,12 @@ external:
     mvp: false      # Only used in Kafka extension - not needed.
     isolated: false # Only used in Kafka extension - not needed.
 
+  - group: dev.galasa
+    artifact: dev.galasa.wrapping.velocity-engine-core
+    obr: true
+    mvp: true
+    isolated: true
+
   # io.opentelemetry dependencies are transitive dependencies of selenium 4.27.0 required for isolated and MVP
   - group: io.opentelemetry
     artifact: opentelemetry-api
@@ -382,12 +388,6 @@ external:
 
   - group: org.apache.logging.log4j
     artifact: log4j-slf4j-impl
-    obr: true
-    mvp: true
-    isolated: true
-
-  - group: org.apache.velocity
-    artifact: velocity-engine-core
     obr: true
     mvp: true
     isolated: true

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -101,6 +101,7 @@ dependencies {
         api 'dev.galasa:dev.galasa.wrapping.io.kubernetes.client-java:'+version
         api 'dev.galasa:dev.galasa.wrapping.jta:'+version
         api 'dev.galasa:dev.galasa.wrapping.kafka.clients:'+version
+        api 'dev.galasa:dev.galasa.wrapping.velocity-engine-core:'+version
         api 'dev.galasa:dev.galasa.wrapping.protobuf-java:'+version
         api 'dev.galasa:galasa-boot:'+version
         api 'dev.galasa:galasa-testharness:'+version

--- a/modules/wrapping/dev.galasa.wrapping.velocity-engine-core/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.velocity-engine-core/pom.xml
@@ -1,0 +1,80 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.galasa</groupId>
+        <artifactId>dev.galasa.wrapping.parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dev.galasa.wrapping.velocity-engine-core</artifactId>
+    <version>1.0.0</version>
+    <packaging>bundle</packaging>
+
+    <!-- velocity-engine-core:2.4.1 does not need to be wrapped, but we have kept this bundle for now
+        to override the commons-lang3:3.17.0 dependency to address a CVE.
+     -->
+    <name>Galasa wrapped version of velocity-engine-core</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity-engine-core</artifactId>
+
+            <!--
+            This dependency depends on:
+            org.slf4j:slf4j-api:1.7.36:compile and commons-lang3:3.17.0
+
+            which we want to upgrade to later versions.
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Upgrade the version of velocity-engine-core being used -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <!-- Upgrade the version of slf4j-api being used -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.16</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <supportedProjectTypes>bundle</supportedProjectTypes>
+                    <instructions>
+                        <Bundle-SymbolicName>dev.galasa.wrapping.velocity-engine-core</Bundle-SymbolicName>
+						<Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
+						<Embed-Transitive>true</Embed-Transitive>
+                        <Export-Package>
+                            org.apache.velocity,
+                            org.apache.velocity.app,
+                            org.apache.velocity.context
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/wrapping/pom.xml
+++ b/modules/wrapping/pom.xml
@@ -44,6 +44,7 @@
 		<module>dev.galasa.wrapping.protobuf-java</module>
 		<module>dev.galasa.wrapping.jta</module>
 		<module>dev.galasa.wrapping.kafka.clients</module>
+		<module>dev.galasa.wrapping.velocity-engine-core</module>
 	</modules>
 
 	<scm>


### PR DESCRIPTION
## Why?

Related to changes in https://github.com/galasa-dev/galasa/pull/645

velocity-engine-core 2.4.1 depends on commons-lang3 3.17.0, which has a vulnerability. Previously, we had dev.galasa.wrapping.velocity-engine-core which unnecessarily wrapped the library into an OSGi bundle, but also overrode the commons-lang3 version. This PR reverts the removal of that bundle and clarifies why it has been left there so that we can investigate a better solution for this.

## Changes
- [x] Added the `dev.galasa.wrapping.velocity-engine-core` bundle back into the wrapping module
