### PR TITLE
Update galasactl runs prepare command to use the new POST /runs/portfolios endpoint to create portfolios

### DIFF
--- a/modules/cli/pkg/cmd/runsPrepare.go
+++ b/modules/cli/pkg/cmd/runsPrepare.go
@@ -157,7 +157,7 @@ func (cmd *RunsPrepareCommand) executeAssemble(
 					if err == nil {
 
 						var testSelection runs.TestSelection
-						testSelection, err = runs.SelectTests(launcherInstance, cmd.values.prepareSelectionFlags)
+						testSelection, err = runs.SelectTestsWithFallback(launcherInstance, cmd.values.prepareSelectionFlags, testOverrides)
 						if err == nil {
 
 							count := len(testSelection.Classes)

--- a/modules/cli/pkg/launcher/jvmLauncher.go
+++ b/modules/cli/pkg/launcher/jvmLauncher.go
@@ -591,6 +591,12 @@ func (launcher *JvmLauncher) GetTestCatalog(stream string) (TestCatalog, error) 
 	return nil, nil
 }
 
+// CreateRunsPortfolio is not supported for local (JVM) launchers — local test selection
+// is performed by SelectTests directly against the test catalog, not via the remote API.
+func (launcher *JvmLauncher) CreateRunsPortfolio(flags *utils.TestSelectionFlagValues, overrides map[string]string) (*galasaapi.RunsPortfolio, error) {
+	return nil, nil
+}
+
 // IsLocal returns true as this launcher runs tests locally
 func (launcher *JvmLauncher) IsLocal() bool {
 	return true

--- a/modules/cli/pkg/launcher/launcher.go
+++ b/modules/cli/pkg/launcher/launcher.go
@@ -7,6 +7,7 @@ package launcher
 
 import (
 	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/galasa-dev/cli/pkg/utils"
 )
 
 type TestCatalog map[string]interface{}
@@ -45,6 +46,10 @@ type Launcher interface {
 
 	// GetTestCatalog gets the test catalog for a given stream.
 	GetTestCatalog(stream string) (TestCatalog, error)
+
+	// CreateRunsPortfolio calls POST /runs/portfolios on the API server, resolving the
+	// set of matching test classes for the given selection flags in a single server-side call.
+	CreateRunsPortfolio(flags *utils.TestSelectionFlagValues, overrides map[string]string) (*galasaapi.RunsPortfolio, error)
 
 	// IsLocal returns true if this launcher runs tests locally, false if remote
 	IsLocal() bool

--- a/modules/cli/pkg/launcher/launcherMock.go
+++ b/modules/cli/pkg/launcher/launcherMock.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/galasa-dev/cli/pkg/utils"
 )
 
 // Structure used to collect parameters which are sent to the mock, so we can get them back in the
@@ -30,10 +31,12 @@ type LaunchParameters struct {
 }
 
 type MockLauncher struct {
-	allTestRuns  *galasaapi.TestRuns
-	nextRunId    int
-	launches     []LaunchParameters
-	submissionId int
+	allTestRuns               *galasaapi.TestRuns
+	nextRunId                 int
+	launches                  []LaunchParameters
+	submissionId              int
+	mockPortfolioToReturn     *galasaapi.RunsPortfolio
+	mockPortfolioErrorToReturn error
 }
 
 func NewMockLauncher() *MockLauncher {
@@ -43,6 +46,14 @@ func NewMockLauncher() *MockLauncher {
 	launcher.nextRunId = 100
 	launcher.submissionId = 0
 	return launcher
+}
+
+func (launcher *MockLauncher) SetPortfolioToReturn(portfolio *galasaapi.RunsPortfolio) {
+	launcher.mockPortfolioToReturn = portfolio
+}
+
+func (launcher *MockLauncher) SetPortfolioErrorToReturn(err error) {
+	launcher.mockPortfolioErrorToReturn = err
 }
 
 //-------------------------------------------------------------------
@@ -144,6 +155,17 @@ func (launcher *MockLauncher) GetStreams() ([]string, error) {
 // GetTestCatalog gets the test catalog for a given stream.
 func (launcher *MockLauncher) GetTestCatalog(stream string) (TestCatalog, error) {
 	return nil, nil
+}
+
+// CreateRunsPortfolio returns the configured mock portfolio or error, or an empty portfolio if neither is set.
+func (launcher *MockLauncher) CreateRunsPortfolio(flags *utils.TestSelectionFlagValues, overrides map[string]string) (*galasaapi.RunsPortfolio, error) {
+	if launcher.mockPortfolioErrorToReturn != nil {
+		return nil, launcher.mockPortfolioErrorToReturn
+	}
+	if launcher.mockPortfolioToReturn != nil {
+		return launcher.mockPortfolioToReturn, nil
+	}
+	return galasaapi.NewRunsPortfolioWithDefaults(), nil
 }
 
 // IsLocal returns false for the mock launcher

--- a/modules/cli/pkg/launcher/remoteLauncher.go
+++ b/modules/cli/pkg/launcher/remoteLauncher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/galasa-dev/cli/pkg/embedded"
 	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
 	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/galasa-dev/cli/pkg/utils"
 )
 
 // RemoteLauncher A launcher, which launches and monitors tests on a remote ecosystem via HTTP/HTTPS.
@@ -294,6 +295,53 @@ func (launcher *RemoteLauncher) GetTestCatalog(stream string) (TestCatalog, erro
 	}
 	
 		return testCatalog, err
+	}
+	
+	// CreateRunsPortfolio calls POST /runs/portfolios, resolving test class selection server-side.
+	func (launcher *RemoteLauncher) CreateRunsPortfolio(flags *utils.TestSelectionFlagValues, overrides map[string]string) (*galasaapi.RunsPortfolio, error) {
+		selection := galasaapi.NewRunsPortfolioSelection(flags.Stream)
+		if len(*flags.Bundles) > 0 {
+			selection.SetBundles(*flags.Bundles)
+		}
+		if len(*flags.Packages) > 0 {
+			selection.SetPackages(*flags.Packages)
+		}
+		if len(*flags.Tests) > 0 {
+			selection.SetTests(*flags.Tests)
+		}
+		if len(*flags.Tags) > 0 {
+			selection.SetTags(*flags.Tags)
+		}
+		if len(*flags.Classes) > 0 {
+			selection.SetClasses(*flags.Classes)
+		}
+		if flags.RegexSelect != nil && *flags.RegexSelect {
+			selection.SetRegex(true)
+		}
+	
+		request := galasaapi.NewRunsPortfolioRequest([]galasaapi.RunsPortfolioSelection{*selection})
+		if len(overrides) > 0 {
+			request.SetOverrides(overrides)
+		}
+	
+		var portfolio *galasaapi.RunsPortfolio
+		var err error
+		var restApiVersion string
+	
+		restApiVersion, err = embedded.GetGalasactlRestApiVersion()
+		if err == nil {
+			err = launcher.commsClient.RunAuthenticatedCommandWithRateLimitRetries(func(apiClient *galasaapi.APIClient) error {
+				var httpResponse *http.Response
+				portfolio, httpResponse, err = apiClient.RunsAPIApi.
+					CreateRunsPortfolio(context.TODO()).
+					RunsPortfolioRequest(*request).
+					ClientApiVersion(restApiVersion).
+					Execute()
+	
+				return galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
+			})
+		}
+		return portfolio, err
 	}
 	
 	// IsLocal returns false as this launcher runs tests remotely

--- a/modules/cli/pkg/runs/testSelection.go
+++ b/modules/cli/pkg/runs/testSelection.go
@@ -149,6 +149,46 @@ func AreSelectionFlagsProvided(flags *utils.TestSelectionFlagValues) bool {
 	return false
 }
 
+// SelectTestsViaPortfolioEndpoint calls POST /runs/portfolios on the API server and converts
+// the response into a TestSelection. This is the implementation used by `runs prepare`.
+func SelectTestsViaPortfolioEndpoint(launcherInstance launcher.Launcher, flags *utils.TestSelectionFlagValues, overrides map[string]string) (TestSelection, error) {
+	var testSelection TestSelection
+
+	portfolio, err := launcherInstance.CreateRunsPortfolio(flags, overrides)
+	if err == nil {
+		testSelection = TestSelection{Classes: make([]TestClass, 0)}
+		if portfolio != nil {
+			for _, portfolioClass := range portfolio.GetClasses() {
+				testSelection.Classes = append(testSelection.Classes, TestClass{
+					Bundle: portfolioClass.GetBundle(),
+					Class:  portfolioClass.GetClass(),
+					Stream: portfolioClass.GetStream(),
+				})
+			}
+		}
+	}
+
+	return testSelection, err
+}
+
+// SelectTestsWithFallback tries SelectTestsViaPortfolioEndpoint first. If the server responds
+// with 404, 405, or 500 (indicating the endpoint is not available on older servers), it falls
+// back to SelectTests which queries streams and catalogs directly.
+func SelectTestsWithFallback(launcherInstance launcher.Launcher, flags *utils.TestSelectionFlagValues, overrides map[string]string) (TestSelection, error) {
+	testSelection, err := SelectTestsViaPortfolioEndpoint(launcherInstance, flags, overrides)
+	if err != nil {
+		if galasaErr, ok := err.(*galasaErrors.GalasaError); ok {
+			statusCode := galasaErr.GetHttpStatusCode()
+			if statusCode == 404 || statusCode == 405 || statusCode == 500 {
+				log.Println("POST /runs/portfolios endpoint not available on this server, falling back to local test selection")
+				err = nil
+				testSelection, err = SelectTests(launcherInstance, flags)
+			}
+		}
+	}
+	return testSelection, err
+}
+
 func SelectTests(launcherInstance launcher.Launcher, flags *utils.TestSelectionFlagValues) (TestSelection, error) {
 
 	var testSelection TestSelection

--- a/modules/cli/pkg/runs/testSelection_test.go
+++ b/modules/cli/pkg/runs/testSelection_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/launcher"
 )
 
@@ -117,4 +119,158 @@ func TestSelectTestMultiplesFromGherkinUrlArrayReturnsTests(t *testing.T) {
 	assert.Equal(t, testSelection.Classes[0].GherkinUrl, "gherkin.feature")
 	assert.Equal(t, testSelection.Classes[1].GherkinUrl, "test.feature")
 	assert.Equal(t, testSelection.Classes[2].GherkinUrl, "excellent.feature")
+}
+
+func TestSelectTestsViaPortfolioEndpointReturnsClassesFromResponse(t *testing.T) {
+	// Given...
+	mockLauncher := launcher.NewMockLauncher()
+
+	bundle := "com.example.bundle"
+	class := "com.example.tests.MyTest"
+	stream := "myStream"
+
+	portfolioClass := galasaapi.NewRunsPortfolioClass()
+	portfolioClass.SetBundle(bundle)
+	portfolioClass.SetClass(class)
+	portfolioClass.SetStream(stream)
+
+	portfolio := galasaapi.NewRunsPortfolioWithDefaults()
+	portfolio.SetClasses([]galasaapi.RunsPortfolioClass{*portfolioClass})
+	mockLauncher.SetPortfolioToReturn(portfolio)
+
+	flags := NewTestSelectionFlagValues()
+	flags.Stream = stream
+	overrides := map[string]string{}
+
+	// When...
+	testSelection, err := SelectTestsViaPortfolioEndpoint(mockLauncher, flags, overrides)
+
+	// Then...
+	assert.Nil(t, err)
+	assert.Len(t, testSelection.Classes, 1)
+	assert.Equal(t, bundle, testSelection.Classes[0].Bundle)
+	assert.Equal(t, class, testSelection.Classes[0].Class)
+	assert.Equal(t, stream, testSelection.Classes[0].Stream)
+	assert.Equal(t, "", testSelection.Classes[0].Obr)
+}
+
+func TestSelectTestsViaPortfolioEndpointWithEmptyResponseReturnsEmptySelection(t *testing.T) {
+	// Given...
+	mockLauncher := launcher.NewMockLauncher()
+	// MockLauncher returns empty portfolio by default
+
+	flags := NewTestSelectionFlagValues()
+	flags.Stream = "myStream"
+	overrides := map[string]string{}
+
+	// When...
+	testSelection, err := SelectTestsViaPortfolioEndpoint(mockLauncher, flags, overrides)
+
+	// Then...
+	assert.Nil(t, err)
+	assert.Empty(t, testSelection.Classes)
+}
+
+func newPortfolioErrorWithStatus(statusCode int) error {
+	return galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.NewMessageTypeFromError(fmt.Errorf("GAL9999E: test error %d", statusCode)))
+}
+
+func TestSelectTestsWithFallbackReturnsResultOnSuccess(t *testing.T) {
+	// Given...
+	mockLauncher := launcher.NewMockLauncher()
+
+	bundle := "com.example.bundle"
+	class := "com.example.tests.MyTest"
+	stream := "myStream"
+
+	portfolioClass := galasaapi.NewRunsPortfolioClass()
+	portfolioClass.SetBundle(bundle)
+	portfolioClass.SetClass(class)
+	portfolioClass.SetStream(stream)
+
+	portfolio := galasaapi.NewRunsPortfolioWithDefaults()
+	portfolio.SetClasses([]galasaapi.RunsPortfolioClass{*portfolioClass})
+	mockLauncher.SetPortfolioToReturn(portfolio)
+
+	flags := NewTestSelectionFlagValues()
+	flags.Stream = stream
+	overrides := map[string]string{}
+
+	// When...
+	testSelection, err := SelectTestsWithFallback(mockLauncher, flags, overrides)
+
+	// Then...
+	assert.Nil(t, err)
+	assert.Len(t, testSelection.Classes, 1)
+	assert.Equal(t, bundle, testSelection.Classes[0].Bundle)
+	assert.Equal(t, class, testSelection.Classes[0].Class)
+}
+
+func TestSelectTestsWithFallbackFallsBackOn404(t *testing.T) {
+	// Given...
+	mockLauncher := launcher.NewMockLauncher()
+	mockLauncher.SetPortfolioErrorToReturn(newPortfolioErrorWithStatus(404))
+
+	flags := NewTestSelectionFlagValues()
+	*flags.GherkinUrl = []string{"file://test.feature"}
+	overrides := map[string]string{}
+
+	// When...
+	testSelection, err := SelectTestsWithFallback(mockLauncher, flags, overrides)
+
+	// Then - fallback SelectTests was used and returned the gherkin URL...
+	assert.Nil(t, err)
+	assert.Len(t, testSelection.Classes, 1)
+	assert.Equal(t, "file://test.feature", testSelection.Classes[0].GherkinUrl)
+}
+
+func TestSelectTestsWithFallbackFallsBackOn405(t *testing.T) {
+	// Given...
+	mockLauncher := launcher.NewMockLauncher()
+	mockLauncher.SetPortfolioErrorToReturn(newPortfolioErrorWithStatus(405))
+
+	flags := NewTestSelectionFlagValues()
+	*flags.GherkinUrl = []string{"file://test.feature"}
+	overrides := map[string]string{}
+
+	// When...
+	testSelection, err := SelectTestsWithFallback(mockLauncher, flags, overrides)
+
+	// Then...
+	assert.Nil(t, err)
+	assert.Len(t, testSelection.Classes, 1)
+	assert.Equal(t, "file://test.feature", testSelection.Classes[0].GherkinUrl)
+}
+
+func TestSelectTestsWithFallbackFallsBackOn500(t *testing.T) {
+	// Given...
+	mockLauncher := launcher.NewMockLauncher()
+	mockLauncher.SetPortfolioErrorToReturn(newPortfolioErrorWithStatus(500))
+
+	flags := NewTestSelectionFlagValues()
+	*flags.GherkinUrl = []string{"file://test.feature"}
+	overrides := map[string]string{}
+
+	// When...
+	testSelection, err := SelectTestsWithFallback(mockLauncher, flags, overrides)
+
+	// Then...
+	assert.Nil(t, err)
+	assert.Len(t, testSelection.Classes, 1)
+	assert.Equal(t, "file://test.feature", testSelection.Classes[0].GherkinUrl)
+}
+
+func TestSelectTestsWithFallbackDoesNotFallBackOnOtherErrors(t *testing.T) {
+	// Given...
+	mockLauncher := launcher.NewMockLauncher()
+	mockLauncher.SetPortfolioErrorToReturn(newPortfolioErrorWithStatus(401))
+
+	flags := NewTestSelectionFlagValues()
+	overrides := map[string]string{}
+
+	// When...
+	_, err := SelectTestsWithFallback(mockLauncher, flags, overrides)
+
+	// Then - the 401 error is propagated, not swallowed...
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2598
Builds off of changes in https://github.com/galasa-dev/galasa/pull/675, so will need to be rebased once that PR is delivered.

## Changes
- [x] Updated the `galasactl runs prepare` command implementation to use the `POST /runs/portfolios` endpoint to create a test portfolio.
  - If the Galasa API server doesn't have that endpoint (e.g. if a user is using the latest CLI but has an older Galasa service), then the CLI will fall back to using the existing method of selecting tests to create a portfolio
- [x] Unit tests (if applicable)
