### PR TITLE
Override jetcd-core transitive dependencies to address CVEs

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -98,6 +98,15 @@ dependencies {
 
         api 'io.netty:netty-codec:4.2.13.Final'
 
+        // Override transitive dependencies for jetcd-core:0.8.6 to address CVEs
+        api 'io.netty:netty-resolver-dns:4.2.15.Final'
+        api 'io.netty:netty-handler:4.2.15.Final'
+        api 'io.netty:netty-codec-http:4.2.15.Final'
+        api 'io.netty:netty-codec-http2:4.2.15.Final'
+        api 'io.netty:netty-codec-compression:4.2.15.Final'
+        api 'io.netty:netty-codec-dns:4.2.15.Final'
+        api 'io.vertx:vertx-core:5.0.12'
+        
         // Most bundles before implementing the Platform used 0.6.0 other than dev.galasa.framework.k8s.controller.
         // Upgrading all to 0.16.0 by using the Platform.
         api 'io.prometheus:simpleclient:0.16.0'

--- a/modules/wrapping/dev.galasa.wrapping.jetcd-core/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.jetcd-core/pom.xml
@@ -20,6 +20,36 @@
             <groupId>io.etcd</groupId>
             <artifactId>jetcd-core</artifactId>
         </dependency>
+
+        <!-- Override transitive dependencies to address CVEs -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-compression</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-dns</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Why?

A security scan reported vulnerabilities in jetcd-core:0.8.6's transitive dependencies (several io.netty dependencies and vertx.core). This PR overrides the transitive dependencies to address these vulnerabilities.

## Changes
- [x] Added overrides to vulnerable io.netty transitive dependencies into the jetcd-core wrapping bundle and platform
