### PR TITLE
Uplift log4j-api to 2.25.5

### DIFF
--- a/modules/framework/galasa-parent/galasa-boot/build.gradle
+++ b/modules/framework/galasa-parent/galasa-boot/build.gradle
@@ -56,13 +56,13 @@ dependencies {
     //
     // Without this, the framework would complain about not being able to find templates
     // on the classpath.
-    embedImplementation 'org.apache.logging.log4j:log4j-layout-template-json:2.25.4'
+    embedImplementation 'org.apache.logging.log4j:log4j-layout-template-json:2.25.5'
 
     bundleDependency 'org.apache.felix:org.apache.felix.bundlerepository:2.0.10'
     bundleDependency 'org.apache.felix:org.apache.felix.scr:2.1.14'
-    bundleDependency 'org.apache.logging.log4j:log4j-api:2.25.4'
-    bundleDependency 'org.apache.logging.log4j:log4j-core:2.25.4'
-    bundleDependency 'org.apache.logging.log4j:log4j-layout-template-json:2.25.4'
+    bundleDependency 'org.apache.logging.log4j:log4j-api:2.25.5'
+    bundleDependency 'org.apache.logging.log4j:log4j-core:2.25.5'
+    bundleDependency 'org.apache.logging.log4j:log4j-layout-template-json:2.25.5'
     bundleDependency project (':dev.galasa.framework.log4j2.bridge')
     bundleDependency project (':dev.galasa.framework.maven.repository')
     bundleDependency project (':dev.galasa.framework.maven.repository.spi')

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -176,10 +176,10 @@ dependencies {
         api 'org.apache.kafka:kafka-clients:4.0.2'
         api 'org.apache.kafka:kafka-server-common:4.0.2'
 
-        api 'org.apache.logging.log4j:log4j-api:2.25.4' // If updating, also update in galasa-boot build.gradle.
-        api 'org.apache.logging.log4j:log4j-core:2.25.4' // If updating, also update in galasa-boot build.gradle.
-        api 'org.apache.logging.log4j:log4j-layout-template-json:2.25.4' // If updating, also update in galasa-boot build.gradle.
-        api 'org.apache.logging.log4j:log4j-slf4j-impl:2.25.4'
+        api 'org.apache.logging.log4j:log4j-api:2.25.5' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.logging.log4j:log4j-core:2.25.5' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.logging.log4j:log4j-layout-template-json:2.25.5' // If updating, also update in galasa-boot build.gradle.
+        api 'org.apache.logging.log4j:log4j-slf4j-impl:2.25.5'
 
         api 'org.apache.maven:maven-core:3.9.9'
         api 'org.apache.maven:maven-artifact:3.9.6'


### PR DESCRIPTION
## Why?

Removes a Medium vulnerability in log4j-api 2.25.4. Also uplifts other org.apache.logging.log4j dependencies to 2.25.5 for consistency across the group.
