### PR TITLE
Uplift jsch to 2.28.6

### DIFF
--- a/modules/platform/dev.galasa.platform/build.gradle
+++ b/modules/platform/dev.galasa.platform/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
         api 'com.ibm.mq:com.ibm.mq.allclient:9.4.5.1'
 
-        api 'com.github.mwiede:jsch:2.27.6'
+        api 'com.github.mwiede:jsch:2.28.6'
 
         api 'com.sun.xml.bind:jaxb-osgi:4.0.5'
 


### PR DESCRIPTION
## Why?

Refer to [https://github.com/galasa-dev/projectmanagement/issues/2643](https://github.com/galasa-dev/projectmanagement/issues/2643). 

One line change in dev.galasa.platform/build.gradle to change jsch version number.

## Changes
- [ ] Unit tests (if applicable)
- [ ] Documentation updates (if applicable)
- [ ] Release notes updates (if applicable)
