### PR TITLE
Remove unused httpcore-osgi from REST API server

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.streams/bnd.bnd
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.streams/bnd.bnd
@@ -2,5 +2,4 @@
 Bundle-Name: Galasa API Streams microservices
 Export-Package: !dev.galasa.framework.api.streams.internal*;dev.galasa.framework.api.streams*;
 Import-Package: dev.galasa.framework.api.common,\
-org.apache.http,\
                 *

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/bnd.bnd
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/bnd.bnd
@@ -3,5 +3,4 @@ Bundle-Name: Galasa API Users microservices
 Export-Package: !dev.galasa.framework.api.users.internal*;dev.galasa.framework.api.users*;
 Import-Package: dev.galasa.framework.api.common,\
 dev.galasa.framework.api.rbac,\
-org.apache.http,\
                 *

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/build.gradle
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     implementation project(':dev.galasa.framework.api.rbac')
     implementation 'dev.galasa:dev.galasa.wrapping.io.grpc.java'
     implementation 'org.apache.commons:commons-lang3'
-    implementation 'org.apache.httpcomponents:httpcore-osgi'
 
     compileOnly 'org.apache.tomcat:annotations-api'
     

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/internal/routes/UserRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.users/src/main/java/dev/galasa/framework/api/users/internal/routes/UserRoute.java
@@ -15,8 +15,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.apache.http.HttpStatus;
-
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 import dev.galasa.framework.spi.auth.IInternalAuthToken;
@@ -193,7 +191,7 @@ public class UserRoute extends AbstractUsersRoute {
             // This isn't allowed. A system owner will remain a system owner until
             // the service is re-configured.
             ServletError msg = new ServletError(GAL5414_USER_CANNOT_UPDATE_SERVICE_OWNER_ROLE);
-            throw new InternalServletException(msg, HttpStatus.SC_FORBIDDEN);
+            throw new InternalServletException(msg, HttpServletResponse.SC_FORBIDDEN);
         }
     }
 
@@ -204,7 +202,7 @@ public class UserRoute extends AbstractUsersRoute {
         String loginIdBeingUpdated = userRecordBeingUpdated.getLoginId();
         if (requestingUserLoginId.equals(loginIdBeingUpdated)) {
             ServletError msg = new ServletError(GAL5413_USER_CANNOT_UPDATE_OWN_USER_ROLE);
-            throw new InternalServletException(msg, HttpStatus.SC_FORBIDDEN);
+            throw new InternalServletException(msg, HttpServletResponse.SC_FORBIDDEN);
         }
     }
 
@@ -215,7 +213,7 @@ public class UserRoute extends AbstractUsersRoute {
         String loginIdBeingUpdated = userRecordBeingUpdated.getLoginId();
         if (requestingUserLoginId.equals(loginIdBeingUpdated)) {
             ServletError msg = new ServletError(GAL5119_USER_CANNOT_UPDATE_OWN_PRIORITY);
-            throw new InternalServletException(msg, HttpStatus.SC_FORBIDDEN);
+            throw new InternalServletException(msg, HttpServletResponse.SC_FORBIDDEN);
         }
     }
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2619

The API server's users servlet was unnecessarily depending on httpcore-osgi to import HTTP status codes, even though they were available via the HttpServletResponse class. This PR replaces HttpStatus with HttpServletResponse codes.

## Changes
- [x] Removed unused httpcore-osgi and applied status codes from HttpServletResponse class
- [x] Removed explicit `org.apache.http` imports from OSGi bundles (nothing in those packages import classes from `org.apache.http`)

