### PR TITLE
Add constraint on opentelemetry-context to resolve opentelemetry-api for isolated

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -219,6 +219,8 @@ dependencies {
         api 'org.reflections:reflections:0.9.11'
 
         // Override transitive dependency for selenium 4.33.0 to address CVEs
+        // opentelemetry-context is required to resolve the overridden opentelemetry-api for isolated
+        api 'io.opentelemetry:opentelemetry-context:1.64.0'
         api 'io.opentelemetry:opentelemetry-api:1.64.0'
 
         api 'org.seleniumhq.selenium:selenium-chrome-driver:4.33.0'


### PR DESCRIPTION
## Why?

Related to changes made for https://github.com/galasa-dev/projectmanagement/issues/2625

This PR fixes the following regression test failure in TestCompilationIsolated:

```
* What went wrong:
Execution failed for task ':dev.galasa.example.compilation:compileJava'.
> Could not resolve all files for configuration ':dev.galasa.example.compilation:compileClasspath'.
   > Could not find io.opentelemetry:opentelemetry-context:1.64.0.
     Searched in the following locations:
       - file:/galasa/maven/io/opentelemetry/opentelemetry-context/1.64.0/opentelemetry-context-1.64.0.pom
     Required by:
         project :dev.galasa.example.compilation > dev.galasa:dev.galasa.selenium.manager:1.0.1 > org.seleniumhq.selenium:selenium-remote-driver:4.33.0
   > Could not find io.opentelemetry:opentelemetry-context:1.64.0.
     Searched in the following locations:
       - file:/galasa/maven/io/opentelemetry/opentelemetry-context/1.64.0/opentelemetry-context-1.64.0.pom
     Required by:
         project :dev.galasa.example.compilation > dev.galasa:dev.galasa.selenium.manager:1.0.1 > org.seleniumhq.selenium:selenium-remote-driver:4.33.0 > io.opentelemetry:opentelemetry-api:1.64.0
```

The `opentelemetry-context` that was included was defaulting to `1.50.0`, so a constraint has been added to the platform to pin this to `1.64.0`.

## Changes
- [x] Added a contraint to `opentelemetry-context` to pin the version to `1.64.0` as required to resolve `opentelemetry-api:1.64.0` for the isolated tests
