### PR TITLE
Bump MQ client library to 9.4.5.1

### DIFF
--- a/modules/obr/release.yaml
+++ b/modules/obr/release.yaml
@@ -364,6 +364,12 @@ external:
     mvp: true
     isolated: true
 
+  - group: org.json
+    artifact: json
+    obr: true
+    mvp: false
+    isolated: true
+
   - group: org.osgi
     artifact: org.osgi.service.component.annotations
     version: 1.3.0

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
         api 'com.ibm.db2.jcc:db2jcc:db2jcc4'
 
-        api 'com.ibm.mq:com.ibm.mq.allclient:9.4.5.0'
+        api 'com.ibm.mq:com.ibm.mq.allclient:9.4.5.1'
 
         api 'com.github.mwiede:jsch:2.27.6'
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2623

org.bouncycastle:bcpkix-jdk18on 1.83 is used in com.ibm.mq.allclient 9.4.5.0 which is vulnerable - bumping up to 9.4.5.1 resolves this.

## Changes
- [x] Bumped com.ibm.mq.allclient to 9.4.5.1
- [x] Added the missing org.json:json bundle into the OBR's release.yaml
