### PR TITLE
fix(secrets): Add property separator to prefix deletions to stop other secrets from being deleted unintentionally

### DIFF
--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3CredentialsStore.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3CredentialsStore.java
@@ -135,7 +135,7 @@ public class Etcd3CredentialsStore extends Etcd3Store implements ICredentialsSto
     @Override
     public void deleteCredentials(String credentialsId) throws CredentialsException {
         try {
-            deletePropertiesWithPrefix(CREDS_PROPERTY_PREFIX + credentialsId);
+            deletePropertiesWithPrefix(CREDS_PROPERTY_PREFIX + credentialsId + ".");
         } catch (InterruptedException | ExecutionException e) {
             Thread.currentThread().interrupt();
             throw new CredentialsException("Failed to delete credentials", e);

--- a/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3CredentialsStoreTest.java
+++ b/modules/extensions/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3CredentialsStoreTest.java
@@ -445,6 +445,57 @@ public class Etcd3CredentialsStoreTest {
     }
 
     @Test
+    public void testDeleteCredentialsDoesNotDeleteSimilarlyNamedSecret() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "SYS1_USER";
+        String similarCredsId = "SYS1_USER_ABC";
+        String username = "user-a";
+        String similarUsername = "user-b";
+
+        Map<String, String> mockCreds = new HashMap<>();
+        mockCreds.put("secure.credentials." + credsId + ".username", username);
+        mockCreds.put("secure.credentials." + similarCredsId + ".username", similarUsername);
+
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        // When...
+        store.deleteCredentials(credsId);
+
+        // Then...
+        assertThat(mockCreds).doesNotContainKey("secure.credentials." + credsId + ".username");
+        assertThat(mockCreds).containsKey("secure.credentials." + similarCredsId + ".username");
+        assertThat(mockCreds.get("secure.credentials." + similarCredsId + ".username")).isEqualTo(similarUsername);
+    }
+
+    @Test
+    public void testSetCredentialsDoesNotDeleteSimilarlyNamedSecret() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "SYS1_ADMIN";
+        String similarCredsId = "SYS1_ADMIN_XYZ";
+        String username = "admin-a";
+        String newUsername = "admin-aaa";
+        String similarUsername = "admin-b";
+
+        Map<String, String> mockCreds = new HashMap<>();
+        mockCreds.put("secure.credentials." + credsId + ".username", username);
+        mockCreds.put("secure.credentials." + similarCredsId + ".username", similarUsername);
+
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        // When...
+        store.setCredentials(credsId, new CredentialsUsername(newUsername));
+
+        // Then...
+        assertThat(mockCreds.get("secure.credentials." + credsId + ".username")).isEqualTo(newUsername);
+        assertThat(mockCreds).containsKey("secure.credentials." + similarCredsId + ".username");
+        assertThat(mockCreds.get("secure.credentials." + similarCredsId + ".username")).isEqualTo(similarUsername);
+    }
+
+    @Test
     public void testShutdownClosesEtcdClientsOk() throws Exception {
         // Given...
         MockEncryptionService mockEncryptionService = new MockEncryptionService();


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2642

## Changes
- [x] Added the property separator (".") to the deletePropertiesWithPrefix call so that properties with similar names do not get deleted unintentionally
- [x] Unit tests (if applicable)
