### PR TITLE
Iss2490 - Add documentation for image registry change from v1.0.0 onwards

### DIFF
--- a/docs/content/docs/upgrading/index.md
+++ b/docs/content/docs/upgrading/index.md
@@ -2,6 +2,32 @@
 title: "Upgrading"
 ---
 
+## Upgrading to v1.0.0
+
+### Docker image registry change
+
+From v1.0.0, Galasa Docker images are published to **`icr.io/galasa`** instead of `icr.io/galasadev`.
+
+To give users time to migrate, images will continue to be published to `icr.io/galasadev` for a number of releases after v1.0.0. However, you are encouraged to update references as soon as possible, as publishing to `icr.io/galasadev` will stop in a future release.
+
+Check any of the following for references to `icr.io/galasadev` and update them to use `icr.io/galasa`:
+
+- Custom Helm `values.yaml` files used to install or upgrade a Galasa Ecosystem
+- CI/CD pipeline definitions (for example, Tekton pipelines, GitHub Actions workflows, Jenkins jobs)
+- Deployment scripts or `docker pull` / `docker run` commands
+- Kubernetes manifests that reference Galasa images directly
+
+**Example:** replace
+```
+icr.io/galasadev/galasa-boot-embedded-amd64:0.48.1
+```
+with:
+```
+icr.io/galasa/galasa-boot-embedded-amd64:1.0.0
+```
+
+---
+
 ## Upgrading your Galasa version
 
 You can upgrade your version of Galasa by completing the following steps:

--- a/docs/content/releases/posts/v1.0.0.md
+++ b/docs/content/releases/posts/v1.0.0.md
@@ -7,6 +7,25 @@ links:
 
 # 1.0.0 - Release Highlights
 
+## ⚠️ Breaking change: Docker image registry change
+
+From v1.0.0, Galasa Docker images are published to **`icr.io/galasa`** instead of `icr.io/galasadev`.
+
+To give users time to migrate, images will continue to be published to `icr.io/galasadev` for a number of releases after v1.0.0. However, you are encouraged to update any references to `icr.io/galasadev` as soon as possible, as publishing to that registry will stop in a future release.
+
+If you have any automation that pulls Galasa images directly — for example, custom Helm `values.yaml` overrides, CI/CD pipelines, scripts, or `docker pull` commands referencing `icr.io/galasadev` — you should update those references to use `icr.io/galasa`.
+
+For example, if you currently reference:
+```
+icr.io/galasadev/galasa-boot-embedded-amd64:0.48.1
+```
+update this to:
+```
+icr.io/galasa/galasa-boot-embedded-amd64:1.0.0
+```
+
+See [Upgrading to v1.0.0](../../docs/upgrading/index.md#upgrading-to-v100) for more details.
+
 ## Changes affecting the Galasa Service
 
 - A new `Opaque` credential type is now supported in the Galasa Credentials Store. Opaque secrets store arbitrary opaque data (for example, licence JAR files such as `my_license.jar`) that tests can retrieve at runtime via the Credentials Store. The `galasactl secrets set` command gains two new flags: `--secret-file` (reads a file from disk and base64-encodes its contents) and `--base64-secret` (accepts an already-encoded string). Opaque secrets are mutually exclusive with all other credential fields. The REST API `PUT /secrets/{name}` and `GET /secrets/{name}` endpoints support the new `Opaque` type alongside the existing types.


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2490

Informs users about the image registry change from icr.io/galasadev to icr.io/galasa in v1.0 release and onwards.

## Changes
- [ ] Unit tests (if applicable)
- [x] Documentation updates (if applicable)
- [x] Release notes updates (if applicable)
