### PR TITLE
Treat normal and secure built-in namespaces as existing namespaces

### DIFF
--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BuiltInCPSNamespace.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BuiltInCPSNamespace.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.common;
+
+import dev.galasa.framework.api.common.resources.Visibility;
+
+public enum BuiltInCPSNamespace {
+    
+    DEX("dex", Visibility.HIDDEN),
+    DSS("dss", Visibility.HIDDEN),
+    FRAMEWORK("framework", Visibility.NORMAL),
+    SECURE("secure", Visibility.SECURE),
+    SERVICE("service", Visibility.NORMAL);
+
+    private String name;
+    private Visibility visibility;
+
+    private BuiltInCPSNamespace(String name, Visibility visibility) {
+        this.name = name;
+        this.visibility = visibility;
+    }
+
+    public static BuiltInCPSNamespace getFromString(String namespaceStr) {
+        BuiltInCPSNamespace match = null;
+        for (BuiltInCPSNamespace namespace : values()) {
+            if (namespace.toString().equalsIgnoreCase(namespaceStr.trim())) {
+                match = namespace;
+                break;
+            }
+        }
+        return match;
+    }
+
+    public Visibility getVisibility() {
+        return this.visibility;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+}

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/CPSFacade.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/CPSFacade.java
@@ -8,6 +8,7 @@ package dev.galasa.framework.api.common.resources;
 
 import java.util.*;
 
+import dev.galasa.framework.api.common.BuiltInCPSNamespace;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IFramework;
@@ -21,18 +22,14 @@ public class CPSFacade {
     public CPSFacade(IFramework framework) throws ConfigurationPropertyStoreException  {
         this.framework = framework;
         this.cpsService = framework.getConfigurationPropertyService("framework");
-        populateBakedInNamespace();
+        populateBakedInNamespaces();
     }
 
-    private void populateBakedInNamespace() throws ConfigurationPropertyStoreException  {
-        addNamespace("framework", Visibility.NORMAL);
-        addNamespace("secure", Visibility.SECURE);
-        addNamespace("dss", Visibility.HIDDEN);
-        addNamespace("dex", Visibility.HIDDEN);
-    }
-
-    private void addNamespace(String name, Visibility visibility) throws ConfigurationPropertyStoreException  {
-        bakedInNamespaceMap.put(name, new CPSNamespace(name, visibility, this.framework));
+    private void populateBakedInNamespaces() throws ConfigurationPropertyStoreException  {
+        for (BuiltInCPSNamespace namespace : BuiltInCPSNamespace.values()) {
+            String namespaceName = namespace.toString();
+            bakedInNamespaceMap.put(namespaceName, new CPSNamespace(namespaceName, namespace.getVisibility(), this.framework));
+        }
     }
 
     public Map<String,CPSNamespace> getNamespaces() throws ConfigurationPropertyStoreException  {

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/CPSRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/CPSRoute.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonObject;
 import dev.galasa.framework.api.beans.GalasaProperty;
 import dev.galasa.framework.api.beans.GalasaPropertyData;
 import dev.galasa.framework.api.beans.GalasaPropertyMetadata;
+import dev.galasa.framework.api.common.BuiltInCPSNamespace;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.ProtectedRoute;
 import dev.galasa.framework.api.common.ResponseBuilder;
@@ -34,6 +35,7 @@ import dev.galasa.framework.api.common.resources.CPSNamespace;
 import dev.galasa.framework.api.common.resources.CPSProperty;
 import dev.galasa.framework.api.common.resources.GalasaPropertyName;
 import dev.galasa.framework.api.common.resources.ResourceNameValidator;
+import dev.galasa.framework.api.common.resources.Visibility;
 import dev.galasa.framework.api.common.resources.beans.GalasaBeanSerialiser;
 import dev.galasa.framework.api.cps.internal.common.PropertyComparator;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
@@ -175,10 +177,17 @@ public abstract class CPSRoute extends ProtectedRoute {
     protected  boolean checkNamespaceExists(String namespaceName) throws ConfigurationPropertyStoreException, InternalServletException {
         boolean valid = false;
         try {
-            CPSFacade cps = new CPSFacade(framework);
-            CPSNamespace namespace = cps.getNamespace(namespaceName);
-            if (namespace.getProperties().size() > 0) {
-                valid = true;
+            if (namespaceName != null) {
+                BuiltInCPSNamespace possibleBuiltInNamespace = BuiltInCPSNamespace.getFromString(namespaceName);
+                if (possibleBuiltInNamespace != null && possibleBuiltInNamespace.getVisibility() != Visibility.HIDDEN) {
+                    valid = true;
+                } else {
+                    CPSFacade cps = new CPSFacade(framework);
+                    CPSNamespace namespace = cps.getNamespace(namespaceName);
+                    if (namespace.getProperties().size() > 0) {
+                        valid = true;
+                    }
+                }
             }
         } catch (Exception e ) {
             //Catch the Exception (namespace is invalid) to throw error in if 

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/CpsServletTest.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/CpsServletTest.java
@@ -20,7 +20,6 @@ import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
 import dev.galasa.framework.api.common.mocks.MockIConfigurationPropertyStoreService;
 import dev.galasa.framework.api.common.mocks.MockServletOutputStream;
 import dev.galasa.framework.spi.IFramework;
-import dev.galasa.framework.spi.utils.GalasaGson;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -38,7 +37,6 @@ import javax.servlet.http.HttpServletResponse;
 
 public class CpsServletTest extends BaseServletTest {
 
-	static final GalasaGson gson = new GalasaGson();
 	private static final Map<String, String> REQUIRED_HEADERS = new HashMap<>(Map.of("Authorization", "Bearer " + DUMMY_JWT));
 
 	MockCpsServlet servlet;

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllNamespaceRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllNamespaceRoute.java
@@ -7,6 +7,8 @@ package dev.galasa.framework.api.cps.internal.routes;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.google.gson.JsonArray;
+
 import java.util.regex.Pattern;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,6 +24,14 @@ import dev.galasa.framework.api.cps.internal.CpsServletTest;
 import dev.galasa.framework.api.cps.internal.mocks.MockCpsServlet;
 
 public class TestAllNamespaceRoute extends CpsServletTest {
+
+	private JsonArray getExpectedBuiltInNamespacesJson() {
+		JsonArray expectedJson = new JsonArray();
+		expectedJson.add("framework");
+		expectedJson.add("secure");
+		expectedJson.add("service");
+		return expectedJson;
+	}
 
     /*
      * Regex Path
@@ -177,7 +187,9 @@ public class TestAllNamespaceRoute extends CpsServletTest {
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[\n  \"framework\",\n  \"secure\"\n]");
+
+		JsonArray expectedJson = getExpectedBuiltInNamespacesJson();
+		assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJson));
     }
 
 	@Test
@@ -196,7 +208,9 @@ public class TestAllNamespaceRoute extends CpsServletTest {
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[\n  \"framework\",\n  \"secure\"\n]");
+
+		JsonArray expectedJson = getExpectedBuiltInNamespacesJson();
+		assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJson));
 	}
 
 	@Test
@@ -217,7 +231,9 @@ public class TestAllNamespaceRoute extends CpsServletTest {
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[\n  \"framework\",\n  \"secure\"\n]");
+
+		JsonArray expectedJson = getExpectedBuiltInNamespacesJson();
+		assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJson));
 	}
 
     @Test

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceFilteredRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceFilteredRoute.java
@@ -7,6 +7,8 @@ package dev.galasa.framework.api.cps.internal.routes;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.google.gson.JsonObject;
+
 import java.util.regex.Pattern;
 import java.util.HashMap;
 import java.util.Map;
@@ -227,13 +229,9 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 		servlet.doGet(req,resp);
 
 		// Then...
-		assertThat(resp.getStatus()).isEqualTo(404);
+		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(
-			outStream.toString(),
-			5016,
-			": Error occurred when trying to access namespace 'framework'. The namespace provided is invalid."
-		);
+		assertThat(outStream.toString()).isEqualTo("{}");
     }
 
 	@Test
@@ -292,7 +290,11 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("{\n  \"name\": \"property.1\",\n  \"value\": \"value1\"\n}");
+
+		JsonObject expectedJson = new JsonObject();
+		expectedJson.addProperty("name", "property.1");
+		expectedJson.addProperty("value", "value1");
+		assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJson));
 	}
    
     @Test

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceRoute.java
@@ -7,6 +7,9 @@ package dev.galasa.framework.api.cps.internal.routes;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
 import java.util.regex.Pattern;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,6 +25,37 @@ import dev.galasa.framework.api.cps.internal.CpsServletTest;
 import dev.galasa.framework.api.cps.internal.mocks.MockCpsServlet;
 
 public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
+
+	private JsonArray getExpectedTestPropertiesJson() {
+		JsonObject property1 = new JsonObject();
+		property1.addProperty("name", "property.1");
+		property1.addProperty("value", "value1");
+
+		JsonObject property2 = new JsonObject();
+		property2.addProperty("name", "property.2");
+		property2.addProperty("value", "value2");
+
+		JsonObject property3 = new JsonObject();
+		property3.addProperty("name", "property.3");
+		property3.addProperty("value", "value3");
+
+		JsonObject property4 = new JsonObject();
+		property4.addProperty("name", "property.4");
+		property4.addProperty("value", "value4");
+
+		JsonObject property5 = new JsonObject();
+		property5.addProperty("name", "property.5");
+		property5.addProperty("value", "value5");
+
+		JsonArray expectedJson = new JsonArray();
+		expectedJson.add(property1);
+		expectedJson.add(property2);
+		expectedJson.add(property3);
+		expectedJson.add(property4);
+		expectedJson.add(property5);
+
+		return expectedJson;
+	}
 
     /*
      * Regex Path
@@ -175,7 +209,7 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
      */
 
     @Test
-	public void testGetNamespacesWithFrameworkNoDataReturnsNotFound() throws Exception{
+	public void testGetNamespacesWithFrameworkNoDataReturnsOk() throws Exception{
 		// Given...
 		setServlet("/namespace/framework/","empty",new HashMap<String,String[]>());
 		MockCpsServlet servlet = getServlet();
@@ -188,13 +222,9 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
 		servlet.doGet(req,resp);
 
 		// Then...
-		assertThat(resp.getStatus()).isEqualTo(404);
+		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(
-			outStream.toString(),
-			5016,
-			": Error occurred when trying to access namespace 'framework'. The namespace provided is invalid."
-		);
+		assertThat(outStream.toString()).isEqualTo("[]");
     }
 
 	@Test
@@ -213,12 +243,9 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[\n  "+
-				"{\n    \"name\": \"property.1\",\n    \"value\": \"value1\"\n  },\n  "+
-				"{\n    \"name\": \"property.2\",\n    \"value\": \"value2\"\n  },\n  "+
-				"{\n    \"name\": \"property.3\",\n    \"value\": \"value3\"\n  },\n  "+
-				"{\n    \"name\": \"property.4\",\n    \"value\": \"value4\"\n  },\n  "+
-				"{\n    \"name\": \"property.5\",\n    \"value\": \"value5\"\n  }\n]");
+
+		JsonArray expectedJson = getExpectedTestPropertiesJson();
+		assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJson));
 	}
 
 	@Test
@@ -239,12 +266,9 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[\n  "+
-				"{\n    \"name\": \"property.1\",\n    \"value\": \"value1\"\n  },\n  "+
-				"{\n    \"name\": \"property.2\",\n    \"value\": \"value2\"\n  },\n  "+
-				"{\n    \"name\": \"property.3\",\n    \"value\": \"value3\"\n  },\n  "+
-				"{\n    \"name\": \"property.4\",\n    \"value\": \"value4\"\n  },\n  "+
-				"{\n    \"name\": \"property.5\",\n    \"value\": \"value5\"\n  }\n]");
+
+		JsonArray expectedJson = getExpectedTestPropertiesJson();
+		assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJson));
 	}
    
     @Test

--- a/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestNamespacesRoute.java
+++ b/modules/framework/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestNamespacesRoute.java
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 package dev.galasa.framework.api.cps.internal.routes;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
 import dev.galasa.framework.api.common.mocks.MockIConfigurationPropertyStoreService;
 import dev.galasa.framework.api.cps.internal.CpsServletTest;
 import dev.galasa.framework.api.cps.internal.mocks.MockCpsServlet;
-import dev.galasa.framework.api.cps.internal.routes.TestNamespacesRoute;
-
-import static org.assertj.core.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,6 +25,30 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.Test;
 
 public class TestNamespacesRoute extends CpsServletTest{
+
+	private JsonArray getExpectedBuiltInNamespacesJson() {
+		JsonObject framework = new JsonObject();
+		framework.addProperty("name", "framework");
+		framework.addProperty("propertiesUrl", "/framework/properties");
+		framework.addProperty("type", "NORMAL");
+
+		JsonObject secure = new JsonObject();
+		secure.addProperty("name", "secure");
+		secure.addProperty("propertiesUrl", "/secure/properties");
+		secure.addProperty("type", "SECURE");
+
+		JsonObject service = new JsonObject();
+		service.addProperty("name", "service");
+		service.addProperty("propertiesUrl", "/service/properties");
+		service.addProperty("type", "NORMAL");
+
+		JsonArray expectedJson = new JsonArray();
+		expectedJson.add(framework);
+		expectedJson.add(secure);
+		expectedJson.add(service);
+
+		return expectedJson;
+	}
 
 	/*
      * Regex Path
@@ -164,10 +191,10 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[\n"+
-		"  {\n    \"name\": \"framework\",\n    \"propertiesUrl\": \"/framework/properties\",\n    \"type\": \"NORMAL\"\n  },\n"+
-		"  {\n    \"name\": \"secure\",\n    \"propertiesUrl\": \"/secure/properties\",\n    \"type\": \"SECURE\"\n  }"+
-		"\n]");	}
+
+		JsonArray expectedJson = getExpectedBuiltInNamespacesJson();
+		assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJson));
+	}
 
 	@Test
 	public void testGetNamespacesWithFrameworkWithDataReturnsOk() throws Exception{
@@ -185,10 +212,9 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[\n"+
-		"  {\n    \"name\": \"framework\",\n    \"propertiesUrl\": \"/framework/properties\",\n    \"type\": \"NORMAL\"\n  },\n"+
-		"  {\n    \"name\": \"secure\",\n    \"propertiesUrl\": \"/secure/properties\",\n    \"type\": \"SECURE\"\n  }"+
-		"\n]");
+
+		JsonArray expectedJson = getExpectedBuiltInNamespacesJson();
+		assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJson));
 	}
 
 	@Test
@@ -209,10 +235,9 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[\n"+
-		"  {\n    \"name\": \"framework\",\n    \"propertiesUrl\": \"/framework/properties\",\n    \"type\": \"NORMAL\"\n  },\n"+
-		"  {\n    \"name\": \"secure\",\n    \"propertiesUrl\": \"/secure/properties\",\n    \"type\": \"SECURE\"\n  }"+
-		"\n]");
+
+		JsonArray expectedJson = getExpectedBuiltInNamespacesJson();
+		assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJson));
 	}
 
 	@Test
@@ -231,10 +256,9 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[\n"+
-		"  {\n    \"name\": \"framework\",\n    \"propertiesUrl\": \"/framework/properties\",\n    \"type\": \"NORMAL\"\n  },\n"+
-		"  {\n    \"name\": \"secure\",\n    \"propertiesUrl\": \"/secure/properties\",\n    \"type\": \"SECURE\"\n  }"+
-		"\n]");
+
+		JsonArray expectedJson = getExpectedBuiltInNamespacesJson();
+		assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJson));
 	}
 
 	@Test


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2631

This PR adds the `service` namespace as a built-in namespace.

Previously, all existing namespaces and non-existent namespaces would be initialised as `CPSNamespace` objects. The API server would then check if a namespace contained any properties to determine whether it actually exists. This meant that if a built-in namespace like `secure` or `service` didn't contain properties, then it would be treated as a non-existent namespace and return a 404 Not Found.

This PR fixes this by treating built-in namespaces as namespaces that always exist, regardless of whether they contain properties, so the API server will not return a 404 Not Found.

## Changes
- [x] Added `service` to the built-in namespaces
- [x] Unit tests (if applicable)
