### PR TITLE
Separate jetcd-core jars from Galasa cps.etcd bundle to its own wrapped bundle

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/bnd.bnd
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/bnd.bnd
@@ -10,50 +10,7 @@ Import-Package: \
     dev.galasa.framework.spi.creds,\
     javax.net.ssl,\
     javax.security.cert,\
-    org.apache.commons.logging
-Embed-Transitive: true
-Embed-Dependency: *;scope=compile|runtime
--includeresource: \
-    checker-qual-*.jar; lib:=true,\
-    failsafe-*.jar; lib:=true,\
-    failureaccess-*.jar; lib:=true,\
-    grpc-api-1.76.0.jar; lib:=true,\
-    grpc-context-1.76.0.jar; lib:=true,\
-    grpc-core-1.76.0.jar; lib:=true,\
-    grpc-grpclb-1.76.0.jar; lib:=true,\
-    grpc-netty-1.76.0.jar; lib:=true,\
-    grpc-protobuf-1.76.0.jar; lib:=true,\
-    grpc-protobuf-lite-1.76.0.jar; lib:=true,\
-    grpc-stub-1.76.0.jar; lib:=true,\
-    grpc-util-1.76.0.jar; lib:=true,\
-    gson-*.jar; lib:=true,\
-    guava-*.jar; lib:=true,\
-    jackson-core-*.jar; lib:=true,\
-    javax.annotation-api-*.jar; lib:=true,\
-    jetcd-api-*.jar; lib:=true,\
-    jetcd-common-*.jar; lib:=true,\
-    jetcd-core-*.jar; lib:=true,\
-    jetcd-grpc-*.jar; lib:=true,\
-    listenablefuture-*.jar; lib:=true,\
-    netty-buffer-*.jar; lib:=true,\
-    netty-codec-*.jar; lib:=true,\
-    netty-codec-dns-*.jar; lib:=true,\
-    netty-codec-http-*.jar; lib:=true,\
-    netty-codec-http2-*.jar; lib:=true,\
-    netty-codec-socks-*.jar; lib:=true,\
-    netty-common-*.jar; lib:=true,\
-    netty-handler-*.jar; lib:=true,\
-    netty-handler-proxy-*.jar; lib:=true,\
-    netty-resolver-*.jar; lib:=true,\
-    netty-resolver-dns-*.jar; lib:=true,\
-    netty-transport-*.jar; lib:=true,\
-    netty-transport-native-unix-common-*.jar; lib:=true,\
-    perfmark-api-0.27.0.jar; lib:=true,\
-    proto-google-common-protos-2.59.2.jar; lib:=true,\
-    protobuf-java-3.25.8.jar; lib:=true,\
-    protobuf-java-util-*.jar; lib:=true,\
-    slf4j-api-2.0.17.jar; lib:=true,\
-    validation-api-*.jar; lib:=true,\
-    vertx-core-*.jar; lib:=true,\
-    vertx-grpc-*.jar; lib:=true
--fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=warning
+    org.apache.commons.logging,\
+    io.etcd.jetcd.*,\
+    io.vertx.core,\
+    io.vertx.core.file

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
@@ -6,59 +6,8 @@ plugins {
 description = 'Galasa etcd3 for CPS, DSS and Credentials - Provides the CPS, DSS and Credential stores from a etcd3 server'
 
 dependencies {
-    implementation ('io.etcd:jetcd-core') 
-    // {
-    //     exclude group: com.google.code.gson ,module: gson
-    // }
-    // We don't want to use their gson implementation.
-    implementation ('com.google.code.gson:gson')
-    
-    // Not required for compile,  but required to force the download of the jars to embed by bnd
-    implementation('com.fasterxml.jackson.core:jackson-core')
-    implementation('com.google.api.grpc:proto-google-common-protos:2.59.2')
-    implementation('com.google.guava:failureaccess')
-    implementation('com.google.guava:guava')
-    implementation('com.google.guava:listenablefuture')
-    implementation('com.google.protobuf:protobuf-java-util')
-    implementation('com.google.protobuf:protobuf-java:3.25.8')
-    implementation('dev.failsafe:failsafe')
-    implementation('io.etcd:jetcd-api')
-    implementation('io.etcd:jetcd-common')
-    implementation('io.etcd:jetcd-core')
-    implementation('io.etcd:jetcd-grpc')
-    implementation('io.grpc:grpc-api:1.76.0')
-    implementation('io.grpc:grpc-context:1.76.0')
-    implementation('io.grpc:grpc-core:1.76.0')
-    implementation('io.grpc:grpc-grpclb:1.76.0')
-    implementation('io.grpc:grpc-netty:1.76.0')
-    implementation('io.grpc:grpc-protobuf-lite:1.76.0')
-    implementation('io.grpc:grpc-protobuf:1.76.0')
-    implementation('io.grpc:grpc-stub:1.76.0')
-    implementation('io.grpc:grpc-util:1.76.0')
-    implementation('io.netty:netty-buffer')
-    implementation('io.netty:netty-codec-dns')
-    implementation('io.netty:netty-codec-http2')
-    implementation('io.netty:netty-codec-http')
-    implementation('io.netty:netty-codec-socks')
-    implementation('io.netty:netty-codec')
-    implementation('io.netty:netty-common')
-    implementation('io.netty:netty-handler-proxy')
-    implementation('io.netty:netty-handler')
-    implementation('io.netty:netty-resolver-dns')
-    implementation('io.netty:netty-resolver')
-    implementation('io.netty:netty-transport-native-unix-common')
-    implementation('io.netty:netty-transport')
-    implementation('io.perfmark:perfmark-api:0.27.0')
-    implementation('io.vertx:vertx-core')
-    implementation('io.vertx:vertx-grpc')
-    implementation('javax.annotation:javax.annotation-api')
-    implementation('javax.validation:validation-api')
-    // logging is already embedded inside the framework bundle....
-    //  implementation('org.apache.logging.log4j:log4j-api:2.17.1')
-    //  implementation('org.apache.logging.log4j:log4j-core:2.17.1')
-    //  implementation('org.apache.logging.log4j:log4j-slf4j-impl:2.17.1')
-    implementation('org.checkerframework:checker-qual')
-    implementation('org.slf4j:slf4j-api:2.0.17')
+    implementation 'dev.galasa:dev.galasa.wrapping.jetcd-core'
+    implementation 'com.google.code.gson:gson'
 
     testImplementation(testFixtures(project(':dev.galasa.extensions.common')))
 }

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -135,6 +135,12 @@ external:
     isolated: true
 
   - group: dev.galasa
+    artifact: dev.galasa.wrapping.jetcd-core
+    obr: true
+    mvp: false      # Only used in etcd extension - not needed.
+    isolated: false # Only used in etcd extension - not needed.
+
+  - group: dev.galasa
     artifact: dev.galasa.wrapping.kafka.clients
     obr: true
     mvp: false      # Only used in Kafka extension - not needed.

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -56,7 +56,6 @@ dependencies {
         api 'com.google.errorprone:error_prone_annotations:2.41.0'
 
         // api 'com.google.protobuf:protobuf-java:4.28.3' - dangerous. Protobuf versions are all explicit elsewhere right now.
-        api 'com.google.protobuf:protobuf-java-util:3.25.3'
 
         api 'com.google.guava:guava:33.5.0-jre'
         api 'com.google.guava:failureaccess:1.0.3'
@@ -99,32 +98,18 @@ dependencies {
         api 'dev.galasa:dev.galasa.wrapping.httpclient5:'+version // If updating, also update in obr/release.yaml.
         api 'dev.galasa:dev.galasa.wrapping.io.grpc.java:'+version
         api 'dev.galasa:dev.galasa.wrapping.io.kubernetes.client-java:'+version
+        api 'dev.galasa:dev.galasa.wrapping.jetcd-core:'+version
         api 'dev.galasa:dev.galasa.wrapping.kafka.clients:'+version
         api 'dev.galasa:dev.galasa.wrapping.velocity-engine-core:'+version
         api 'dev.galasa:dev.galasa.wrapping.protobuf-java:'+version
         api 'dev.galasa:galasa-boot:'+version
         api 'dev.galasa:galasa-testharness:'+version
 
-        api 'io.etcd:jetcd-api:0.8.6'
-        api 'io.etcd:jetcd-common:0.8.6'
         api 'io.etcd:jetcd-core:0.8.6'
-        api 'io.etcd:jetcd-grpc:0.8.6'
 
         api 'io.kubernetes:client-java:26.0.1'
 
-        api 'io.netty:netty-buffer:4.2.13.Final'
         api 'io.netty:netty-codec:4.2.13.Final'
-        api 'io.netty:netty-codec-dns:4.2.13.Final'
-        api 'io.netty:netty-codec-http:4.2.13.Final'
-        api 'io.netty:netty-codec-http2:4.2.13.Final'
-        api 'io.netty:netty-codec-socks:4.2.13.Final'
-        api 'io.netty:netty-common:4.2.13.Final'
-        api 'io.netty:netty-handler:4.2.13.Final'
-        api 'io.netty:netty-handler-proxy:4.2.13.Final'
-        api 'io.netty:netty-resolver:4.2.13.Final'
-        api 'io.netty:netty-resolver-dns:4.2.13.Final'
-        api 'io.netty:netty-transport:4.2.13.Final'
-        api 'io.netty:netty-transport-native-unix-common:4.2.13.Final'
 
         api 'io.opentelemetry:opentelemetry-api:1.62.0'
         api 'io.opentelemetry:opentelemetry-api-incubator:1.62.0-alpha'
@@ -139,8 +124,6 @@ dependencies {
         api 'io.opentelemetry:opentelemetry-sdk-logs:1.62.0'
         api 'io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha'
 
-        api 'io.perfmark:perfmark-api:0.26.0'
-
         // Most bundles before implementing the Platform used 0.6.0 other than dev.galasa.framework.k8s.controller.
         // Upgrading all to 0.16.0 by using the Platform.
         api 'io.prometheus:simpleclient:0.16.0'
@@ -152,9 +135,6 @@ dependencies {
         api 'io.prometheus:simpleclient_tracer_otel_agent:0.16.0'
 
         api 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.41'
-
-        api 'io.vertx:vertx-core:5.0.5'
-        api 'io.vertx:vertx-grpc:5.0.5'
 
         api 'jakarta.activation:jakarta.activation-api:2.1.3'
 

--- a/modules/wrapping/dev.galasa.wrapping.jetcd-core/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.jetcd-core/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.galasa</groupId>
+        <artifactId>dev.galasa.wrapping.parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dev.galasa.wrapping.jetcd-core</artifactId>
+    <version>1.0.0</version>
+    <packaging>bundle</packaging>
+
+    <name>Galasa wrapped version of jetcd-core</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.etcd</groupId>
+            <artifactId>jetcd-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <supportedProjectTypes>bundle</supportedProjectTypes>
+                    <instructions>
+                        <Bundle-SymbolicName>dev.galasa.wrapping.jetcd-core</Bundle-SymbolicName>
+                        <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                        <Import-Package>
+							javax.net.ssl,
+							javax.security.cert,
+                            org.apache.commons.logging
+                        </Import-Package>
+                        <Export-Package>
+                            io.etcd.*,
+                            io.vertx.*
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/wrapping/pom.xml
+++ b/modules/wrapping/pom.xml
@@ -41,6 +41,7 @@
         <module>dev.galasa.wrapping.httpclient5</module>
 		<module>dev.galasa.wrapping.io.grpc.java</module>
 		<module>dev.galasa.wrapping.io.kubernetes.client-java</module>
+		<module>dev.galasa.wrapping.jetcd-core</module>
 		<module>dev.galasa.wrapping.protobuf-java</module>
 		<module>dev.galasa.wrapping.kafka.clients</module>
 		<module>dev.galasa.wrapping.velocity-engine-core</module>


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2608

This PR creates a new wrapping bundle for the non-OSGi jetcd-core library, separating the library out from the CPS etcd extension.

## Changes
- [x] Added dev.galasa.wrapping.jetcd-core wrapping bundle
- [x] Removed explicit `-includeresource` jars from the CPS etcd extension's bnd.bnd file
- [x] Removed explicit transitive dependencies listed in the CPS etcd extension's build.gradle file
- [x] Removed transitive dependencies that were specific to the jetcd library from the gradle platform