### PR TITLE
Remove USER_EDIT_OTHER from Tester role actions

### DIFF
--- a/docs/content/docs/ecosystem/ecosystem-role-based-access.md
+++ b/docs/content/docs/ecosystem/ecosystem-role-based-access.md
@@ -59,7 +59,7 @@ This table shows the list of built-in roles:
 |-----------|-------------|--------------------------------------------|
 | deactivated | A user who has no permissions at all, and is able to do nothing on the Galasa service | none |
 | viewer | A user who can query and read test results from the CLI or webui | GENERAL_API_ACCESS |
-| tester | A user who writes and runs tests, looks at the test results and diagnoses errors in the system under test | GENERAL_API_ACCESS, TEST_RUN_LAUNCH and USER_EDIT_OTHER |
+| tester | A user who writes and runs tests, looks at the test results and diagnoses errors in the system under test | GENERAL_API_ACCESS, TEST_RUN_LAUNCH |
 | admin     | A Galasa service administrator. Able to do any operation supported by the Galasa service | all |
 | owner       | The owner of the Galasa service. Such users have all the rights of an administrator, but nobody can delete their id or change their role without changing the kubernetes configuration | all |
 

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/RBACRoles.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/rbac/RBACRoles.java
@@ -16,7 +16,7 @@ public enum RBACRoles {
 
     DEACTIVATED(new RoleImpl("deactivated", "0", "User has no access", new ArrayList<>(), true)),
     TESTER(new RoleImpl("tester", "1", "Test developer and runner",
-    List.of(TEST_RUN_LAUNCH.getAction().getId(), USER_EDIT_OTHER.getAction().getId(), GENERAL_API_ACCESS.getAction().getId()), true)),
+    List.of(TEST_RUN_LAUNCH.getAction().getId(), GENERAL_API_ACCESS.getAction().getId()), true)),
     ADMIN(new RoleImpl("admin", "2", "Administrator access", getAllActionIds(), true)),
     OWNER(new RoleImpl("owner", "3", "Galasa service owner", getAllActionIds(), false)),
     VIEWER(new RoleImpl("viewer", "4", "User can view Galasa test results", List.of(GENERAL_API_ACCESS.getAction().getId()), true));

--- a/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestRBACServiceImpl.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/rbac/TestRBACServiceImpl.java
@@ -68,8 +68,7 @@ public class TestRBACServiceImpl {
         assertThat(roleGot.getName()).isEqualTo("tester");
 
         assertThat(roleGot.getActionIds())
-            .hasSize(3)
-            .contains("USER_EDIT_OTHER")
+            .hasSize(2)
             .contains("GENERAL_API_ACCESS")
             .contains("TEST_RUN_LAUNCH");
     }


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2635

Testers should not be able to edit other users. This should only be allowed for admins and owners.

## Changes
- [x] Removed the `USER_EDIT_OTHER` action from the "Tester" role's actions
- [x] Unit tests (if applicable)
