### PR TITLE
fix(selenium): remove redundant close call in try-with-resources block

### DIFF
--- a/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/src/main/java/dev/galasa/selenium/internal/WebPageImpl.java
+++ b/modules/managers/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/src/main/java/dev/galasa/selenium/internal/WebPageImpl.java
@@ -659,9 +659,8 @@ public class WebPageImpl implements IWebPage {
             		resolve(selMan.getCurrentMethod()).
             		resolve("screenshot_" + time + ".png"));
             try(OutputStream os = Files.newOutputStream(screenshotRasDirectory.resolve(selMan.getCurrentMethod()).resolve("screenshot_" + time + ".png"), new SetContentType(ResultArchiveStoreContentType.PNG))) {
-                Files.copy(scrFile.toPath(), os); 
+                Files.copy(scrFile.toPath(), os);
                 os.flush();
-                os.close();
             }
         } catch (IOException e) {
             throw new SeleniumManagerException("Unable to take screenshot", e);


### PR DESCRIPTION
## Why?

Refer to [issue #1913.](https://github.com/galasa-dev/projectmanagement/issues/1913#issuecomment-5349970674) 
close() gets called twice. Once explicitly via os.close(), while the second one via try-with-resources' auto-close on exit. CouchdbRasWriteByteChannel.close() reads and deletes its own temp file for each call to build a fresh CouchDB upload. The second call fails on a file the first one already deleted.

<!-- Provide a brief description of your changes -->

## Changes
- [x] Removed os.close(); in  WebPageImpl.takeScreenShot(), as it is redundant and is potentially what's causing 'takeScreenShot()' to not work in the Ecosystem. 
