### PR TITLE
Only mark opaque secret flags as mutually exclusive with others rather than marking all flags mutually exclusive

### DIFF
--- a/modules/cli/pkg/cmd/secretsSet.go
+++ b/modules/cli/pkg/cmd/secretsSet.go
@@ -148,8 +148,8 @@ func (cmd *SecretsSetCommand) createCobraCmd(
     // A token cannot be provided alongside a keystore
     secretsSetCobraCmd.MarkFlagsMutuallyExclusive(tokenFlag, base64TokenFlag, keystoreFileFlag, base64KeystoreEncodedFlag)
 
-    // Opaque cannot be provided alongside any other credential field
-    secretsSetCobraCmd.MarkFlagsMutuallyExclusive(opaqueFileFlag, base64OpaqueEncodedFlag, usernameFlag, base64UsernameFlag, passwordFlag, base64PasswordFlag, tokenFlag, base64TokenFlag, keystoreFileFlag, base64KeystoreEncodedFlag)
+    // Opaque flags cannot be provided alongside any other credential field
+    markOpaqueFlagsMutuallyExclusive(secretsSetCobraCmd, opaqueFileFlag, base64OpaqueEncodedFlag, usernameFlag, base64UsernameFlag, passwordFlag, base64PasswordFlag, tokenFlag, base64TokenFlag, keystoreFileFlag, base64KeystoreEncodedFlag)
 
     // A secret must have a name and at least one of the credentials flags
     secretsSetCobraCmd.MarkFlagsOneRequired(
@@ -242,3 +242,35 @@ func (cmd *SecretsSetCommand) executeSecretsSet(
 
     return err
 }
+
+func markOpaqueFlagsMutuallyExclusive(
+    cobraCmd *cobra.Command,
+    opaqueFileFlag string,
+    base64OpaqueEncodedFlag string,
+    usernameFlag string,
+    base64UsernameFlag string,
+    passwordFlag string,
+    base64PasswordFlag string,
+    tokenFlag string,
+    base64TokenFlag string,
+    keystoreFileFlag string,
+    base64KeystoreEncodedFlag string,
+) {
+    opaqueFlags := []string{opaqueFileFlag, base64OpaqueEncodedFlag}
+    otherCredentialFlags := []string{
+        usernameFlag,
+        base64UsernameFlag,
+        passwordFlag,
+        base64PasswordFlag,
+        tokenFlag,
+        base64TokenFlag,
+        keystoreFileFlag,
+        base64KeystoreEncodedFlag,
+    }
+    for _, opaqueFlag := range opaqueFlags {
+        for _, otherCredentialFlag := range otherCredentialFlags {
+            cobraCmd.MarkFlagsMutuallyExclusive(opaqueFlag, otherCredentialFlag)
+        }
+    }
+}
+

--- a/modules/cli/pkg/cmd/secretsSet_test.go
+++ b/modules/cli/pkg/cmd/secretsSet_test.go
@@ -57,6 +57,63 @@ func TestSecretsSetNoNameFlagProducesErrorMessage(t *testing.T) {
     checkOutput("", `Error: required flag(s) "name" not set`, factory, t)
 }
 
+func TestSecretsSetValidFlagCombinationsDoNotThrowError(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "username password",
+			args: []string{"secrets", "set", "--name", "MYSECRET", "--username", "username", "--password", "password"},
+		},
+		{
+			name: "username token",
+			args: []string{"secrets", "set", "--name", "MYSECRET", "--username", "username", "--token", "token"},
+		},
+		{
+			name: "username base64 password",
+			args: []string{"secrets", "set", "--name", "MYSECRET", "--username", "username", "--base64-password", "cGFzc3dvcmQ="},
+		},
+		{
+			name: "base64 username password",
+			args: []string{"secrets", "set", "--name", "MYSECRET", "--base64-username", "dXNlcm5hbWU=", "--password", "password"},
+		},
+		{
+			name: "keystore password",
+			args: []string{"secrets", "set", "--name", "MYSECRET", "--keystore-file", "./keystore.p12", "--password", "password"},
+		},
+		{
+			name: "base64 keystore base64 password",
+			args: []string{"secrets", "set", "--name", "MYSECRET", "--base64-keystore-encoded", "a2V5c3RvcmU=", "--base64-password", "cGFzc3dvcmQ="},
+		},
+		{
+			name: "opaque secret file",
+			args: []string{"secrets", "set", "--name", "MYSECRET", "--secret-file", "./secret.bin"},
+		},
+		{
+			name: "base64 opaque secret",
+			args: []string{"secrets", "set", "--name", "MYSECRET", "--base64-secret", "c2VjcmV0"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Given...
+			factory := utils.NewMockFactory()
+			commandCollection, _ := setupTestCommandCollection(COMMAND_NAME_SECRETS_SET, factory, t)
+
+			// When...
+			err := commandCollection.Execute(testCase.args)
+
+			// Then...
+			assert.Nil(t, err)
+
+			// Check what the user saw was reasonable
+			checkOutput("", "", factory, t)
+		})
+	}
+}
+
 func TestSecretsSetNonEncodedUsernameFlagWithEncodedFlagProducesErrorMessage(t *testing.T) {
     // Given...
     factory := utils.NewMockFactory()
@@ -72,7 +129,7 @@ func TestSecretsSetNonEncodedUsernameFlagWithEncodedFlagProducesErrorMessage(t *
     // Then...
     assert.NotNil(t, err)
 
-    checkOutput("", "Error: if any flags in the group [secret-file base64-secret username base64-username password base64-password token base64-token keystore-file base64-keystore-encoded] are set none of the others can be", factory, t)
+    checkOutput("", "Error: if any flags in the group [username base64-username] are set none of the others can be", factory, t)
 }
 
 func TestSecretsSetNonEncodedPasswordFlagWithEncodedFlagProducesErrorMessage(t *testing.T) {


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2628

## Changes
- [x] Fixed an issue where supplying valid flags (e.g. `--username` and `--password`) would cause the CLI to throw an error due to the flags being mutually exclusive
- [x] Unit tests (if applicable)
