### PR TITLE
Uplift httpclient5 to 5.6.4

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -159,7 +159,7 @@ dependencies {
         api 'org.apache.felix:org.apache.felix.http.servlet-api:2.1.0'
         api 'org.apache.felix:org.apache.felix.scr:2.1.14' // If updating, also update in galasa-boot build.gradle.
 
-        api 'org.apache.httpcomponents.client5:httpclient5:5.6.3'
+        api 'org.apache.httpcomponents.client5:httpclient5:5.6.4'
 
         api 'org.apache.kafka:kafka-clients:4.0.2'
         api 'org.apache.kafka:kafka-server-common:4.0.2'


### PR DESCRIPTION
## Why?

Refer to [[link-to-github-issue]](https://github.com/galasa-dev/projectmanagement/issues/2630). 

One line change to modules/platform/dev.galasa.platform/build.gradle to change httpclient5 version from 5.6.3 to 5.6.4

## Changes
- [ ] Unit tests (if applicable)
- [ ] Documentation updates (if applicable)
- [ ] Release notes updates (if applicable)
