### PR TITLE
Uplift jackson-databind to 2.21.6

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -35,7 +35,7 @@ dependencies {
         
         api 'com.fasterxml.jackson.core:jackson-annotations:2.21' // used by wrapper.
         api 'com.fasterxml.jackson.core:jackson-core:2.21.4' // used by wrapper.
-        api 'com.fasterxml.jackson.core:jackson-databind:2.21.5' // used by wrapper.
+        api 'com.fasterxml.jackson.core:jackson-databind:2.21.6' // used by wrapper.
 
         api 'com.google.android:annotations:4.1.1.4'
 


### PR DESCRIPTION
## Why?

Refer to [https://github.com/galasa-dev/projectmanagement/issues/2641](https://github.com/galasa-dev/projectmanagement/issues/2641). 

Uplift jackson-databind from 2.21.5 to 2.21.6.

## Changes
- [ ] Unit tests (if applicable)
- [ ] Documentation updates (if applicable)
- [ ] Release notes updates (if applicable)
