### PR TITLE
Generated pom.xmls with galasabld template can list dependency exclusions 

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2293,7 +2293,7 @@
         "hashed_secret": "22199ec38c6bedb7616f8e42aa3ad6e9f196cd24",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 114,
+        "line_number": 127,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/modules/buildutils/pkg/cmd/template.go
+++ b/modules/buildutils/pkg/cmd/template.go
@@ -50,6 +50,11 @@ type artifact struct {
 	ArtifactId string
 	Version    string
 	Type       string
+	Exclusions []exclusion
+}
+type exclusion struct {
+	GroupId    string
+	ArtifactId string
 }
 
 func init() {
@@ -67,6 +72,19 @@ func init() {
 
 	rootCmd.AddCommand(templateCmd)
 }
+
+
+func bundleExclusions(yamlExclusions []galasayaml.Exclusion) []exclusion {
+	if len(yamlExclusions) == 0 {
+		return nil
+	}
+	result := make([]exclusion, len(yamlExclusions))
+	for i, e := range yamlExclusions {
+		result[i] = exclusion{GroupId: e.GroupId, ArtifactId: e.ArtifactId}
+	}
+	return result
+}
+
 
 func templateExecute(cmd *cobra.Command, args []string) {
 	fmt.Printf("Galasa Build - Template - version %v\n", rootCmd.Version)
@@ -202,6 +220,7 @@ func templateExecute(cmd *cobra.Command, args []string) {
 				ArtifactId: bundle.Artifact,
 				Version:    bundle.Version,
 				Type:       bundle.Type,
+				Exclusions: bundleExclusions(bundle.Exclusions),
 			}
 
 			t.Artifacts = append(t.Artifacts, artifact)
@@ -244,6 +263,7 @@ func templateExecute(cmd *cobra.Command, args []string) {
 				ArtifactId: bundle.Artifact,
 				Version:    bundle.Version,
 				Type:       bundle.Type,
+				Exclusions: bundleExclusions(bundle.Exclusions),
 			}
 
 			t.Artifacts = append(t.Artifacts, artifact)
@@ -281,6 +301,7 @@ func templateExecute(cmd *cobra.Command, args []string) {
 				ArtifactId: bundle.Artifact,
 				Version:    bundle.Version,
 				Type:       bundle.Type,
+				Exclusions: bundleExclusions(bundle.Exclusions),
 			}
 
 			t.Artifacts = append(t.Artifacts, artifact)
@@ -318,6 +339,7 @@ func templateExecute(cmd *cobra.Command, args []string) {
 				ArtifactId: bundle.Artifact,
 				Version:    bundle.Version,
 				Type:       bundle.Type,
+				Exclusions: bundleExclusions(bundle.Exclusions),
 			}
 
 			t.Artifacts = append(t.Artifacts, artifact)

--- a/modules/buildutils/pkg/cmd/template_test.go
+++ b/modules/buildutils/pkg/cmd/template_test.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+
+	"galasa.dev/buildUtilities/pkg/galasayaml"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+// ---------------------------------------------------------------------------
+// YAML parsing tests
+// ---------------------------------------------------------------------------
+
+const releaseYamlWithExclusions = `
+apiVersion: galasa.dev/v1alpha
+kind: Release
+metadata:
+  name: galasa-release
+release:
+  version: 1.0.0
+framework:
+  bundles:
+    - artifact: some-artifact
+      version: 1.2.3
+      isolated: true
+      exclusions:
+        - groupId: org.unwanted
+          artifactId: transitive-dep
+        - groupId: org.also-unwanted
+          artifactId: another-dep
+`
+
+const releaseYamlWithoutExclusions = `
+apiVersion: galasa.dev/v1alpha
+kind: Release
+metadata:
+  name: galasa-release
+release:
+  version: 1.0.0
+framework:
+  bundles:
+    - artifact: plain-artifact
+      version: 2.0.0
+      isolated: true
+`
+
+func TestYamlParsing_BundleWithExclusions_PopulatesExclusionsField(t *testing.T) {
+	// Given...
+	var rel galasayaml.Release
+
+	// When...
+	err := yaml.Unmarshal([]byte(releaseYamlWithExclusions), &rel)
+
+	// Then...
+	assert.Nil(t, err)
+	assert.Len(t, rel.Framework.Bundles, 1)
+
+	bundle := rel.Framework.Bundles[0]
+	assert.Equal(t, "some-artifact", bundle.Artifact)
+	assert.Len(t, bundle.Exclusions, 2)
+
+	assert.Equal(t, "org.unwanted", bundle.Exclusions[0].GroupId)
+	assert.Equal(t, "transitive-dep", bundle.Exclusions[0].ArtifactId)
+	assert.Equal(t, "org.also-unwanted", bundle.Exclusions[1].GroupId)
+	assert.Equal(t, "another-dep", bundle.Exclusions[1].ArtifactId)
+}
+
+func TestYamlParsing_BundleWithoutExclusions_ExclusionsFieldIsNil(t *testing.T) {
+	// Given...
+	var rel galasayaml.Release
+
+	// When...
+	err := yaml.Unmarshal([]byte(releaseYamlWithoutExclusions), &rel)
+
+	// Then...
+	assert.Nil(t, err)
+	assert.Len(t, rel.Framework.Bundles, 1)
+	assert.Nil(t, rel.Framework.Bundles[0].Exclusions)
+}
+
+// ---------------------------------------------------------------------------
+// bundleExclusions helper tests
+// ---------------------------------------------------------------------------
+
+func TestBundleExclusions_WithEntries_ReturnsMappedSlice(t *testing.T) {
+	// Given...
+	yamlExclusions := []galasayaml.Exclusion{
+		{GroupId: "org.unwanted", ArtifactId: "transitive-dep"},
+	}
+
+	// When...
+	result := bundleExclusions(yamlExclusions)
+
+	// Then...
+	assert.Len(t, result, 1)
+	assert.Equal(t, "org.unwanted", result[0].GroupId)
+	assert.Equal(t, "transitive-dep", result[0].ArtifactId)
+}
+
+func TestBundleExclusions_WithEmptySlice_ReturnsNil(t *testing.T) {
+	// Given / When...
+	result := bundleExclusions([]galasayaml.Exclusion{})
+
+	// Then...
+	assert.Nil(t, result)
+}
+
+func TestBundleExclusions_WithNilSlice_ReturnsNil(t *testing.T) {
+	// Given / When...
+	result := bundleExclusions(nil)
+
+	// Then...
+	assert.Nil(t, result)
+}
+
+// ---------------------------------------------------------------------------
+// Template rendering tests
+// ---------------------------------------------------------------------------
+
+const pomTemplate = `{{range .Artifacts}}<dependency>
+<groupId>{{.GroupId}}</groupId>
+<artifactId>{{.ArtifactId}}</artifactId>{{if .Version}}
+<version>{{.Version}}</version>{{end}}{{if .Exclusions}}
+<exclusions>{{range .Exclusions}}
+<exclusion>
+<groupId>{{.GroupId}}</groupId>
+<artifactId>{{.ArtifactId}}</artifactId>
+</exclusion>{{end}}
+</exclusions>{{end}}
+</dependency>
+{{end}}`
+
+func renderTemplate(t *testing.T, data templateData) string {
+	t.Helper()
+	tmpl, err := template.New("test").Parse(pomTemplate)
+	assert.Nil(t, err)
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, data)
+	assert.Nil(t, err)
+	return buf.String()
+}
+
+func TestTemplateRendering_ArtifactWithExclusions_RendersExclusionsBlock(t *testing.T) {
+	// Given...
+	data := templateData{
+		Release: "1.0.0",
+		Artifacts: []artifact{
+			{
+				GroupId:    "com.example",
+				ArtifactId: "some-artifact",
+				Version:    "1.2.3",
+				Exclusions: []exclusion{
+					{GroupId: "org.unwanted", ArtifactId: "transitive-dep"},
+				},
+			},
+		},
+	}
+
+	// When...
+	output := renderTemplate(t, data)
+
+	// Then...
+	assert.True(t, strings.Contains(output, "<exclusions>"), "expected <exclusions> block in output")
+	assert.True(t, strings.Contains(output, "<exclusion>"), "expected <exclusion> element in output")
+	assert.True(t, strings.Contains(output, "<groupId>org.unwanted</groupId>"), "expected exclusion groupId")
+	assert.True(t, strings.Contains(output, "<artifactId>transitive-dep</artifactId>"), "expected exclusion artifactId")
+}
+
+func TestTemplateRendering_ArtifactWithoutExclusions_NoExclusionsBlock(t *testing.T) {
+	// Given...
+	data := templateData{
+		Release: "1.0.0",
+		Artifacts: []artifact{
+			{
+				GroupId:    "com.example",
+				ArtifactId: "plain-artifact",
+				Version:    "2.0.0",
+			},
+		},
+	}
+
+	// When...
+	output := renderTemplate(t, data)
+
+	// Then...
+	assert.False(t, strings.Contains(output, "<exclusions>"), "unexpected <exclusions> block in output")
+	assert.True(t, strings.Contains(output, "<artifactId>plain-artifact</artifactId>"))
+}

--- a/modules/buildutils/pkg/galasayaml/release.go
+++ b/modules/buildutils/pkg/galasayaml/release.go
@@ -41,4 +41,10 @@ type Bundle struct {
 	Javadoc      bool
 	Managerdoc   bool
 	Codecoverage bool
+	Exclusions   []Exclusion
+}
+
+type Exclusion struct {
+	GroupId    string `yaml:"groupId"`
+	ArtifactId string `yaml:"artifactId"`
 }

--- a/modules/obr/dev.galasa.uber.obr/pom.template
+++ b/modules/obr/dev.galasa.uber.obr/pom.template
@@ -68,7 +68,13 @@
         <dependency>
             <groupId>{{.GroupId}}</groupId>
             <artifactId>{{.ArtifactId}}</artifactId>{{if .Version}}
-            <version>{{.Version}}</version>{{end}}
+            <version>{{.Version}}</version>{{end}}{{if .Exclusions}}
+            <exclusions>{{range .Exclusions}}
+                <exclusion>
+                    <groupId>{{.GroupId}}</groupId>
+                    <artifactId>{{.ArtifactId}}</artifactId>
+                </exclusion>{{end}}
+            </exclusions>{{end}}
         </dependency>
     {{end}}
 	</dependencies>

--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -20,6 +20,19 @@ release:
 
 external:
   bundles:
+
+  # 
+  # Example of bundle with exclusions in the generated pom.xml:
+  # 
+  # - artifact: some-artifact
+  #   version: 1.2.3
+  #   isolated: true
+  #   exclusions:
+  #     - groupId: org.unwanted
+  #       artifactId: transitive-dep
+  #     - groupId: org.also-unwanted
+  #       artifactId: another-dep
+
   - group: com.github.mwiede
     artifact: jsch
     obr: true


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2608

Added support for an optional exclusions field on artifact entries in release.yaml, which is parsed by the `galasabld template` command and passed through to the Go template engine so that `<exclusions>` blocks are conditionally included for certain dependencies in generated pom.xml files. 

This will make it easier going forward to exclude vulnerable transitive dependencies from generated pom.xmls for both the dev.galasa.uber.obr and Isolated/MVP pom.xmls.

**Note:** a second PR in the Isolated repo is to follow to update the pom.template stored there.

## Changes
- [x] Updates to `galasabld template` to add `Exclusions` struct and add to the overall `artifact` struct if present in the release.yaml
- [x] Update to the Go template (pom.template) to add `<exclusions>` if present in the struct
- [x] Unit tests for `galasabld template`
- [x] Example of an artifact with exclusions added to the release.yaml
