### PR TITLE
Bump jackson-databind to 2.21.5

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -38,7 +38,7 @@ dependencies {
         
         api 'com.fasterxml.jackson.core:jackson-annotations:2.21' // used by wrapper.
         api 'com.fasterxml.jackson.core:jackson-core:2.21.4' // used by wrapper.
-        api 'com.fasterxml.jackson.core:jackson-databind:2.21.4' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-databind:2.21.5' // used by wrapper.
 
         api 'com.github.docker-java:docker-java-api:3.2.14' // bnd.bnd only
         api 'com.github.docker-java:docker-java-core:3.2.14'


### PR DESCRIPTION
## Why?

Related to https://github.com/galasa-dev/projectmanagement/issues/2614

jackson-databind 2.21.4 has a CVE associated with it https://nvd.nist.gov/vuln/detail/CVE-2026-54515. This PR addresses this CVE

## Changes
- [x] Bumped jackson-databind to 2.21.5
