### PR TITLE
Bump transitive bc*-jdk18on in kubernetes client library and httpclient5 versions

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -91,6 +91,11 @@ dependencies {
 
         api 'io.kubernetes:client-java:27.0.0'
 
+        // Override transitive dependencies for client-java:27.0.0 to address CVEs
+        api 'org.bouncycastle:bcprov-jdk18on:1.85'
+        api 'org.bouncycastle:bcpkix-jdk18on:1.85'
+        api 'org.bouncycastle:bcutil-jdk18on:1.85'
+
         api 'io.netty:netty-codec:4.2.16.Final'
 
         // Override transitive dependencies for jetcd-core:0.8.6 to address CVEs
@@ -158,7 +163,7 @@ dependencies {
         api 'org.apache.felix:org.apache.felix.http.servlet-api:2.1.0'
         api 'org.apache.felix:org.apache.felix.scr:2.1.14' // If updating, also update in galasa-boot build.gradle.
 
-        api 'org.apache.httpcomponents.client5:httpclient5:5.6.2'
+        api 'org.apache.httpcomponents.client5:httpclient5:5.6.3'
 
         api 'org.apache.httpcomponents:httpclient:4.5.14'
         api 'org.apache.httpcomponents:httpclient-osgi:4.5.14'

--- a/modules/wrapping/dev.galasa.wrapping.io.kubernetes.client-java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.io.kubernetes.client-java/pom.xml
@@ -40,6 +40,21 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
         </dependency>
+
+        <!-- Security fix: Override transitive bcprov-jdk18on, bcpkix-jdk18on, and bcutil-jdk18on 
+            versions to address CVEs -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk18on</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2624

## Changes
- [x] Bumped transitive bc*-jdk18on dependencies in kubernetes client-java from 1.84 to 1.85
- [x] Bumped httpclient5 from 5.6.2 to 5.6.3
