### PR TITLE
Override transitive opentelemetry-api dependency and bump selenium dependencies

### DIFF
--- a/docs/content/releases/posts/v1.0.1.md
+++ b/docs/content/releases/posts/v1.0.1.md
@@ -7,6 +7,14 @@ links:
 
 # 1.0.1 - Release Highlights
 
+## Deprecation notices
+
+### `IFirefoxOptions.getBinaryOrNull()` deprecated
+
+The `getBinaryOrNull()` method on `IFirefoxOptions` has been deprecated and marked for removal as `FirefoxBinary` has been removed from Selenium 4.
+
+**Action required:** Remove any calls to `getBinaryOrNull()` from your test code. If you were using the returned `FirefoxBinary` to configure the Firefox executable path, use `IFirefoxOptions.setBinary(Path)` or `IFirefoxOptions.setBinary(String)` instead.
+
 ## Changes affecting the Galasa Service
 
 - A new `POST /runs/portfolios` REST API endpoint resolves a portfolio of test classes server-side. Clients supply a `selections` array, where each entry names a stream and optional filters (bundle, package, test name, class, tag, with optional regex mode), and the server returns all matching classes from the stream's test catalog. If no filters are provided for a stream, all classes in that stream's catalog are returned. The response is stateless; no portfolio resource is persisted. See the [Runs API reference](../../docs/reference/rest-api/index.html) for more details.

--- a/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/src/main/java/dev/galasa/selenium/IFirefoxOptions.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/src/main/java/dev/galasa/selenium/IFirefoxOptions.java
@@ -64,6 +64,11 @@ public interface IFirefoxOptions {
 
     public Map<String,Object> asMap();
 
+    /**
+     * @deprecated FirefoxBinary is deprecated in Selenium 4 and will be removed in a future release.
+     * Use {@link IFirefoxOptions#setBinary(Path)} or {@link IFirefoxOptions#setBinary(String)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.0.1")
     public Optional<FirefoxBinary> getBinaryOrNull();
 
     public String getBrowserName();

--- a/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/src/main/java/dev/galasa/selenium/internal/FirefoxOptionsImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/src/main/java/dev/galasa/selenium/internal/FirefoxOptionsImpl.java
@@ -128,6 +128,11 @@ public class FirefoxOptionsImpl implements IFirefoxOptions {
 		return options.asMap();
 	}
 
+	/**
+	 * @deprecated FirefoxBinary is deprecated in Selenium 4 and will be removed in a future release.
+	 * Use {@link IFirefoxOptions#setBinary(Path)} or {@link IFirefoxOptions#setBinary(String)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.1")
 	@Override
 	public Optional<FirefoxBinary> getBinaryOrNull() {
 		return options.getBinaryOrNull();

--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -213,13 +213,16 @@ dependencies {
 
         api 'org.reflections:reflections:0.9.11'
 
-        api 'org.seleniumhq.selenium:selenium-chrome-driver:4.27.0'
-        api 'org.seleniumhq.selenium:selenium-chromium-driver:4.27.0'
-        api 'org.seleniumhq.selenium:selenium-edge-driver:4.27.0'
-        api 'org.seleniumhq.selenium:selenium-firefox-driver:4.27.0'
-        api 'org.seleniumhq.selenium:selenium-ie-driver:4.27.0'
-        api 'org.seleniumhq.selenium:selenium-java:4.27.0'
-        api 'org.seleniumhq.selenium:selenium-remote-driver:4.27.0'
+        // Override transitive dependency for selenium 4.33.0 to address CVEs
+        api 'io.opentelemetry:opentelemetry-api:1.64.0'
+
+        api 'org.seleniumhq.selenium:selenium-chrome-driver:4.33.0'
+        api 'org.seleniumhq.selenium:selenium-chromium-driver:4.33.0'
+        api 'org.seleniumhq.selenium:selenium-edge-driver:4.33.0'
+        api 'org.seleniumhq.selenium:selenium-firefox-driver:4.33.0'
+        api 'org.seleniumhq.selenium:selenium-ie-driver:4.33.0'
+        api 'org.seleniumhq.selenium:selenium-java:4.33.0'
+        api 'org.seleniumhq.selenium:selenium-remote-driver:4.33.0'
 
         api 'org.slf4j:slf4j-api:1.7.36'
 

--- a/modules/wrapping/dev.galasa.wrapping.selenium-java/pom.xml
+++ b/modules/wrapping/dev.galasa.wrapping.selenium-java/pom.xml
@@ -20,6 +20,12 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
         </dependency>
+
+        <!-- Security fix: Override transitive opentelemetry-api version to address CVE -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2625

opentelemetry-api-1.44.1 has a CVE associated with it, so this PR overrides that dependency to 1.64.0. It's worth noting that opentelemetry-api is a transitive dependency within selenium-java (direct dependency of selenium-remote-driver) and upgrading selenium-java to 4.46.0 would resolve this without needing to override the transitive dependency.

However, Selenium removed the `FirefoxBinary` type in 4.35.0, so to avoid breaking users, the `getBinaryOrNull` method has been marked as deprecated in the Selenium manager. We can then remove the method and upgrade selenium to the latest version (and remove the opentelemetry-api override).

This has been tested by running the Selenium manager IVT.

## Changes
- [x] Bumped transitive opentelemetry-api from 1.44.1 to 1.64.0
- [x] Bumped selenium dependencies from 4.27.0 to 4.33.0
- [x] Added deprecation notice for the `getBinaryOrNull` method
