### PR TITLE
Add missing versions for gson and protobuf-java in release.yaml

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -41,6 +41,7 @@ external:
 
   - group: com.google.code.gson
     artifact: gson
+    version: 2.14.0
     obr: true
     bom: true
     mvp: true
@@ -48,6 +49,7 @@ external:
 
   - group: com.google.protobuf
     artifact: protobuf-java
+    version: 4.35.1
     obr: true
     bom: true
     mvp: true

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -42,9 +42,9 @@ dependencies {
 
         api 'com.google.android:annotations:4.1.1.4'
 
-        api 'com.google.code.gson:gson:2.14.0'
+        api 'com.google.code.gson:gson:2.14.0' // If updating, also update in obr/release.yaml
 
-        api 'com.google.protobuf:protobuf-java:4.35.1'
+        api 'com.google.protobuf:protobuf-java:4.35.1' // If updating, also update in obr/release.yaml
 
         api 'com.google.guava:guava:33.5.0-jre'
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2621

## Changes
- [x] Added explicit versions for gson and protobuf-java in the OBR's release.yaml as per [this comment](https://github.com/galasa-dev/galasa/blob/main/modules/obr/release.yaml#L17-L19) in the release.yaml
